### PR TITLE
sync v7: run heavy blocking work on the blocking pool

### DIFF
--- a/server/repository/src/syncv7/sync_record.rs
+++ b/server/repository/src/syncv7/sync_record.rs
@@ -4,6 +4,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use ts_rs::TS;
+use util::format_error;
 
 diesel_json_type! {
     #[derive(Debug, Error, Clone, PartialEq, TS)]
@@ -58,6 +59,12 @@ diesel_json_type! {
         RequestSiteAuthError(String),
         #[error("Unmatched error {0}")]
         Other(String),
+    }
+}
+
+impl SyncError {
+    pub fn other(error: impl std::error::Error) -> Self {
+        SyncError::Other(format_error(&error))
     }
 }
 

--- a/server/server/src/central/sync_v7.rs
+++ b/server/server/src/central/sync_v7.rs
@@ -39,7 +39,7 @@ async fn get_token(
     service_provider: Data<ServiceProvider>,
 ) -> actix_web::Result<impl Responder> {
     let response: api::get_token::Response =
-        handlers::get_token(&service_provider, request.into_inner()).await;
+        handlers::get_token(service_provider.into_inner(), request.into_inner()).await;
 
     Ok(web::Json(response))
 }
@@ -50,7 +50,7 @@ async fn site_status(
     service_provider: Data<ServiceProvider>,
 ) -> actix_web::Result<impl Responder> {
     let response: api::status::Response = match extract_common(&http_req) {
-        Ok(common) => handlers::site_status(&service_provider, common).await,
+        Ok(common) => handlers::site_status(service_provider.into_inner(), common).await,
         Err(e) => Err(e),
     };
     Ok(web::Json(response))
@@ -63,7 +63,7 @@ async fn pull(
     service_provider: Data<ServiceProvider>,
 ) -> actix_web::Result<impl Responder> {
     let response: api::pull::Response = match extract_common(&http_req) {
-        Ok(common) => handlers::pull(&service_provider, common, body.into_inner()).await,
+        Ok(common) => handlers::pull(service_provider.into_inner(), common, body.into_inner()).await,
         Err(e) => Err(e),
     };
     Ok(web::Json(response))
@@ -92,7 +92,8 @@ async fn patient_data_for_site(
 ) -> actix_web::Result<impl Responder> {
     let response: api::patient_data_for_site::Response = match extract_common(&http_req) {
         Ok(common) => {
-            handlers::patient_data_for_site(&service_provider, common, body.into_inner()).await
+            handlers::patient_data_for_site(service_provider.into_inner(), common, body.into_inner())
+                .await
         }
         Err(e) => Err(e),
     };
@@ -106,7 +107,9 @@ async fn patient_search(
     service_provider: Data<ServiceProvider>,
 ) -> actix_web::Result<impl Responder> {
     let response: api::patient_search::Response = match extract_common(&http_req) {
-        Ok(common) => handlers::patient_search(&service_provider, common, body.into_inner()).await,
+        Ok(common) => {
+            handlers::patient_search(service_provider.into_inner(), common, body.into_inner()).await
+        }
         Err(e) => Err(e),
     };
     Ok(web::Json(response))

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -34,9 +34,22 @@ use crate::{
     },
 };
 
+/// Run synchronous work (DB queries, transactions, JSON serialization, bcrypt)
+/// on tokio's blocking pool so it doesn't starve the actix worker's async
+/// runtime. Mirrors the pattern in `sync.rs::integrate` for the integration path.
+async fn run_blocking<T, F>(f: F) -> Result<T, SyncError>
+where
+    F: FnOnce() -> Result<T, SyncError> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| SyncError::Other(format!("blocking join error: {e:?}")))?
+}
+
 /// TODO: revisit token format
 pub async fn get_token(
-    service_provider: &ServiceProvider,
+    service_provider: Arc<ServiceProvider>,
     input: GetTokenInput,
 ) -> Result<GetTokenOutput, SyncError> {
     if !CentralServerConfig::is_central_server() {
@@ -51,12 +64,34 @@ pub async fn get_token(
         });
     }
 
+    // Authenticate on the blocking pool (site lookup + bcrypt verify). Done
+    // first so a wrong-password caller never triggers a legacy server roundtrip
+    // via ensure_site_is_v7.
+    let sp = service_provider.clone();
+    let (site, input) = run_blocking(move || authenticate_for_token(&sp, input)).await?;
+
+    // Now that the caller is authenticated, gate on sync_version. If still
+    // v5/v6 locally, ask the legacy server: if it reports v7 (or
+    // v7_url_and_upgrade succeeds for a fresh remote), bump the local record
+    // and continue. Otherwise refuse with SiteIsNotV7. This may hit the network
+    // so it stays on the async runtime.
+    let site = ensure_site_is_v7(&service_provider, site, &input).await?;
+
+    // Sync tx phase: hardware-id assignment + token allocation, on the blocking pool.
+    run_blocking(move || allocate_token(&service_provider, site, input)).await
+}
+
+/// Blocking phase of `get_token`: look up the site, guard against a remote
+/// authenticating as the central site itself, and verify the password (bcrypt
+/// is CPU-heavy). Returns the site and the (unconsumed) input.
+fn authenticate_for_token(
+    service_provider: &ServiceProvider,
+    input: GetTokenInput,
+) -> Result<(SiteRow, GetTokenInput), SyncError> {
     let ctx = service_provider
         .basic_context()
         .map_err(|e| SyncError::Other(e.to_string()))?;
 
-    // Authenticate first so a wrong-password caller never triggers a legacy
-    // server roundtrip via ensure_site_is_v7.
     let site = get_site_by_name(&ctx.connection, &input.name)?
         .ok_or(SyncError::InvalidSiteNameOrPassword)?;
 
@@ -80,13 +115,19 @@ pub async fn get_token(
         return Err(SyncError::InvalidSiteNameOrPassword);
     }
 
-    // Now that the caller is authenticated, gate on sync_version. If still
-    // v5/v6 locally, ask the legacy server: if it reports v7 (or
-    // v7_url_and_upgrade succeeds for a fresh remote), bump the local record
-    // and continue. Otherwise refuse with SiteIsNotV7.
-    let site = ensure_site_is_v7(&ctx.connection, site, &input).await?;
+    Ok((site, input))
+}
 
-    // Sync tx phase: hardware-id assignment + token allocation.
+/// Blocking phase of `get_token`: allocate token + hardware id in a transaction.
+fn allocate_token(
+    service_provider: &ServiceProvider,
+    site: SiteRow,
+    input: GetTokenInput,
+) -> Result<GetTokenOutput, SyncError> {
+    let ctx = service_provider
+        .basic_context()
+        .map_err(|e| SyncError::Other(e.to_string()))?;
+
     ctx.connection
         .transaction_sync(|connection| {
             if site.token.is_some() {
@@ -126,8 +167,11 @@ pub async fn get_token(
 /// (covers fresh remotes that haven't had a final v5+v6 sync yet), updates the
 /// local row to v7 and returns it. Returns SiteIsNotV7 only when the legacy
 /// server still says v5/v6 *and* v7_url_and_upgrade refuses.
+///
+/// Acquires a connection per DB touch rather than holding one across the legacy
+/// server roundtrip, so a pool slot isn't tied up during the network call.
 async fn ensure_site_is_v7(
-    connection: &StorageConnection,
+    service_provider: &ServiceProvider,
     site: SiteRow,
     input: &GetTokenInput,
 ) -> Result<SiteRow, SyncError> {
@@ -135,7 +179,12 @@ async fn ensure_site_is_v7(
         return Ok(site);
     }
 
-    let api_v5 = build_v5_api_for_request(connection, input)?;
+    let api_v5 = {
+        let ctx = service_provider
+            .basic_context()
+            .map_err(|e| SyncError::Other(e.to_string()))?;
+        build_v5_api_for_request(&ctx.connection, input)?
+    };
 
     let info = api_v5.get_site_info().await.map_err(|error| {
         if error.is_connection() {
@@ -162,7 +211,10 @@ async fn ensure_site_is_v7(
         sync_version: SyncVersion::V7,
         ..site
     };
-    SiteRowRepository::new(connection).upsert(&updated)?;
+    let ctx = service_provider
+        .basic_context()
+        .map_err(|e| SyncError::Other(e.to_string()))?;
+    SiteRowRepository::new(&ctx.connection).upsert(&updated)?;
     Ok(updated)
 }
 
@@ -253,7 +305,11 @@ fn validate(
 /// Report site status to a remote open-mSupply Server.
 /// Errors with `SiteLockError::IntegrationInProgress` while integration is running, so clients
 /// can poll until it clears.
-pub async fn site_status(service_provider: &ServiceProvider, common: Common) -> status::Response {
+pub async fn site_status(service_provider: Arc<ServiceProvider>, common: Common) -> status::Response {
+    run_blocking(move || site_status_inner(&service_provider, common)).await
+}
+
+fn site_status_inner(service_provider: &ServiceProvider, common: Common) -> status::Response {
     let (site, ctx) = validate(service_provider, &common)?;
     let central_site_id = SourceSiteId::CurrentSiteId
         .get_id(&ctx.connection)?
@@ -266,6 +322,14 @@ pub async fn site_status(service_provider: &ServiceProvider, common: Common) -> 
 
 /// Send Records to a remote open-mSupply Server
 pub async fn pull(
+    service_provider: Arc<ServiceProvider>,
+    common: Common,
+    input: pull::Input,
+) -> pull::Response {
+    run_blocking(move || pull_inner(&service_provider, common, input)).await
+}
+
+fn pull_inner(
     service_provider: &ServiceProvider,
     common: Common,
     input: pull::Input,
@@ -289,6 +353,14 @@ pub async fn pull(
 }
 
 pub async fn patient_search(
+    service_provider: Arc<ServiceProvider>,
+    common: Common,
+    input: patient_search::Input,
+) -> patient_search::Response {
+    run_blocking(move || patient_search_inner(&service_provider, common, input)).await
+}
+
+fn patient_search_inner(
     service_provider: &ServiceProvider,
     common: Common,
     input: patient_search::Input,
@@ -322,6 +394,14 @@ fn name_row_to_patient_v4(name: repository::NameRow) -> PatientV4 {
 
 /// Send patient records to a remote
 pub async fn patient_data_for_site(
+    service_provider: Arc<ServiceProvider>,
+    common: Common,
+    input: patient_data_for_site::Input,
+) -> patient_data_for_site::Response {
+    run_blocking(move || patient_data_for_site_inner(&service_provider, common, input)).await
+}
+
+fn patient_data_for_site_inner(
     service_provider: &ServiceProvider,
     common: Common,
     input: patient_data_for_site::Input,
@@ -360,7 +440,27 @@ pub async fn push(
     common: Common,
     input: push::Input,
 ) -> push::Response {
-    let (site, ctx) = validate(&service_provider, &common)?;
+    let sp = service_provider.clone();
+    let (records_in_this_batch, remaining, site_id) =
+        run_blocking(move || buffer_push_records(&sp, common, input)).await?;
+
+    if remaining == 0 {
+        spawn_integration(service_provider, site_id);
+    }
+
+    Ok(records_in_this_batch)
+}
+
+/// Blocking phase of `push`: validate, then buffer the batch's records into the
+/// sync buffer in a single transaction. Returns
+/// `(records_in_this_batch, remaining, site_id)` so the caller can decide
+/// whether to kick off integration.
+fn buffer_push_records(
+    service_provider: &ServiceProvider,
+    common: Common,
+    input: push::Input,
+) -> Result<(i64, u64, i32), SyncError> {
+    let (site, ctx) = validate(service_provider, &common)?;
     let site_id = site.id;
 
     let SyncBatchV7 {
@@ -391,11 +491,7 @@ pub async fn push(
         .transaction_sync(|t_con| SyncBufferRepository::new(t_con).insert_many(&sync_buffer_rows))
         .map_err(|e| e.to_inner_error())?;
 
-    if remaining == 0 {
-        spawn_integration(service_provider, site_id);
-    }
-
-    Ok(records_in_this_batch)
+    Ok((records_in_this_batch, remaining, site_id))
 }
 
 fn spawn_integration(service_provider: Arc<ServiceProvider>, site_id: i32) {
@@ -404,9 +500,15 @@ fn spawn_integration(service_provider: Arc<ServiceProvider>, site_id: i32) {
         return;
     }
 
-    tokio::spawn(async move {
+    // Integration is substantial blocking DB work, so run the whole thing on the
+    // blocking pool rather than bouncing through an async task just to await it.
+    tokio::task::spawn_blocking(move || {
         set_site_lock(site_id, Some(SiteLockError::IntegrationInProgress));
-        match spawn_integration_inner(service_provider, site_id).await {
+        // Release the lock on every exit path, including a panic in integration —
+        // otherwise the site stays wedged on IntegrationInProgress until restart.
+        let _lock_guard = SiteLockGuard(site_id);
+
+        match integrate_for_site(&service_provider, site_id) {
             Ok(_) => log::info!("Integration for site {} completed successfully", site_id),
             Err(e) => log::info!(
                 "Integration for site {} failed: {}",
@@ -414,9 +516,15 @@ fn spawn_integration(service_provider: Arc<ServiceProvider>, site_id: i32) {
                 format_error(&e),
             ),
         }
-
-        set_site_lock(site_id, None);
     });
+}
+
+/// Clears the integration lock for a site when dropped (panic-safe cleanup).
+struct SiteLockGuard(i32);
+impl Drop for SiteLockGuard {
+    fn drop(&mut self) {
+        set_site_lock(self.0, None);
+    }
 }
 
 #[derive(Error, Debug)]
@@ -427,8 +535,8 @@ pub enum SpawnIntegrationError {
     GetActiveStoresOnSiteError(#[from] GetActiveStoresOnSiteError),
 }
 
-async fn spawn_integration_inner(
-    service_provider: Arc<ServiceProvider>,
+fn integrate_for_site(
+    service_provider: &ServiceProvider,
     site_id: i32,
 ) -> Result<(), SpawnIntegrationError> {
     let ctx = service_provider.basic_context()?;
@@ -524,7 +632,9 @@ mod tests {
             .set_i32(KeyType::SettingsSyncSiteId, Some(CENTRAL_SITE_ID))
             .unwrap();
         test_site(&context.connection, None);
-        let site_info = get_token(&context.service_provider, input()).await.unwrap();
+        let site_info = get_token(context.service_provider.clone(), input())
+            .await
+            .unwrap();
         let common = Common {
             token: site_info.token,
             hardware_id: HARDWARE_ID.to_string(),
@@ -545,8 +655,8 @@ mod tests {
             .set_i32(KeyType::SettingsSyncSiteId, Some(CENTRAL_SITE_ID))
             .unwrap();
         test_site(&connection, None);
-        let service_provider = ServiceProvider::new(connection_manager);
-        let output = get_token(&service_provider, input()).await.unwrap();
+        let service_provider = Arc::new(ServiceProvider::new(connection_manager));
+        let output = get_token(service_provider.clone(), input()).await.unwrap();
 
         assert!(!output.token.is_empty());
         assert_eq!(output.site_id, 1);
@@ -560,7 +670,7 @@ mod tests {
         assert_eq!(stored.hardware_id.as_deref(), Some(HARDWARE_ID));
 
         // Using same valid credentials must not reallocate a new token or change hardware id.
-        let err = get_token(&service_provider, input()).await.unwrap_err();
+        let err = get_token(service_provider, input()).await.unwrap_err();
         assert!(matches!(err, SyncError::TokenAlreadyAllocated));
         let site = SiteRowRepository::new(&connection)
             .find_one_by_id(1)
@@ -578,12 +688,12 @@ mod tests {
         KeyValueStoreRepository::new(&connection)
             .set_i32(KeyType::SettingsSyncSiteId, Some(CENTRAL_SITE_ID))
             .unwrap();
-        let service_provider = ServiceProvider::new(connection_manager);
+        let service_provider = Arc::new(ServiceProvider::new(connection_manager));
 
         // Site not found
         let mut unknown = input();
         unknown.name = "nonexistent".to_string();
-        let err = super::get_token(&service_provider, unknown)
+        let err = super::get_token(service_provider.clone(), unknown)
             .await
             .unwrap_err();
         assert!(matches!(err, SyncError::InvalidSiteNameOrPassword));
@@ -592,12 +702,14 @@ mod tests {
         test_site(&connection, None);
         let mut bad = input();
         bad.password_sha256 = "wrong".to_string();
-        let err = super::get_token(&service_provider, bad).await.unwrap_err();
+        let err = super::get_token(service_provider.clone(), bad)
+            .await
+            .unwrap_err();
         assert!(matches!(err, SyncError::InvalidSiteNameOrPassword));
 
         // Token already set
         test_site(&connection, Some("existing_token".to_string()));
-        let err = super::get_token(&service_provider, input())
+        let err = super::get_token(service_provider, input())
             .await
             .unwrap_err();
         assert!(matches!(err, SyncError::TokenAlreadyAllocated));
@@ -615,11 +727,11 @@ mod tests {
             .set_i32(KeyType::SettingsSyncSiteId, Some(CENTRAL_SITE_ID))
             .unwrap();
         test_site(&connection, None);
-        let service_provider = ServiceProvider::new(connection_manager);
+        let service_provider = Arc::new(ServiceProvider::new(connection_manager));
 
         let mut mixed_case = input();
         mixed_case.name = SITE_NAME.to_uppercase();
-        let output = get_token(&service_provider, mixed_case).await.unwrap();
+        let output = get_token(service_provider, mixed_case).await.unwrap();
 
         assert_eq!(output.site_id, 1);
         assert!(!output.token.is_empty());
@@ -637,9 +749,9 @@ mod tests {
             .set_i32(KeyType::SettingsSyncSiteId, Some(CENTRAL_SITE_ID))
             .unwrap();
         test_site(&connection, None);
-        let sp = ServiceProvider::new(connection_manager);
+        let sp = Arc::new(ServiceProvider::new(connection_manager));
 
-        let allocated = get_token(&sp, input()).await.unwrap();
+        let allocated = get_token(sp.clone(), input()).await.unwrap();
 
         let common = Common {
             token: allocated.token.clone(),
@@ -703,7 +815,7 @@ mod tests {
         connection_manager.execute("DELETE FROM changelog").unwrap();
 
         let batch = pull(
-            &service_provider,
+            service_provider,
             common,
             pull::Input {
                 cursor: 0,
@@ -755,7 +867,7 @@ mod tests {
         ) = setup("sync_v7_version_mismatch").await;
 
         let response = pull(
-            &service_provider,
+            service_provider,
             Common {
                 version: Version::from_str("99.99.99"),
                 ..common

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -34,17 +34,13 @@ use crate::{
     },
 };
 
-/// Run synchronous work (DB queries, transactions, JSON serialization, bcrypt)
-/// on tokio's blocking pool so it doesn't starve the actix worker's async
-/// runtime. Mirrors the pattern in `sync.rs::integrate` for the integration path.
-async fn run_blocking<T, F>(f: F) -> Result<T, SyncError>
-where
-    F: FnOnce() -> Result<T, SyncError> + Send + 'static,
-    T: Send + 'static,
-{
-    tokio::task::spawn_blocking(f)
-        .await
-        .map_err(|e| SyncError::Other(format!("blocking join error: {e:?}")))?
+fn other_error(e: impl std::fmt::Display) -> SyncError {
+    SyncError::Other(e.to_string())
+}
+
+/// Map a `spawn_blocking` join failure (panic or cancellation) into `SyncError`.
+fn join_error(e: tokio::task::JoinError) -> SyncError {
+    SyncError::Other(format!("blocking join error: {e:?}"))
 }
 
 /// TODO: revisit token format
@@ -64,102 +60,78 @@ pub async fn get_token(
         });
     }
 
-    // Authenticate on the blocking pool (site lookup + bcrypt verify). Done
-    // first so a wrong-password caller never triggers a legacy server roundtrip
-    // via ensure_site_is_v7.
     let sp = service_provider.clone();
-    let (site, input) = run_blocking(move || authenticate_for_token(&sp, input)).await?;
+    let (site, input) = tokio::task::spawn_blocking(move || {
+        let ctx = sp.basic_context().map_err(other_error)?;
 
-    // Now that the caller is authenticated, gate on sync_version. If still
-    // v5/v6 locally, ask the legacy server: if it reports v7 (or
-    // v7_url_and_upgrade succeeds for a fresh remote), bump the local record
-    // and continue. Otherwise refuse with SiteIsNotV7. This may hit the network
-    // so it stays on the async runtime.
+        let site = get_site_by_name(&ctx.connection, &input.name)?
+            .ok_or(SyncError::InvalidSiteNameOrPassword)?;
+
+        // Reject before password check — a remote must not authenticate as the central site itself.
+        let central_site_id = SourceSiteId::CurrentSiteId
+            .get_id(&ctx.connection)?
+            .ok_or(SyncError::SiteIdNotSet)?;
+        if site.id == central_site_id {
+            log::warn!(
+                "Device with hardware_id: {} attempted to authenticate as the central site (name: {}, id: {}). Rejecting.",
+                input.hardware_id,
+                input.name,
+                site.id
+            );
+            return Err(SyncError::InvalidSiteNameOrPassword);
+        }
+
+        let valid = bcrypt::verify(&input.password_sha256, &site.hashed_password)
+            .map_err(other_error)?;
+        if !valid {
+            return Err(SyncError::InvalidSiteNameOrPassword);
+        }
+
+        Ok((site, input))
+    })
+    .await
+    .map_err(join_error)??;
+
     let site = ensure_site_is_v7(&service_provider, site, &input).await?;
 
-    // Sync tx phase: hardware-id assignment + token allocation, on the blocking pool.
-    run_blocking(move || allocate_token(&service_provider, site, input)).await
-}
+    tokio::task::spawn_blocking(move || {
+        let ctx = service_provider.basic_context().map_err(other_error)?;
 
-/// Blocking phase of `get_token`: look up the site, guard against a remote
-/// authenticating as the central site itself, and verify the password (bcrypt
-/// is CPU-heavy). Returns the site and the (unconsumed) input.
-fn authenticate_for_token(
-    service_provider: &ServiceProvider,
-    input: GetTokenInput,
-) -> Result<(SiteRow, GetTokenInput), SyncError> {
-    let ctx = service_provider
-        .basic_context()
-        .map_err(|e| SyncError::Other(e.to_string()))?;
-
-    let site = get_site_by_name(&ctx.connection, &input.name)?
-        .ok_or(SyncError::InvalidSiteNameOrPassword)?;
-
-    // Reject before password check — a remote must not authenticate as the central site itself.
-    let central_site_id = SourceSiteId::CurrentSiteId
-        .get_id(&ctx.connection)?
-        .ok_or(SyncError::SiteIdNotSet)?;
-    if site.id == central_site_id {
-        log::warn!(
-            "Device with hardware_id: {} attempted to authenticate as the central site (name: {}, id: {}). Rejecting.",
-            input.hardware_id,
-            input.name,
-            site.id
-        );
-        return Err(SyncError::InvalidSiteNameOrPassword);
-    }
-
-    let valid = bcrypt::verify(&input.password_sha256, &site.hashed_password)
-        .map_err(|e| SyncError::Other(e.to_string()))?;
-    if !valid {
-        return Err(SyncError::InvalidSiteNameOrPassword);
-    }
-
-    Ok((site, input))
-}
-
-/// Blocking phase of `get_token`: allocate token + hardware id in a transaction.
-fn allocate_token(
-    service_provider: &ServiceProvider,
-    site: SiteRow,
-    input: GetTokenInput,
-) -> Result<GetTokenOutput, SyncError> {
-    let ctx = service_provider
-        .basic_context()
-        .map_err(|e| SyncError::Other(e.to_string()))?;
-
-    ctx.connection
-        .transaction_sync(|connection| {
-            if site.token.is_some() {
-                return Err(SyncError::TokenAlreadyAllocated);
-            }
-
-            let hardware_id = match &site.hardware_id {
-                Some(existing) if existing != &input.hardware_id => {
-                    return Err(SyncError::HardwareIdMismatch);
+        ctx.connection
+            .transaction_sync(|connection| {
+                if site.token.is_some() {
+                    return Err(SyncError::TokenAlreadyAllocated);
                 }
-                _ => input.hardware_id.clone(),
-            };
 
-            let token = util::uuid::uuid();
+                let hardware_id = match &site.hardware_id {
+                    Some(existing) if existing != &input.hardware_id => {
+                        return Err(SyncError::HardwareIdMismatch);
+                    }
+                    _ => input.hardware_id.clone(),
+                };
 
-            SiteRowRepository::new(connection).upsert(&SiteRow {
-                hardware_id: Some(hardware_id),
-                token: Some(token.clone()),
-                ..site.clone()
-            })?;
+                let token = util::uuid::uuid();
 
-            let central_site_id = SourceSiteId::CurrentSiteId
-                .get_id(connection)?
-                .ok_or(SyncError::SiteIdNotSet)?;
+                SiteRowRepository::new(connection).upsert(&SiteRow {
+                    hardware_id: Some(hardware_id),
+                    token: Some(token.clone()),
+                    ..site.clone()
+                })?;
 
-            Ok(GetTokenOutput {
-                token,
-                site_id: site.id,
-                central_site_id,
+                let central_site_id = SourceSiteId::CurrentSiteId
+                    .get_id(connection)?
+                    .ok_or(SyncError::SiteIdNotSet)?;
+
+                Ok(GetTokenOutput {
+                    token,
+                    site_id: site.id,
+                    central_site_id,
+                })
             })
-        })
-        .map_err(|e| e.to_inner_error())
+            .map_err(|e| e.to_inner_error())
+    })
+    .await
+    .map_err(join_error)?
 }
 
 /// If the site already shows v7 locally, returns it unchanged. Otherwise asks
@@ -180,9 +152,7 @@ async fn ensure_site_is_v7(
     }
 
     let api_v5 = {
-        let ctx = service_provider
-            .basic_context()
-            .map_err(|e| SyncError::Other(e.to_string()))?;
+        let ctx = service_provider.basic_context().map_err(other_error)?;
         build_v5_api_for_request(&ctx.connection, input)?
     };
 
@@ -211,9 +181,7 @@ async fn ensure_site_is_v7(
         sync_version: SyncVersion::V7,
         ..site
     };
-    let ctx = service_provider
-        .basic_context()
-        .map_err(|e| SyncError::Other(e.to_string()))?;
+    let ctx = service_provider.basic_context().map_err(other_error)?;
     SiteRowRepository::new(&ctx.connection).upsert(&updated)?;
     Ok(updated)
 }
@@ -277,9 +245,7 @@ fn validate(
         });
     }
 
-    let ctx = service_provider
-        .basic_context()
-        .map_err(|e| SyncError::Other(e.to_string()))?;
+    let ctx = service_provider.basic_context().map_err(other_error)?;
 
     let site =
         get_site_by_token(&ctx.connection, &common.token)?.ok_or(SyncError::TokenNotFound)?;
@@ -305,19 +271,22 @@ fn validate(
 /// Report site status to a remote open-mSupply Server.
 /// Errors with `SiteLockError::IntegrationInProgress` while integration is running, so clients
 /// can poll until it clears.
-pub async fn site_status(service_provider: Arc<ServiceProvider>, common: Common) -> status::Response {
-    run_blocking(move || site_status_inner(&service_provider, common)).await
-}
-
-fn site_status_inner(service_provider: &ServiceProvider, common: Common) -> status::Response {
-    let (site, ctx) = validate(service_provider, &common)?;
-    let central_site_id = SourceSiteId::CurrentSiteId
-        .get_id(&ctx.connection)?
-        .ok_or(SyncError::SiteIdNotSet)?;
-    Ok(status::Output {
-        site_id: site.id,
-        central_site_id,
+pub async fn site_status(
+    service_provider: Arc<ServiceProvider>,
+    common: Common,
+) -> status::Response {
+    tokio::task::spawn_blocking(move || {
+        let (site, ctx) = validate(&service_provider, &common)?;
+        let central_site_id = SourceSiteId::CurrentSiteId
+            .get_id(&ctx.connection)?
+            .ok_or(SyncError::SiteIdNotSet)?;
+        Ok(status::Output {
+            site_id: site.id,
+            central_site_id,
+        })
     })
+    .await
+    .map_err(join_error)?
 }
 
 /// Send Records to a remote open-mSupply Server
@@ -326,30 +295,26 @@ pub async fn pull(
     common: Common,
     input: pull::Input,
 ) -> pull::Response {
-    run_blocking(move || pull_inner(&service_provider, common, input)).await
-}
+    tokio::task::spawn_blocking(move || {
+        let (site, ctx) = validate(&service_provider, &common)?;
 
-fn pull_inner(
-    service_provider: &ServiceProvider,
-    common: Common,
-    input: pull::Input,
-) -> pull::Response {
-    let (site, ctx) = validate(service_provider, &common)?;
+        let base = ChangelogFilter::all_data_for_site(site.id, input.is_initialising, None);
+        let filter = match input.filter {
+            Some(extra) => ChangelogCondition::And(vec![base, extra]),
+            None => base,
+        };
 
-    let base = ChangelogFilter::all_data_for_site(site.id, input.is_initialising, None);
-    let filter = match input.filter {
-        Some(extra) => ChangelogCondition::And(vec![base, extra]),
-        None => base,
-    };
+        let batch = SyncBatchV7::generate(
+            &ctx.connection,
+            filter,
+            input.cursor,
+            Some(input.batch_size),
+        )?;
 
-    let batch = SyncBatchV7::generate(
-        &ctx.connection,
-        filter,
-        input.cursor,
-        Some(input.batch_size),
-    )?;
-
-    Ok(batch)
+        Ok(batch)
+    })
+    .await
+    .map_err(join_error)?
 }
 
 pub async fn patient_search(
@@ -357,26 +322,22 @@ pub async fn patient_search(
     common: Common,
     input: patient_search::Input,
 ) -> patient_search::Response {
-    run_blocking(move || patient_search_inner(&service_provider, common, input)).await
-}
+    tokio::task::spawn_blocking(move || {
+        let (_, ctx) = validate(&service_provider, &common)?;
 
-fn patient_search_inner(
-    service_provider: &ServiceProvider,
-    common: Common,
-    input: patient_search::Input,
-) -> patient_search::Response {
-    let (_, ctx) = validate(service_provider, &common)?;
+        let results =
+            service_provider
+                .patient_service
+                .get_patients(&ctx, None, Some(input), None, None)?;
 
-    let results =
-        service_provider
-            .patient_service
-            .get_patients(&ctx, None, Some(input), None, None)?;
-
-    Ok(results
-        .rows
-        .into_iter()
-        .map(name_row_to_patient_v4)
-        .collect())
+        Ok(results
+            .rows
+            .into_iter()
+            .map(name_row_to_patient_v4)
+            .collect())
+    })
+    .await
+    .map_err(join_error)?
 }
 
 fn name_row_to_patient_v4(name: repository::NameRow) -> PatientV4 {
@@ -398,40 +359,41 @@ pub async fn patient_data_for_site(
     common: Common,
     input: patient_data_for_site::Input,
 ) -> patient_data_for_site::Response {
-    run_blocking(move || patient_data_for_site_inner(&service_provider, common, input)).await
-}
+    tokio::task::spawn_blocking(move || {
+        let (site, ctx) = validate(&service_provider, &common)?;
 
-fn patient_data_for_site_inner(
-    service_provider: &ServiceProvider,
-    common: Common,
-    input: patient_data_for_site::Input,
-) -> patient_data_for_site::Response {
-    let (site, ctx) = validate(service_provider, &common)?;
+        let patient_data_for_site::Input {
+            patient_id,
+            store_id,
+            name_store_join_id,
+        } = input;
 
-    let patient_data_for_site::Input {
-        patient_id,
-        store_id,
-        name_store_join_id,
-    } = input;
+        let nsj_id = ctx
+            .connection
+            .transaction_sync(|con| {
+                create_patient_name_store_join(
+                    con,
+                    &store_id,
+                    &patient_id,
+                    Some(name_store_join_id),
+                )
+            })
+            .map_err(|e| e.to_inner_error())?;
 
-    let nsj_id = ctx
-        .connection
-        .transaction_sync(|con| {
-            create_patient_name_store_join(con, &store_id, &patient_id, Some(name_store_join_id))
+        let filter = ChangelogCondition::And(vec![
+            ChangelogFilter::patient_data_for_site(site.id, None),
+            ChangelogCondition::patient_id::equal(patient_id),
+        ]);
+
+        let batch = SyncBatchV7::generate(&ctx.connection, filter, 0, None)?;
+
+        Ok(patient_data_for_site::Output {
+            batch,
+            name_store_join_id: nsj_id,
         })
-        .map_err(|e| e.to_inner_error())?;
-
-    let filter = ChangelogCondition::And(vec![
-        ChangelogFilter::patient_data_for_site(site.id, None),
-        ChangelogCondition::patient_id::equal(patient_id),
-    ]);
-
-    let batch = SyncBatchV7::generate(&ctx.connection, filter, 0, None)?;
-
-    Ok(patient_data_for_site::Output {
-        batch,
-        name_store_join_id: nsj_id,
     })
+    .await
+    .map_err(join_error)?
 }
 
 /// Receive Records from a remote open-mSupply Server
@@ -440,58 +402,54 @@ pub async fn push(
     common: Common,
     input: push::Input,
 ) -> push::Response {
+    // Blocking phase: validate, then buffer the batch's records into the sync
+    // buffer in a single transaction. Returns the batch size, the remaining
+    // count, and the site id so we can decide whether to kick off integration.
     let sp = service_provider.clone();
-    let (records_in_this_batch, remaining, site_id) =
-        run_blocking(move || buffer_push_records(&sp, common, input)).await?;
+    let (records_in_this_batch, remaining, site_id) = tokio::task::spawn_blocking(move || {
+        let (site, ctx) = validate(&sp, &common)?;
+        let site_id = site.id;
+
+        let SyncBatchV7 {
+            site_id: from_site_id,
+            records,
+            remaining,
+            ..
+        } = input;
+
+        if from_site_id != site_id {
+            return Err(SyncError::SiteIdMismatch {
+                expected: site_id,
+                found: from_site_id,
+            });
+        }
+
+        let records_in_this_batch = records.len() as i64;
+
+        // The remote site's app_version arrives in the request header (Common::version).
+        let app_version = Some(common.version.clone());
+
+        let sync_buffer_rows = records
+            .into_iter()
+            .map(|record| sync_record_to_buffer_row(record, site_id, app_version.clone(), None))
+            .collect::<Vec<_>>();
+
+        ctx.connection
+            .transaction_sync(|t_con| {
+                SyncBufferRepository::new(t_con).insert_many(&sync_buffer_rows)
+            })
+            .map_err(|e| e.to_inner_error())?;
+
+        Ok((records_in_this_batch, remaining, site_id))
+    })
+    .await
+    .map_err(join_error)??;
 
     if remaining == 0 {
         spawn_integration(service_provider, site_id);
     }
 
     Ok(records_in_this_batch)
-}
-
-/// Blocking phase of `push`: validate, then buffer the batch's records into the
-/// sync buffer in a single transaction. Returns
-/// `(records_in_this_batch, remaining, site_id)` so the caller can decide
-/// whether to kick off integration.
-fn buffer_push_records(
-    service_provider: &ServiceProvider,
-    common: Common,
-    input: push::Input,
-) -> Result<(i64, u64, i32), SyncError> {
-    let (site, ctx) = validate(service_provider, &common)?;
-    let site_id = site.id;
-
-    let SyncBatchV7 {
-        site_id: from_site_id,
-        records,
-        remaining,
-        ..
-    } = input;
-
-    if from_site_id != site_id {
-        return Err(SyncError::SiteIdMismatch {
-            expected: site_id,
-            found: from_site_id,
-        });
-    }
-
-    let records_in_this_batch = records.len() as i64;
-
-    // The remote site's app_version arrives in the request header (Common::version).
-    let app_version = Some(common.version.clone());
-
-    let sync_buffer_rows = records
-        .into_iter()
-        .map(|record| sync_record_to_buffer_row(record, site_id, app_version.clone(), None))
-        .collect::<Vec<_>>();
-
-    ctx.connection
-        .transaction_sync(|t_con| SyncBufferRepository::new(t_con).insert_many(&sync_buffer_rows))
-        .map_err(|e| e.to_inner_error())?;
-
-    Ok((records_in_this_batch, remaining, site_id))
 }
 
 fn spawn_integration(service_provider: Arc<ServiceProvider>, site_id: i32) {

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -34,13 +34,9 @@ use crate::{
     },
 };
 
-fn other_error(e: impl std::fmt::Display) -> SyncError {
-    SyncError::Other(e.to_string())
-}
-
 /// Map a `spawn_blocking` join failure (panic or cancellation) into `SyncError`.
 fn join_error(e: tokio::task::JoinError) -> SyncError {
-    SyncError::Other(format!("blocking join error: {e:?}"))
+    SyncError::Other(format!("blocking join error: {0}", format_error(&e)))
 }
 
 /// TODO: revisit token format
@@ -62,7 +58,7 @@ pub async fn get_token(
 
     let sp = service_provider.clone();
     let (site, input) = tokio::task::spawn_blocking(move || {
-        let ctx = sp.basic_context().map_err(other_error)?;
+        let ctx = sp.basic_context()?;
 
         let site = get_site_by_name(&ctx.connection, &input.name)?
             .ok_or(SyncError::InvalidSiteNameOrPassword)?;
@@ -82,7 +78,7 @@ pub async fn get_token(
         }
 
         let valid = bcrypt::verify(&input.password_sha256, &site.hashed_password)
-            .map_err(other_error)?;
+            .map_err(SyncError::other)?;
         if !valid {
             return Err(SyncError::InvalidSiteNameOrPassword);
         }
@@ -95,7 +91,7 @@ pub async fn get_token(
     let site = ensure_site_is_v7(&service_provider, site, &input).await?;
 
     tokio::task::spawn_blocking(move || {
-        let ctx = service_provider.basic_context().map_err(other_error)?;
+        let ctx = service_provider.basic_context()?;
 
         ctx.connection
             .transaction_sync(|connection| {
@@ -151,10 +147,8 @@ async fn ensure_site_is_v7(
         return Ok(site);
     }
 
-    let api_v5 = {
-        let ctx = service_provider.basic_context().map_err(other_error)?;
-        build_v5_api_for_request(&ctx.connection, input)?
-    };
+    let ctx = service_provider.basic_context()?;
+    let api_v5 = build_v5_api_for_request(&ctx.connection, input)?;
 
     let info = api_v5.get_site_info().await.map_err(|error| {
         if error.is_connection() {
@@ -163,7 +157,7 @@ async fn ensure_site_is_v7(
                 e: format_error(&error),
             }
         } else {
-            SyncError::Other(format_error(&error))
+            SyncError::other(error)
         }
     })?;
 
@@ -174,14 +168,13 @@ async fn ensure_site_is_v7(
         api_v5
             .v7_url_and_upgrade()
             .await
-            .map_err(|error| SyncError::Other(format_error(&error)))?;
+            .map_err(SyncError::other)?;
     };
 
     let updated = SiteRow {
         sync_version: SyncVersion::V7,
         ..site
     };
-    let ctx = service_provider.basic_context().map_err(other_error)?;
     SiteRowRepository::new(&ctx.connection).upsert(&updated)?;
     Ok(updated)
 }
@@ -245,7 +238,7 @@ fn validate(
         });
     }
 
-    let ctx = service_provider.basic_context().map_err(other_error)?;
+    let ctx = service_provider.basic_context().map_err(SyncError::other)?;
 
     let site =
         get_site_by_token(&ctx.connection, &common.token)?.ok_or(SyncError::TokenNotFound)?;

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -268,9 +268,7 @@ fn validate(
 
     Ok((site, ctx))
 }
-/// Report site status to a remote open-mSupply Server.
-/// Errors with `SiteLockError::IntegrationInProgress` while integration is running, so clients
-/// can poll until it clears.
+
 pub async fn site_status(
     service_provider: Arc<ServiceProvider>,
     common: Common,
@@ -402,9 +400,6 @@ pub async fn push(
     common: Common,
     input: push::Input,
 ) -> push::Response {
-    // Blocking phase: validate, then buffer the batch's records into the sync
-    // buffer in a single transaction. Returns the batch size, the remaining
-    // count, and the site id so we can decide whether to kick off integration.
     let sp = service_provider.clone();
     let (records_in_this_batch, remaining, site_id) = tokio::task::spawn_blocking(move || {
         let (site, ctx) = validate(&sp, &common)?;
@@ -458,8 +453,6 @@ fn spawn_integration(service_provider: Arc<ServiceProvider>, site_id: i32) {
         return;
     }
 
-    // Integration is substantial blocking DB work, so run the whole thing on the
-    // blocking pool rather than bouncing through an async task just to await it.
     tokio::task::spawn_blocking(move || {
         set_site_lock(site_id, Some(SiteLockError::IntegrationInProgress));
         // Release the lock on every exit path, including a panic in integration —


### PR DESCRIPTION
Fixes #11877 

## Summary

The sync v7 central handlers were `async fn`s doing synchronous DB queries, transactions, JSON serialization and bcrypt verification directly on the actix worker's async runtime — where heavy work starves other tasks and a pool checkout can block for up to the connection timeout.

This wraps the synchronous core of each handler in `tokio::task::spawn_blocking` (via a small `run_blocking` helper), mirroring the existing `sync.rs::integrate` pattern. Handlers now take `Arc<ServiceProvider>` and the HTTP layer passes `service_provider.into_inner()`. `basic_context()` moves inside the blocking closure so connection acquisition is also off the async thread.

- **pull / site_status / patient_search / patient_data_for_site** — straight wrap of the body.
- **push** — buffer the batch in the blocking closure; the `remaining == 0` → integration decision happens afterwards on the async side.
- **get_token** — split into blocking auth (incl. bcrypt) + async `ensure_site_is_v7` (legacy-server network call) + blocking token allocation. `ensure_site_is_v7` now acquires a connection per DB touch instead of holding a pool slot across the network roundtrip.
- **spawn_integration** — collapsed the `tokio::spawn` → `spawn_blocking` nesting into a single `spawn_blocking`, releasing the site lock via a panic-safe drop guard.

## Test plan
- `cargo nextest run -p service sync_v7` — 13 passed
- `cargo nextest run -p server sync_v7` — 5 passed (HTTP-layer tests exercise `spawn_blocking` under actix's runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)