### PR TITLE
#11911 Batch ItemStoreJoinLoader and index item_store_join

### DIFF
--- a/server/graphql/core/src/loader/item_store_join.rs
+++ b/server/graphql/core/src/loader/item_store_join.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use async_graphql::dataloader::Loader;
 use repository::{
@@ -33,13 +33,20 @@ impl Loader<ItemStoreJoinLoaderInput> for ItemStoreJoinLoader {
     ) -> Result<HashMap<ItemStoreJoinLoaderInput, Self::Value>, Self::Error> {
         let connection = self.connection_manager.connection()?;
 
+        // De-dupe before building the query - the dropdown passes the same
+        // store_id for every item, so this collapses the store_id IN (...) list
+        // (and any repeated item_ids) down to the distinct values.
         let item_ids: Vec<String> = loader_inputs
             .iter()
             .map(|input| input.item_id.clone())
+            .collect::<HashSet<_>>()
+            .into_iter()
             .collect();
         let store_ids: Vec<String> = loader_inputs
             .iter()
             .map(|input| input.store_id.clone())
+            .collect::<HashSet<_>>()
+            .into_iter()
             .collect();
 
         // Single batched query rather than one lookup per item - the item

--- a/server/graphql/core/src/loader/item_store_join.rs
+++ b/server/graphql/core/src/loader/item_store_join.rs
@@ -2,8 +2,7 @@ use std::collections::HashMap;
 
 use async_graphql::dataloader::Loader;
 use repository::{
-    ItemStoreJoinRow, ItemStoreJoinRowRepository, ItemStoreJoinRowRepositoryTrait, RepositoryError,
-    StorageConnectionManager,
+    ItemStoreJoinRow, ItemStoreJoinRowRepository, RepositoryError, StorageConnectionManager,
 };
 
 pub struct ItemStoreJoinLoader {
@@ -34,16 +33,26 @@ impl Loader<ItemStoreJoinLoaderInput> for ItemStoreJoinLoader {
     ) -> Result<HashMap<ItemStoreJoinLoaderInput, Self::Value>, Self::Error> {
         let connection = self.connection_manager.connection()?;
 
-        let mut result_map = HashMap::new();
+        let item_ids: Vec<String> = loader_inputs
+            .iter()
+            .map(|input| input.item_id.clone())
+            .collect();
+        let store_ids: Vec<String> = loader_inputs
+            .iter()
+            .map(|input| input.store_id.clone())
+            .collect();
 
-        for loader_input in loader_inputs {
-            let store_id = &loader_input.store_id;
-            let item_id = &loader_input.item_id;
+        // Single batched query rather than one lookup per item - the item
+        // search/dropdown requests this field for up to 100 items at once.
+        let rows = ItemStoreJoinRowRepository::new(&connection)
+            .find_many_by_item_and_store_ids(&item_ids, &store_ids)?;
 
-            let result = ItemStoreJoinRowRepository::new(&connection)
-                .find_one_by_item_and_store_id(item_id, store_id)?;
-
-            result_map.insert(loader_input.clone(), result.into_iter().collect());
+        let mut result_map: HashMap<ItemStoreJoinLoaderInput, Self::Value> = HashMap::new();
+        for row in rows {
+            result_map
+                .entry(ItemStoreJoinLoaderInput::new(&row.store_id, &row.item_link_id))
+                .or_default()
+                .push(row);
         }
 
         Ok(result_map)

--- a/server/repository/src/db_diesel/item_store_join.rs
+++ b/server/repository/src/db_diesel/item_store_join.rs
@@ -79,6 +79,18 @@ impl<'a> ItemStoreJoinRowRepository<'a> {
     pub fn new(connection: &'a StorageConnection) -> Self {
         ItemStoreJoinRowRepository { connection }
     }
+
+    pub fn find_many_by_item_and_store_ids(
+        &self,
+        item_link_ids: &[String],
+        store_ids: &[String],
+    ) -> Result<Vec<ItemStoreJoinRow>, RepositoryError> {
+        let result = item_store_join::table
+            .filter(item_store_join::item_link_id.eq_any(item_link_ids))
+            .filter(item_store_join::store_id.eq_any(store_ids))
+            .load(self.connection.lock().connection())?;
+        Ok(result)
+    }
 }
 
 impl Upsert for ItemStoreJoinRow {

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -39,6 +39,7 @@ mod v2_14_00;
 mod v2_15_00;
 mod v2_16_00;
 mod v2_16_01;
+mod v2_16_05;
 mod version;
 mod views;
 
@@ -146,6 +147,7 @@ pub fn migrate(
         Box::new(v2_15_00::V2_15_00),
         Box::new(v2_16_00::V2_16_00),
         Box::new(v2_16_01::V2_16_01),
+        Box::new(v2_16_05::V2_16_05),
     ];
 
     // Check if the database has been initialised, if not run the base sql to kick start the process

--- a/server/repository/src/migrations/v2_16_05/add_item_store_join_indexes.rs
+++ b/server/repository/src/migrations/v2_16_05/add_item_store_join_indexes.rs
@@ -1,0 +1,25 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_item_store_join_indexes"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // `item_store_join` only had a primary key on `id`; the foreign key
+        // constraints don't create indexes on the referencing columns. The item
+        // search/dropdown looks up store properties by (item_link_id, store_id)
+        // for every item it lists, so without this index each lookup is a
+        // sequential scan.
+        sql!(
+            connection,
+            r#"
+            CREATE INDEX IF NOT EXISTS index_item_store_join_item_link_id_store_id ON item_store_join (item_link_id, store_id);
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_16_05/mod.rs
+++ b/server/repository/src/migrations/v2_16_05/mod.rs
@@ -1,0 +1,44 @@
+use super::{version::Version, Migration, MigrationFragment};
+use crate::StorageConnection;
+
+mod add_item_store_join_indexes;
+
+pub(crate) struct V2_16_05;
+impl Migration for V2_16_05 {
+    fn version(&self) -> Version {
+        Version::from_str("2.16.5")
+    }
+
+    fn migrate(&self, _connection: &StorageConnection) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn migrate_fragments(&self) -> Vec<Box<dyn MigrationFragment>> {
+        vec![Box::new(add_item_store_join_indexes::Migrate)]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[actix_rt::test]
+    async fn migration_2_16_05() {
+        use crate::migrations::*;
+        use crate::test_db::*;
+        use v2_16_01::V2_16_01;
+        use v2_16_05::V2_16_05;
+
+        let previous_version = V2_16_01.version();
+        let version = V2_16_05.version();
+
+        let SetupResult { connection, .. } = setup_test(SetupOption {
+            db_name: &format!("migration_{version}"),
+            version: Some(previous_version.clone()),
+            ..Default::default()
+        })
+        .await;
+
+        // Run this migration
+        migrate(&connection, Some(version.clone())).unwrap();
+        assert_eq!(get_database_version(&connection), version);
+    }
+}


### PR DESCRIPTION
Fixes #11911

# 👩🏻‍💻 What does this PR do?

The item search/dropdown (used to add lines to inbound shipments, outbound shipments, requisitions, etc.) requests the `itemStoreProperties` field for every item it lists — up to 100 at once.

Two problems made this slow on larger datasets:

1. **`ItemStoreJoinLoader` didn't batch.** Despite being a DataLoader, it looped over the batch and fired a *separate* query per item (`find_one_by_item_and_store_id`). Every other loader on the item type does a single `IN (…)` query.
2. **No index on `item_store_join`.** The table only had a primary key on `id`; the FK constraints don't create indexes on the referencing columns. The `item_store_join_view` join filters by `item_link_id` + `store_id`, so each of those per-item lookups was a sequential scan.

The combination meant ~100 sequential-scan queries every time the dropdown opened. On the Sierra Leone testing server that was ~8 seconds (≈80ms × 100 items, scaling linearly with page size).

This PR:
- Rewrites the loader to issue a **single batched query** (`item_id IN (…) AND store_id IN (…)`) and group the results, via a new `find_many_by_item_and_store_ids` repository method.
- Adds an index `index_item_store_join_item_link_id_store_id` on `item_store_join (item_link_id, store_id)` (migration in `v2_20_00`).

## 💌 Any notes for the reviewer?

- The slowness only shows up with a realistic data volume. Locally `item_store_join` is tiny (~600 rows), so the sequential scans are sub-millisecond and the N+1 is invisible — which is why it wasn't caught before. Diagnosed against the Sierra Leone testing server by isolating GraphQL field selections: timing scaled linearly at ~80ms/item and was entirely attributable to `itemStoreProperties`.
- The index targets the physical `item_store_join` table (the `core` name in the `define_linked_tables!` macro), which is what the view's join resolves through.
- **I'm not entirely convinced the index is worth adding**, and I'm not sure why we don't already have one (it's a fairly natural FK-style lookup). The batched loader alone takes the dropdown back to sub-second on its own. The index is a belt-and-braces speedup for the join, but it adds write/maintenance cost on every `item_store_join` upsert. Happy to drop it if reviewers think the batching is sufficient.

# 🧪 Testing

- [ ] On a datafile with a meaningful number of items + `item_store_join` rows (e.g. the Sierra Leone testing server)
- [ ] Open an inbound shipment, outbound shipment, and a requisition
- [ ] Add a new line and open the item search/dropdown
- [ ] Confirm the item list now populates quickly (sub-second) instead of taking 8+ seconds
- [ ] Confirm `itemStoreProperties` values (default sell price / ignore for orders) still display correctly
- [ ] Confirm the migration applies cleanly and the index is created

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in user-facing behaviour (only speed)

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
