### PR TITLE
Downgrade changelog lock from ACCESS EXCLUSIVE to EXCLUSIVE

### DIFF
--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -661,8 +661,17 @@ fn create_filtered_outgoing_patient_sync_query(
 /// we might update the latest changelog cursor to 5 and the changelog with cursor = 2 will be left
 /// unhandled when continuing from the latest cursor position.
 ///
-/// Locking the changelog table will wait for ongoing writers and will prevent new writers while
-/// reading the changelog.
+/// We use EXCLUSIVE mode (not ACCESS EXCLUSIVE) because:
+///
+/// EXCLUSIVE is safe here because it conflicts with ROW EXCLUSIVE (the implicit lock held by
+/// any in-flight INSERT/UPDATE/DELETE). This means `LOCK TABLE ... IN EXCLUSIVE MODE` will
+/// wait for all uncommitted writes to commit before proceeding, so we are guaranteed to see
+/// all changelog entries up to the point we read — no cursor gaps.
+///
+/// The key difference from ACCESS EXCLUSIVE: EXCLUSIVE allows concurrent SELECTs (which only
+/// hold ACCESS SHARE locks). Since reads cannot create cursor gaps, there is no reason to
+/// block them. ACCESS EXCLUSIVE blocks reads too, which under load causes all GraphQL list
+/// queries to queue behind changelog processing.
 fn with_locked_changelog_table<T, F>(
     connection: &StorageConnection,
     f: F,
@@ -677,7 +686,7 @@ where
                 let mut locked_con = con.lock();
                 locked_con
                     .connection()
-                    .batch_execute("LOCK TABLE ONLY changelog IN ACCESS EXCLUSIVE MODE")?;
+                    .batch_execute("LOCK TABLE ONLY changelog IN EXCLUSIVE MODE")?;
 
                 f(&mut locked_con)
             },


### PR DESCRIPTION
## Summary

Forward-port of #11036 onto the mainline release line. That PR was merged into `2.16.1-sl-hotfix` on 2026-03-27 (commit 0a247e5) but never made it onto `develop` / the RC line, so `v2.16.05-RC` still carries the more aggressive `ACCESS EXCLUSIVE` lock.

Single-line change in `server/repository/src/db_diesel/changelog/changelog.rs` plus the rationale comment lifted verbatim from #11036.

## Why

The `changelog` table is locked every time sync/transfer processors read changelog entries, to prevent cursor gaps (see the doc comment above `with_locked_changelog_table`). `ACCESS EXCLUSIVE` is the most aggressive Postgres lock — it blocks **all** operations on the table, including plain `SELECT`s.

Independent evidence from the SL trial server (postgresql-2026-05-29.csv) shows bursts of 7–8 of these locks every 5 minutes (one per cursor-driven sync consumer per tick). Under concurrent load on the previous SL hotfix run, this cascaded into pool exhaustion and HTTP 408s as GraphQL list queries queued behind changelog reads.

## Why EXCLUSIVE is safe

`EXCLUSIVE` mode conflicts with `ROW EXCLUSIVE` (the implicit lock held by any in-flight `INSERT`/`UPDATE`/`DELETE`), so `LOCK TABLE ... IN EXCLUSIVE MODE` will still **wait for all uncommitted writes to commit** before proceeding. The cursor-gap guarantee — and `test_late_changelog_rows`, the regression test that covers it — is preserved.

The only difference from `ACCESS EXCLUSIVE`: `EXCLUSIVE` does **not** conflict with `ACCESS SHARE` (the lock held by plain `SELECT`), so unrelated read queries are no longer blocked. Reads cannot create cursor gaps, so blocking them was unnecessary.

## Load test results from #11036 (50 VUs)

| Metric | ACCESS EXCLUSIVE (before) | EXCLUSIVE (after) |
|--------|--------------------------|-------------------|
| p(95) response time | 10.19s | **7.71s** |
| failure rate | 1.00% (32 failures) | **0.08%** (3 failures) |
| blocked INSERT queries | 8+, waiting 4-9s each | 1-2, waiting <1s |

## Test plan

- [ ] `test_late_changelog_rows` (cursor-gap regression) passes on the Postgres feature flavour: `cargo test --features postgres -p repository changelog`
- [ ] Default-features (SQLite) tests still pass — this change only affects the Postgres branch
- [ ] Manual smoke against real Postgres: create an invoice on a remote site, wait one sync tick, confirm row appears on central and `sync_log` is populated
- [ ] With `log_statement=all`, confirm the log shows `LOCK TABLE ONLY changelog IN EXCLUSIVE MODE` (not `ACCESS EXCLUSIVE`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)