### PR TITLE
11906 - Request sync token if central has cleared it

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2020,7 +2020,7 @@
   "messages.confirm-change-location": "This will change the location of all selected lines",
   "messages.confirm-changing-from-new": "Note: changing from 'New' will remove any lines with zero quantity.",
   "messages.confirm-clear-hardware-id": "Clearing the hardware id will allow a new device to register itself as this site. Only proceed if you intend to move the site to another device",
-  "messages.confirm-clear-sync-token": "Clearing the token will block sync for this site until the device has the user name and password reentered.",
+  "messages.confirm-clear-sync-token": "Clearing the token will block sync for this site until the device has the site password re-entered.",
   "messages.confirm-close-purchase-order-lines_few": "This will permanently close {{count}} lines from this purchase order. Once closed you cannot receive any more stock against these lines.",
   "messages.confirm-close-purchase-order-lines_many": "This will permanently close {{count}} lines from this purchase order. Once closed you cannot receive any more stock against these lines.",
   "messages.confirm-close-purchase-order-lines_one": "This will permanently close 1 line from this purchase order. Once closed you cannot receive any more stock against this line.",

--- a/server/graphql/general/src/mutations/sync_settings.rs
+++ b/server/graphql/general/src/mutations/sync_settings.rs
@@ -4,7 +4,10 @@ use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
-use service::auth::{Resource, ResourceAccessRequest};
+use service::{
+    auth::{Resource, ResourceAccessRequest},
+    sync_v7::sync::is_central_token_cleared,
+};
 
 use crate::{
     queries::sync_settings::SyncSettingsNode,
@@ -44,7 +47,9 @@ pub async fn update_sync_settings(
 
     let sync_settings = input.to_domain();
 
-    if sync_settings.core_site_details_changed(&database_sync_settings) {
+    if sync_settings.core_site_details_changed(&database_sync_settings)
+        || is_central_token_cleared(service_provider, &sync_settings).await
+    {
         if let Err(error) = service_provider
             .site_auth_service
             .request_and_set_site_auth(service_provider, &sync_settings)

--- a/server/service/src/sync_v7/sync.rs
+++ b/server/service/src/sync_v7/sync.rs
@@ -229,6 +229,22 @@ async fn load_or_request_auth<'a>(
     })
 }
 
+// True when central has cleared this site's token
+pub async fn is_central_token_cleared(
+    service_provider: &ServiceProvider,
+    settings: &SyncSettings,
+) -> bool {
+    let api = match SyncApiV7::new(service_provider, &settings.url) {
+        Ok(api) => api,
+        Err(_) => return false,
+    };
+
+    match api.site_status(()).await {
+        Err(SyncError::TokenNotFound) => true,
+        _ => false,
+    }
+}
+
 /// Probe the central server's site_status and persist its site id so other
 /// code paths (notably v5/v6 fallbacks) can read it from KV without an
 /// extra round-trip.


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11906

# 👩🏻‍💻 What does this PR do?

Re-entering the site password successfully on a remote site (Settings -> Synchronisation)  gets a refreshed token from central, when central has cleared this site's token. This only refreshes the token if it does not already exist on central

Updated messaging when clearing the token:

<img width="624" height="217" alt="Screenshot 2026-06-03 at 5 24 44 PM" src="https://github.com/user-attachments/assets/30ad21b2-7f70-42b6-a85e-b43a47bd65e5" />

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

Set up a v3.0.0 central and remote site

To verify the token isn't refreshed every save, check the local KV value before/after:
```
SELECT * FROM key_value_store WHERE id = 'SETTINGS_SYNC_V7_TOKEN';
```

- [ ] Clear a remote site's token on central
- [ ] On the remote site, attempt to sync -> see `Token not found` error
- [ ] Enter remote sync settings password (no changes to settings) → token value changes, sync now works (no error)
- [ ] Save settings again (without clearing token) → token value stays the same.

Existing behaviour verification:
Change password to wrong value → save fails, no new token
Change remote site name -> sync central -> update remote site sync settings -> save -> token is regenerated

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

