### PR TITLE
Translations update from mSupply Foundation Translation Server

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -400,7 +400,7 @@
   "error.invalid-custom-translation": "Translations can only contain known variables and must be wrapped in the correct number of curly braces",
   "error.invalid-field-value": "{{ value }} isn't a valid {{ field }}",
   "error.invalid-json": "Invalid JSON format",
-  "error.invalid-url": "Invalid url",
+  "error.invalid-url": "Invalid URL",
   "error.invoice-status-inbound-requires-delivered-or-received": "At least one of 'Delivered' or 'Received' status must be selected for inbound shipments",
   "error.is-locked": "Stocktake is locked.",
   "error.item-cannot-be-ordered-on-line": "You cannot update this item because it cannot be ordered. Cancel and delete the line.",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1921,7 +1921,7 @@
   "message.confirm-delete-encounter": "Are you sure?",
   "message.confirm-save-new": "Click OK to save the new item, or Cancel to continue editing",
   "message.contact-support": "Please contact support@msupply.foundation about configuring reports",
-  "message.continue-to-make-inbound-shipment": "Click Next to continue to make an inbound shipment without linking an internal order.",
+  "message.continue-to-make-inbound-shipment": "Click Next to continue making an inbound shipment without linking an internal order.",
   "message.copy-success": "Copied to clipboard successfully",
   "message.create-blank-stocktake": "This will create a blank stocktake",
   "message.database-not-local": "Database is running on a server, so can't be downloaded here",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -758,7 +758,7 @@
   "info.manual-shipment": "This shipment was created manually. The delivery status will not be automatically updated.",
   "info.no-shipment": "Finalising this requisition will prevent you from creating a shipment for it.",
   "info.server-restarting": "Server restarting...",
-  "initialise.body": "To get started, we'll need to configure the settings to synchronise with mSupply. Please enter the values and click Save.\n\nIf you're not sure what to enter, contact support@msupply.foundation.",
+  "initialise.body": "To get started, we'll need to configure the settings to synchronise with mSupply. Please enter the values and click Initialise.\n\nIf you're not sure what to enter, contact support@msupply.foundation.",
   "initialise.heading": "Welcome!",
   "internal-order": "Internal Orders",
   "inventory": "Inventory",


### PR DESCRIPTION
Translations update from [mSupply Foundation Translation Server](https://translate.msupply.org) for [Open mSupply/Common](https://translate.msupply.org/projects/open-msupply/common/).


It also includes following components:

* [Open mSupply/Desktop](https://translate.msupply.org/projects/open-msupply/desktop/)



Current translation status:

![Weblate translation status](https://translate.msupply.org/widget/open-msupply/common/horizontal-auto.svg)