### PR TITLE
#11824 Android: bundled loading page eliminates cold-start WebView error

### DIFF
--- a/client/packages/android/app/src/main/assets/native/error_page.html
+++ b/client/packages/android/app/src/main/assets/native/error_page.html
@@ -1,0 +1,296 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <title>omSupply error</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+      }
+      body {
+        background: #f2f2f5;
+        color: #1c1c28;
+        font-family: -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+      }
+      .container {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        justify-content: center;
+        width: 100%;
+      }
+      .url-display {
+        text-align: center;
+        margin-bottom: 16px;
+        font-size: 0.875rem;
+        color: #677285;
+      }
+      h5 {
+        text-align: center;
+      }
+      button {
+        display: block;
+        margin: 0 auto;
+        background: #e95c30;
+        color: #fff;
+        border: none;
+        border-radius: 24px;
+        font-size: 0.875rem;
+        font-weight: 600;
+        height: 40px;
+        min-width: 115px;
+        padding: 0 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div>
+        <svg
+          width="301"
+          height="300"
+          viewBox="0 0 301 300"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+        >
+          <title>Error illustration</title>
+          <defs>
+            <linearGradient x1="30.668%" y1="40.384%" x2="65.881%" y2="53.418%" id="prefix__c">
+              <stop stop-color="#E1E7EA" offset="0%"></stop>
+              <stop stop-color="#D0D6DC" offset="100%"></stop>
+            </linearGradient>
+            <linearGradient x1="31.432%" y1="42.349%" x2="72.312%" y2="56.615%" id="prefix__e">
+              <stop stop-color="#E1E7EA" offset="0%"></stop>
+              <stop stop-color="#D0D6DC" offset="100%"></stop>
+            </linearGradient>
+            <linearGradient x1="50%" y1="45.808%" x2="79.143%" y2="65.232%" id="prefix__f">
+              <stop stop-color="#FBFBFB" offset="0%"></stop>
+              <stop stop-color="#D9DFE3" offset="100%"></stop>
+            </linearGradient>
+            <linearGradient x1="25.16%" y1="3.067%" x2="49.928%" y2="89.514%" id="prefix__g">
+              <stop stop-color="#ECECEC" offset="0%"></stop>
+              <stop stop-color="#E1E7EA" offset="71.754%"></stop>
+              <stop stop-color="#BCC3CA" offset="100%"></stop>
+            </linearGradient>
+            <linearGradient x1="29.489%" y1="50%" x2="100%" y2="50%" id="prefix__h">
+              <stop stop-color="#BAC6D2" offset="0%"></stop>
+              <stop stop-color="#7F8F9F" offset="100%"></stop>
+            </linearGradient>
+            <linearGradient x1="50%" y1="50%" x2="76.359%" y2="71.293%" id="prefix__i">
+              <stop stop-color="#E1E7EA" offset="0%"></stop>
+              <stop stop-color="#D0D6DC" offset="100%"></stop>
+            </linearGradient>
+            <linearGradient x1="73.341%" y1="89.804%" x2="23.909%" y2="5.486%" id="prefix__j">
+              <stop stop-color="#DAE2E6" offset="0%"></stop>
+              <stop stop-color="#E3EBEF" offset="58%"></stop>
+              <stop stop-color="#EDF6F9" offset="100%"></stop>
+            </linearGradient>
+            <linearGradient x1="29.814%" y1="47.36%" x2="111.048%" y2="50%" id="prefix__k">
+              <stop stop-color="#C4CDD1" offset="0%"></stop>
+              <stop stop-color="#C6CFD3" stop-opacity="0" offset="100%"></stop>
+            </linearGradient>
+            <linearGradient x1="50%" y1="100%" x2="50%" y2="0%" id="prefix__l">
+              <stop stop-color="#7A87AF" offset="0%"></stop>
+              <stop stop-color="#444F77" offset="100%"></stop>
+            </linearGradient>
+            <linearGradient x1="50%" y1="100%" x2="50%" y2="0%" id="prefix__m">
+              <stop stop-color="#7A87AF" offset="0%"></stop>
+              <stop stop-color="#444F77" offset="100%"></stop>
+            </linearGradient>
+            <linearGradient x1="18.13%" y1="4.088%" x2="74.703%" y2="111.588%" id="prefix__n">
+              <stop stop-color="#E5E9F0" offset="0%"></stop>
+              <stop stop-color="#D2DAE8" offset="100%"></stop>
+            </linearGradient>
+            <radialGradient
+              cx="43.37%"
+              cy="34.68%"
+              fx="43.37%"
+              fy="34.68%"
+              r="58.142%"
+              gradientTransform="matrix(0 -1 .90933 0 .118 .78)"
+              id="prefix__b"
+            >
+              <stop stop-color="#EBEDF0" stop-opacity="0.24" offset="0%"></stop>
+              <stop stop-color="#EBEDF0" stop-opacity="0.846" offset="53.678%"></stop>
+              <stop stop-color="#E0E4E7" stop-opacity="0" offset="100%"></stop>
+            </radialGradient>
+            <path
+              d="M297.818 86.074C305.031 71.728 284.416 0 141.479 0 38.307 0-9.046 58.71 1.423 88.465"
+              id="prefix__a"
+            ></path>
+          </defs>
+          <g fill="none" fill-rule="evenodd">
+            <path d="M.469 0h299.063v300H.469z"></path>
+            <g transform="translate(.469 27.273)">
+              <g transform="translate(0 156.212)">
+                <mask id="prefix__d" fill="#fff"><use xlink:href="#prefix__a"></use></mask>
+                <use fill="url(#prefix__b)" fill-rule="nonzero" xlink:href="#prefix__a"></use>
+                <ellipse
+                  fill="url(#prefix__c)"
+                  fill-rule="nonzero"
+                  opacity="0.672"
+                  mask="url(#prefix__d)"
+                  cx="119.434"
+                  cy="40.224"
+                  rx="7.861"
+                  ry="4.388"
+                ></ellipse>
+                <ellipse
+                  fill="url(#prefix__e)"
+                  fill-rule="nonzero"
+                  opacity="0.73"
+                  mask="url(#prefix__d)"
+                  cx="199.666"
+                  cy="33.525"
+                  rx="12.403"
+                  ry="6.845"
+                ></ellipse>
+                <ellipse
+                  fill="url(#prefix__f)"
+                  fill-rule="nonzero"
+                  opacity="0.73"
+                  mask="url(#prefix__d)"
+                  cx="58.52"
+                  cy="15.271"
+                  rx="12.403"
+                  ry="6.845"
+                ></ellipse>
+              </g>
+              <g opacity="0.321" transform="translate(218.546 27.493)" fill-rule="nonzero">
+                <ellipse
+                  fill="url(#prefix__g)"
+                  cx="13.416"
+                  cy="9.078"
+                  rx="8.385"
+                  ry="8.425"
+                ></ellipse>
+                <path
+                  d="M6.385 4.741C2.828 5.493.493 6.768.495 8.218c.004 2.325 6.017 4.22 13.43 4.231 7.414.011 13.42-1.864 13.417-4.19-.002-1.463-2.806-2.49-6.419-3.25"
+                  stroke="url(#prefix__h)"
+                  stroke-width="5.888"
+                  transform="rotate(20 13.919 8.595)"
+                ></path>
+                <path
+                  d="M21.818 9.078c0-4.653-3.754-8.425-8.385-8.425-4.63 0-7.531 2.975-8.13 6.33 3.214 2.021 5.562 3.25 7.046 3.684.71.208 1.413.477 2.13.716a32.16 32.16 0 002.443.708c.565.14 1.34.357 2.064.492.953.178 1.808.258 1.875.258.118 0 .248-.53.515-1.148.178-.411.325-1.283.442-2.615z"
+                  fill="url(#prefix__i)"
+                ></path>
+              </g>
+              <ellipse
+                fill="url(#prefix__j)"
+                opacity="0.418"
+                cx="47.735"
+                cy="86.275"
+                rx="9.777"
+                ry="9.826"
+              ></ellipse>
+              <ellipse
+                fill="url(#prefix__k)"
+                fill-rule="nonzero"
+                opacity="0.5"
+                cx="153.557"
+                cy="170.084"
+                rx="29.331"
+                ry="8.092"
+              ></ellipse>
+              <g fill-rule="nonzero">
+                <g transform="rotate(20 71.002 403.935)">
+                  <path
+                    d="M1.2 3.222h3.45v176.297a1.725 1.725 0 01-3.45 0V3.222z"
+                    fill="#D8D8D8"
+                  ></path>
+                  <path
+                    d="M1.15 3.325l19.62 4.69a72.666 72.666 0 0027.705 1.182c7.746-1.165 14.991 4.107 16.265 11.836l6.423 38.97a.97.97 0 01-1.762.696l-3.337-4.987a12.115 12.115 0 00-15.285-4.196l-3.407 1.625a31.605 31.605 0 01-25.98.557L1.15 45.087V3.325z"
+                    fill="#E57A77"
+                  ></path>
+                  <path
+                    d="M49.344 19.623a3.45 3.45 0 010 4.88l-8.199 8.199 8.2 8.2a3.45 3.45 0 11-4.88 4.88l-8.2-8.2-8.198 8.198a3.45 3.45 0 11-4.88-4.88l8.198-8.198-8.198-8.197a3.45 3.45 0 114.88-4.88l8.198 8.197 8.2-8.199a3.45 3.45 0 014.88 0z"
+                    fill="#FFF"
+                  ></path>
+                  <ellipse fill="#D8D8D8" cx="2.3" cy="2.312" rx="2.3" ry="2.312"></ellipse>
+                </g>
+                <path
+                  d="M105.132 102.531c1.15-.578 1.725-.77 1.725-.578v3.468l-1.15.578-.575-3.468z"
+                  fill="#FFE9E9"
+                ></path>
+              </g>
+              <g fill-rule="nonzero">
+                <path
+                  d="M137.81 160.417c-.386-1.416-1.089-2.17-2.106-2.263-1.527-.138-5.827 4.434-6.725 6.321-.9 1.888 1.556 4.533 4.359 1.99 1.869-1.694 3.36-3.71 4.472-6.048z"
+                  fill="#677285"
+                ></path>
+                <path
+                  d="M11.757 15.031L9.221 7.919a1.38 1.38 0 00-2.492-.232L5.234 10.25c-.14 5.65.911 8.8 3.156 9.449 2.245.649 3.367-.907 3.367-4.668z"
+                  fill="url(#prefix__l)"
+                  transform="translate(127.85 151.588)"
+                ></path>
+                <path
+                  d="M161.252 160.417c.387-1.416 1.09-2.17 2.107-2.263 1.526-.138 5.826 4.434 6.725 6.321.899 1.888-1.556 4.533-4.36 1.99-1.868-1.694-3.359-3.71-4.472-6.048z"
+                  fill="#677285"
+                ></path>
+                <path
+                  d="M11.757 10.638L9.221 3.527a1.38 1.38 0 00-2.492-.232L5.234 5.857c-.14 5.65.911 8.8 3.156 9.449 2.245.65 3.367-.907 3.367-4.668z"
+                  fill="url(#prefix__l)"
+                  transform="matrix(-1 0 0 1 171.213 155.981)"
+                ></path>
+                <path
+                  d="M12.25.268c-.64 1.266-.961 2.344-.961 3.234-.962 2.165-2.547 5.078-5.291 11.155a4.268 4.268 0 006.603 5.051l8.815-7.262 8.684 7.206a4.327 4.327 0 005.553-.022 4.473 4.473 0 001.13-5.395c-1.233-2.504-2.836-6.082-4.812-10.733 0-.88-.28-1.743-.839-2.588L12.251.268z"
+                  fill="url(#prefix__m)"
+                  transform="translate(127.85 151.588)"
+                ></path>
+              </g>
+              <path
+                d="M7.673 19.074c-1.046 1.535-1.43 4.222-1.15 8.062h4.601L9.348 39.133a1.83 1.83 0 001.17 1.983c4 1.494 7.215 2.313 9.647 2.457 2.423.144 5.824-.525 10.204-2.007a1.83 1.83 0 001.177-2.223c-.782-2.823-2.367-6.892-4.756-12.207-.64.752.848.752 4.463 0-.225-3.42-.8-6.107-1.725-8.062-.925-1.956-2.458-3.587-4.601-4.894L16.8 12.94c-2.25.441-3.95.97-5.1 1.586-1.726.924-2.458 2.244-4.027 4.548z"
+                fill="url(#prefix__n)"
+                fill-rule="nonzero"
+                transform="matrix(-1 0 0 1 168.707 117.757)"
+              ></path>
+              <path
+                d="M161.75 144.87l-.184 5.477-.617 2.741-4.247 17.608.677 1.469.438 1.907-.438 1.214-1.15-.431-2.3-1.88-.352-1.059a1.615 1.615 0 01.124-1.297l1.03-1.84 3.086-16.438-.31-7.265 4.242-.207zM137.569 145.076l.496 5.27.618 2.742 4.247 17.608-.677 1.469-.438 1.907.438 1.214 1.15-.431 2.3-1.88.351-1.059c.143-.43.098-.901-.123-1.297l-1.03-1.84-3.086-16.438.24-7.265h-4.486z"
+                fill="#FDE7E6"
+                fill-rule="nonzero"
+              ></path>
+              <path
+                d="M146.886 126.213h4.53v6.102l-.162.26c-1.704 2.714-2.556 3.792-2.556 3.232 0-.578-.604-1.742-1.812-3.492v-6.102z"
+                fill="#FECECD"
+                fill-rule="nonzero"
+              ></path>
+              <path
+                d="M149.048 131.213c1.607.082 3.856-3.005 3.856-6.01s-.839-6.011-3.856-6.011c-3.016 0-4.177 2.692-4.177 6.011 0 3.32 2.57 5.928 4.177 6.01z"
+                fill="#FFE9E9"
+                fill-rule="nonzero"
+              ></path>
+              <path
+                d="M144.479 126.205c.321-1.146.321-3.672.964-3.755.643-.082 1.928.396 3.213-.532.643-.51.964-.573.964-.83 3.213.61 1.292 2.45 2.892 4.477.111.141.326.141.643 0 0-3.327-.107-5.139-.322-5.436-.321-.445-1.606-2.238-2.249-.959 0-.64-1.285-1.3-2.57-.81-1.286.49-3.214 1.45-3.535 2.729-.321 1.279-.643 3.837 0 5.116z"
+                fill="#513450"
+              ></path>
+            </g>
+          </g>
+        </svg>
+      </div>
+      <div>
+        <h5>Oops! Something's gone wrong.</h5>
+        <div id="failed-url" class="url-display"></div>
+        <button onclick="ErrorPageInject.showLogs()">Show Log File</button>
+      </div>
+    </div>
+    <script>
+      // Populate the failed URL from the Java-side interface.
+      try {
+        if (window.ErrorPageInject && ErrorPageInject.getFailedUrl) {
+          var url = ErrorPageInject.getFailedUrl();
+          if (url) {
+            document.getElementById("failed-url").textContent = url;
+          }
+        }
+      } catch (e) {}
+    </script>
+  </body>
+</html>

--- a/client/packages/android/app/src/main/assets/native/loading_page.html
+++ b/client/packages/android/app/src/main/assets/native/loading_page.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <title>Starting omSupply</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+      }
+      body {
+        background: #f2f2f5;
+        color: #1c1c28;
+        font-family: -apple-system, system-ui, 'Segoe UI', Roboto, sans-serif;
+        display: grid;
+        place-items: center;
+        min-height: 100vh;
+      }
+      .root {
+        text-align: center;
+        padding: 24px;
+      }
+      .spinner {
+        width: 64px;
+        height: 64px;
+        margin: 0 auto 24px;
+        border-radius: 50%;
+        background: conic-gradient(
+          from 0deg,
+          #ff7a0a,
+          #e83b30,
+          rgba(232, 59, 48, 0)
+        );
+        -webkit-mask: radial-gradient(
+          circle at center,
+          transparent 58%,
+          #000 60%
+        );
+        mask: radial-gradient(circle at center, transparent 58%, #000 60%);
+        animation: spin 1s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(1turn);
+        }
+      }
+      h2 {
+        margin: 0 0 8px;
+        font-weight: 600;
+        font-size: 1.125rem;
+      }
+      .subtext {
+        margin: 0;
+        color: #677285;
+        font-size: 0.875rem;
+      }
+      #logBtn {
+        display: block;
+        margin: 32px auto 0;
+        background: #e95c30;
+        color: #fff;
+        border: none;
+        border-radius: 24px;
+        font-size: 0.875rem;
+        font-weight: 600;
+        height: 40px;
+        min-width: 115px;
+        padding: 0 24px;
+        opacity: 0;
+        transition: opacity 400ms ease;
+      }
+      #logBtn[hidden] {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="root">
+      <div class="spinner" role="status" aria-label="Loading"></div>
+      <h2>Starting omSupply…</h2>
+      <p class="subtext">This usually only takes a few seconds.</p>
+      <button id="logBtn" hidden onclick="LoadingPageInject.showLogs()">
+        Show Log File
+      </button>
+    </div>
+    <script>
+      // Reveal the log button after 5s — fast cold starts (~500ms) never see
+      // it; slow startups give the user a way to grab logs for support.
+      setTimeout(function () {
+        var b = document.getElementById('logBtn');
+        if (!b) return;
+        b.hidden = false;
+        requestAnimationFrame(function () {
+          b.style.opacity = 1;
+        });
+      }, 5000);
+    </script>
+  </body>
+</html>

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/AppState.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/AppState.java
@@ -1,15 +1,19 @@
 package org.openmsupply.client;
 public class AppState {
     private static final AppState instance = new AppState();
-    private boolean isServerReady = false;
+    // Tracks whether the WebView has been given its initial content (the inline
+    // LoadingPage). Gates native-splash dismissal and is used as the "have we
+    // already gone through cold-start setup?" signal for warm-resume detection.
+    // NOT a signal about Rust server readiness.
+    private boolean isWebViewReady = false;
     private AppState() {} // Private constructor
     public static AppState getInstance() {
         return instance;
     }
-    public boolean isServerReady() {
-        return isServerReady;
+    public boolean isWebViewReady() {
+        return isWebViewReady;
     }
-    public void setServerReady(boolean serverReady) {
-        isServerReady = serverReady;
+    public void setWebViewReady(boolean webViewReady) {
+        isWebViewReady = webViewReady;
     }
 }

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
@@ -1,6 +1,10 @@
 package org.openmsupply.client;
 
 import android.graphics.Bitmap;
+import android.util.Log;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 
 import com.getcapacitor.Bridge;
@@ -31,6 +35,29 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
         }
     }
 
+    @Override
+    public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+        Log.e(NativeApi.OM_SUPPLY, "WebView onReceivedError"
+                + " url=" + request.getUrl()
+                + " mainFrame=" + request.isForMainFrame()
+                + " method=" + request.getMethod()
+                + " errorCode=" + error.getErrorCode()
+                + " description=" + error.getDescription()
+                + " atMs=" + System.currentTimeMillis());
+        super.onReceivedError(view, request, error);
+    }
+
+    @Override
+    public void onReceivedHttpError(WebView view, WebResourceRequest request, WebResourceResponse errorResponse) {
+        Log.e(NativeApi.OM_SUPPLY, "WebView onReceivedHttpError"
+                + " url=" + request.getUrl()
+                + " mainFrame=" + request.isForMainFrame()
+                + " status=" + errorResponse.getStatusCode()
+                + " reason=" + errorResponse.getReasonPhrase()
+                + " atMs=" + System.currentTimeMillis());
+        super.onReceivedHttpError(view, request, errorResponse);
+    }
+
     // Have to manually inject Capacitor JS, this typically happens in
     // WebViewLocalServer.handleProxyRequest
     // but since it manually uses net.URL to fetch the content of request, this
@@ -38,6 +65,10 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
     @Override
     public void onPageStarted(WebView webView, String url, Bitmap favicon) {
         if (url.startsWith("data:text")) return;
+        // Skip Capacitor JS injection for our bundled native pages
+        // (LoadingPage / ErrorPage). They only need their own JS bridge
+        // and don't talk to the rest of the Capacitor plugin system.
+        if (url.startsWith("file:///android_asset/native/")) return;
 
         // Just incase the js hasn't been generated yet, generate it here.
         this.loadJsInject();

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/LoadingPage.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/LoadingPage.java
@@ -13,25 +13,17 @@ import java.io.FileReader;
 import java.io.IOException;
 
 /**
- * JavaScript bridge for the inline error page shown when the readiness poll
- * gives up. The actual HTML lives at {@link #URL} (assets/native/error_page.html).
+ * JavaScript bridge for the inline loading page shown while the Rust server
+ * warms up. The actual HTML lives at {@link #URL} (assets/native/loading_page.html).
  */
-public class ErrorPage {
-    public static final String URL = "file:///android_asset/native/error_page.html";
+public class LoadingPage {
+    public static final String URL = "file:///android_asset/native/loading_page.html";
     private static final String LOG_FILE_NAME = "remote_server.log";
 
     private final Context mContext;
-    private final String mFailedUrl;
 
-    ErrorPage(Context c, String failedUrl) {
+    LoadingPage(Context c) {
         mContext = c;
-        mFailedUrl = failedUrl;
-    }
-
-    /** Returned to the page's JS so it can render the URL the WebView failed to reach. */
-    @JavascriptInterface
-    public String getFailedUrl() {
-        return mFailedUrl != null ? mFailedUrl : "";
     }
 
     @JavascriptInterface

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/MainActivity.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewTreeObserver;
+import android.webkit.WebView;
 
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
@@ -25,18 +26,33 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(HoneywellScannerPlugin.class);
         super.onCreate(savedInstanceState);
 
+        // Replace Capacitor's auto-loaded https://localhost:<PORT>/ with an inline
+        // "Starting omSupply…" page. Without this, the WebView fires a GET against
+        // a server that hasn't bound yet, which paints Chromium's native error page
+        // and leaks through the brief window between splash dismissal and the real
+        // /android URL finishing its load.
+        WebView webView = getBridge().getWebView();
+        webView.addJavascriptInterface(new LoadingPage(this), "LoadingPageInject");
+        webView.loadUrl(LoadingPage.URL);
+
+        // The LoadingPage IS our loading UX now — release the native splash on the
+        // next UI message (after loadData has been queued for rendering) so the
+        // spinner becomes visible immediately rather than waiting for the readiness
+        // poll to finish.
+        webView.post(() -> AppState.getInstance().setWebViewReady(true));
+
         discoveryConstants = new DiscoveryConstants(getContentResolver());
         fileManager = new FileManager(this);
 
         // Set up an OnPreDrawListener to the root view
-        // This allows us to show the splash until the server is ready
+        // This holds the native splash up until the WebView has its initial
+        // content (the LoadingPage), so there's no white flash on cold start.
         final View content = findViewById(android.R.id.content);
         content.getViewTreeObserver().addOnPreDrawListener(
                 new ViewTreeObserver.OnPreDrawListener() {
                     @Override
                     public boolean onPreDraw() {
-                        // Check whether the server has started (or is in error state)
-                        if (AppState.getInstance().isServerReady()) {
+                        if (AppState.getInstance().isWebViewReady()) {
                             // The content is ready: start drawing
                             content.getViewTreeObserver().removeOnPreDrawListener(this);
                             return true;

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -132,18 +132,27 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
         // Potentially avoiding issues if it takes too long to generate.
         client.loadJsInject();
 
-        // this method (handleOnStart) is called when resuming and switching to the app
-        // the webView url will be DEFAULT_URL only on the initial load
-        // so this test is a quick check to see if we should be redirecting to the
-        // /android loader or not
-        if (!webView.getUrl().matches(DEFAULT_URL))
+        // handleOnStart fires on cold start AND on warm resume. On cold start we
+        // begin on the inline LoadingPage (set in MainActivity.onCreate), not on
+        // DEFAULT_URL — so the old `getUrl().matches(DEFAULT_URL)` check no longer
+        // distinguishes the two. Use the readiness/server state instead: if we've
+        // already completed a successful startup and have a connected server,
+        // this is a resume and we should not re-run the poll.
+        if (AppState.getInstance().isWebViewReady() && connectedServer != null)
             return;
         Thread thread = new Thread(new Runnable() {
             @Override
             public void run() {
                 Boolean isServerRunning = false;
-                Integer retryCount = 5;
+                // Generous budget — the LoadingPage is visible to the user while we wait,
+                // so erring long is cheap and helps slow devices succeed without an error page.
+                Integer retryCount = 30;
+                int attempt = 0;
+                String readySignal = null;
+                final long pollStart = System.currentTimeMillis();
+                Log.i(OM_SUPPLY, "Readiness poll start url=" + localUrl + " retryBudget=" + retryCount);
                 while (!isServerRunning && retryCount > 0) {
+                    attempt++;
                     try {
                         URL url = new URL(localUrl);
                         HttpURLConnection urlc = (HttpURLConnection) url.openConnection();
@@ -152,36 +161,62 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
                         // responding
                         urlc.setConnectTimeout(1000);
                         urlc.connect();
-                        if (urlc.getResponseCode() == 200) {
+                        int code = urlc.getResponseCode();
+                        Log.i(OM_SUPPLY, "Readiness poll attempt=" + attempt + " connect ok responseCode=" + code);
+                        if (code == 200) {
                             isServerRunning = true;
+                            readySignal = "HTTP 200";
                         }
                     } catch (SSLHandshakeException e) {
+                        Throwable cause = e.getCause();
+                        String causeDesc = cause == null
+                                ? "null"
+                                : cause.getClass().getName() + ":" + cause.getMessage();
+                        Log.i(OM_SUPPLY, "Readiness poll attempt=" + attempt
+                                + " SSLHandshakeException msg=" + e.getMessage()
+                                + " cause=" + causeDesc);
                         // server is running and responding with an SSL error
                         // which we will ignore, so ok to proceed
                         isServerRunning = true;
+                        readySignal = "SSLHandshakeException(cause="
+                                + (cause == null ? "null" : cause.getClass().getSimpleName()) + ")";
                     } catch (Exception e) {
-                        Log.e(OM_SUPPLY, e.getMessage());
+                        Throwable cause = e.getCause();
+                        String causeDesc = cause == null
+                                ? "null"
+                                : cause.getClass().getName() + ":" + cause.getMessage();
+                        Log.e(OM_SUPPLY, "Readiness poll attempt=" + attempt
+                                + " " + e.getClass().getName()
+                                + " msg=" + e.getMessage()
+                                + " cause=" + causeDesc);
                         isServerRunning = false;
                     }
                     retryCount--;
                     sleep(1000);
                 }
 
+                final long pollElapsed = System.currentTimeMillis() - pollStart;
+                Log.i(OM_SUPPLY, "Readiness poll end isServerRunning=" + isServerRunning
+                        + " readySignal=" + readySignal + " elapsedMs=" + pollElapsed);
+
                 final Handler handler = new Handler(Looper.getMainLooper());
                 handler.postDelayed(new Runnable() {
                     @Override
                     public void run() {
-                        AppState.getInstance().setServerReady(true);
+                        AppState.getInstance().setWebViewReady(true);
                     }
                 }, 250);
 
                 // .post to run on UI thread in the two calls below
                 if (isServerRunning) {
-                    webView.post(() -> webView.loadUrl(localUrl + "/android"));
+                    final String targetUrl = localUrl + "/android";
+                    Log.i(OM_SUPPLY, "Loading WebView url=" + targetUrl);
+                    webView.post(() -> webView.loadUrl(targetUrl));
                 } else {
                     Log.e(OM_SUPPLY, "Server not running, displaying error page");
-                    webView.post(() -> webView.addJavascriptInterface(new ErrorPage(getContext()), "ErrorPageInject"));
-                    webView.post(() -> webView.loadData(ErrorPage.getEncodedHtml(localUrl), "text/html", "base64"));
+                    final ErrorPage errorPage = new ErrorPage(getContext(), localUrl);
+                    webView.post(() -> webView.addJavascriptInterface(errorPage, "ErrorPageInject"));
+                    webView.post(() -> webView.loadUrl(ErrorPage.URL));
                 }
             }
         });

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -48,6 +48,7 @@ use service::{
 
 use actix_web::{web, web::Data, App, HttpServer};
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::Instant;
 use util::format_error;
 
 mod authentication;
@@ -115,6 +116,7 @@ pub async fn start_server(
     }
 
     info!("Run DB migrations...");
+    let migrations_start = Instant::now();
     let connection = connection_manager.connection().unwrap();
     let (version, messages) = match migrate(&connection, None) {
         Ok(result) => result,
@@ -123,6 +125,10 @@ pub async fn start_server(
             std::process::exit(1);
         }
     };
+    info!(
+        "DB migrations completed in {} ms",
+        migrations_start.elapsed().as_millis()
+    );
     // Log the server starting message with the startup timestamp
     let status_log = StatusLog(&connection);
     status_log.no_console_with_timestamp(&server_start_message, server_start_timestamp);
@@ -141,13 +147,13 @@ pub async fn start_server(
     // Wire transaction notifications to the subscription worker.
     // Fired after outermost transaction commits.
     let commit_trigger = subscription_trigger.clone();
-    connection_manager.set_on_commit(std::sync::Arc::new(move |notification| {
-        match notification {
+    connection_manager.set_on_commit(std::sync::Arc::new(
+        move |notification| match notification {
             repository::TransactionNotification::ChangelogInsert => {
                 commit_trigger.send(SubscriptionTrigger::PushQueueChanged);
             }
-        }
-    }));
+        },
+    ));
     let (file_sync_trigger, file_sync_driver) = FileSyncDriver::init(&settings);
     let (sync_trigger, synchroniser_driver) = SynchroniserDriver::init(file_sync_trigger.clone()); // Cloning as we want to expose this for stop messages
     let (ledger_fix_trigger, ledger_fix_driver) = LedgerFixDriver::init();
@@ -164,7 +170,12 @@ pub async fn start_server(
         subscription_trigger,
     ));
     let loaders = get_loaders(&connection_manager, service_provider.clone()).await;
+    let cert_start = Instant::now();
     let certificates = Certificates::try_load(&settings.server).unwrap();
+    info!(
+        "Certificates loaded in {} ms",
+        cert_start.elapsed().as_millis()
+    );
     let token_bucket = Arc::new(RwLock::new(TokenBucket::new()));
     let token_secret = get_or_create_token_secret(&connection_manager.connection().unwrap());
     let auth = auth_data(&settings.server, token_bucket, token_secret, &certificates);
@@ -278,10 +289,7 @@ pub async fn start_server(
     } else {
         OperationalStatus::Initialising
     };
-    info!(
-        "Creating graphql schema in {:?} mode..",
-        initial_status
-    );
+    info!("Creating graphql schema in {:?} mode..", initial_status);
 
     let validated_plugins = ValidatedPluginBucket::new(&settings.server.base_dir).unwrap();
     let validated_plugins = Data::new(Mutex::new(validated_plugins));
@@ -306,7 +314,10 @@ pub async fn start_server(
         let graphql_schema = graphql_schema.clone();
         site_is_initialised_callback.on_trigger(async move {
             info!("Changing graphql schema to operational mode");
-            graphql_schema.clone().set_operational_status(OperationalStatus::Operational).await;
+            graphql_schema
+                .clone()
+                .set_operational_status(OperationalStatus::Operational)
+                .await;
         });
     }
     info!("Creating graphql schema..done");
@@ -416,12 +427,24 @@ pub async fn start_server(
         http_server = http_server.workers(workers);
     }
 
+    let bind_start = Instant::now();
+    info!(
+        "Binding listener on {} (tls={})",
+        settings.server.address(),
+        certificates.config().is_some()
+    );
     http_server = match certificates.config() {
         Some(config) => http_server
             .bind_rustls_0_23(settings.server.address(), config)
             .unwrap(),
         None => http_server.bind(settings.server.address()).unwrap(),
     };
+    let bind_elapsed_ms = bind_start.elapsed().as_millis();
+    info!(
+        "Listener bound in {} ms (tls={})",
+        bind_elapsed_ms,
+        certificates.is_https()
+    );
     info!("Initialising http server..done",);
 
     let running_server = http_server.run();
@@ -431,6 +454,10 @@ pub async fn start_server(
         settings.server.port, version
     );
     // run server in another task so that we can handle restart/off events here
+    info!(
+        "Spawning accept loop ({} ms after bind)",
+        bind_start.elapsed().as_millis()
+    );
     tokio::spawn(running_server);
 
     tokio::select! {


### PR DESCRIPTION
Fixes #11824

## Summary

- The Android WebView briefly shows Chromium's native error page on cold start because Capacitor's `BridgeActivity` auto-loads `https://localhost:8000/` before the in-process Rust server has bound the port. This PR replaces that initial URL with a bundled `assets/native/loading_page.html` so the live server URL is never requested until the readiness poll confirms the server is up.
- The custom `ErrorPage` HTML is also externalised to `assets/native/error_page.html` (same `loadUrl` pattern; the unhappy-face SVG no longer lives as a 250-line Java string literal).
- `AppState.isServerReady` is renamed to `isWebViewReady` — what it actually gates now is splash dismissal based on the WebView having its initial content, not Rust server state.
- Java readiness retry budget restored to 30 attempts (cheap; the LoadingPage is the visible state during the wait, so erring long is free).
- Adds permanent startup timing logs (Rust DB migrations / certs / bind+spawn; Java poll attempt + `WebView onReceivedError` hook) for future field diagnostics. These are cheap and only fire once per cold start.

## Diagnostic findings backing the fix

Measured on a Pixel-class emulator (M-chip Mac, debug build):

- **Rust cold-start → listener bound:** ~525 ms on fresh install ("Empty database detected"), ~590 ms on warm DB. Dominated by DB migrations + reports upsert + GraphQL schema build + cert generate on first run.
- **Bind → accept-loop draining first connection:** ~25 ms (measured with a TCP self-loopback probe spawned after `tokio::spawn(running_server)`, since removed). This window is a possible source of the field `ERR_CONNECTION_CLOSED` symptom — the kernel accepts the TCP connect into its backlog before actix's accept loop reads from the socket, so the WebView's TLS handshake stalls.
- **The visible error came from Capacitor's auto-load, not from any of our code.** `BridgeActivity.onCreate` calls `loadUrl(server.url)` synchronously, before `NativeApi.handleOnStart` ever fires. Repro logs showed `WebView onReceivedError url=https://localhost:8000/ errorCode=-6 description=net::ERR_CONNECTION_REFUSED` firing 100–200 ms **before** the Rust server even bound the port.

Layer-1 fix in this PR makes the WebView start on a bundled inline page, eliminating the race. Two follow-on improvements remain for a later PR:
- Layer 2: move `setWebViewReady(true)` from the immediate `webView.post(...)` to an `onPageFinished` for the `/android` URL — would guarantee zero flash even during the LoadingPage → app transition.
- Layer 3: tighten the `SSLHandshakeException` triage in the Java poll (only treat `CertPathValidatorException`-caused failures as ready) — defence-in-depth.

## What the user sees now

<img width="497" height="818" alt="image" src="https://github.com/user-attachments/assets/5b622ad8-2d41-4dff-9b88-613761773c85" />


Cold start:
- 0 – ~200 ms: native splash (background `#f2f2f5`)
- ~200 ms – server-ready: brand-coloured CSS spinner + "Starting omSupply…" on the same `#f2f2f5` background
- At 5 s of waiting: "Show Log File" button fades in (slow-startup escape hatch)
- Server ready: `loadUrl("/android")` swaps the spinner for the React app
- Server times out: the existing custom `ErrorPage` (unhappy face + URL + Show Log button) loads from `assets/native/error_page.html`

No `https://localhost:8000/` is requested before the poll declares ready; the Chromium native error page should no longer appear.

## Files touched

**Java**
- `MainActivity.java` — `loadUrl(LoadingPage.URL)` immediately after `super.onCreate(...)`, register `LoadingPageInject`, post `setWebViewReady(true)` so splash dismisses on the next UI message.
- `NativeApi.java` — initial-load check uses `isWebViewReady() && connectedServer != null` (URL is now a `file://` URL on cold start); retry budget back to 30; poll-attempt logging + new `localUrl + "/android"` logging.
- `LoadingPage.java` (new) — `JavascriptInterface showLogs()` + `public static final String URL`.
- `ErrorPage.java` — HTML string removed; constructor now takes the failed URL, exposed via new `JavascriptInterface getFailedUrl()`; `showLogs()` unchanged.
- `AppState.java` — rename `isServerReady` → `isWebViewReady` (with comment clarifying semantics).
- `ExtendedWebViewClient.java` — `onPageStarted` skips Capacitor JS injection for `file:///android_asset/native/` URLs and adds `onReceivedError` / `onReceivedHttpError` logging.

**Bundled assets**
- `assets/native/loading_page.html` — spinner, headline, deferred-reveal log button.
- `assets/native/error_page.html` — unhappy-face SVG, URL display populated via `ErrorPageInject.getFailedUrl()`, log button.

**Rust**
- `server/server/src/lib.rs` — timing logs around DB migrations, cert load, bind, accept-loop spawn. No behavioural change.

## Test plan

- [ ] `yarn android:build:debug` + reinstall on emulator
- [ ] Fresh install cold start (`adb shell pm clear org.openmsupply.client`) — verify native splash → loading spinner → `/android` app, no Chromium error page at any point
- [ ] Warm restart (background → foreground) — verify no flash of loading page; app remains on `/android`
- [ ] Stuck-server simulation (temporarily add a sleep before `bind_rustls_0_23` longer than the poll budget) — verify ErrorPage with unhappy-face SVG renders correctly, "Show Log File" opens an AlertDialog with `remote_server.log` contents
- [ ] Slow cold-start simulation (sleep ~5 s before bind) — verify the "Show Log File" button fades in on the LoadingPage after 5 s, and tapping it shows logs
- [ ] Verify `adb logcat -v time | grep omSupply` shows the new poll-attempt + WebView-error logs; `adb shell run-as org.openmsupply.client cat files/remote_server.log` shows the new timing lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)