### PR TITLE
11909 fix: correct dose calculations in stocktake for vaccines with pack size > 1

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/UnitsAndDosesCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/UnitsAndDosesCell.tsx
@@ -21,12 +21,15 @@ export const UnitsAndDosesCell = <T extends MRT_RowData>({
   showAlert,
   roundUp,
   decimalLimit,
+  packSize,
 }: {
   cell: MRT_Cell<T>;
   row: MRT_Row<T & { item?: ItemData }>;
   showAlert?: boolean;
   roundUp?: boolean;
   decimalLimit?: number;
+  /** When the cell value is in packs (not units), pass packSize to get correct dose count */
+  packSize?: number;
 }) => {
   const t = useTranslation();
   const { format } = useFormatNumber();
@@ -37,7 +40,7 @@ export const UnitsAndDosesCell = <T extends MRT_RowData>({
 
   // Doses should always be a whole number, round if fractional packs are giving
   // us funky decimals
-  const doseCount = format((item?.doses ?? 1) * (value ?? 0), {
+  const doseCount = format((item?.doses ?? 1) * (packSize ?? 1) * (value ?? 0), {
     maximumFractionDigits: 0,
   });
 

--- a/client/packages/inventory/src/Stocktake/DetailView/columns.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/columns.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   useTranslation,
   usePreferences,
@@ -140,7 +140,11 @@ export const useStocktakeColumns = () => {
           if (!row.item.isVaccine) return null;
           const counted = row.countedNumberOfPacks;
           if (counted === null || counted === undefined) return null;
-          return counted * (row.packSize ?? 1) * (row.item.doses ?? 1);
+          return (
+            counted *
+            (row.packSize || row.item.defaultPackSize || 1) *
+            (row.item.doses ?? 1)
+          );
         },
       },
       {
@@ -151,7 +155,17 @@ export const useStocktakeColumns = () => {
         header: t('label.difference'),
         columnType: ColumnType.Number,
         aggregationFn: 'sum',
-        Cell: UnitsAndDosesCell,
+        Cell: ({ cell, row }) => (
+          <UnitsAndDosesCell
+            cell={cell}
+            row={row}
+            packSize={
+              row.original.packSize ||
+              row.original.item.defaultPackSize ||
+              1
+            }
+          />
+        ),
       },
       {
         id: 'reason',

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -202,7 +202,11 @@ export const BatchTable = ({
         accessorFn: row => {
           const counted = row.countedNumberOfPacks;
           if (counted === null || counted === undefined) return null;
-          return counted * (row.packSize ?? 1) * (row.item.doses ?? 1);
+          return (
+            counted *
+            (row.packSize || row.item.defaultPackSize || 1) *
+            (row.item.doses ?? 1)
+          );
         },
       },
       {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11909 

# 👩🏻‍💻 What does this PR do?
Fixes incorrect dose calculations in the Stocktake detail view for vaccines with a pack size greater than 1.
  
**Changes made:**
- `UnitsAndDosesCell`: added optional `packSize` prop so callers can indicate the cell value is in packs rather than units. All existing callers are unaffected (default `packSize = 1`).
- `columns.tsx` (`difference` column): passes `row.original.packSize || row.original.item.defaultPackSize || 1` to `UnitsAndDosesCell` so the dose annotation correctly reflects the full pack × dose count. 
- `columns.tsx` and `StocktakeLineEditTables.tsx` (`dosesCounted` column): changed `(row.packSize ?? 1)` to `(row.packSize || row.item.defaultPackSize || 1)` so a null pack size properly falls back to the item's default.
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?
The `UnitsAndDosesCell` component is shared across the Stock list view and requisitions. In those contexts the value passed is already in **units** (e.g. `totalNumberOfPacks * packSize`), so the new `packSize` prop defaults to `1` and those views are unaffected. Only the stocktake difference column explicitly passes `packSize`.
  
Worth checking: any other `Cell: UnitsAndDosesCell` usages where the accessor value is in packs rather than units they would have the same latent bug.
<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up a vaccine item with `doses > 1` and a stocktake line with `packSize > 1`
- [ ] In the Stocktake detail view, verify the **Difference** column dose annotation equals `difference_packs × packSize × doses`(e.g. 100 packs, packSize 2, doses 3 → `100 (600 ds)`)
- [ ] Open the line edit modal and verify **Doses counted** equals `countedPacks × packSize × doses`
- [ ] Verify the **Doses counted** column in the detail view shows the same value
- [ ] Verify non-vaccine items (no doses) and items with `packSize = 1` are unaffected
- [ ] Verify the Stock list SOH and Available SOH dose annotations are unaffected

# 📃 Documentation
- [ ] **No documentation required**: bug fix, not a change in intended behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

