### PR TITLE
#11920 sync v7: changelog partition DDL contention fixes

### DIFF
--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -68,7 +68,7 @@
 #   example_feature: true
 # changelog_partition: # postgres-only; controls partitioning of the changelog table
 #   partition_size: 5000000      # cursor values per partition
-#   lookahead_partitions: 2      # empty future partitions kept ahead of max(cursor)
+#   lookahead: 30000000          # number of insertable records headroom for changelog; also the lower bound — yaml values below this are clamped up
 #   interval:                    # poll period for the runtime top-up task
 #     hours: 0
 #     mins: 1

--- a/server/repository/src/db_diesel/changelog/partition.rs
+++ b/server/repository/src/db_diesel/changelog/partition.rs
@@ -5,7 +5,7 @@ use crate::{
 use diesel::{prelude::*, sql_types::Text};
 
 /// Ensure enough future cursor-range partitions exist on `changelog` to keep
-/// `lookahead_partitions * partition_size` rows of headroom above `max(cursor)`.
+/// `config.lookahead` cursor records of empty headroom above `max(cursor)`.
 ///
 /// Postgres-only behaviour. Under SQLite the function returns immediately —
 /// SQLite has no partitions to top up.
@@ -29,8 +29,7 @@ pub fn ensure_partition_lookahead(
     let current_max = max_sequence(connection)?;
 
     let size = config.partition_size;
-    let lookahead = config.lookahead_partitions;
-    let target_headroom = lookahead * size;
+    let target_headroom = config.lookahead;
 
     let mut created = 0;
     let mut next_lower = max_upper;
@@ -152,7 +151,7 @@ mod tests {
     }
 
     /// 4 pre-seeded rows (cursors 1..=4) on a starting layout of two
-    /// partitions [1,3), [3,5). With size=2, lookahead=2:
+    /// partitions [1,3), [3,5). With size=2, lookahead=4:
     /// target_headroom = 4, actual = max_upper(5) - max_cursor(4) = 1, so
     /// ensure_partition_lookahead must create 2 new partitions (p_5, p_7) to
     /// restore headroom.
@@ -182,7 +181,7 @@ mod tests {
 
         let config = ChangelogPartitionConfig {
             partition_size: 2,
-            lookahead_partitions: 2,
+            lookahead: 4,
         };
         let created = ensure_partition_lookahead(&connection, &config).unwrap();
 
@@ -191,7 +190,7 @@ mod tests {
         assert_eq!(count_partitions(&connection), 4);
     }
 
-    /// Same tight starting layout but no rows. With size=2, lookahead=2:
+    /// Same tight starting layout but no rows. With size=2, lookahead=4:
     /// target_headroom = 4, actual = max_upper(5) - max_cursor(0) = 5, so
     /// ensure_partition_lookahead is a no-op and creates nothing.
     #[actix_rt::test]
@@ -206,7 +205,7 @@ mod tests {
 
         let config = ChangelogPartitionConfig {
             partition_size: 2,
-            lookahead_partitions: 2,
+            lookahead: 4,
         };
         let created = ensure_partition_lookahead(&connection, &config).unwrap();
 
@@ -215,9 +214,10 @@ mod tests {
     }
 
     /// Records exist but the partition layout already has enough headroom on
-    /// top. With cursors 1..=2 and partitions [1,3), [3,5), [5,7), [7,9):
-    /// target_headroom = 4, actual = max_upper(9) - max_cursor(2) = 7, so
-    /// ensure_partition_lookahead is a no-op even though the table is non-empty.
+    /// top. With cursors 1..=2 and partitions [1,3), [3,5), [5,7), [7,9), and
+    /// lookahead=4: target_headroom = 4, actual = max_upper(9) -
+    /// max_cursor(2) = 7, so ensure_partition_lookahead is a no-op even
+    /// though the table is non-empty.
     #[actix_rt::test]
     async fn test_ensure_partition_lookahead_noop_when_records_have_enough_headroom() {
         let (_, connection, _, _) = test_db::setup_all(
@@ -250,7 +250,7 @@ mod tests {
 
         let config = ChangelogPartitionConfig {
             partition_size: 2,
-            lookahead_partitions: 2,
+            lookahead: 4,
         };
         let created = ensure_partition_lookahead(&connection, &config).unwrap();
 

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -65,10 +65,14 @@ use diesel::connection::SimpleConnection;
 use thiserror::Error;
 
 /// Default partition size used by both the migration and the yaml-bound
-/// `ChangelogPartitionSettings` in `service::settings`.
+/// `ChangelogPartitionSettings` in `service::settings`. Also acts as minimum size
 pub const DEFAULT_CHANGELOG_PARTITION_SIZE: i64 = 5_000_000;
-/// Default empty-future-partition headroom kept above max(cursor).
-pub const DEFAULT_CHANGELOG_LOOKAHEAD_PARTITIONS: i64 = 2;
+
+/// Default empty-cursor headroom kept above max(cursor), in cursor records.
+/// Also acts as the lower-bound clamp — yaml values below this are clamped up.
+/// Internally the migration / runtime top-up convert to a partition count via
+/// `ceil(lookahead / partition_size)`.
+pub const DEFAULT_CHANGELOG_LOOKAHEAD: i64 = 30_000_000;
 
 /// Migration-internal partition config — primitive values only, no serde. The
 /// yaml-bound counterpart (`ChangelogPartitionSettings`) lives in `service::settings`
@@ -77,14 +81,15 @@ pub const DEFAULT_CHANGELOG_LOOKAHEAD_PARTITIONS: i64 = 2;
 #[derive(Clone, Debug)]
 pub struct ChangelogPartitionConfig {
     pub partition_size: i64,
-    pub lookahead_partitions: i64,
+    /// Cursor records of empty headroom to keep above max(cursor).
+    pub lookahead: i64,
 }
 
 impl Default for ChangelogPartitionConfig {
     fn default() -> Self {
         Self {
             partition_size: DEFAULT_CHANGELOG_PARTITION_SIZE,
-            lookahead_partitions: DEFAULT_CHANGELOG_LOOKAHEAD_PARTITIONS,
+            lookahead: DEFAULT_CHANGELOG_LOOKAHEAD,
         }
     }
 }
@@ -319,7 +324,9 @@ pub fn migrate(
                 );
 
                 connection
-                    .transaction_sync(|connection| fragment.migrate_with_config(connection, &config))
+                    .transaction_sync(|connection| {
+                        fragment.migrate_with_config(connection, &config)
+                    })
                     .map_err(|source| MigrationError::FragmentMigrationError {
                         source: source.to_inner_error(),
                         version: migration_version.clone(),

--- a/server/repository/src/migrations/mod.rs
+++ b/server/repository/src/migrations/mod.rs
@@ -70,8 +70,9 @@ pub const DEFAULT_CHANGELOG_PARTITION_SIZE: i64 = 5_000_000;
 
 /// Default empty-cursor headroom kept above max(cursor), in cursor records.
 /// Also acts as the lower-bound clamp — yaml values below this are clamped up.
-/// Internally the migration / runtime top-up convert to a partition count via
-/// `ceil(lookahead / partition_size)`.
+/// The migration derives the partition count via
+/// `(max_cursor + lookahead) / partition_size + 1`; the runtime top-up tops up
+/// partitions iteratively until the same headroom is satisfied.
 pub const DEFAULT_CHANGELOG_LOOKAHEAD: i64 = 30_000_000;
 
 /// Migration-internal partition config — primitive values only, no serde. The

--- a/server/repository/src/migrations/v3_00_00/partition_changelog_by_cursor.rs
+++ b/server/repository/src/migrations/v3_00_00/partition_changelog_by_cursor.rs
@@ -24,10 +24,7 @@ impl MigrationFragment for Migrate {
 
         let max_cursor = max_sequence(connection)?;
         let partition_size = config.changelog_partition.partition_size;
-        // `lookahead` is in cursor records; the migration needs a partition count,
-        // so ceil-divide by partition_size.
         let lookahead = config.changelog_partition.lookahead;
-        let lookahead_partition_count = (lookahead + partition_size - 1) / partition_size;
 
         // 1. Rename the existing changelog out of the way so the new partitioned
         //    table can reuse the `changelog` name.
@@ -71,11 +68,11 @@ impl MigrationFragment for Migrate {
             "#
         )?;
 
-        // 5. Pre-create N partitions covering [1, N * partition_size + 1). N =
-        //    (max_cursor / partition_size) + 1 + lookahead_partition_count, ensuring
-        //    the partition that contains max_cursor itself exists plus the lookahead
-        //    empty future partitions on top.
-        let partition_count = max_cursor / partition_size + 1 + lookahead_partition_count;
+        // 5. Pre-create N partitions covering [1, N * partition_size + 1) so
+        //    the topmost partition contains `max_cursor + lookahead`. N is the
+        //    index of the partition holding that target, plus one. Guarantees
+        //    `max_upper - max_cursor >= lookahead`.
+        let partition_count = (max_cursor + lookahead) / partition_size + 1;
         create_future_partitions(connection, 1, partition_size, partition_count)?;
 
         // 6. Copy every row, preserving cursors. PG routes each row to the
@@ -143,8 +140,8 @@ mod tests {
     /// Partition migration on a populated changelog: rows copied across with
     /// cursors preserved, old_changelog dropped, exactly the expected number of
     /// partitions created. Uses small partition_size + lookahead so the math is
-    /// easy to eyeball: cursors 1..=4, partition_size=2, lookahead=2 →
-    /// 4/2+1+2 = 5 partitions.
+    /// easy to eyeball: cursors 1..=4, partition_size=2, lookahead=4 →
+    /// (4+4)/2 + 1 = 5 partitions.
     #[actix_rt::test]
     async fn test_partition_changelog_with_existing_data() {
         let connection = setup_pre_partition("migration_partition_changelog_existing").await;
@@ -194,17 +191,16 @@ mod tests {
         .value;
         assert_eq!(preserved_cursors, 4);
 
-        // Exact partition count: 4/2 + 1 + ceil(4/2) = 5.
+        // Exact partition count: (4 + 4) / 2 + 1 = 5.
         let max_cursor: i64 = 4;
-        let expected_partitions =
-            max_cursor / partition_size + 1 + (lookahead + partition_size - 1) / partition_size;
+        let expected_partitions = (max_cursor + lookahead) / partition_size + 1;
         assert_eq!(count_partitions(&connection), expected_partitions);
 
         assert_insert_routes_to_partition(&connection, "u_new");
     }
 
     /// Partition migration on an empty changelog. The partition count formula
-    /// collapses to `1 + ceil(lookahead/partition_size)`. New inserts after
+    /// collapses to `lookahead / partition_size + 1`. New inserts after
     /// migration must still route to a partition without error and start at
     /// cursor 1.
     #[actix_rt::test]
@@ -219,10 +215,10 @@ mod tests {
         // Still empty after migration — nothing to copy.
         assert_eq!(changelog_count(&connection), 0);
 
-        // Exact partition count: 0/partition_size + 1 + ceil(lookahead/partition_size).
+        // Exact partition count: (0 + lookahead) / partition_size + 1.
         let partition_size = config.changelog_partition.partition_size;
         let lookahead = config.changelog_partition.lookahead;
-        let expected_partitions = 1 + (lookahead + partition_size - 1) / partition_size;
+        let expected_partitions = lookahead / partition_size + 1;
         assert_eq!(count_partitions(&connection), expected_partitions);
 
         assert_insert_routes_to_partition(&connection, "first_row");

--- a/server/repository/src/migrations/v3_00_00/partition_changelog_by_cursor.rs
+++ b/server/repository/src/migrations/v3_00_00/partition_changelog_by_cursor.rs
@@ -24,7 +24,10 @@ impl MigrationFragment for Migrate {
 
         let max_cursor = max_sequence(connection)?;
         let partition_size = config.changelog_partition.partition_size;
-        let lookahead = config.changelog_partition.lookahead_partitions;
+        // `lookahead` is in cursor records; the migration needs a partition count,
+        // so ceil-divide by partition_size.
+        let lookahead = config.changelog_partition.lookahead;
+        let lookahead_partition_count = (lookahead + partition_size - 1) / partition_size;
 
         // 1. Rename the existing changelog out of the way so the new partitioned
         //    table can reuse the `changelog` name.
@@ -69,10 +72,10 @@ impl MigrationFragment for Migrate {
         )?;
 
         // 5. Pre-create N partitions covering [1, N * partition_size + 1). N =
-        //    (max_cursor / partition_size) + 1 + lookahead, ensuring the partition
-        //    that contains max_cursor itself exists plus `lookahead` empty future
-        //    partitions on top.
-        let partition_count = max_cursor / partition_size + 1 + lookahead;
+        //    (max_cursor / partition_size) + 1 + lookahead_partition_count, ensuring
+        //    the partition that contains max_cursor itself exists plus the lookahead
+        //    empty future partitions on top.
+        let partition_count = max_cursor / partition_size + 1 + lookahead_partition_count;
         create_future_partitions(connection, 1, partition_size, partition_count)?;
 
         // 6. Copy every row, preserving cursors. PG routes each row to the
@@ -169,11 +172,11 @@ mod tests {
             .unwrap();
 
         let partition_size: i64 = 2;
-        let lookahead: i64 = 2;
+        let lookahead: i64 = 4;
         let config = MigrationConfig {
             changelog_partition: ChangelogPartitionConfig {
                 partition_size,
-                lookahead_partitions: lookahead,
+                lookahead,
             },
         };
 
@@ -191,17 +194,19 @@ mod tests {
         .value;
         assert_eq!(preserved_cursors, 4);
 
-        // Exact partition count: 4/2 + 1 + 2 = 5.
+        // Exact partition count: 4/2 + 1 + ceil(4/2) = 5.
         let max_cursor: i64 = 4;
-        let expected_partitions = max_cursor / partition_size + 1 + lookahead;
+        let expected_partitions =
+            max_cursor / partition_size + 1 + (lookahead + partition_size - 1) / partition_size;
         assert_eq!(count_partitions(&connection), expected_partitions);
 
         assert_insert_routes_to_partition(&connection, "u_new");
     }
 
     /// Partition migration on an empty changelog. The partition count formula
-    /// collapses to `1 + lookahead`. New inserts after migration must still
-    /// route to a partition without error and start at cursor 1.
+    /// collapses to `1 + ceil(lookahead/partition_size)`. New inserts after
+    /// migration must still route to a partition without error and start at
+    /// cursor 1.
     #[actix_rt::test]
     async fn test_partition_changelog_empty() {
         let connection = setup_pre_partition("migration_partition_changelog_empty").await;
@@ -214,8 +219,10 @@ mod tests {
         // Still empty after migration — nothing to copy.
         assert_eq!(changelog_count(&connection), 0);
 
-        // Exact partition count: 0/partition_size + 1 + lookahead = 1 + lookahead.
-        let expected_partitions = 1 + config.changelog_partition.lookahead_partitions;
+        // Exact partition count: 0/partition_size + 1 + ceil(lookahead/partition_size).
+        let partition_size = config.changelog_partition.partition_size;
+        let lookahead = config.changelog_partition.lookahead;
+        let expected_partitions = 1 + (lookahead + partition_size - 1) / partition_size;
         assert_eq!(count_partitions(&connection), expected_partitions);
 
         assert_insert_routes_to_partition(&connection, "first_row");

--- a/server/server/src/changelog_partitions.rs
+++ b/server/server/src/changelog_partitions.rs
@@ -12,9 +12,10 @@ pub fn spawn(
         loop {
             interval.tick().await;
             let Ok(ctx) = service_provider.basic_context() else {
-                log::error!("changelog partition task: failed to get context: {e:?}");
+                log::error!("changelog partition task: failed to get context");
                 continue;
             };
+
             // `ensure_partition_lookahead` is a no-op under SQLite (no partitions
             // to top up); under Postgres it adds partitions when headroom is low.
             // Diesel calls are blocking, so run on a blocking worker to avoid

--- a/server/server/src/changelog_partitions.rs
+++ b/server/server/src/changelog_partitions.rs
@@ -18,7 +18,6 @@ pub fn spawn(
                 // stalling the async runtime.
                 Ok(ctx) => {
                     let partition_config = partition_config.clone();
-                    
                     let result = tokio::task::spawn_blocking(move || {
                         repository::ensure_partition_lookahead(&ctx.connection, &partition_config)
                     })
@@ -26,7 +25,9 @@ pub fn spawn(
 
                     match result {
                         Ok(Ok(i)) => {
-                            log::info!("changelog partition task created {i} new partition(s)")
+                            if i > 0 {
+                                log::info!("changelog partition task created {i} new partition(s)")
+                            }
                         }
                         Ok(Err(e)) => log::error!("changelog partition task: {e:?}"),
                         Err(e) => log::error!("changelog partition task: join error: {e:?}"),

--- a/server/server/src/changelog_partitions.rs
+++ b/server/server/src/changelog_partitions.rs
@@ -14,14 +14,25 @@ pub fn spawn(
             match service_provider.basic_context() {
                 // `ensure_partition_lookahead` is a no-op under SQLite (no partitions
                 // to top up); under Postgres it adds partitions when headroom is low.
+                // Diesel calls are blocking, so run on a blocking worker to avoid
+                // stalling the async runtime.
                 Ok(ctx) => {
-                    if let Err(e) =
+                    let partition_config = partition_config.clone();
+                    
+                    let result = tokio::task::spawn_blocking(move || {
                         repository::ensure_partition_lookahead(&ctx.connection, &partition_config)
-                    {
-                        log::error!("changelog partition top-up: {e:?}");
+                    })
+                    .await;
+
+                    match result {
+                        Ok(Ok(i)) => {
+                            log::info!("changelog partition task created {i} new partition(s)")
+                        }
+                        Ok(Err(e)) => log::error!("changelog partition task: {e:?}"),
+                        Err(e) => log::error!("changelog partition task: join error: {e:?}"),
                     }
                 }
-                Err(e) => log::error!("changelog partition top-up: failed to get context: {e:?}"),
+                Err(e) => log::error!("changelog partition task: failed to get context: {e:?}"),
             }
         }
     })

--- a/server/server/src/changelog_partitions.rs
+++ b/server/server/src/changelog_partitions.rs
@@ -11,29 +11,29 @@ pub fn spawn(
         let partition_config = settings.to_migration_config();
         loop {
             interval.tick().await;
-            match service_provider.basic_context() {
-                // `ensure_partition_lookahead` is a no-op under SQLite (no partitions
-                // to top up); under Postgres it adds partitions when headroom is low.
-                // Diesel calls are blocking, so run on a blocking worker to avoid
-                // stalling the async runtime.
-                Ok(ctx) => {
-                    let partition_config = partition_config.clone();
-                    let result = tokio::task::spawn_blocking(move || {
-                        repository::ensure_partition_lookahead(&ctx.connection, &partition_config)
-                    })
-                    .await;
+            let Ok(ctx) = service_provider.basic_context() else {
+                log::error!("changelog partition task: failed to get context: {e:?}");
+                continue;
+            };
+            // `ensure_partition_lookahead` is a no-op under SQLite (no partitions
+            // to top up); under Postgres it adds partitions when headroom is low.
+            // Diesel calls are blocking, so run on a blocking worker to avoid
+            // stalling the async runtime.
 
-                    match result {
-                        Ok(Ok(i)) => {
-                            if i > 0 {
-                                log::info!("changelog partition task created {i} new partition(s)")
-                            }
-                        }
-                        Ok(Err(e)) => log::error!("changelog partition task: {e:?}"),
-                        Err(e) => log::error!("changelog partition task: join error: {e:?}"),
+            let partition_config = partition_config.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                repository::ensure_partition_lookahead(&ctx.connection, &partition_config)
+            })
+            .await;
+
+            match result {
+                Ok(Ok(i)) => {
+                    if i > 0 {
+                        log::info!("changelog partition task created {i} new partition(s)")
                     }
                 }
-                Err(e) => log::error!("changelog partition task: failed to get context: {e:?}"),
+                Ok(Err(e)) => log::error!("changelog partition task: {e:?}"),
+                Err(e) => log::error!("changelog partition task: join error: {e:?}"),
             }
         }
     })

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -157,6 +157,11 @@ pub async fn start_server(
         .as_ref()
         .map(|s| s.batch_size.clone())
         .unwrap_or_default();
+    let disable_integration_transaction = settings
+        .sync
+        .as_ref()
+        .map(|s| s.disable_integration_transaction)
+        .unwrap_or(false);
     let service_provider = Data::new(ServiceProvider::new_with_triggers(
         connection_manager.clone(),
         processors_trigger,
@@ -166,6 +171,7 @@ pub async fn start_server(
         settings.mail.clone(),
         subscription_trigger,
         batch_size,
+        disable_integration_transaction,
     ));
     let loaders = get_loaders(&connection_manager, service_provider.clone()).await;
     let certificates = Certificates::try_load(&settings.server).unwrap();

--- a/server/service/src/service_provider.rs
+++ b/server/service/src/service_provider.rs
@@ -210,7 +210,9 @@ pub struct ServiceProvider {
     // Subscription trigger handle — used by SyncLogger and changelog callbacks
     // to send events to the shared subscription worker.
     pub subscription_trigger: SubscriptionTriggerHandle,
+    // Yaml only fields ----- Not stored in KV store
     pub(crate) batch_size: BatchSize,
+    pub(crate) disable_integration_transaction: bool,
 }
 
 pub struct ServiceContext {
@@ -220,6 +222,7 @@ pub struct ServiceContext {
     pub user_id: String,
     pub store_id: String,
     pub batch_size: BatchSize,
+    pub disable_integration_transaction: bool,
 }
 
 impl ServiceProvider {
@@ -238,6 +241,7 @@ impl ServiceProvider {
             None, // Mail not required for test/CLI setups
             SubscriptionTriggerHandle::new_void(),
             BatchSize::default(),
+            false,
         )
     }
 
@@ -250,6 +254,7 @@ impl ServiceProvider {
         mail_settings: Option<MailSettings>,
         subscription_trigger: SubscriptionTriggerHandle,
         batch_size: BatchSize,
+        disable_integration_transaction: bool,
     ) -> Self {
         ServiceProvider {
             connection_manager: connection_manager.clone(),
@@ -331,6 +336,7 @@ impl ServiceProvider {
             ledger_fix_trigger,
             shipping_method_service: Box::new(ShippingMethodService {}),
             subscription_trigger,
+            disable_integration_transaction,
         }
     }
 
@@ -343,6 +349,7 @@ impl ServiceProvider {
             store_id: "".to_string(),
             frontend_plugins_cache: self.frontend_plugins_cache.clone(),
             batch_size: self.batch_size.clone(),
+            disable_integration_transaction: self.disable_integration_transaction,
         })
     }
 
@@ -357,6 +364,7 @@ impl ServiceProvider {
             store_id: store_id.unwrap_or("".to_string()),
             frontend_plugins_cache: self.frontend_plugins_cache.clone(),
             batch_size: self.batch_size.clone(),
+            disable_integration_transaction: self.disable_integration_transaction,
         })
     }
 
@@ -372,6 +380,7 @@ impl ServiceProvider {
             store_id,
             frontend_plugins_cache: self.frontend_plugins_cache.clone(),
             batch_size: self.batch_size.clone(),
+            disable_integration_transaction: self.disable_integration_transaction,
         })
     }
 
@@ -391,6 +400,7 @@ impl ServiceContext {
             store_id: "".to_string(),
             frontend_plugins_cache: FrontendPluginCache::new(),
             batch_size: BatchSize::default(),
+            disable_integration_transaction: false,
         }
     }
 }

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -6,8 +6,7 @@ use std::{
 use repository::{
     database_settings::DatabaseSettings,
     migrations::{
-        ChangelogPartitionConfig, DEFAULT_CHANGELOG_LOOKAHEAD_PARTITIONS,
-        DEFAULT_CHANGELOG_PARTITION_SIZE,
+        ChangelogPartitionConfig, DEFAULT_CHANGELOG_LOOKAHEAD, DEFAULT_CHANGELOG_PARTITION_SIZE,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -25,8 +24,6 @@ pub struct Settings {
     pub features: Option<HashMap<String, bool>>,
     pub changelog_partition: Option<ChangelogPartitionSettings>,
 }
-
-
 
 #[derive(Deserialize, Serialize, Clone)]
 pub struct ServerSettings {
@@ -203,10 +200,13 @@ pub struct MailSettings {
 /// before calling `migrate()`.
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct ChangelogPartitionSettings {
+    // Privates — exposed via getter
     #[serde(default = "default_partition_size")]
-    pub partition_size: i64,
-    #[serde(default = "default_lookahead_partitions")]
-    pub lookahead_partitions: i64,
+    partition_size: i64,
+    #[serde(default = "default_lookahead")]
+    lookahead: i64,
+
+    // public fields
     #[serde(default)]
     pub interval: IntervalSettings,
 }
@@ -224,8 +224,8 @@ pub struct IntervalSettings {
 fn default_partition_size() -> i64 {
     DEFAULT_CHANGELOG_PARTITION_SIZE
 }
-fn default_lookahead_partitions() -> i64 {
-    DEFAULT_CHANGELOG_LOOKAHEAD_PARTITIONS
+fn default_lookahead() -> i64 {
+    DEFAULT_CHANGELOG_LOOKAHEAD
 }
 fn default_interval_mins() -> u64 {
     30
@@ -235,7 +235,7 @@ impl Default for ChangelogPartitionSettings {
     fn default() -> Self {
         Self {
             partition_size: default_partition_size(),
-            lookahead_partitions: default_lookahead_partitions(),
+            lookahead: default_lookahead(),
             interval: IntervalSettings::default(),
         }
     }
@@ -258,12 +258,25 @@ impl IntervalSettings {
 }
 
 impl ChangelogPartitionSettings {
+    /// Effective partition size — yaml value clamped to at least 1
+    /// 1 is purely defensive to prevent division by zero
+    pub fn partition_size(&self) -> i64 {
+        self.partition_size.max(1)
+    }
+
+    /// Effective lookahead in cursor records — yaml value clamped up to
+    /// `DEFAULT_CHANGELOG_LOOKAHEAD` (the default doubles as the lower bound,
+    /// so the runtime top-up always has at least the default headroom).
+    pub fn lookahead(&self) -> i64 {
+        self.lookahead.max(DEFAULT_CHANGELOG_LOOKAHEAD)
+    }
+
     /// Convert to the migration-internal primitive config that
     /// `migrate()` and `ensure_partition_lookahead` accept.
     pub fn to_migration_config(&self) -> ChangelogPartitionConfig {
         ChangelogPartitionConfig {
-            partition_size: self.partition_size,
-            lookahead_partitions: self.lookahead_partitions,
+            partition_size: self.partition_size(),
+            lookahead: self.lookahead(),
         }
     }
 }

--- a/server/service/src/settings_service.rs
+++ b/server/service/src/settings_service.rs
@@ -40,6 +40,7 @@ pub trait SettingsServiceTrait: Sync + Send {
         let interval_seconds = key_value_store.get_i64(KeyType::SettingsSyncIntervalSeconds)?;
 
         let batch_size = ctx.batch_size.clone();
+        let disable_integration_transaction = ctx.disable_integration_transaction;
 
         // `?` inside this closure would result in closure returning `None`
         let make_settings = || {
@@ -49,7 +50,7 @@ pub trait SettingsServiceTrait: Sync + Send {
                 password_sha256: password_sha256?,
                 interval_seconds: interval_seconds? as u64,
                 batch_size,
-                disable_integration_transaction: false,
+                disable_integration_transaction,
             })
         };
 

--- a/server/service/src/test_helpers.rs
+++ b/server/service/src/test_helpers.rs
@@ -81,6 +81,7 @@ pub(crate) async fn setup_all_with_data_and_service_provider(
         settings.mail.clone(),
         SubscriptionTriggerHandle::new_void(),
         BatchSize::default(),
+        false,
     ));
 
     let processors_task = processors.spawn(service_provider.clone());


### PR DESCRIPTION
Fixes #11920

# 👩🏻‍💻 What does this PR do?

The issue: during a large sync integration, login (and everything else that goes through the repository layer) stalls because the runtime `CREATE TABLE … PARTITION OF changelog` DDL gets queued behind an integration query holding a row-exclusive lock on `changelog`. Once the DDL is queued, every subsequent `INSERT INTO changelog` queues behind the DDL too — the user's login flow tries to write an `activity_log` and never returns.

The user had `disable_integration_transaction: true` set in yaml to avoid wrapping integration in one giant tx, but pg_stat_activity still showed a long-running integration query blocking the DDL. That turned out to be the root cause: the yaml flag wasn't being honored.

This PR addresses that and a couple of related partitioning rough edges:

1. **Wireup `disable_integration_transaction` from yaml through the runtime** (`fix(sync-v7): wire up disable integration transaction`). Previously the value was hard-coded to `false` inside `SettingsServiceTrait::sync_settings()` — yaml could set it to `true` but the runtime `Synchroniser` always saw `false`. Now threaded through `ServiceProvider` → `ServiceContext` → `settings_service::sync_settings` (mirroring the `batch_size` pattern, which is also yaml-only / not persisted to KV).

2. **Run the runtime partition top-up on the blocking pool** (`fix(async): wrap partitioning in spawn_blocking`). The diesel call inside the periodic `tokio::spawn` in `changelog_partitions.rs` was running on an async worker thread; wrapped it in `tokio::task::spawn_blocking` to match how the sync integration paths already handle blocking DB work.

3. **Changelog partitioning task logging** (`logs: cleaner logging for partitioning task`). The info log now only fires when a partition was actually created (`if i > 0`) .

4. **Refactor lookahead config to be in cursor records, not partition count** (`feat(sync-v7): partitioning settings now uses lookahead records`). Renamed `ChangelogPartitionConfig.lookahead_partitions` → `lookahead`; semantics changed from "N empty partitions ahead" to "N cursor records of empty headroom". Migration ceil-divs by `partition_size` internally. Added clamping getters on `ChangelogPartitionSettings`: `partition_size()` to ≥ 1 (defensive), `lookahead()` to ≥ `DEFAULT_CHANGELOG_LOOKAHEAD` (30M; default doubles as lower bound).

5. **Simpler partition-count formula in the migration** (`cleanup: use a cleaner calculation in migration for generating partitions`). The migration's `partition_count` was computed in two steps (current-partition count + ceil-divided lookahead partitions). Collapsed to `(max_cursor + lookahead) / partition_size + 1`, which is tighter (never creates more partitions than needed when `lookahead % partition_size != 0`) and maps directly to the invariant: "the topmost partition must contain `max_cursor + lookahead`".

## 💌 Any notes for the reviewer?

**Implementation differences vs the issue**

- The issue is focused on the *symptom* (login blocked) and shares the `pg_stat_activity` snapshot but doesn't prescribe a fix. The PR addresses the root cause it surfaces — the disable-tx flag plumbing — and bundles a few correctness/readability improvements in the same area.
- **Deferred**: pre-creating enough partitions before each integration runs (so the runtime top-up never has to issue DDL while an integration tx is open) is *not* in this PR. That's the more thorough mitigation for the case where the outer tx genuinely is wanted; it's stashed locally for now. The defaults for partitioning along with value clamping should provide more than enough headroom for most cases.

# 🧪 Testing

Reproduce the original symptom + verify the fix:

- [ ] Set `disable_integration_transaction: true` in central.yaml and small `partition_size` (e.g. 50000) to force frequent runtime partition creation during init.
- [ ] Drop the local central db, restart the server, kick off OG → OMS Central init sync (~250k changelog rows).
- [ ] Run the diagnostic query from the issue (`pg_stat_activity` + `pg_blocking_pids`) periodically during integration. Expect:
  - No `CREATE TABLE … PARTITION OF changelog` rows blocked by anything.
  - No integration-tx PID appears in `pg_blocking_pids(...)` for any other connection.
- [ ] Concurrently attempt to log in during integration — login returns immediately rather than hanging until integration finishes.
- [ ] Watch the log for `integrate_and_translate_sync_buffer: use_transaction=false` (smoke test that the plumbing is honored). (Note: the temporary log line I had in development for this has been removed; if you want to verify, you can add it back in `synchroniser.rs:529` or check pg_stat_activity for the absence of savepoints during integration.)


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: backend-only changes, no user-facing surface area changed.
- [ ] **These areas should be updated or checked**:
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [x] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend