### PR TITLE
#11941 Count sync push queue by deduping only the changelog head

### DIFF
--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -58,6 +58,14 @@ jobs:
             armv7-linux-androideabi
         # Targets need to match in the config.toml of the self-hosted machine
 
+      - name: Add Android targets for pinned toolchain
+        # The self-hosted runner pre-installs the Android targets for its default
+        # (stable) toolchain only. Now that cargo runs under the pinned channel
+        # (RUSTUP_TOOLCHAIN), those targets must be installed for it explicitly or
+        # the std crate can't be found (E0463). actions-rs/toolchain's `targets`
+        # input doesn't reliably cover the named channel on this runner.
+        run: rustup target add aarch64-linux-android armv7-linux-androideabi --toolchain "${{ steps.rust_toolchain.outputs.channel }}"
+
       - name: Set Up Java
         uses: actions/setup-java@v4
         with:

--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -46,6 +46,14 @@ joinable!(changelog_deduped -> name_link (name_link_id));
 allow_tables_to_appear_in_same_query!(changelog_deduped, name_link);
 allow_tables_to_appear_in_same_query!(changelog_deduped, vaccination);
 
+joinable!(changelog -> name_link (name_link_id));
+allow_tables_to_appear_in_same_query!(changelog, name_link);
+
+// Aliased changelog used to build the head-dedupe subquery in `create_filtered_head_count_query`.
+// Diesel rejects a subquery on the same table as the outer query's FROM clause; the alias makes
+// the inner `changelog` distinct from the outer one.
+diesel::alias!(changelog as changelog_head: ChangelogHead);
+
 #[cfg(not(feature = "postgres"))]
 define_sql_function!(
     fn last_insert_rowid() -> BigInt
@@ -318,6 +326,19 @@ impl<'a> ChangelogRepository<'a> {
         Ok(result.into_iter().map(ChangelogRow::from_join).collect())
     }
 
+    /// Counts deduped changelog records with cursor >= `earliest` that match `filter`.
+    ///
+    /// This is equivalent to counting rows of the `changelog_deduped` view (see
+    /// [`create_filtered_query`]), but only dedupes the "head" of the changelog
+    /// (rows with cursor >= `earliest`) instead of grouping the entire history and
+    /// trimming afterwards.
+    ///
+    /// It is exact, not approximate: the deduped view keeps the global-max-cursor row
+    /// per (record_id, store_id) group, and a group's global max is >= `earliest` iff
+    /// the group has any row >= `earliest` — in which case that max row is itself in the
+    /// head. So grouping only over the head yields the same latest row per group, and the
+    /// filter is applied to that same row (important for fields like `is_sync_update` /
+    /// `source_site_id` that can vary within a group).
     pub fn count(
         &self,
         earliest: u64,
@@ -326,9 +347,8 @@ impl<'a> ChangelogRepository<'a> {
         // Clamp identically to the row reader so callers that drive a push/processor loop off
         // `count` (e.g. the `_ => continue` termination check) stay consistent with `changelogs()`
         // while a tx is in flight — otherwise count could report rows the clamped reader won't
-        // return, spinning the loop.
-        let query = clamp_to_safe_cursor(self.connection, create_filtered_query(earliest, filter));
-        let result = query
+        // return, spinning the loop. The clamp is applied inside the head-count query.
+        let result = create_filtered_head_count_query(self.connection, earliest, filter)
             .count()
             .get_result::<i64>(self.connection.lock().connection())?;
         Ok(result as u64)
@@ -544,6 +564,66 @@ fn create_filtered_query(earliest: u64, filter: Option<ChangelogFilter>) -> Boxe
         apply_equal_filter!(query, action, changelog_deduped::row_action);
         apply_equal_filter!(query, is_sync_update, changelog_deduped::is_sync_update);
         apply_equal_filter!(query, source_site_id, changelog_deduped::source_site_id);
+    }
+
+    query
+}
+
+type BoxedRawChangelogQuery =
+    IntoBoxed<'static, LeftJoin<changelog::table, name_link::table>, DBType>;
+
+/// Builds the filtered count query for [`ChangelogRepository::count`], deduping only the
+/// head of the changelog (cursor >= `earliest`) rather than the whole history.
+///
+/// `head_max_cursors` is the latest cursor per (record_id, store_id) group restricted to the
+/// head — one cursor per group, and (since cursor is unique) exactly the global-latest row of
+/// each group present in the head. Filtering `cursor IN (head_max_cursors)` therefore selects
+/// the same rows the `changelog_deduped` view would keep, and the `ChangelogFilter` is applied
+/// to those latest rows — matching the view's filter-on-latest semantics.
+fn create_filtered_head_count_query(
+    connection: &StorageConnection,
+    earliest: u64,
+    filter: Option<ChangelogFilter>,
+) -> BoxedRawChangelogQuery {
+    let head_max_cursors = changelog_head
+        .filter(changelog_head.field(changelog::cursor).ge(earliest.try_into().unwrap_or(0)))
+        .group_by((
+            changelog_head.field(changelog::record_id),
+            changelog_head.field(changelog::store_id),
+        ))
+        .select(diesel::dsl::max(changelog_head.field(changelog::cursor)));
+
+    let mut query = changelog::table
+        .left_join(name_link::table)
+        .into_boxed()
+        .filter(changelog::cursor.nullable().eq_any(head_max_cursors));
+
+    // Apply the same safe-cursor ceiling as [`clamp_to_safe_cursor`] (see its docs for why).
+    // The clamp goes on the OUTER query only: the inner subquery still takes the unbounded global
+    // max per group, so a group whose latest change sits above the safe cursor is excluded
+    // entirely — exactly matching `clamp_to_safe_cursor(create_filtered_query(..))`.
+    if let Some(safe) = ChangelogCursorTracker::max_safe_cursor(connection) {
+        query = query.filter(changelog::cursor.le(safe as i64));
+    }
+
+    if let Some(f) = filter {
+        let ChangelogFilter {
+            table_name,
+            name_id,
+            store_id,
+            record_id,
+            is_sync_update,
+            action,
+            source_site_id,
+        } = f;
+
+        apply_equal_filter!(query, table_name, changelog::table_name);
+        apply_equal_filter!(query, name_id, name_link::name_id);
+        apply_equal_filter!(query, store_id, changelog::store_id);
+        apply_equal_filter!(query, record_id, changelog::record_id);
+        apply_equal_filter!(query, action, changelog::row_action);
+        apply_equal_filter!(query, is_sync_update, changelog::is_sync_update);
+        apply_equal_filter!(query, source_site_id, changelog::source_site_id);
     }
 
     query
@@ -778,9 +858,12 @@ mod test {
     use strum::IntoEnumIterator;
     use util::assert_matches;
 
+    use crate::{mock::MockDataInserts, test_db::setup_all};
+    // Only used by the postgres-only `test_changelog_clamped_by_in_flight_tx` below.
+    #[cfg(feature = "postgres")]
     use crate::{
-        mock::MockDataInserts, test_db::setup_all, ClinicianRow, ClinicianRowRepository,
-        ClinicianRowRepositoryTrait, RepositoryError, TransactionError,
+        ClinicianRow, ClinicianRowRepository, ClinicianRowRepositoryTrait, RepositoryError,
+        TransactionError,
     };
 
     /// Concurrent-tx race (the scenario the `ChangelogCursorTracker` guards): while connection A
@@ -809,6 +892,22 @@ mod test {
         };
 
         let observer = connection_manager.connection().unwrap();
+
+        // A record committed *before* the clamp: its first version lands in the head, at/below the
+        // safe boundary. Connection B re-upserts it during the clamp (below) so its *latest*
+        // version sits above the safe cursor — exercising dedup + clamp together. Because the
+        // deduped row is the higher, clamped-out version, the record must be absent from both
+        // `changelogs()` and `count()` while the tx is in flight, even though an older version is
+        // below the boundary. (This is why the head-count clamps only the outer query and keeps the
+        // inner MAX unbounded.)
+        ClinicianRowRepository::new(&connection)
+            .upsert_one(&ClinicianRow {
+                id: "clinician_reupserted".to_string(),
+                is_active: true,
+                ..Default::default()
+            })
+            .unwrap();
+
         let cursor_before = ChangelogRepository::new(&observer).latest_cursor().unwrap();
 
         // Channels to drive connection A: signal it has registered an in-flight cursor, then
@@ -843,6 +942,15 @@ mod test {
             })
             .unwrap();
 
+        // ...and re-upserts the pre-clamp record so its latest version is now above the safe cursor.
+        ClinicianRowRepository::new(&connection)
+            .upsert_one(&ClinicianRow {
+                id: "clinician_reupserted".to_string(),
+                is_active: false,
+                ..Default::default()
+            })
+            .unwrap();
+
         // The clamp is active: safe cursor is pegged below the (now higher) raw max.
         assert!(ChangelogCursorTracker::max_safe_cursor(&observer).is_some());
         let safe_during = ChangelogRepository::new(&observer)
@@ -851,7 +959,8 @@ mod test {
         let raw_during = ChangelogRepository::new(&observer).latest_cursor().unwrap();
         assert!(
             safe_during <= cursor_before && safe_during < raw_during,
-            "expected safe cursor clamped (<= {cursor_before}, < raw {raw_during}), got {safe_during}"
+            "expected safe cursor clamped (<= {}, < raw {}), got {}",
+            cursor_before, raw_during, safe_during
         );
 
         // The reader must not return the committed-after row past the clamp.
@@ -863,6 +972,14 @@ mod test {
                 .iter()
                 .any(|r| r.record_id == "clinician_committed_after"),
             "reader returned a row past the in-flight clamp"
+        );
+        // The re-upserted record's latest version is above the clamp, so its deduped row is gone —
+        // even though an older version sits below the boundary.
+        assert!(
+            !rows_during
+                .iter()
+                .any(|r| r.record_id == "clinician_reupserted"),
+            "reader returned a deduped record whose latest version is past the clamp"
         );
 
         // `count` must clamp identically to the row reader, otherwise a push/processor loop that
@@ -888,7 +1005,8 @@ mod test {
             .unwrap();
         assert!(
             safe_after > cursor_before,
-            "expected cursor to advance past {cursor_before} after commit, got {safe_after}"
+            "expected cursor to advance past {} after commit, got {}",
+            cursor_before, safe_after
         );
 
         let rows_after = ChangelogRepository::new(&observer)
@@ -900,6 +1018,15 @@ mod test {
         assert!(rows_after
             .iter()
             .any(|r| r.record_id == "clinician_committed_after"));
+        // The re-upserted record reappears exactly once (deduped) now that the clamp has lifted.
+        assert_eq!(
+            rows_after
+                .iter()
+                .filter(|r| r.record_id == "clinician_reupserted")
+                .count(),
+            1,
+            "re-upserted record should appear once (deduped) after the clamp lifts"
+        );
     }
 
     #[actix_rt::test]

--- a/server/repository/src/db_diesel/changelog/test.rs
+++ b/server/repository/src/db_diesel/changelog/test.rs
@@ -313,6 +313,70 @@ async fn test_changelog_filter() {
     );
 }
 
+/// `count` dedupes only the head of the changelog (cursor >= earliest) instead of the whole
+/// view, but must stay exactly equal to the deduped result. We pin that against `changelogs`
+/// (which reads the `changelog_deduped` view) for the same earliest/filter — this is the same
+/// consistency the sync push loop relies on (count vs the batch fetch).
+#[actix_rt::test]
+async fn test_changelog_count_head_dedupe() {
+    let (_, connection, _, _) =
+        setup_all("test_changelog_count_head_dedupe", MockDataInserts::none().names()).await;
+
+    let repo = ChangelogRepository::new(&connection);
+    repo.delete(0).unwrap();
+
+    let row = |cursor: i64, record_id: &str, is_sync_update: bool| ChangelogRow {
+        cursor,
+        table_name: ChangelogTableName::Invoice,
+        record_id: record_id.to_string(),
+        row_action: RowActionType::Upsert,
+        name_id: None,
+        store_id: Some("store1".to_string()),
+        is_sync_update,
+        source_site_id: None,
+    };
+
+    let logs = vec![
+        // record "A": changed three times -> dedupes to one (latest cursor 3)
+        row(1, "A", false),
+        row(2, "A", false),
+        row(3, "A", false),
+        // record "B": changed once
+        row(4, "B", false),
+        // record "C": changed twice, latest change (cursor 6) is a sync update.
+        // A naive pre-grouping filter on is_sync_update would wrongly count C via cursor 5.
+        row(5, "C", false),
+        row(6, "C", true),
+    ];
+    for log in &logs {
+        diesel::insert_into(changelog::table)
+            .values(log)
+            .execute(connection.lock().connection())
+            .unwrap();
+    }
+
+    // Assert count matches the deduped fetch for the same earliest/filter, and return the value.
+    let count_matching_fetch = |earliest: u64, filter: Option<ChangelogFilter>| -> u64 {
+        let fetched = repo.changelogs(earliest, 1000, filter.clone()).unwrap().len() as u64;
+        let counted = repo.count(earliest, filter).unwrap();
+        assert_eq!(counted, fetched, "count must equal deduped fetch (earliest={earliest})");
+        counted
+    };
+
+    // From the start, no filter: A, B, C each dedupe to one -> 3 (not 6 raw rows).
+    assert_eq!(count_matching_fetch(0, None), 3);
+
+    // is_sync_update = false: latest row of C (cursor 6) is a sync update, so C is excluded -> 2.
+    let local_only = ChangelogFilter::new().is_sync_update(EqualFilter::equal_any_or_null(vec![false]));
+    assert_eq!(count_matching_fetch(0, Some(local_only)), 2);
+
+    // From cursor 5, only C has rows in the head; it still dedupes to one.
+    assert_eq!(count_matching_fetch(5, None), 1);
+
+    // From beyond the last cursor, nothing remains.
+    assert_eq!(count_matching_fetch(7, None), 0);
+}
+
 struct TestRecord<T> {
     record: T,
     record_id: String,


### PR DESCRIPTION
Fixes #11941

> [!NOTE]
> **Stacked on #11947** (`11940-backport-changelog-lock-removal`). This PR targets that
> branch, so the diff is just the changelog-count change. Merge #11947 first, then this.

# 👩🏻‍💻 What does this PR do?

Load testing flagged the push-queue count as slow: `ChangelogRepository::count` read the
`changelog_deduped` view, whose `GROUP BY record_id, store_id` runs over the **entire**
changelog history and only then trims to the push cursor. We were deduping the whole table
just to count the small "head".

Instead this dedupes **only the head** (`cursor >= earliest`):

1. inner subquery takes `MAX(cursor)` per `(record_id, store_id)` over the head — one cursor
   per group;
2. outer query counts the rows whose cursor is in that set and that match the filter.

This is **exact, not approximate**. A group's global-max cursor is `>= earliest` iff the
group has any row in the head, and in that case the max row *is* in the head — so the latest
row per group is identical to the deduped view's, and the filter is applied to that same row
(matters for `is_sync_update` / `source_site_id`, which can vary within a group). Both the
`numberOfRecordsInPushQueue` / `syncInfoUpdated` display path **and** the V5/V6 sync push
loops go through `count()`, so all of them benefit.

## 💌 Any notes for the reviewer?

- **Why it's equivalent:** counting head-deduped rows == counting `changelog_deduped` rows for
  the same `earliest`/filter. The unit test pins this against `changelogs()` (which reads the
  view) so the invariant is enforced, not just asserted in prose.
- **Diesel:** the inner subquery is on an aliased `changelog` (`changelog_head`) because Diesel
  rejects a subquery on the same table as the outer query's FROM clause.
- **Interaction with #11947 (lock removal):** that PR replaces the `LOCK TABLE` with a
  safe-cursor clamp and requires `count()` to clamp identically to `changelogs()` or a push
  loop spins. This PR carries that clamp on the **outer query only** — the inner `MAX` stays
  unbounded, so a group whose latest change is past the safe cursor is excluded entirely,
  exactly matching `clamp_to_safe_cursor(create_filtered_query(..))`.
- **Tests:** added `test_changelog_count_head_dedupe` (dedup correctness + filter-on-latest),
  and extended #11947's `test_changelog_clamped_by_in_flight_tx` with a re-upserted record so
  the dedup-and-clamp interaction is covered. Also fixed a couple of warnings inherited from
  the stacked base (non-fmt panic messages; sqlite-only unused imports behind the postgres test).
- Touches `server/repository/src/db_diesel/changelog/changelog.rs` only (+ its test file). No
  GraphQL/API change.

# 🧪 Testing

- [ ] `cd server && cargo test -p repository changelog` (SQLite)
- [ ] `cd server && cargo test -p repository --features postgres changelog -- --test-threads=1` (Postgres)
- [ ] On a site with a backlogged push queue: confirm `numberOfRecordsInPushQueue` /
      `syncInfoUpdated` returns the same number as before but resolves quickly.
- [ ] Run a full sync push and confirm the queue drains to 0 with correct `is_last_batch`
      behaviour (no loop spinning).

# 📃 Documentation

- [x] **No documentation required**: performance fix, no change in user-facing behaviour.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API
- [ ] Technically some Breaking Changes but not expected to impact any integrations

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
