### PR TITLE
11361 fix: CCE not shown for all linked locations in Sensors table

### DIFF
--- a/server/graphql/core/src/loader/asset.rs
+++ b/server/graphql/core/src/loader/asset.rs
@@ -29,9 +29,12 @@ impl Loader<String> for AssetByLocationLoader {
                 EqualFilter::equal_any(ids.iter().map(String::clone).collect()),
             ))?;
 
-        let mut location_ids_by_asset: HashMap<String, String> = HashMap::new();
+        let mut location_ids_by_asset: HashMap<String, Vec<String>> = HashMap::new();
         for location in locations {
-            location_ids_by_asset.insert(location.asset_id, location.location_id);
+            location_ids_by_asset
+                .entry(location.asset_id)
+                .or_default()
+                .push(location.location_id);
         }
 
         let assets = asset_repo.query_by_filter(AssetFilter::new().id(EqualFilter::equal_any(
@@ -40,13 +43,12 @@ impl Loader<String> for AssetByLocationLoader {
 
         let mut map: HashMap<String, Vec<Asset>> = HashMap::new();
         for asset in assets {
-            let location_id = location_ids_by_asset
-                .get(&asset.id)
-                .unwrap_or(&"".to_string())
-                .to_owned();
-
-            let list = map.entry(location_id).or_default();
-            list.push(asset);
+            if let Some(loc_ids) = location_ids_by_asset.get(&asset.id) {
+                for location_id in loc_ids {
+                    let list = map.entry(location_id.clone()).or_default();
+                    list.push(asset.clone());
+                }
+            }
         }
 
         Ok(map)

--- a/server/graphql/core/src/loader/asset.rs
+++ b/server/graphql/core/src/loader/asset.rs
@@ -54,3 +54,72 @@ impl Loader<String> for AssetByLocationLoader {
         Ok(map)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use async_graphql::dataloader::Loader;
+    use repository::{
+        asset_internal_location_row::AssetInternalLocationRow,
+        mock::{
+            mock_asset_a, mock_asset_b, mock_location_1, mock_location_2, mock_location_3,
+            MockDataInserts,
+        },
+        test_db, Upsert,
+    };
+
+    use crate::loader::AssetByLocationLoader;
+
+    #[tokio::test]
+    async fn asset_by_location_loader() {
+        // Prepare
+        let (_, storage_connection, connection_manager, _) = test_db::setup_all(
+            "asset_by_location_loader",
+            MockDataInserts::none().assets().locations(),
+        )
+        .await;
+
+        // Link asset_a to two locations (location_1 and location_2), and
+        // asset_b to a single location (location_3)
+        for (id, asset_id, location_id) in [
+            ("ail_1", mock_asset_a().id, mock_location_1().id),
+            ("ail_2", mock_asset_a().id, mock_location_2().id),
+            ("ail_3", mock_asset_b().id, mock_location_3().id),
+        ] {
+            AssetInternalLocationRow {
+                id: id.to_string(),
+                asset_id,
+                location_id,
+            }
+            .upsert(&storage_connection)
+            .unwrap();
+        }
+
+        let loader = AssetByLocationLoader { connection_manager };
+
+        let ids: &[String] = &[
+            mock_location_1().id,
+            mock_location_2().id,
+            mock_location_3().id,
+        ];
+
+        let result = loader.load(ids).await.unwrap();
+
+        // asset_a should be returned for BOTH of its linked locations.
+        // This is the regression that was previously broken: only the last
+        // location processed for an asset would return that asset.
+        assert_eq!(
+            result.get(&mock_location_1().id),
+            Some(&vec![mock_asset_a()])
+        );
+        assert_eq!(
+            result.get(&mock_location_2().id),
+            Some(&vec![mock_asset_a()])
+        );
+
+        // asset_b is returned for its single location
+        assert_eq!(
+            result.get(&mock_location_3().id),
+            Some(&vec![mock_asset_b()])
+        );
+    }
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11361

# 👩🏻‍💻 What does this PR do?
Fixes a bug where the CCE column in the Sensors table was blank for sensors whose location was not the last one saved to the `asset_internal_location` table for that CCE. When a CCE has multiple locations linked to it, the `AssetByLocationLoader` was building an intermediate map keyed by `asset_id` with a single `location_id` value. Each iteration of the loop overwrote the previous entry, so only the last location processed was retained. As a result, only the sensor assigned to that "surviving" location would display the CCE name — all others showed blank.

The fix changes the intermediate map from `HashMap<String, String>` to `HashMap<String, Vec<String>>`, collecting all location per asset. The asset is then inserted into the result map under every one of its locations, so all sensors at any of those locations correctly show the CCE.
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?
The only change is in `server/graphql/core/src/loader/asset.rs` — the `AssetByLocationLoader`. No schema, migration, or client changes were needed.

The asset clone inside the loop is unavoidable since the same asset needs to be placed under multiple location keys in the result map.
<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create a CCE and link **multiple locations** to it (e.g. ILR25, WH1-L, WH1-F)
- [ ] Import a separate sensor data file (Berlinger/LogTag `.txt`) for each linked location
- [ ] After import, edit each sensor and assign it to one of the CCE's linked locations
- [ ] Go to **Cold Chain → Monitoring → Sensors**
- [ ] Verify the **CCE column** shows the correct CCE name for **all** sensors, not just one

# 📃 Documentation

- [ ] **No documentation required**: bug fix restoring expected behaviour — CCE column in the Sensors table now correctly shows 
  the CCE for all linked locations


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

