### PR TITLE
Alert Slack when Android build fails or never runs

### DIFF
--- a/.github/scripts/send-slack-notification.py
+++ b/.github/scripts/send-slack-notification.py
@@ -50,6 +50,7 @@ def handle_android_build_notification(filenames):
         "success": ("✅", "Completed Successfully"),
         "failure": ("❌", "Failed"),
         "cancelled": ("⏹️", "Cancelled"),
+        "timed_out": ("⏱️", "Timed Out"),
         "skipped": ("⏭️", "Skipped")
     }
 
@@ -59,11 +60,22 @@ def handle_android_build_notification(filenames):
     message += f"Tag: `{tag}`\n"
     message += f"Status: {status_text}"
 
+    # A cancelled build is most often the self-hosted runner being offline: the
+    # queued job is force-cancelled after waiting too long for a runner. Surface
+    # an actionable hint (manual cancellation is the other possibility).
+    if build_status == "cancelled":
+        message += "\n\n⚠️ Often caused by the self-hosted build runner being offline or unavailable (the queued job is cancelled if no runner picks it up) — check the runner. Otherwise the build was cancelled manually."
+
     for filename in filenames:
         # Construct the full URL for the APK file
         file_url = f"{BASE_URL}/{tag}/{filename}"
         print(f"📦 File URL: {file_url}")
         message += f"\n\n Download: <{file_url}|{filename}>"
+
+    # Link straight to the workflow run when available (set by the notify job).
+    run_url = os.getenv("RUN_URL")
+    if run_url:
+        message += f"\n\n<{run_url}|View workflow run>"
 
     print(f"Sending Message:\n {message}")
     if send_slack_notification(webhook_url, message):

--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -84,12 +84,22 @@ jobs:
           B2_APPLICATION_KEY: ${{ secrets.B2_APPLICATION_KEY }}
         run: bash .github/scripts/mac_backblaze_upload.sh
 
+  # Reports non-success outcomes (failure, cancellation, and the queue-timeout
+  # that happens when no self-hosted runner is available) to Slack. Runs on a
+  # GitHub-hosted runner so it still fires when the self-hosted runner is down -
+  # the build job's own steps never execute in that case, so they cannot notify.
+  notify-build-result:
+    needs: create-android-build
+    if: ${{ always() && needs.create-android-build.result != 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - name: Send build completion notification
-        if: ${{ failure() }}
         env:
           SLACK_DEV_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_DEV_RELEASE_WEBHOOK_URL }}
           SLACK_RC_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_RC_RELEASE_WEBHOOK_URL }}
           NOTIFICATION_TYPE: 'android_build'
-          BUILD_STATUS: ${{ job.status }}
+          BUILD_STATUS: ${{ needs.create-android-build.result }}
           TAG_NAME: ${{ github.ref_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: bash .github/scripts/send-slack-notification.sh


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Build completion messages stopped appearing in the Slack dev/RC build channels. The "🚀 Build Started" messages still arrive (they come from `nightly-automated-builds.yaml`, which runs on a GitHub-hosted runner and creates the `v*` tags), but no success/failure message ever follows.

Root cause: the **Android Build** workflow (`build-android-apk.yaml`) runs on a **self-hosted** runner and sends its completion message from *inside* that job. When the self-hosted runner is offline, GitHub force-cancels the still-queued job after 24h — none of the job's steps ever execute, so nothing can notify. The previous in-job `if: ${{ failure() }}` step also never matched a `cancelled` result, so even ordinary build failures were silent.

This PR makes non-success outcomes loud:

- Adds a separate **`notify-build-result`** job that runs on `ubuntu-latest` (so it still fires when the self-hosted runner is down), `needs: create-android-build`, gated by `if: ${{ always() && needs.create-android-build.result != 'success' }}`. It reports `failure`, `cancelled` (including the runner-offline queue-timeout) and `skipped` to the correct RC/Dev Slack channel.
- Removes the old in-job `if: ${{ failure() }}` notification step (it could never fire on the queue-timeout case and is now redundant).
- Leaves the success path untouched — the Backblaze upload step still posts the success message with APK download links, since it needs the built filenames and the runner.
- Updates `send-slack-notification.py`: adds a `timed_out` status, an actionable "the self-hosted build runner is probably offline" hint on `cancelled` messages, and a "View workflow run" link (via a new `RUN_URL` env var).

## 💌 Any notes for the reviewer?

- No linked issue — this came out of debugging why the Slack build channel went quiet.
- **Trade-off:** for the runner-offline case specifically, the alert only arrives once GitHub force-cancels the queued job, which is its fixed ~24h queue timeout. This ends the silence but is not immediate; a faster runner-availability probe was discussed and deliberately left out of scope.
- The fix is intentionally a *separate GitHub-hosted job* — a job on the self-hosted runner cannot notify when the self-hosted runner is the thing that's missing.
- The `if: ${{ always() && ... != 'success' }}` guard avoids double-posting on the happy path, where success is already announced by the in-job Backblaze step.
- Scope limited to the Android Build workflow; `build-mac-demo.yaml` and other self-hosted workflows are unchanged.

# 🧪 Testing

The notification script was dry-run locally (stubbing the webhook + `requests`) for each non-success status, confirming correct message text, RC-vs-Dev channel routing, the run link, and the cancelled-runner hint. End-to-end:

- [ ] Trigger `Android Build` via `workflow_dispatch` on a healthy runner → success message still posts with download links, and `notify-build-result` is correctly skipped (no duplicate).
- [ ] Force an early build step to fail on a test branch → a single `❌ Android Build Failed` message arrives in the matching channel with a working "View workflow run" link.
- [ ] Cancel a run manually (or observe the next genuine runner-offline event) → `⏹️ Android Build Cancelled` message arrives carrying the runner-offline hint.

# 📃 Documentation

- [x] **No documentation required**: CI/infra change only, no user-facing behaviour change.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
