### PR TITLE
11869 - Sync v7 internal orders and requisitions

### DIFF
--- a/server/repository/src/db_diesel/changelog/generate_changelog.rs
+++ b/server/repository/src/db_diesel/changelog/generate_changelog.rs
@@ -119,7 +119,7 @@ impl RequisitionRow {
             record_id: row.id.clone(),
             row_action: action,
             store_id: Some(row.store_id.clone()),
-            transfer_store_id: row.name_store_id.clone(),
+            transfer_store_id: transfer_store_id_for_name(con, &row.name_id)?,
             source_site_id: source_site_id.get_id(con)?,
             ..Default::default()
         })

--- a/server/repository/src/db_diesel/changelog/test.rs
+++ b/server/repository/src/db_diesel/changelog/test.rs
@@ -770,16 +770,14 @@ async fn test_changelog_outgoing_sync_records() {
 
     // A requisition at store_a addressed to the name backing store_b should
     // reach site 1 via store_id (RemoteOwned, during initialisation only) and
-    // site 2 via transfer_store_id (Transfer).
-    // `RequisitionRow::generate_changelog` reads `transfer_store_id` directly
-    // from `name_store_id`, so set it explicitly here.
+    // site 2 via transfer_store_id (Transfer). `RequisitionRow::generate_changelog`
+    // derives `transfer_store_id` from `name_id` via the store lookup.
     let req_id = "req_transfer".to_string();
     RequisitionRowRepository::new(&connection)
         .upsert_one(&RequisitionRow {
             id: req_id.clone(),
             store_id: site1_store_id.clone(),
             name_id: mock_name_store_b().id,
-            name_store_id: Some(mock_store_b().id),
             ..Default::default()
         })
         .unwrap();


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11869

# 👩🏻‍💻 What does this PR do?

Fix transfer routing for v5/v6-integrated requisitions — transfer_store_id is now derived from name_id in RequisitionRow::generate_changelog, matching the RnRForm / NameStoreJoin pattern, so requests from v5/v6 sites correctly route to v7 suppliers.

There is an additional bug where OMS remote records are not being received by OG. To be fixed in OG: https://github.com/msupply-foundation/msupply/issues/18311. Now fixed [here ](https://github.com/msupply-foundation/msupply/pull/18322/changes) and merged into oms-sync-v7 branch



<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

I've tested and updated the results with the fix for remote sites above

I thought there was a potential issue with item lines syncing in an IO from v2.17 -> 3.0 central - confirmed it does work correctly, it was a user error 😬 

| Requesting store | Syncs fully | Requisition OMS | IO OG        | Requisition OG | Supplying store |
| ---------------- | ----------- | --------------- | ------------ | -------------- | --------------- |
| v2.17            | y           | y               | y            | y              | v2.19           |
| v2.17            | y           | y               | y  | y              | 3.0 central     |
| v2.17            | y           | y               | y            | y              | 3.0 remote      |
| v2.19            | y           | y               | y            | y              | v2.17           |
| v2.19            | y           | y               | y            | y              | 3.0 central     |
| v2.19            | y            | y               | y            | y              | 3.0 remote      |
| 3.0 central      | y           | y               | y            | y              | v2.17           |
| 3.0 central      | y           | y               | y            | y              | v2.19           |
| 3.0 central      | y           | y               | y            | y              | 3.0 remote      |
| 3.0 remote       | y           | y               | y            | y              | v2.17           |
| 3.0 remote       | y           | y               | y            | y              | v2.19           |
| 3.0 remote       | y           | y               | y            | y              | 3.0 central     |

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->


Setup: two <v3.0 sites (eg v2.17, v2.19) and 3.0 central site. All stores should be able to supply and recieve from each other
I used docker for the v2 sites, and local for v3.0

Every combination below should pass all checks:

| Requester | Supplier |
| ----------- | ----------- |
| v2.17 | v2.19 |
| v2.17 | 3.0 central |
| v2.19 | v2.17 |
| v2.19 | 3.0 central |
| 3.0 central | v2.17 |
| 3.0 central | v2.19 |

For each combination:

1. On the requesting store, create an internal order with the supplying store as supplier.
2. Run sync on related sites + central.
3. Verify:
   - [ ] Response requisition exists in OMS (on the supplying store)
   - [ ] Internal order exists in OG
   - [ ] Response requisition exists in OG


# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

