### PR TITLE
11889 Stocktake detail view columns compatibility with plugin 

### DIFF
--- a/client/packages/common/src/plugins/types.ts
+++ b/client/packages/common/src/plugins/types.ts
@@ -10,6 +10,7 @@ import {
 import { InboundFragment } from '@openmsupply-client/invoices';
 import { PrescriptionPaymentComponentProps } from './prescriptionTypes';
 import { DraftRequestLine } from 'packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit';
+import { StocktakeLineFragment } from 'packages/inventory/src/Stocktake/api';
 import { UserPermission } from '../types/schema';
 
 // Plugins import any icon they want from `@openmsupply-client/common` (e.g.
@@ -99,6 +100,9 @@ export type Plugins = {
       masterLists: MasterListRowFragment[];
     }>[];
     tableColumn: ColumnDef<MasterListRowFragment>[];
+  };
+  stocktakeLine?: {
+    tableColumn: ColumnDef<StocktakeLineFragment>[];
   };
   pages?: PluginPage[];
 };

--- a/client/packages/common/src/plugins/types.ts
+++ b/client/packages/common/src/plugins/types.ts
@@ -10,7 +10,7 @@ import {
 import { InboundFragment } from '@openmsupply-client/invoices';
 import { PrescriptionPaymentComponentProps } from './prescriptionTypes';
 import { DraftRequestLine } from 'packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit';
-import { StocktakeLineFragment } from 'packages/inventory/src/Stocktake/api';
+import { StocktakeLineFragment } from '@openmsupply-client/inventory';
 import { UserPermission } from '../types/schema';
 
 // Plugins import any icon they want from `@openmsupply-client/common` (e.g.

--- a/client/packages/inventory/src/Stocktake/DetailView/columns.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/columns.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import {
   useTranslation,
   usePreferences,
+  usePluginProvider,
   ColumnDef,
   ColumnType,
   ExpiryDateCell,
@@ -14,6 +15,7 @@ export const useStocktakeColumns = () => {
   const t = useTranslation();
   const { manageVaccinesInDoses, allowTrackingOfStockByDonor } =
     usePreferences();
+  const { plugins } = usePluginProvider();
   const { errors } = useStocktakeLineErrorContext();
 
   const getIsError = useCallback(
@@ -176,6 +178,7 @@ export const useStocktakeColumns = () => {
         header: t('label.comment'),
         columnType: ColumnType.Comment,
       },
+      ...(plugins.stocktakeLine?.tableColumn || []),
     ];
     return cols;
   }, [
@@ -184,6 +187,7 @@ export const useStocktakeColumns = () => {
     allowTrackingOfStockByDonor,
     getIsError,
     getRowHasError,
+    plugins.stocktakeLine?.tableColumn,
   ]);
 
   return columns;

--- a/client/packages/inventory/src/index.ts
+++ b/client/packages/inventory/src/index.ts
@@ -1,2 +1,3 @@
 export { ListView, DetailView } from './Stocktake';
 export { InventoryService } from './InventoryService';
+export type { StocktakeLineFragment } from './Stocktake/api';


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11889

# 👩🏻‍💻 What does this PR do?
Set up stocktake detail view table with plugin compatibility. Linked issue coming up. Test with https://github.com/msupply-foundation/haiti-plugins/pull/3

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Install above plugin
- [ ] Go to stocktake -> see unit columns

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

