### PR TITLE
10198 Different keys used for CCE status when importing new equipment

### DIFF
--- a/client/packages/coldchain/src/Equipment/ImportAsset/ImportReviewTable.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/ImportReviewTable.tsx
@@ -91,7 +91,7 @@ export const ImportReviewTable: FC<ImportReviewTableProps> = ({
       {
         id: 'status',
         accessorFn: row => row.status,
-        header: t('label.status'),
+        header: t('label.functional-status'),
         size: 100,
         Cell: ({ cell }) => (
           <StatusCell cell={cell} statusMap={fullStatusColourMap(t)} />

--- a/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
+++ b/client/packages/coldchain/src/Equipment/ImportAsset/UploadTab.tsx
@@ -320,7 +320,7 @@ export const EquipmentUploadTab = ({
       );
       addCell(
         'status',
-        'label.status',
+        'label.functional-status',
         status =>
           parseStatusFromString(status, t) ?? AssetLogStatusNodeType.Functioning
       );

--- a/client/packages/coldchain/src/Equipment/utils.ts
+++ b/client/packages/coldchain/src/Equipment/utils.ts
@@ -82,7 +82,7 @@ const baseAssetFields = (t: TypedTFunction<LocaleKey>): string[] => [
   t('label.warranty-start-date'),
   t('label.warranty-end-date'),
   t('label.serial'),
-  t('label.status'),
+  t('label.functional-status'),
   t('label.needs-replacement'),
   t('label.asset-notes'),
 ];


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10198

# 👩🏻‍💻 What does this PR do?
Use same keys for equipment status

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Check equipment status uses functional status instead of status

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

