### PR TITLE
integration use smol vecs

### DIFF
--- a/server/repository/src/db_diesel/sync_buffer.rs
+++ b/server/repository/src/db_diesel/sync_buffer.rs
@@ -215,6 +215,7 @@ pub struct PendingQuery<'a> {
     pub table_name: &'a str,
     pub action: SyncAction,
     pub direction: CursorDirection,
+    pub limit: i64,
 }
 
 pub struct SyncBufferRepository<'a> {
@@ -250,6 +251,7 @@ impl<'a> SyncBufferRepository<'a> {
             table_name,
             action,
             direction,
+            limit,
         } = query;
 
         let mut q = sync_buffer::table
@@ -258,6 +260,7 @@ impl<'a> SyncBufferRepository<'a> {
             .filter(sync_buffer::table_name.eq(table_name.to_string()))
             .filter(sync_buffer::action.eq(action))
             .filter(sync_buffer::source_site_id.eq(source_site_id))
+            .limit(limit)
             .into_boxed();
 
         if let Some(reference_id) = reference_id {
@@ -266,6 +269,8 @@ impl<'a> SyncBufferRepository<'a> {
             q = q.filter(sync_buffer::reference_id.is_null());
         }
 
+        // Why does cursor order matter? I believe one of the assertions of atomic sync is that we don't have
+        // worry about record order beyond table sort? If true then this order by is wasted CPU.
         let rows = match direction {
             CursorDirection::Asc => q
                 .order(sync_buffer::cursor.asc())
@@ -405,6 +410,7 @@ mod test {
                 table_name: "store",
                 action: SyncAction::Upsert,
                 direction: CursorDirection::Asc,
+                limit: i64::MAX,
             })
             .unwrap();
         let ids: Vec<_> = rows.iter().map(|r| r.record_id.as_str()).collect();
@@ -419,6 +425,7 @@ mod test {
                 table_name: "store",
                 action: SyncAction::Upsert,
                 direction: CursorDirection::Asc,
+                limit: i64::MAX,
             })
             .unwrap();
         let ids: Vec<_> = rows.iter().map(|r| r.record_id.as_str()).collect();
@@ -433,6 +440,7 @@ mod test {
                 table_name: "store",
                 action: SyncAction::Upsert,
                 direction: CursorDirection::Desc,
+                limit: i64::MAX,
             })
             .unwrap();
         let ids: Vec<_> = rows.iter().map(|r| r.record_id.as_str()).collect();
@@ -447,6 +455,7 @@ mod test {
                 table_name: "store",
                 action: SyncAction::Upsert,
                 direction: CursorDirection::Asc,
+                limit: i64::MAX,
             })
             .unwrap();
         let ids: Vec<_> = rows.iter().map(|r| r.record_id.as_str()).collect();
@@ -487,6 +496,7 @@ mod test {
                 table_name: "store",
                 action: SyncAction::Upsert,
                 direction: CursorDirection::Asc,
+                limit: i64::MAX,
             })
             .unwrap();
         assert_eq!(rows.len(), 3);
@@ -518,6 +528,7 @@ mod test {
                 table_name: "store",
                 action: SyncAction::Upsert,
                 direction: CursorDirection::Asc,
+                limit: i64::MAX,
             })
             .unwrap();
         assert!(pending.is_empty());
@@ -558,6 +569,7 @@ mod test {
                 table_name: "store",
                 action: SyncAction::Upsert,
                 direction: CursorDirection::Asc,
+                limit: i64::MAX,
             })
             .unwrap();
         assert_eq!(pending.len(), 2);

--- a/server/repository/src/db_diesel/sync_buffer.rs
+++ b/server/repository/src/db_diesel/sync_buffer.rs
@@ -269,8 +269,6 @@ impl<'a> SyncBufferRepository<'a> {
             q = q.filter(sync_buffer::reference_id.is_null());
         }
 
-        // Why does cursor order matter? I believe one of the assertions of atomic sync is that we don't have
-        // worry about record order beyond table sort? If true then this order by is wasted CPU.
         let rows = match direction {
             CursorDirection::Asc => q
                 .order(sync_buffer::cursor.asc())

--- a/server/service/src/sync/sync_buffer.rs
+++ b/server/service/src/sync/sync_buffer.rs
@@ -45,6 +45,32 @@ pub(crate) fn write_sync_buffer_ignored(
     )
 }
 
+pub(crate) fn get_sync_buffer_for_table(
+    connection: &StorageConnection,
+    action: SyncAction,
+    table_name: &str,
+    source_site_id: i32,
+    limit: i64,
+) -> Result<Vec<SyncBufferRow>, RepositoryError> {
+    let direction = match action {
+        SyncAction::Delete => CursorDirection::Desc,
+        _ => CursorDirection::Asc,
+    };
+
+    let repo = SyncBufferRepository::new(connection);
+    let rows = repo.pending_ordered_by_cursor(PendingQuery {
+        source_site_id,
+        sync_version: SyncVersion::V5V6,
+        reference_id: None,
+        table_name,
+        action: action.clone(),
+        direction,
+        limit,
+    })?;
+
+    Ok(rows)
+}
+
 /// Get pending V5/V6 sync_buffer rows ready for integration.
 ///
 /// Caller walks `ordered_table_names` in FK dependency order for upserts and
@@ -76,6 +102,7 @@ pub(crate) fn get_ordered_sync_buffer_records(
             table_name,
             action: action.clone(),
             direction,
+            limit: i64::MAX,
         })?;
         result.append(&mut rows);
     }

--- a/server/service/src/sync/sync_buffer.rs
+++ b/server/service/src/sync/sync_buffer.rs
@@ -71,45 +71,6 @@ pub(crate) fn get_sync_buffer_for_table(
     Ok(rows)
 }
 
-/// Get pending V5/V6 sync_buffer rows ready for integration.
-///
-/// Caller walks `ordered_table_names` in FK dependency order for upserts and
-/// reverse FK order for deletes. Within each `(table, action)` slice, rows are
-/// returned in cursor order (Asc for upserts/merges, Desc for deletes).
-pub(crate) fn get_ordered_sync_buffer_records(
-    connection: &StorageConnection,
-    action: SyncAction,
-    ordered_table_names: &[&str],
-    source_site_id: i32,
-) -> Result<Vec<SyncBufferRow>, RepositoryError> {
-    let direction = match action {
-        SyncAction::Delete => CursorDirection::Desc,
-        _ => CursorDirection::Asc,
-    };
-
-    let mut tables: Vec<&str> = ordered_table_names.iter().copied().collect();
-    if let SyncAction::Delete = action {
-        tables.reverse();
-    }
-
-    let repo = SyncBufferRepository::new(connection);
-    let mut result = Vec::new();
-    for table_name in tables {
-        let mut rows = repo.pending_ordered_by_cursor(PendingQuery {
-            source_site_id,
-            sync_version: SyncVersion::V5V6,
-            reference_id: None,
-            table_name,
-            action: action.clone(),
-            direction,
-            limit: i64::MAX,
-        })?;
-        result.append(&mut rows);
-    }
-
-    Ok(result)
-}
-
 #[cfg(test)]
 mod test {
     use repository::{
@@ -118,7 +79,6 @@ mod test {
         IntegrationResult, SyncAction, SyncBufferRepository, SyncBufferRow,
     };
 
-    use crate::sync::translations::{all_translators, pull_integration_order};
     use util::datetime_now;
 
     use super::*;
@@ -133,11 +93,12 @@ mod test {
         }
     }
 
+    fn ids(rows: &[SyncBufferRow]) -> Vec<&str> {
+        rows.iter().map(|r| r.record_id.as_str()).collect()
+    }
+
     #[actix_rt::test]
     async fn test_sync_buffer_service() {
-        let translators = all_translators();
-        let table_order = pull_integration_order(&translators);
-
         let row_1 = row("1", "transact");
         let row_2 = row("2", "trans_line");
         let row_3 = row("3", "store");
@@ -180,30 +141,46 @@ mod test {
         )
         .await;
 
-        // UPSERTS for OMS-Central (source_site_id 0): tables in FK order, cursor ASC.
-        let upserts =
-            get_ordered_sync_buffer_records(&connection, SyncAction::Upsert, &table_order, 0)
+        // Upserts for OMS-Central (source_site_id 0): one pending row per table.
+        let names =
+            get_sync_buffer_for_table(&connection, SyncAction::Upsert, "name", 0, 100).unwrap();
+        assert_eq!(ids(&names), vec!["4"]);
+        let stores =
+            get_sync_buffer_for_table(&connection, SyncAction::Upsert, "store", 0, 100).unwrap();
+        assert_eq!(ids(&stores), vec!["3"]);
+        let transacts =
+            get_sync_buffer_for_table(&connection, SyncAction::Upsert, "transact", 0, 100).unwrap();
+        assert_eq!(ids(&transacts), vec!["1"]);
+        let trans_lines =
+            get_sync_buffer_for_table(&connection, SyncAction::Upsert, "trans_line", 0, 100)
                 .unwrap();
-        let ids: Vec<_> = upserts.iter().map(|r| r.record_id.as_str()).collect();
-        assert_eq!(ids, vec!["4", "3", "1", "2"]);
+        assert_eq!(ids(&trans_lines), vec!["2"]);
 
-        // DELETES for OMS-Central: tables in REVERSE FK order, cursor DESC.
-        let deletes =
-            get_ordered_sync_buffer_records(&connection, SyncAction::Delete, &table_order, 0)
+        // Deletes for OMS-Central. Foreign source_site_id rows must not leak in.
+        let list_master_deletes =
+            get_sync_buffer_for_table(&connection, SyncAction::Delete, "list_master", 0, 100)
                 .unwrap();
-        let ids: Vec<_> = deletes.iter().map(|r| r.record_id.as_str()).collect();
-        assert_eq!(ids, vec!["6", "5"]);
+        assert_eq!(ids(&list_master_deletes), vec!["5"]);
+        let list_master_line_deletes =
+            get_sync_buffer_for_table(&connection, SyncAction::Delete, "list_master_line", 0, 100)
+                .unwrap();
+        assert_eq!(ids(&list_master_line_deletes), vec!["6"]);
 
         // Recording results moves rows out of the pending set.
         let started = datetime_now();
-        write_sync_buffer_error(&connection, upserts[2].cursor, started, "Error 1").unwrap();
-        write_sync_buffer_error(&connection, upserts[3].cursor, started, "Error 2").unwrap();
+        write_sync_buffer_error(&connection, transacts[0].cursor, started, "Error 1").unwrap();
+        write_sync_buffer_error(&connection, trans_lines[0].cursor, started, "Error 2").unwrap();
 
-        let upserts =
-            get_ordered_sync_buffer_records(&connection, SyncAction::Upsert, &table_order, 0)
-                .unwrap();
-        let ids: Vec<_> = upserts.iter().map(|r| r.record_id.as_str()).collect();
-        assert_eq!(ids, vec!["4", "3"]);
+        assert!(
+            get_sync_buffer_for_table(&connection, SyncAction::Upsert, "transact", 0, 100)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            get_sync_buffer_for_table(&connection, SyncAction::Upsert, "trans_line", 0, 100)
+                .unwrap()
+                .is_empty()
+        );
 
         let r1 = SyncBufferRepository::new(&connection)
             .find_one_by_record_id("1")
@@ -212,22 +189,28 @@ mod test {
         assert_eq!(r1.integration_result, Some(IntegrationResult::Error));
         assert_eq!(r1.integration_error.as_deref(), Some("Error 1"));
 
-        write_sync_buffer_success(&connection, upserts[0].cursor, started).unwrap();
-        write_sync_buffer_success(&connection, upserts[1].cursor, started).unwrap();
+        write_sync_buffer_success(&connection, names[0].cursor, started).unwrap();
+        write_sync_buffer_success(&connection, stores[0].cursor, started).unwrap();
 
-        let upserts =
-            get_ordered_sync_buffer_records(&connection, SyncAction::Upsert, &table_order, 0)
-                .unwrap();
-        assert!(upserts.is_empty());
+        assert!(
+            get_sync_buffer_for_table(&connection, SyncAction::Upsert, "name", 0, 100)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            get_sync_buffer_for_table(&connection, SyncAction::Upsert, "store", 0, 100)
+                .unwrap()
+                .is_empty()
+        );
 
-        // Remote source_site_id 1: only the site_1 rows are returned.
-        let remote_deletes =
-            get_ordered_sync_buffer_records(&connection, SyncAction::Delete, &table_order, 1)
+        // Remote source_site_id 1: only the site_1 rows are returned, isolated from site 0.
+        let remote_list_master =
+            get_sync_buffer_for_table(&connection, SyncAction::Delete, "list_master", 1, 100)
                 .unwrap();
-        let ids: Vec<_> = remote_deletes
-            .iter()
-            .map(|r| r.record_id.as_str())
-            .collect();
-        assert_eq!(ids, vec!["1-2", "1-1"]);
+        assert_eq!(ids(&remote_list_master), vec!["1-1"]);
+        let remote_list_master_line =
+            get_sync_buffer_for_table(&connection, SyncAction::Delete, "list_master_line", 1, 100)
+                .unwrap();
+        assert_eq!(ids(&remote_list_master_line), vec!["1-2"]);
     }
 }

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -12,6 +12,7 @@ use repository::{
 };
 
 use std::sync::Arc;
+use std::time::Instant;
 use thiserror::Error;
 use util::format_error;
 
@@ -30,11 +31,13 @@ use super::{
     sync_on_central::adjust_v6_cursor,
     sync_status::logger::{SyncLogger, SyncLoggerError, SyncStepProgress},
     translation_and_integration::{TranslationAndIntegration, TranslationAndIntegrationResults},
-    translations::{all_translators, pull_integration_order},
+    translations::{all_translators, pull_integration_order, SyncTranslators},
 };
 
+const INTEGRATION_BATCH_SIZE: i64 = 10_000;
 const INTEGRATION_POLL_PERIOD_SECONDS: u64 = 1;
 const INTEGRATION_TIMEOUT_SECONDS: u64 = 30;
+
 pub struct SynchroniserV5V6 {
     settings: SyncSettings,
     service_provider: Arc<ServiceProvider>,
@@ -481,81 +484,25 @@ pub fn integrate_and_translate_sync_buffer(
             SyncVersion::V5V6,
             None,
         )? as u64;
-        let mut done_so_far: u64 = 0;
         if let Some(logger) = logger.as_mut() {
             logger
                 .progress(SyncStepProgress::Integrate, total_pending)
                 .map_err(SyncLoggerError::to_repository_error)?;
         }
 
-        let mut upserter = TranslationAndIntegration::new(connection);
-        for table in &table_order {
-            loop {
-                let records = get_sync_buffer_for_table(
-                    connection,
-                    SyncAction::Upsert,
-                    table,
-                    source_site_id,
-                    10000,
-                )?;
-                if records.is_empty() {
-                    break;
-                }
-                upserter.translate_and_integrate_sync_records(
-                    &records,
-                    &translators,
-                    logger.as_deref_mut(),
-                    total_pending,
-                    &mut done_so_far,
-                )?;
-            }
-        }
-        let mut deleter = TranslationAndIntegration::new(connection);
-        for table in &table_order {
-            loop {
-                let records = get_sync_buffer_for_table(
-                    connection,
-                    SyncAction::Delete,
-                    table,
-                    source_site_id,
-                    10000,
-                )?;
-                if records.is_empty() {
-                    break;
-                }
-                deleter.translate_and_integrate_sync_records(
-                    &records,
-                    &translators,
-                    logger.as_deref_mut(),
-                    total_pending,
-                    &mut done_so_far,
-                )?;
-            }
-        }
-        let mut merger = TranslationAndIntegration::new(connection);
-        for table in &table_order {
-            loop {
-                let records = get_sync_buffer_for_table(
-                    connection,
-                    SyncAction::Merge,
-                    table,
-                    source_site_id,
-                    10000,
-                )?;
-                if records.is_empty() {
-                    break;
-                }
-                merger.translate_and_integrate_sync_records(
-                    &records,
-                    &translators,
-                    logger.as_deref_mut(),
-                    total_pending,
-                    &mut done_so_far,
-                )?;
-            }
-        }
+        let mut integrator = SyncBufferIntegrator::new(
+            connection,
+            &table_order,
+            &translators,
+            source_site_id,
+            total_pending,
+        );
 
-        Ok((upserter.result, deleter.result, merger.result))
+        let upserts = integrator.process_action(SyncAction::Upsert, logger.as_deref_mut())?;
+        let deletes = integrator.process_action(SyncAction::Delete, logger.as_deref_mut())?;
+        let merges = integrator.process_action(SyncAction::Merge, logger.as_deref_mut())?;
+
+        Ok((upserts, deletes, merges))
     };
 
     let result = if use_transaction {
@@ -567,6 +514,100 @@ pub fn integrate_and_translate_sync_buffer(
     };
 
     Ok(result)
+}
+
+/// Drives integration of every pending sync buffer row for each `SyncAction`
+/// (Upsert/Delete/Merge), one `INTEGRATION_BATCH_SIZE`-sized chunk per table at a time.
+///
+/// `done_so_far`, `total_errored`, and `last_progress_time` accumulate across every
+/// `process_action` call, so the progress log reports cumulative totals and a rec/s window that
+/// spans both integration and the next batch's fetch, rather than resetting between actions.
+struct SyncBufferIntegrator<'a> {
+    connection: &'a StorageConnection,
+    table_order: &'a [&'a str],
+    translators: &'a SyncTranslators,
+    source_site_id: i32,
+    total_pending: u64,
+    done_so_far: u64,
+    total_errored: u32,
+    last_progress_time: Instant,
+}
+
+impl<'a> SyncBufferIntegrator<'a> {
+    fn new(
+        connection: &'a StorageConnection,
+        table_order: &'a [&'a str],
+        translators: &'a SyncTranslators,
+        source_site_id: i32,
+        total_pending: u64,
+    ) -> Self {
+        Self {
+            connection,
+            table_order,
+            translators,
+            source_site_id,
+            total_pending,
+            done_so_far: 0,
+            total_errored: 0,
+            // Reset *after* each log, so the next batch's rec/s window covers both the fetch of
+            // the next 10k records and their integration.
+            last_progress_time: Instant::now(),
+        }
+    }
+
+    /// Process every pending row for a single `SyncAction`, one `INTEGRATION_BATCH_SIZE`-sized
+    /// chunk per table at a time, accumulating progress into `self`.
+    fn process_action(
+        &mut self,
+        action: SyncAction,
+        mut logger: Option<&mut SyncLogger>,
+    ) -> Result<TranslationAndIntegrationResults, RepositoryError> {
+        let mut integrator = TranslationAndIntegration::new(self.connection);
+        for table in self.table_order {
+            loop {
+                let records = get_sync_buffer_for_table(
+                    self.connection,
+                    action.clone(),
+                    table,
+                    self.source_site_id,
+                    INTEGRATION_BATCH_SIZE,
+                )?;
+                if records.is_empty() {
+                    break;
+                }
+                let batch_size = records.len() as u64;
+                let batch_errors =
+                    integrator.translate_and_integrate_sync_records(&records, self.translators)?;
+                self.done_so_far += batch_size;
+                self.total_errored += batch_errors;
+
+                let elapsed = self.last_progress_time.elapsed();
+                let rec_per_sec = if elapsed.as_secs_f64() > 0.0 {
+                    batch_size as f64 / elapsed.as_secs_f64()
+                } else {
+                    0.0
+                };
+                log::info!(
+                    "Integration progress - table: {table}, integrated: {}, total: {}, errored: {} ({:.1} rec/s)",
+                    self.done_so_far,
+                    self.total_pending,
+                    self.total_errored,
+                    rec_per_sec,
+                );
+                self.last_progress_time = Instant::now();
+
+                if let Some(logger) = logger.as_deref_mut() {
+                    logger
+                        .progress(
+                            SyncStepProgress::Integrate,
+                            self.total_pending.saturating_sub(self.done_so_far),
+                        )
+                        .map_err(SyncLoggerError::to_repository_error)?;
+                }
+            }
+        }
+        Ok(integrator.result)
+    }
 }
 
 #[cfg(test)]

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -490,54 +490,69 @@ pub fn integrate_and_translate_sync_buffer(
 
         let mut upserter = TranslationAndIntegration::new(connection);
         for table in &table_order {
-            let records = get_sync_buffer_for_table(
-                connection,
-                SyncAction::Upsert,
-                table,
-                source_site_id,
-                10000,
-            )?;
-            upserter.translate_and_integrate_sync_records(
-                &records,
-                &translators,
-                logger.as_deref_mut(),
-                total_pending,
-                &mut done_so_far,
-            )?;
+            loop {
+                let records = get_sync_buffer_for_table(
+                    connection,
+                    SyncAction::Upsert,
+                    table,
+                    source_site_id,
+                    10000,
+                )?;
+                if records.is_empty() {
+                    break;
+                }
+                upserter.translate_and_integrate_sync_records(
+                    &records,
+                    &translators,
+                    logger.as_deref_mut(),
+                    total_pending,
+                    &mut done_so_far,
+                )?;
+            }
         }
         let mut deleter = TranslationAndIntegration::new(connection);
         for table in &table_order {
-            let records = get_sync_buffer_for_table(
-                connection,
-                SyncAction::Delete,
-                table,
-                source_site_id,
-                10000,
-            )?;
-            deleter.translate_and_integrate_sync_records(
-                &records,
-                &translators,
-                logger.as_deref_mut(),
-                total_pending,
-                &mut done_so_far,
-            )?;
+            loop {
+                let records = get_sync_buffer_for_table(
+                    connection,
+                    SyncAction::Delete,
+                    table,
+                    source_site_id,
+                    10000,
+                )?;
+                if records.is_empty() {
+                    break;
+                }
+                deleter.translate_and_integrate_sync_records(
+                    &records,
+                    &translators,
+                    logger.as_deref_mut(),
+                    total_pending,
+                    &mut done_so_far,
+                )?;
+            }
         }
         let mut merger = TranslationAndIntegration::new(connection);
         for table in &table_order {
-            let records = get_sync_buffer_for_table(
-                connection,
-                SyncAction::Merge,
-                table,
-                source_site_id,
-                10000,
-            )?;
-            merger.translate_and_integrate_sync_records(
-                &records,
-                &translators,
-                logger.as_deref_mut(),
-                total_pending,
-                &mut done_so_far,
-            )?;
+            loop {
+                let records = get_sync_buffer_for_table(
+                    connection,
+                    SyncAction::Merge,
+                    table,
+                    source_site_id,
+                    10000,
+                )?;
+                if records.is_empty() {
+                    break;
+                }
+                merger.translate_and_integrate_sync_records(
+                    &records,
+                    &translators,
+                    logger.as_deref_mut(),
+                    total_pending,
+                    &mut done_so_far,
+                )?;
+            }
         }
 
         Ok((upserter.result, deleter.result, merger.result))

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -1,11 +1,14 @@
 use crate::{
     processors::ProcessorType,
     service_provider::{ServiceContext, ServiceProvider},
-    sync::{sync_status::logger::SyncStep, CentralServerConfig},
+    sync::{
+        sync_buffer::get_sync_buffer_for_table, sync_status::logger::SyncStep, CentralServerConfig,
+    },
 };
 use log::warn;
 use repository::{
     KeyType, KeyValueStoreRepository, RepositoryError, StorageConnection, SyncAction,
+    SyncBufferRepository, SyncVersion,
 };
 
 use std::sync::Arc;
@@ -24,9 +27,8 @@ use super::{
         WaitForSyncOperationError,
     },
     settings::{SyncSettings, SYNC_V5_VERSION, SYNC_V6_VERSION},
-    sync_buffer::get_ordered_sync_buffer_records,
     sync_on_central::adjust_v6_cursor,
-    sync_status::logger::{SyncLogger, SyncLoggerError},
+    sync_status::logger::{SyncLogger, SyncLoggerError, SyncStepProgress},
     translation_and_integration::{TranslationAndIntegration, TranslationAndIntegrationResults},
     translations::{all_translators, pull_integration_order},
 };
@@ -441,7 +443,7 @@ async fn integrate_and_translate_sync_outer(
 /// Translation And Integration of sync buffer, pub since used in CLI
 pub fn integrate_and_translate_sync_buffer(
     connection: &StorageConnection,
-    logger: Option<&mut SyncLogger<'_>>,
+    mut logger: Option<&mut SyncLogger<'_>>,
     source_site_id: i32,
     use_transaction: bool,
 ) -> Result<
@@ -461,7 +463,7 @@ pub fn integrate_and_translate_sync_buffer(
     // - not initialised: no transactions at all
 
     // Closure, to be run in a transaction or without a transaction
-    let integrate_and_translate = |connection: &StorageConnection| -> Result<
+    let mut integrate_and_translate = |connection: &StorageConnection| -> Result<
         (
             TranslationAndIntegrationResults,
             TranslationAndIntegrationResults,
@@ -472,58 +474,73 @@ pub fn integrate_and_translate_sync_buffer(
         let translators = all_translators();
         let table_order = pull_integration_order(&translators);
 
-        let translation_and_integration = TranslationAndIntegration::new(connection);
-
-        // Translate and integrate upserts (ordered by referential database constraints)
-        let upsert_sync_buffer_records = get_ordered_sync_buffer_records(
-            connection,
-            SyncAction::Upsert,
-            &table_order,
+        // Seed integration progress total with the global pending count so the logger
+        // reports a real total across all (action, table) batches, not just the first 10k slice.
+        let total_pending = SyncBufferRepository::new(connection).count_pending(
             source_site_id,
-        )?;
+            SyncVersion::V5V6,
+            None,
+        )? as u64;
+        let mut done_so_far: u64 = 0;
+        if let Some(logger) = logger.as_mut() {
+            logger
+                .progress(SyncStepProgress::Integrate, total_pending)
+                .map_err(SyncLoggerError::to_repository_error)?;
+        }
 
-        // Translate and integrate delete (ordered by referential database constraints, in reverse)
-        let delete_sync_buffer_records = get_ordered_sync_buffer_records(
-            connection,
-            SyncAction::Delete,
-            &table_order,
-            source_site_id,
-        )?;
-
-        let upsert_integration_result = translation_and_integration
-            .translate_and_integrate_sync_records(
-                &upsert_sync_buffer_records,
-                &translators,
-                logger,
+        let mut upserter = TranslationAndIntegration::new(connection);
+        for table in &table_order {
+            let records = get_sync_buffer_for_table(
+                connection,
+                SyncAction::Upsert,
+                table,
+                source_site_id,
+                10000,
             )?;
-
-        // pass the logger here
-        let delete_integration_result = translation_and_integration
-            .translate_and_integrate_sync_records(
-                &delete_sync_buffer_records,
+            upserter.translate_and_integrate_sync_records(
+                &records,
                 &translators,
-                None,
+                logger.as_deref_mut(),
+                total_pending,
+                &mut done_so_far,
             )?;
-
-        let merge_sync_buffer_records = get_ordered_sync_buffer_records(
-            connection,
-            SyncAction::Merge,
-            &table_order,
-            source_site_id,
-        )?;
-
-        let merge_integration_result: TranslationAndIntegrationResults =
-            translation_and_integration.translate_and_integrate_sync_records(
-                &merge_sync_buffer_records,
+        }
+        let mut deleter = TranslationAndIntegration::new(connection);
+        for table in &table_order {
+            let records = get_sync_buffer_for_table(
+                connection,
+                SyncAction::Delete,
+                table,
+                source_site_id,
+                10000,
+            )?;
+            deleter.translate_and_integrate_sync_records(
+                &records,
                 &translators,
-                None,
+                logger.as_deref_mut(),
+                total_pending,
+                &mut done_so_far,
             )?;
+        }
+        let mut merger = TranslationAndIntegration::new(connection);
+        for table in &table_order {
+            let records = get_sync_buffer_for_table(
+                connection,
+                SyncAction::Merge,
+                table,
+                source_site_id,
+                10000,
+            )?;
+            merger.translate_and_integrate_sync_records(
+                &records,
+                &translators,
+                logger.as_deref_mut(),
+                total_pending,
+                &mut done_so_far,
+            )?;
+        }
 
-        Ok((
-            upsert_integration_result,
-            delete_integration_result,
-            merge_integration_result,
-        ))
+        Ok((upserter.result, deleter.result, merger.result))
     };
 
     let result = if use_transaction {

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -3,7 +3,6 @@ use super::{
     sync_buffer::{write_sync_buffer_error, write_sync_buffer_ignored, write_sync_buffer_success},
     translations::{IntegrationOperation, PullTranslateResult, SyncTranslation, SyncTranslators},
 };
-use crate::usize_to_u64;
 use log::{debug, warn};
 use repository::*;
 use std::collections::HashMap;
@@ -14,6 +13,7 @@ static PROGRESS_STEP_LEN: usize = 1000;
 
 pub(crate) struct TranslationAndIntegration<'a> {
     connection: &'a StorageConnection,
+    pub(crate) result: TranslationAndIntegrationResults,
 }
 
 #[derive(Default, Debug)]
@@ -27,7 +27,10 @@ pub struct TranslationAndIntegrationResults(HashMap<TableName, TranslationAndInt
 
 impl<'a> TranslationAndIntegration<'a> {
     pub(crate) fn new(connection: &'a StorageConnection) -> TranslationAndIntegration<'a> {
-        TranslationAndIntegration { connection }
+        TranslationAndIntegration {
+            connection,
+            result: TranslationAndIntegrationResults::new(),
+        }
     }
 
     // Go through each translator, adding translations to result, if no translators matched return None
@@ -60,27 +63,28 @@ impl<'a> TranslationAndIntegration<'a> {
     }
 
     pub(crate) fn translate_and_integrate_sync_records(
-        &self,
+        &mut self,
         sync_records: &[SyncBufferRow],
         translators: &Vec<Box<dyn SyncTranslation>>,
         mut logger: Option<&mut SyncLogger>,
-    ) -> Result<TranslationAndIntegrationResults, RepositoryError> {
-        let step_progress = SyncStepProgress::Integrate;
-        let mut result = TranslationAndIntegrationResults::new();
+        total_pending: u64,
+        done_so_far: &mut u64,
+    ) -> Result<(), RepositoryError> {
         let mut error_count: u32 = 0;
-
-        // Try translate
-        // Record initial progress (will be set as total progress)
-        let total_to_integrate = sync_records.len();
 
         let mut last_progress_time = Instant::now();
 
-        // Helper to make below logic less verbose
-        let mut record_progress = |progress: usize| -> Result<(), RepositoryError> {
+        // Caller pre-seeds `integration_progress_total` via `count_pending` and threads
+        // `done_so_far` across batches, so the logger reports global progress rather than
+        // resetting `total` to the current batch's size.
+        let mut record_progress = |done: u64| -> Result<(), RepositoryError> {
             match logger.as_mut() {
                 None => Ok(()),
                 Some(logger) => logger
-                    .progress(step_progress.clone(), usize_to_u64(progress))
+                    .progress(
+                        SyncStepProgress::Integrate,
+                        total_pending.saturating_sub(done),
+                    )
                     .map_err(SyncLoggerError::to_repository_error),
             }
         };
@@ -99,7 +103,7 @@ impl<'a> TranslationAndIntegration<'a> {
                         started,
                         &format!("{:?}", translation_error),
                     )?;
-                    result.insert_error(&sync_record.table_name);
+                    self.result.insert_error(&sync_record.table_name);
                     error_count += 1; // We want to count these as errors as this is likely to be FK or other data issues, that might affect performance of integration and we want to track that.
                     warn!(
                         "{:?} {:?} {:?}",
@@ -129,7 +133,7 @@ impl<'a> TranslationAndIntegration<'a> {
                             started,
                             &ignore_message,
                         )?;
-                        result.insert_error(&sync_record.table_name);
+                        self.result.insert_error(&sync_record.table_name);
                         // Don't count this as an error in the count, it's valid to have records that are ignored based on translation logic.
 
                         debug!(
@@ -150,7 +154,7 @@ impl<'a> TranslationAndIntegration<'a> {
             if integration_records.is_empty() {
                 let error = "Translator for record not found";
                 write_sync_buffer_error(self.connection, cursor, started, error)?;
-                result.insert_error(&sync_record.table_name);
+                self.result.insert_error(&sync_record.table_name);
                 // Don't count this as an error in the count, it's valid to have no translators for a record matching.
                 warn!(
                     "{:?} {:?} {:?}",
@@ -165,13 +169,13 @@ impl<'a> TranslationAndIntegration<'a> {
             match integration_result {
                 Ok(_) => {
                     write_sync_buffer_success(self.connection, cursor, started)?;
-                    result.insert_success(&sync_record.table_name)
+                    self.result.insert_success(&sync_record.table_name)
                 }
                 // Record database_error in sync buffer and in result
                 Err(database_error) => {
                     let error = format!("{database_error:?}");
                     write_sync_buffer_error(self.connection, cursor, started, &error)?;
-                    result.insert_error(&sync_record.table_name);
+                    self.result.insert_error(&sync_record.table_name);
                     error_count += 1;
                     warn!(
                         "{:?} {:?} {:?}",
@@ -180,19 +184,19 @@ impl<'a> TranslationAndIntegration<'a> {
                 }
             }
 
-            if number_of_records_integrated % PROGRESS_STEP_LEN == 0 {
-                record_progress(total_to_integrate - number_of_records_integrated)?;
+            if (number_of_records_integrated + 1) % PROGRESS_STEP_LEN == 0 {
+                let done = *done_so_far + number_of_records_integrated as u64 + 1;
+                record_progress(done)?;
                 let elapsed = last_progress_time.elapsed();
-                let rec_per_sec = if number_of_records_integrated > 0 && elapsed.as_secs_f64() > 0.0
-                {
+                let rec_per_sec = if elapsed.as_secs_f64() > 0.0 {
                     PROGRESS_STEP_LEN as f64 / elapsed.as_secs_f64()
                 } else {
                     0.0
                 };
                 log::info!(
                     "Integration progress: integrated: {}, total: {}, errored: {} ({:.1} rec/s, last table: {})",
-                    number_of_records_integrated,
-                    total_to_integrate,
+                    done,
+                    total_pending,
                     error_count,
                     rec_per_sec,
                     sync_record.table_name
@@ -201,10 +205,10 @@ impl<'a> TranslationAndIntegration<'a> {
             }
         }
 
-        // Record final progress
-        record_progress(0)?;
+        *done_so_far += sync_records.len() as u64;
+        record_progress(*done_so_far)?;
 
-        Ok(result)
+        Ok(())
     }
 }
 
@@ -224,7 +228,10 @@ impl IntegrationOperation {
             }
 
             IntegrationOperation::Delete(delete) => {
-                delete.delete_sync(connection, ChangelogSyncType::SyncTypeV5V6 { source_site_id })?;
+                delete.delete_sync(
+                    connection,
+                    ChangelogSyncType::SyncTypeV5V6 { source_site_id },
+                )?;
                 Ok(())
             }
         }
@@ -258,7 +265,7 @@ pub(crate) fn integrate(
 }
 
 impl TranslationAndIntegrationResults {
-    fn new() -> TranslationAndIntegrationResults {
+    pub(crate) fn new() -> TranslationAndIntegrationResults {
         Default::default()
     }
 

--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -1,4 +1,3 @@
-use super::sync_status::logger::{SyncLogger, SyncLoggerError, SyncStepProgress};
 use super::{
     sync_buffer::{write_sync_buffer_error, write_sync_buffer_ignored, write_sync_buffer_success},
     translations::{IntegrationOperation, PullTranslateResult, SyncTranslation, SyncTranslators},
@@ -6,10 +5,7 @@ use super::{
 use log::{debug, warn};
 use repository::*;
 use std::collections::HashMap;
-use std::time::Instant;
 use util::datetime_now;
-
-static PROGRESS_STEP_LEN: usize = 1000;
 
 pub(crate) struct TranslationAndIntegration<'a> {
     connection: &'a StorageConnection,
@@ -62,34 +58,17 @@ impl<'a> TranslationAndIntegration<'a> {
         Ok(translation_results)
     }
 
+    /// Translate and integrate a single batch of sync records. Returns the number of records in
+    /// this batch that errored — the caller accumulates this across batches to report a true
+    /// cumulative error count (instead of resetting per batch).
     pub(crate) fn translate_and_integrate_sync_records(
         &mut self,
         sync_records: &[SyncBufferRow],
         translators: &Vec<Box<dyn SyncTranslation>>,
-        mut logger: Option<&mut SyncLogger>,
-        total_pending: u64,
-        done_so_far: &mut u64,
-    ) -> Result<(), RepositoryError> {
+    ) -> Result<u32, RepositoryError> {
         let mut error_count: u32 = 0;
 
-        let mut last_progress_time = Instant::now();
-
-        // Caller pre-seeds `integration_progress_total` via `count_pending` and threads
-        // `done_so_far` across batches, so the logger reports global progress rather than
-        // resetting `total` to the current batch's size.
-        let mut record_progress = |done: u64| -> Result<(), RepositoryError> {
-            match logger.as_mut() {
-                None => Ok(()),
-                Some(logger) => logger
-                    .progress(
-                        SyncStepProgress::Integrate,
-                        total_pending.saturating_sub(done),
-                    )
-                    .map_err(SyncLoggerError::to_repository_error),
-            }
-        };
-
-        for (number_of_records_integrated, sync_record) in sync_records.iter().enumerate() {
+        for sync_record in sync_records.iter() {
             let started = datetime_now();
             let cursor = sync_record.cursor;
 
@@ -183,32 +162,9 @@ impl<'a> TranslationAndIntegration<'a> {
                     );
                 }
             }
-
-            if (number_of_records_integrated + 1) % PROGRESS_STEP_LEN == 0 {
-                let done = *done_so_far + number_of_records_integrated as u64 + 1;
-                record_progress(done)?;
-                let elapsed = last_progress_time.elapsed();
-                let rec_per_sec = if elapsed.as_secs_f64() > 0.0 {
-                    PROGRESS_STEP_LEN as f64 / elapsed.as_secs_f64()
-                } else {
-                    0.0
-                };
-                log::info!(
-                    "Integration progress: integrated: {}, total: {}, errored: {} ({:.1} rec/s, last table: {})",
-                    done,
-                    total_pending,
-                    error_count,
-                    rec_per_sec,
-                    sync_record.table_name
-                );
-                last_progress_time = Instant::now();
-            }
         }
 
-        *done_so_far += sync_records.len() as u64;
-        record_progress(*done_so_far)?;
-
-        Ok(())
+        Ok(error_count)
     }
 }
 

--- a/server/service/src/sync_v7/validate_translate_integrate.rs
+++ b/server/service/src/sync_v7/validate_translate_integrate.rs
@@ -326,6 +326,7 @@ fn validate_translate_integrate_inner<'a>(
             table_name: table.as_ref(),
             action: action.clone(),
             direction,
+            limit: i64::MAX,
         })?;
 
         log::info!("Number of records to integrate  {}", rows.len());


### PR DESCRIPTION
Fixes #10294 

# 👩🏻‍💻 What does this PR do?

Integration iterates over batches of 10k records (yup arbitrary number from gut feel) rather than pulling literally all of them into a giant Vec. I see memory usage fluctuate from around 50MB up to 200MB depending on the table being integrated, e.g. list_master_name_join 50MB, trans_line 100MB, transact 200MB.

This is a good improvement over 49GB of RAM 😆.

Had to do a fair bit of shenanigans 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Syncing OMS central server with COGS works noice :) memory is smol
- [ ] Syncing OMS remote server with COMS works noice :) memory is smol (dunno how you check with android. Maybe just get a big site with 1 million records and see if the app crashes? lol)

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

