### PR TITLE
#11952 Migrate wiki developer docs into docs/content/

### DIFF
--- a/docs/content/code-review/_index.md
+++ b/docs/content/code-review/_index.md
@@ -1,0 +1,127 @@
++++
+title = "Code Review"
+weight = 60
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Code Review Comments
+
+This page aims to support common code review comments and feedback to open-mSupply code, and related projects.
+
+As a code reviewer, we recommend you point to the explanations here when referring to a common code review feedback.
+If you find yourself making a similar comment regularly add it here so we can improve our knowledge base and support new developers learning without repeating yourself too often.
+
+See also:
+- [Code Review Comments for Rust](@/code-review/rust/_index.md)
+- [Code Review Comments for Typescript](@/code-review/typescript/_index.md)
+- [Suggestion Snippets](@/code-review/snippets/_index.md)
+
+## Remember PRs are for the reviewer
+When working on code, it's common to think about what will be fast to write, what will make code faster, trying to optimise for future use cases, etc.
+However when creating a PR it's important to think about the code reviewer's time, as well as people reading the code in the future.
+
+When writing code keep in mind how the code will be reviewed and try to make sure the PR is focussed and easy to understand.
+This might mean including screenshots of any UI changes to add context, breaking a PR up into smaller PRs to make reviewing easier, pulling unrelated changes into a separate PR, adding good test cases, and pointing out tricky edge cases in comments.
+
+## Self review
+
+Before submitting the PR, do a self review:
+- Run the tests
+- Run through the workflow + testing steps
+- Review your code
+  - Remove any commented code
+  - Ensure naming is all up to date
+  - Add review comments if more context is required for a certain change (or perhaps a code comment, if the context might not be apparent when someone comes back to this code in future!)
+
+## Prefer a simple solution over a complex one
+Experienced Developers often argue for a simple solution rather than a complex and re-usable approach.
+**Why?**
+> Complex code is hard to read, debug and understand, which means it can take time to review, test and is more likely to contain errors.
+
+We often end up with overly complex or complicated code when...
+* Trying to anticipate future requirements that may never come
+* Trying to optimise code performance
+* Lack of experience with the code base, or time pressure
+
+If one of these factors is encouraging you to choose a complex solution, it might be worth discussing your solution with another developer to get another brain on the task.
+
+Obviously sometimes we need complex code, and some problems are inherently complex, it isn't always possible to simplify.
+
+When using this comment, it should always come with a suggestion on how to simplify the code.
+
+**Too Complex**
+```
+type stringTransformer {
+     stringTransformerFunction: fn(s:string):string
+}
+
+fn uppercaser = (str:string, num_chars:number):string {
+ let return_str = "";
+ let i = 0;
+ while(i < num_chars){
+   return_str += str.charAt(i).toUpperCase();
+ }
+ return return_str + str.slice(i);
+}
+
+fn uppercaseFirstLetter(str:string): string{
+   let transformFunction = stringTransformer{ stringTransformerFunction: uppercaser }
+
+   return transformFunction.stringTransformerFunction(str, 1);
+}
+```
+
+**Suggestion**
+
+"It's unlikely we'll need to uppercase anything but the first character of the string so a simpler solution like this could be considered."
+```
+function uppercaseFirstLetter(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+```
+
+> Note: Simplicity can be subjective, so take care when using this comment. Remember to respect other developers ideas and code, even if someone has gone about a change differently to what you might have, it doesn't mean it's bad or wrong.
+
+See also: https://go.dev/talks/2015/simplicity-is-complicated.slide#11
+
+
+## Should I make small unrelated `fixes` in my PR?
+
+When working on an issue it's common to notice small things that could be fixed or improved along the way.
+For example you might see a misspelling in a comment, or find that the one of the screens has a small UI bug that's easy to fix or improve.
+
+Even though it's a lot more work to create an issue, and separate PR for these kinds of things, if in doubt we prefer to make these kinds of changes in a separate PR.
+
+Obviously it can be a lot more work to create issues, PRs, and commits for small changes so there is a judgement call to be made here.
+
+If the change is closely related to the issue you are working on, and doesn't obfuscate the core code changes then it's fine to make the change in the same PR, but if it's affecting multiple files, would require new test cases, it should almost certainly be done in a separate PR.
+
+> Note: It should be considered acceptable for a reviewer to ask for unrelated changes to be moved to a separate PR, if they feel that it justifies it.
+
+In the case that you have a change ready to go, it is sometimes ok to just raise PR with a suggested improvement or change without first creating an issue. However in most cases it's better to have an issue to allow prioritisation of that work against other things we could spend our time on.
+
+For example imagine you are working on an issue which requires increasing MAX_SIZE to 1000 and you come across this code...
+
+```
+const MAX_SZIE: i32 = 100;
+
+pub fn limted_add(a: i32, b: i32) -> i32 {
+    let sum = a + b;
+    if sum > MAX_SZIE{
+        return MAX_SZIE; // If we add beyond the max size we coul dhave a buffer over
+    }
+    sum
+}
+```
+In this case it would probably make sense to also fix the spelling of `MAX_SZIE` to `MAX_SIZE` and fix the typos in the comment as part of the issue.
+
+However, if the constant `MAX_SZIE` was used in 100 files through our the project, it would be better to first rename the constant in separate PR, otherwise the key change of the size going from 100 to 1000 would be lost amongst the other changes in the code base.
+
+## Nit's Don't need to be actioned
+Comments are often prefixed with `nit:` this represents something a reviewer has noticed about the code, but doesn't think is important to enough to stop the code from being merged. Often used for spelling mistakes in comments for example.
+
+Reviewers may want to commit changes fixing spelling errors to a review branch, rather than polluting the PR Comments with lots of spelling improvements. Obviously if the spelling correction isn't obvious, or might require associated code changes, a PR Comment might be more approriate.

--- a/docs/content/code-review/rust/_index.md
+++ b/docs/content/code-review/rust/_index.md
@@ -1,0 +1,223 @@
++++
+title = "Rust"
+weight = 20
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Code Review Comments/Preferences for mSupply Rust Code
+
+## Run Clippy
+
+Installing and running clippy can help identify a lot of common rust style issues, see https://github.com/rust-lang/rust-clippy
+
+Unfortunately, a lot of our code doesn't follow clippy style guides right now, so it can be hard to identify where your code represented amongst other errors.
+
+The list of clippy lints can be found here:
+https://rust-lang.github.io/rust-clippy/master/index.html
+
+## Prefer `.to_string()`
+
+When working with strings in rust, there's a number of ways to convert a `str` value into a Owned String.
+
+Given this code:
+`let hello = "Hello World";`
+
+We prefer using
+```
+let hello = hello.to_string();
+```
+
+This is fast to type, is easy to read, and logically the easiest to follow for less experienced rust developers.
+
+**Avoid** alternatives such as `let hello = hello.to_owned();` or `let hello = String::from(hello);`
+
+## Soft Delete
+
+Any record that is deletable and used in sync must be `soft deleted`. This means that instead of entirely removing the record from the database, it is marked as deleted. This `Delete` status of the record can be synced across to any related sites.
+This allows a record to essentially be removed for new data entry, but available for reference.
+
+* When soft deleting a new record type, we recommend creating a nullable database field `deleted_datetime`.
+This allows for recording the status of deleted, but also tells us when it happened which can be useful if tracing back an issue related to the record.
+
+> HOWEVER if we are migrating a record from legacy mSupply and it uses another field type such as `is_active` or `is_enabled` we should keep this naming to avoid confusion across the databases.
+
+* If a record is soft deleted, the repository `delete` method should be named `mark_deleted` to signal that it is using a soft delete
+* Repository `query` methods should filter out all deleted records by default
+* Id based requests such as `find_one_by_id` should still succeed even if the record is deleted, as it's often used to look up associated records that might be needed for viewing in an historical context (e.g. Invoices should still show the associated supplier and receiver even if one of them is now deleted).
+
+## Record `modified_datetime` and `created_datetime` in database records
+
+When investigating an issue, it is often helpful to see when a record was first created and when it was last modified. For most records that can be updated (e.g. master_data records, user accounts, items, etc) `modified_datetime` and `created_datetime` should be recorded in the database.
+
+
+## Record `user_id` in database records
+
+When investigating an issue, it is often helpful to see who last modified a record.
+
+## Don't use `unwrap()` unless in tests
+
+When you make a call to `unwrap()` if an error was to occur in the code the whole server could crash.
+In tests this is ok, but in production code it should almost never be used.
+If you have a use case where unwrap does make sense (say if you can't connect to the database on server start up) this useage must include a comment and justification.
+See Also: https://levelup.gitconnected.com/rust-never-use-unwrap-in-production-c123b311f620
+
+## Avoid indirection with From implementation
+
+Avoid using `From` implementation, unless it's for a common type like `RepositoryError`.
+
+Generally in Rust, `From` implementation is used to translate between types, then translations are done with `.into()` or `?` (for errors), this created a bit of indirection which is harder to trace (navigation to implementation or definition in IDE brings you to `trait` implementation). Although it's possible to navigate to actual implementation of the trait (by examining implementations of a type), it's much easier to navigate to a standard method for a type, like `to_domain`. And when re-mapping errors, it's more clearly done inline.
+
+```rust
+// Preferred:
+
+let result = validate_parameter(&parameter).map_err(|e| match e {
+     ValidateParameterResult::One(extra) => ValidateResult::One(extra),
+     ValidateParameterResult::Two => ValidateResult::Two,
+     ValidateParameterResult::Three => ValidateResult::Three,
+})?;
+
+// vs To be avoided:
+
+let result = validate_parameter(&parameter)?; // Can't navigate to `?`
+
+// ..
+
+impl From<ValidateParameterResult> for ValidateResult {
+    fn from(result: ValidateParameterResult) -> ValidateResult {
+        match e {
+            ValidateParameterResult::One(extra) => ValidateResult::One(extra),
+            ValidateParameterResult::Two => ValidateResult::Two,
+            ValidateParameterResult::Three => ValidateResult::Three,
+        }
+    }
+}
+
+
+// Preferred:
+
+let result = get_record().map(RecordNode::to_domain)?;
+
+// ..
+
+impl RecordNode {
+    fn to_domain(row: RecordRow) -> RecordNode {
+        //  mapper
+    }
+}
+
+// vs To be avoided:
+
+let result = get_record().map(RecordNode::from)?;
+
+// or
+
+let result = get_record().map(|r| r.into())?;
+
+// ..
+
+impl From<RecordRow> for RecordNode {
+    fn from(row: RecordRow) -> RecordNode {
+        //  mapper
+    }
+}
+
+```
+
+## Prefer using Diesel table modules over DSL
+
+Diesel's [getting started page](https://diesel.rs/guides/getting-started) has this to say:
+
+> The use self::schema::posts::dsl::* line imports a bunch of aliases so that we can say `posts` instead of `posts::table`, and `published` instead of `posts::published`. It's useful when we're only dealing with a single table, but that's not always what we want. It's always important to keep imports to `schema::table::dsl::*` inside of the current function to prevent polluting the module namespace.
+
+TL;DR: Use DSL for convenience if just working with one table in a function. Import the DSL local to functions rather than pollute the namespace of the whole module file.
+
+Our experience has been that polluting the namespace is more trouble than it's worth, and it frequently conflicts as field names are often close to our variable naming. For instance when working near something like `requisition_line::stock_on_hand` it is appealing to have a local variable named `stock_on_hand`. If you've imported the DSL, it'll include `requisition_line::stock_on_hand` as just `stock_on_hand`, there will be a name space conflict when you make a variable called `stock_on_hand` with cryptic messaging. The pollution is hidden behind the `*` wildcard so it's not always intuitive what's happening.
+
+## Don't alias Diesel DSLs
+
+An early pattern in the codebase was to alias DSLs to get access to table definitions. The table modules already give access to all the fields in a more concise way, so we should prefer just using them directly:
+
+```rust
+db_diesel::{
+  master_list_name_join::master_list_name_join::dsl as master_list_name_join_dsl,
+  name_link_row::name_link::dsl as name_link_dsl,
+  //...
+}
+//...
+NameRepository::create_filtered_query(store_id.to_string(), Some(name_filter))
+  .inner_join(
+    master_list_name_join_dsl::master_list_name_join
+      .on(master_list_name_join_dsl::name_link_id.eq(name_link_dsl::id)),
+```
+
+Can be:
+
+```rust
+db_diesel::{
+  master_list_name_join::master_list_name_join,
+  name_link_row::name_link,
+  //...
+}
+//...
+NameRepository::create_filtered_query(store_id.to_string(), Some(name_filter))
+  .inner_join(
+    master_list_name_join::table
+      .on(master_list_name_join::name_link_id.eq(name_link::id)),
+```
+
+## Diesel Field Orders
+
+The field order in your struct must match the column order in your database table when using [#[derive(Queryable)]](https://diesel.rs/guides/getting-started.html#:~:text=A%20Note%20on%20Field%20Order). If the order is inconsistent, it can result in data being assigned to the wrong fields, causing unexpected behavior such as swapped or incorrect values.
+
+To prevent this, ensure that the fields in your struct are defined in the exact same order as the columns in your table. Maintaining this alignment is crucial for reliable data mapping and consistent query results.
+
+```rust
+table! {
+    table_name (id) {
+        id -> Text
+        field_one -> Text
+        field_two -> Text
+        field_three -> Text
+        field_four -> Text
+    }
+}
+```
+
+Matches
+```rust
+// RIGHT WAY
+pub struct TableName {
+    pub id: string,
+    pub field_one: string,
+    pub field_two: string,
+    pub field_three: string,
+    pub field_four: string,
+}
+
+// WRONG WAY
+pub struct TableName {
+    pub id: string,
+    pub field_one: string,
+    pub field_three: string,
+    pub field_two: string,
+    pub field_four: string,
+}
+```
+
+## "empty_str_as_option" for Legacy Sync
+
+In our Legacy mSupply product, often when records are saved, default values are used for the columns. In the case of a String/Alpha/Text column this equates to an `""` or empty string. It's important that we handle this correctly when syncing to open-mSupply because empty string would normally be seen as a value value, and if it's a foreign key constraint may prevent records from being inserted into the database.
+
+For example `donor_id` on the `stock_line` table is a foreign key constraint to the `name`.
+
+If we don't have code like this when deserializing the `LegacyStockLineRow`, all stocklines WITHOUT a `donor_id` set will not be inserted into the database.
+
+```rust
+#[serde(default)]
+#[serde(deserialize_with = "empty_str_as_option_string")]
+pub donor_id: Option<String>,
+```

--- a/docs/content/code-review/snippets/_index.md
+++ b/docs/content/code-review/snippets/_index.md
@@ -1,0 +1,70 @@
++++
+title = "Suggestion Snippets"
+weight = 40
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Suggestion Snippets
+
+## Summary
+
+In this page you can find common commits that can be changed and applied to help with common coding tasking.
+
+Use `git reset HEAD` if you need to discard all the changes
+
+If you want to manually edit instead of `| git apply --3 -C1` do ` > out.diff` then edit out.diff and `git apply --3 -C1 < out.diff`
+
+Make sure to apply diff from root dir.
+
+Sometimes git apply will fail, can try with `--reject` flag (instead of `--3way`)
+
+## Commit snippets
+
+<details>
+<summary> New version and migration </summary>
+
+From [this commit](https://github.com/msupply-foundation/open-msupply/commit/1df4fcac3e09ccc428e1740fc44b7b815bfda429)
+
+```bash
+NEW_VERSION=2_07_00
+NEW_VERSION_DOT=2.7.0
+PREVIOUS_VERSION=2_06_00
+MIGRATION=new_migration_name
+git show 1df4fcac3e09ccc428e1740fc44b7b815bfda429 | sed 's/2_06_00/'${NEW_VERSION}'/g ; s/2.6.0/'${NEW_VERSION_DOT}'/g ; s/2_05_00/'${PREVIOUS_VERSION}'/g ; s/add_index_to_sync_buffer/'${MIGRATION}'/g' | git apply --3 -C1 --whitespace=fix
+```
+</details>
+
+
+<details>
+<summary> New table with sync (as omSupply central data) </summary>
+
+From [this commit](https://github.com/msupply-foundation/open-msupply/commit/acc8bce66e49cd0f91f9351e3be02ba188664dd4)
+
+```bash
+NEW_TABLE_NAME=new_table
+NEW_TABLE_NAME_CAMEL=NewTable
+MIGRATION=2_06_00
+MIGRATION_NAME=add_new_table
+
+git show acc8bce66e49cd0f91f9351e3be02ba188664dd4 | sed 's/ExampleTable/'${NEW_TABLE_NAME_CAMEL}'/g ; s/example_table/'${NEW_TABLE_NAME}'/g ; s/2_06_00/'${MIGRATION}'/g ; s/add_example_table/'${MIGRATION_NAME}'/g' | git apply --3 -C1 --whitespace=fix
+```
+</details>
+
+<details>
+<summary> New Key Type for KeyValueStore </summary>
+
+Part of [this commit](https://github.com/msupply-foundation/open-msupply/commit/6741380effd7be7f24e5865ad4af6b0f7af90c53)
+
+```bash
+NEW_VARIANT=LoadPluginProcessorCursor
+NEW_VARIANT_PG=LOAD_PLUGIN_PROCESSOR_CURSOR
+MIGRATION=2_06_00
+MIGRATION_NAME=add_some_variant
+
+git show acc8bce66e49cd0f91f9351e3be02ba188664dd4 | sed 's/LoadPluginProcessorCursor/'${NEW_VARIANT}'/g ; s/LOAD_PLUGIN_PROCESSOR_CURSOR/'${LOAD_PLUGIN_PROCESSOR_CURSOR}'/g ; s/2_06_00/'${MIGRATION}'/g ; s/add_load_plugin_processor_pg_enum_type/'${MIGRATION_NAME}'/g' | git apply --3 -C1 --whitespace=fix
+```
+</details>

--- a/docs/content/code-review/typescript/_index.md
+++ b/docs/content/code-review/typescript/_index.md
@@ -1,0 +1,164 @@
++++
+title = "Typescript"
+weight = 30
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Code Review Comments for Typescript
+
+## useTranslation()
+
+Translations are now being translated in the `common` translation file.
+
+We're using [react-i18next](https://react.i18next.com/) for localisations.
+Collections of translatable items are grouped into namespaces so that we can reduce bundle sizes and keep files contained to specific areas.
+
+## useTranslation() with plurals
+
+When translating strings, it's common to need a singular and plural option.
+This can be accomplished using a `_one` and `_other` suffix on the translation key and passing a parameter to the translation request called 'count'.
+
+**Example**
+
+`common.json`
+```
+{
+  "permissions_one": "Permission",
+  "permissions_other": "Permissions"
+}
+```
+
+`example.ts`
+```
+const t = useTranslation();
+
+let permissionList = ['Permission a'];
+
+let translation = t("permissions", {count: permissionList.length});
+// translation will contain 'Permission'
+
+let permissionList = ['Permission a', 'Permission b'];
+
+let translation = t("permissions", {count: permissionList.length});
+// translation will now contain 'Permissions'
+```
+
+## Avoid using type assertions ('as' keyword)
+
+Use of [type assertion](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions) should be avoided, it can cause runtime errors in what looks like safe code. If type assertions have to be used, the resulting type should be consumed entirely in the same scope (with maximum amount of safety checks):
+
+```typescript
+const myCanvas = document.getElementById("main_canvas") as HTMLCanvasElement;
+if (!myCanvas) throw new Error("no canvas");
+if (!myCanvas.getContext) throw new Error("not a canvas");
+
+const gl = myCanvas.getContext("webgl", {
+  antialias: false,
+  depth: false,
+});
+```
+
+Example of why type assertions can be dangerous
+
+```typescript
+interface Check {
+   id: string,
+   willBeMissing: string
+}
+
+// ..
+
+const doCheck = (check: Check) => {
+   console.log(check.id)
+   // ..
+   helper(check)
+}
+
+const helper = (check: Check) => {
+   console.log(check.willBeMissing.length) // runtime error (if check not Check)
+}
+
+// ..
+
+const getLooksLikeCheck = () => ({ id: 'one' });
+
+doCheck(getLooksLikeCheck() as Check) // runtime error
+```
+
+[Union alternative to the above](https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgMIAsIINbIN4BQyxYAngA4QhwC2EAXMgOQZbZMA0RxwAJowGcwUUAHMuxZAHdgAG1kAhCAFlgAgWMHCxBAL4ECoSLEQoA8iFmkAkr3zdkZStTqMmFq7c4O+WkSHE9AwB6YOQAOnCDBAB7ECFkXhjWHGQAXmQACgRMHEYU3AAfZA8bXgBKdIA+e0lY+JjZCHDZGNFs3OxwvnKHUIioyWAYLJy2cKcqWhQ02eYCpl7JTFlKKA62Xv0CeoSVtfTRzvzOyrSawjq4gUbm1vaxnHCZeSVVdTEWqlEwdC2QsKRZDRa5gZCiCBgAAyMRi2AEUOA2AgBUOmXKjFKtmqWTwyF8zDiEE4jgoU1czCxvCYyF05QA3AYkgVMhDobD4YjkSzyr0gA) (with minimum changes)
+
+## Imports
+
+If using co-pilot ( and possibly other helpers 🤷 ), you may have an auto generated import appear which has the format 'packages/..'
+Do not use these! While it will work as a standard runtime import, it will cause jest tests to fail.
+
+Prefer
+
+`import { InternalSupplierSearchModal, NameRowFragment } from '@openmsupply-client/system';`
+
+Instead of
+
+`import { InternalSupplierSearchModal, InternalSupplierSearchModal, NameRowFragment, NameRowFragment } from 'packages/system/src';`
+
+You can generally find an aliased path to use instead, or a reference which is relative to the current file.
+
+When exporting from packages, if an item is to be used outside of the package, export it from the package itself. This may require exporting from the root `index.ts` of the package and back up the tree of index files.
+
+Prefer
+
+`import { InternalSupplierSearchModal, NameRowFragment } from '@openmsupply-client/system';`
+
+Instead of
+
+`import { NameRowFragment } from '@openmsupply-client/system/src/Name/api';`
+
+This makes is clear exactly what is being exported, and therefore depended on, out of the package. It's also neater ( personal opinion! ) and less fragile. If you are exporting from the root of the package then the internal structure can safely change.
+
+## Avoid nested ternary
+
+Nested ternary operators can make code difficult to read and understand, which can lead to maintenance issues and bugs.
+
+Instead:
+
+* Using `if/else` statements:
+
+```typescript
+let result;
+if (condition1) {
+    result = value1;
+} else {
+    result = value2;
+}
+```
+
+* Using functions:
+
+```typescript
+function getResult(condition1, value1, value2) {
+    if (condition1) {
+        return value1;
+    } else {
+        return value2;
+    }
+}
+```
+
+* Using switch statements:
+
+```typescript
+let result;
+switch (true) {
+    case condition1:
+        result = value1;
+        break;
+    case condition2:
+        result = value2;
+        break;
+    default:
+        result = value3;
+}
+```

--- a/docs/content/github-actions/_index.md
+++ b/docs/content/github-actions/_index.md
@@ -1,0 +1,31 @@
++++
+title = "GitHub Actions"
+weight = 80
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# GitHub Actions
+
+Documentation for our GitHub Actions workflows. See also:
+
+- [Nightly Automated Builds](@/github-actions/nightly-builds/_index.md)
+- [Client Code Checks](@/github-actions/client-code-checks/_index.md)
+
+## Self Hosted Runner
+
+We have a self hosted runner for github actions.
+
+For TMF Staff the login details should be in Bitwarden.
+
+To debug, start with this doc from github.
+https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/monitoring-and-troubleshooting-self-hosted-runners?platform=mac
+
+The runner is installed in `~/actions-runner/` which is consistent with the docs.
+
+To find the latest log file you can run `ls -r ~/actions-runner/_diag | tail -1`
+
+To see the end of that log file use `tail ~/action-running/_diag/FILENAME_FROM_COMMAND_ABOVE`

--- a/docs/content/github-actions/client-code-checks/_index.md
+++ b/docs/content/github-actions/client-code-checks/_index.md
@@ -1,0 +1,83 @@
++++
+title = "Client Code Checks"
+weight = 20
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Client Code Checks
+
+This GitHub Actions workflow ensures that the client-side code is correctly formatted, free of linting errors, and successfully recompiled.
+
+## Triggering the Workflow
+
+The workflow runs automatically on pull requests that modify files in the `client` directory. It can also be triggered manually if needed.
+
+## Handling Linting Warnings
+
+Some areas of the codebase may generate linting warnings, which could cause the `prettier` check in GitHub Actions to return an error. This is expected and can be ignored.
+
+### Example Output
+
+On a successful run, the workflow will output a result similar to this:
+![Successful run output](https://github.com/user-attachments/assets/e66fa96a-cc20-445a-89a3-6fdaecf58cb7)
+
+### Error Output
+
+When it fails it'll tell you what file specifically needs fixing. But as you go through it, you'll be greeted by a sea of warnings.
+
+It's OKAY to ignore these and just fix the files with the errors. The warnings requires further discussion on how we'll support some of them.
+
+![Error output with warnings](https://github.com/user-attachments/assets/52dbbddd-9a7d-4cf9-a8cb-673edfbbc77f)
+
+
+## Common Linting Warnings
+
+In some cases, you may encounter linting warnings in your code.
+
+A common example involves the dependency array in `useEffect`. ESLint rules can be strict about dependencies, but real-world use cases sometimes require omitting certain dependencies.
+
+If a `useEffect` is functioning correctly without the suggested dependencies, you can safely suppress the warning using an ESLint directive:
+
+```tsx
+// eslint-disable-next-line react-hooks/exhaustive-deps
+```
+
+Before ignoring a warning, check if it actually matters. If the suggested fix isn't needed, you can progress without working on it or suppress it.
+
+## ESLint Version
+
+Currently running on version `^8.50.0`. This is behind the latest version of ESLint. Need to work on migrating it to the latest version.
+
+
+## Prettier
+
+To make life easier and to get rid of the big list of warnings for this GitHub Action, please ensure that you have Prettier set as your formatter when auto-saving.
+
+### Configure Prettier on Auto Save
+
+1. **Set Prettier as Default Formatter**
+   - Open VS Code settings (`Ctrl + ,` or `Cmd + ,` on Mac).
+   - Search for `"editor.defaultFormatter"` and select `"Prettier - Code formatter"`.
+
+2. **Enable Format on Save**
+   - In VS Code settings, search for `"editor.formatOnSave"`.
+   - Ensure it is checked (`true`).
+
+Our Prettier config is set up under `.prettierrc` in the `client` directory.
+
+Can also just grab this code snippet and add to your `settings.json` for VSCode.
+
+```
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer",
+    "editor.formatOnSave": true
+  },
+```
+
+💡 *Note: Prettier only affects `client` directory.* 🚀

--- a/docs/content/github-actions/nightly-builds/_index.md
+++ b/docs/content/github-actions/nightly-builds/_index.md
@@ -1,0 +1,34 @@
++++
+title = "Nightly Automated Builds"
+weight = 10
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Nightly Automated Builds
+
+This GitHub Action automatically generates new tags in the repository to trigger our build pipeline and send Telegram notifications to relevant channels. The primary goal is to generate fresh builds automatically for QA and internal testing without manual intervention.
+
+---
+
+## Current Workflow
+
+### 1️⃣ Tag Creation & Telegram Notification
+
+- Runs daily at 6:30 PM NZST (7:30 PM NZDT) to align with UTC schedules.
+- Generates a new tag automatically and pushes it to GitHub.
+- Sends a Telegram message to the Open-mSupply build channels immediately after the tag is created, notifying the team that a new build cycle has started.
+
+---
+
+### 2️⃣ Triggering Builds on Tag Detection (WIP)
+
+Once a tag is created:
+
+- The CI/CD pipeline will detect the new tag automatically.
+- Builds release artifacts in Jenkins and Android pipelines based on the tagged commit.
+- Uploads built artifacts to our cloud storage for easy access by QA and testers.
+- Sends a Telegram message upon successful build and upload.

--- a/docs/content/patterns/_index.md
+++ b/docs/content/patterns/_index.md
@@ -1,0 +1,57 @@
++++
+title = "Patterns"
+weight = 70
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Patterns
+
+Recurring implementation patterns used across the codebase.
+
+- [Changelog & Sync](#changelog-sync)
+- [Feature Development](@/patterns/feature-development/_index.md) — feature branches and feature flags
+- [Unit Testing & Mocking](@/patterns/unit-testing/_index.md)
+- [Table Implementation](@/patterns/table-implementation/_index.md)
+- [Card List Implementation](@/patterns/card-list-implementation/_index.md)
+
+## Changelog & Sync
+
+Any data that needs to be synced to a central server should have a change record in the changelog table each time the record is updated or created. This allows open-mSupply to identify which records need to be sent to central server next time it syncs.
+
+To Implement this, we are using a pattern like this.
+
+https://github.com/msupply-foundation/open-msupply/blob/03f55909a39079cb994bb2a1cb6a4961343d51d9/server/repository/src/db_diesel/assets/asset_row.rs#L90
+
+Example from `asset_row.rs`
+```rs
+    pub fn upsert_one(&self, asset_row: &AssetRow) -> Result<i64, RepositoryError> {
+        self._upsert_one(asset_row)?;
+        self.insert_changelog(
+            asset_row.id.to_owned(),
+            RowActionType::Upsert,
+            Some(asset_row.clone()),
+        )
+    }
+
+    fn insert_changelog(
+        &self,
+        asset_id: String,
+        action: RowActionType,
+        row: Option<AssetRow>,
+    ) -> Result<i64, RepositoryError> {
+        let row = ChangeLogInsertRow {
+            table_name: ChangelogTableName::Asset,
+            record_id: asset_id,
+            row_action: action,
+            store_id: row.map(|r| r.store_id).unwrap_or(None),
+            ..Default::default()
+        };
+        ChangelogRepository::new(self.connection).insert(&row)
+    }
+```
+
+This will mean that the changelog record is created every time `upsert_one` is called.

--- a/docs/content/patterns/card-list-implementation/_index.md
+++ b/docs/content/patterns/card-list-implementation/_index.md
@@ -1,0 +1,141 @@
++++
+title = "Card List Implementation"
+weight = 40
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Card List Implementation
+
+## Card View
+
+### Overview
+
+The **Card View** provides a card-based layout for displaying and editing data as an alternative to the traditional table layout. It was introduced in [PR #10725](https://github.com/msupply-foundation/open-msupply/pull/10725), initially for Inbound Shipment line editing. This replaces the previous tabbed table approach (Quantities / Pricing / Other tabs) with a single card per batch that shows all fields grouped visually.
+
+The card view is built on top of the same **Material React Table** infrastructure used by our standard tables — it reads column definitions from `useSimpleMaterialTable` and renders them as cards instead of table rows.
+
+> [!TIP]
+> For a reference implementation, see the **Inbound Shipment** `InboundLineEditCards` component. This is the first full implementation using the card view, so refer to it if you're unsure how to do something.
+
+### Architecture
+
+The card view is composed of four generic components, all located in:
+
+```
+client/packages/common/src/ui/layout/tables/components/CardList/
+```
+
+- **`CardList`** — The top-level container. Takes a `table` instance (from any of our `useMaterialTable` hooks) and renders each row as a `CardListItem`. Also renders the column visibility toggle and a "reset to defaults" button.
+- **`CardListItem`** — Renders a single card. Categorises visible cells into **summary cells** (shown in a heading row), **action cells** (buttons pinned to the heading row), and **data cells** (grouped into field groups).
+- **`CardListFieldGroup`** — Renders a group of fields in a CSS grid layout, optionally prefixed with a group icon.
+- **`CardListField`** — Renders a single label/value pair within a group.
+
+All elements can be imported from `@open-msupply/common`.
+
+### How it works
+
+The card view uses the **same column definitions** and the **same `useSimpleMaterialTable` hook** as the table view. This means:
+
+- Column visibility, ordering, and all user customisations are shared between card and table views (they use the same `tableId` for local storage persistence)
+- The `Cell` component defined for each column is rendered inside the card — so editable inputs work the same way
+- Filtering and sorting are not applicable in the card view context (the "Simple" table type doesn't use them)
+
+### Usage
+
+```tsx
+const table = useSimpleMaterialTable<DraftInboundLine>({
+  tableId: "inbound-line-edit",
+  columns,
+  data: lines,
+  getIsRestrictedRow: isDisabled ? () => true : undefined,
+});
+
+return (
+  <CardList
+    table={table}
+    tableId="inbound-line-edit"
+    lastItemRef={lastCardRef}
+    groupIcons={groupIcons}
+    actions={actions}
+  />
+);
+```
+
+### CardList props
+
+**Required**:
+
+- `table`: `MRT_TableInstance<T>` The table instance from any of our `useMaterialTable` hooks
+- `tableId`: `string` Must match the `tableId` used in the hook — used for resetting saved state
+
+**Optional**:
+
+- `lastItemRef`: `React.RefObject<HTMLDivElement>` Ref attached to the last card in the list. Useful for auto-scrolling when new items are added
+- `groupIcons`: `Record<string, React.ReactNode>` A map of `columnGroup` names to icon components. When provided, fields are grouped visually with the icon displayed at the start of each group. When omitted, fields render in an ungrouped label/value layout (used for mobile list views)
+- `actions`: `React.ReactNode` Additional action buttons to display in the sticky toolbar alongside the column visibility and reset buttons
+- `stickyTopOffset`: `number` Offset (in px) for the sticky toolbar at the top of the card list. Defaults to `0`
+
+### Column definition extensions for Card View
+
+Three new properties have been added to our `ColumnDef<T>` type to control card-specific behaviour:
+
+- **`columnGroup`**: `string` Logical grouping for the column (e.g. `'general'`, `'quantities'`, `'pricing'`, `'other'`). Columns with the same `columnGroup` are rendered together in a `CardListFieldGroup`. The order of groups follows the order columns are defined
+- **`cardSummary`**: `(row: T) => React.ReactNode` When provided, the column's value appears as bold summary text in the card's heading row. The column still appears as an editable field within its group. Receives the row data and returns a formatted string, e.g.:
+  ```ts
+  cardSummary: (row) => `${t("label.batch")} ${row.batch || ""}`;
+  ```
+- **`cardSpan`**: `number` Number of CSS grid columns to span in the card layout. Defaults to `1`. Useful for wider fields like notes/comments
+
+### Action columns
+
+Columns with an empty `header` or `pin: 'right'` are treated as **action columns**. They render as icon buttons in the card's heading row (to the right of the summary text), rather than as labelled fields in the body. This is how the delete and duplicate buttons are positioned.
+
+### Grouped vs ungrouped layout
+
+The card view supports two distinct rendering modes, determined by whether `groupIcons` is provided:
+
+- **Grouped** (with `groupIcons`): Fields are organised into visual groups using `CardListFieldGroup`, each with an icon prefix. Fields within each group are laid out in a responsive CSS grid (`repeat(auto-fill, minmax(200px, 1fr))`). This is used in the line edit modal.
+- **Ungrouped** (without `groupIcons`): Fields render as simple label/value rows (label on the left, value on the right). This is used for mobile list views where cards replace the table entirely.
+
+Example of defining group icons:
+
+```tsx
+const groupIcons = {
+  general: <EditIcon />,
+  quantities: <StockIcon />,
+  pricing: <InvoiceIcon />,
+  other: <SlidersIcon />,
+};
+```
+
+### Responsive behaviour
+
+- On **landscape tablets** (detected via `useIsLandscapeTablet`), padding and spacing are reduced, and the grid column minimum width shrinks from `200px` to `140px` for a more compact layout
+- On **mobile** (extra small screens), the `CardList` is used directly in list views (e.g. Inbound Shipment list) with the ungrouped layout. Cards in mobile list views are not clickable for editing
+- When the **Simplified Tablet UI** preference is enabled, group icons are omitted for a more compact card appearance
+
+### Additional features
+
+- **Duplicate Batch**: Each card can include a duplicate button (as an action column with `pin: 'right'`). When duplicated, the new card is appended to the bottom and auto-scrolls into view using `lastItemRef`
+- **Add Batch**: The "Add Batch" button is passed as an `actions` prop to `CardList` and similarly auto-scrolls to the new card
+- **Sticky Item Name**: In the Inbound Shipment line edit modal, the item selector and divider are sticky at the top, so the user always has context while scrolling through cards
+- **Reset to Defaults**: Resets column visibility, order, sizing, pinning, and density to their initial state. Note: this does not currently respect global custom table defaults
+- **Column Visibility**: The MRT column visibility menu (`MRT_ShowHideColumnsButton`) is available, allowing users to show/hide fields just as in table view
+- **Empty state fallback**: When there are no rows, the card view uses the table's `renderEmptyRowsFallback`, showing the same "Nothing to display" UI as tables
+
+### Where card view is currently used
+
+- **Inbound Shipment line edit modal** (both internal and external) — grouped layout with editable fields
+- **Inbound Shipment list view on mobile** — ungrouped layout, read-only cards
+- **Inbound Shipment detail view on mobile** — ungrouped layout via `CardList` replacing the old `MobileCardList`
+
+### Future improvements
+
+- Hide field labels on mobile where they are self-explanatory (e.g. status)
+- Experiment with accordion/collapsible groups
+- Move action buttons (add batch, reset) into the modal header
+- Support for global custom table defaults in the reset functionality

--- a/docs/content/patterns/feature-development/_index.md
+++ b/docs/content/patterns/feature-development/_index.md
@@ -1,0 +1,73 @@
++++
+title = "Feature Development"
+weight = 10
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Feature Development
+
+## Feature branches
+
+We do use feature branches for specific cases; these should be short lived however, to avoid issues in keeping feature and development branches synchronised. The general rule is that the development branch should regularly be merged back into the feature branch to keep it current.
+
+When the feature is complete, create a PR to merge the entire branch into develop, even though the individual commits have been PR'd into the feature branch. This is for consistency, to comply with branch protection rules, and to ensure visibility of changes.
+
+## Feature flags
+
+Rather than creating an entire feature branch, another approach is to create a feature flag and control the visibility of changes with that. A new API implementation can exist safely and UI components can be enabled and/or visible only when the flag is enabled. This allows development to continue without changing the user experience, all in the develop branch.
+
+A limitation is that the flag is enabled only at compile time, so is not suitable for dynamically enabling or disabling a feature on a demo server. You could compile a feature-enabled version and deploy that to a feature server though.
+
+### Adding a feature flag
+
+In `packages/config/src/config.ts`, at the top of the file, add a const:
+
+```
+declare const FEATURE_COOL_NEW_THING: boolean;
+```
+
+and then, just before the end of file, add to the `Environment` object:
+
+```
+  FEATURE_COOL_NEW_THING:
+    typeof FEATURE_COOL_NEW_THING === 'undefined'
+      ? false
+      : FEATURE_COOL_NEW_THING,
+```
+
+In `packages/host/webpack.config.js` add to the `DefinePlugin` plugin:
+
+```
+    plugins: [
+      ...
+      new webpack.DefinePlugin({
+        FEATURE_COOL_NEW_THING: env.FEATURE_COOL_NEW_THING,
+        ...
+      }),
+      ...
+```
+
+### Usage
+
+With this in place you can do the following in your page:
+
+```
+import { Environment } from '@openmsupply-client/config';
+
+...
+
+if (Environment.FEATURE_COOL_NEW_THING) {
+  // do something cool
+}
+
+```
+
+The flag can be set when running the script `start-local-features` e.g.
+
+```
+yarn start-local-features FEATURE_COOL_NEW_THING=true
+```

--- a/docs/content/patterns/table-implementation/_index.md
+++ b/docs/content/patterns/table-implementation/_index.md
@@ -1,0 +1,297 @@
++++
+title = "Table Implementation"
+weight = 30
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Table Implementation
+
+The new implementation of front-end **Data Tables** uses the [**Material React Table**](https://www.material-react-table.com/) library, which is Material-UI wrapper around [**Tanstack Table**](https://tanstack.com/table/latest) — **Tanstack Table** provides a powerful (though headless) table framework, and **Material React Table** provides Material UI components to work with it.
+
+Both those libraries are very well documented, so you are encouraged to read and understand the relevant areas if you need to make any changes to our implementations.
+
+These new tables provide much-expanded functionality for the user as well as making implementation and configuration simpler and more powerful for developers. New functionality (for the user) includes:
+- 🚀 Much better **performance**, even with tables that have thousands of rows
+- 🔍 Built-in **filtering** and **sorting**
+- ↔️ Variable table **density**
+- 📐 User-controlled **column widths** and **column order**
+- 📌 User-controlled **"pinned" columns**
+- 💾 Reliable persistence (via local storage) of *all* user customisations, with reset capability.
+
+Using Material React Table, we've created some abstractions that allow developers to easily implement tables using a standardised pattern, with minimal boilerplate and a UI consistent with the existing app.
+
+There are three main types of tables used throughout OMS, and we've created a different hook to implement each one:
+
+## Paginated tables
+
+These are tables that fetch a single **page** of data at a time, and therefore every change to the sorting or filtering requires an additional query to the server.
+
+The hook for this type of table is `usePaginatedMaterialTable`
+
+## Non-paginated tables
+
+These are tables that fetch the *full* data set in one query, and so all filtering/sorting is done in the front-end by the table library itself.
+
+The hook for this type of table is `useNonPaginatedMaterialTable`
+
+## "Simple" tables
+
+These are the tables used in the "Line Edit" views -- i.e. one line per batch, with inputs for stock allocation. They only have a handful of rows, so don't require any filtering/sorting UI and don't interact with the URL Query.
+
+The hook for this type of table is `useSimpleMaterialTable`
+
+These hooks are just wrappers around MRT's standard `useMaterialReactTable` hook, but with a lot of settings pre-defined with appropriate defaults for the given context. Note that *any* pre-defined value can still be overridden with explicit props.
+
+## Usage
+
+> [!TIP]
+> For a reference implementation example, please check out **Outbound Shipments**' `ListView`, `DetailView` and `OutboundLineEditTable` components for a version of each of these table types. This is the "OG" implementation of the new table library, so always refer to that if you're unsure how to do something, and branch out from those examples if new functionality is needed.
+
+All code related to these table implementations can be found in:
+
+```
+client/packages/common/src/ui/layout/tables/material-react-table
+```
+
+And all elements can be imported using the `@open-msupply/common` package.
+
+The basic implementation for a table is to use the hook to generate the `table` object (and `selectedRows` array), which is then passed to the `MaterialTable` component (and `Footer` if required):
+
+```tsx
+const { table, selectedRows } =
+    useNonPaginatedMaterialTable<StockOutLineFragment>({
+        tableId: 'outbound-shipment-detail-view',
+        columns,
+        data,
+        ...otherProperties
+        ),
+    });
+
+
+return <>
+        <MaterialTable table={table} />
+        // ...Other JSX
+        <Footer selectedRows={selectedRows} {...otherFooterProps}>
+    </>
+```
+
+> [!NOTE]
+> - Usage is the same for all three hooks
+> - The hook call is **typed** with a generic parameter, which should correspond to the type of the data **row**s
+
+### Input props
+
+**Required**:
+- `tableId`: Must be unique throughout the whole app — this is used as part of the data key when the table config is saved to local storage. You should stick to the naming pattern established for the Outbound Shipments, which includes the area of the app and the specific table, e.g. `outbound-shipment-detail-view`
+- `columns`: Column definitions, as described [below](#column-definitions)
+- `data`: `T[] | undefined` The data to display, as an array of objects which correspond to rows in the table
+- `totalCount`: `number` Number of rows in the table, only required for paginated tables
+
+**Optional**:
+- `onRowClick`: `(row: T) => void` Callback to execute when table rows are clicked
+- `isLoading`: `boolean` Loading state of the data, will be reflected in table as a "Loading" spinner
+- `initialSort`: `{ key: string; dir: 'asc' | 'desc' }` Field to sort data by initially, as per the `UrlQuerySort` type in `useUrlQueryParams`
+- `getIsPlaceholderRow`: `(row: T) => boolean` Tester function to determine if a row should be formatted as a **placeholder**
+- `getIsRestrictedRow`: `(row: T) => boolean` Tester function to determine if a row should be `disabled` — i.e. greyed out and unable to be clicked
+- `grouping`: `{ enabled: boolean; field?: string; groupedByDefault?: boolean }` used to enable grouping for the table as well as define what column to group on. Currently only works on non paginated tables.
+- `noDataElement`: `React.ReactNode` JSX to display when there is no data to display in the table. Defaults to a generic "Nothing to display" icon and message
+- `noUrlFiltering`: `boolean` used to disable storing filter state in the url. This is useful when you have a table in a popup and don't want its filters to affect other tables on the page or persist when the popup is closed.
+
+The above should be sufficient for most implementations, but all of the Material React Table options are available to use if needed: https://www.material-react-table.com/docs/api/table-options
+
+
+## Column definitions
+
+The **column definitions** form the backbone of the table configuration, where we describe what data to display in each column, how to access it, how to filter it, and how users are allowed to interact with the column (plus a lot more!).
+
+Here is a small example:
+
+```tsx
+const columns = useMemo(() => {
+    return [
+        {
+            accessorKey: 'item.code',
+            header: t('label.code'),
+            size: 120,
+            pin: 'left',
+            enableColumnFilter: true,
+            enableSorting: true,
+        },
+        {
+            accessorKey: 'itemName',
+            header: t('label.name'),
+            size: 400,
+            enableColumnFilter: true,
+            enableSorting: true,
+        },
+        {
+            id: 'expiryDate',
+            // expiryDate is a string - use accessorFn to convert to Date object for sort and filtering
+            accessorFn: row => (row.expiryDate ? new Date(row.expiryDate) : null),
+            header: t('label.expiry-date'),
+            columnType: ColumnType.Date,
+            defaultHideOnMobile: true,
+            enableColumnFilter: true,
+            enableSorting: true,
+        },
+        {
+            id: 'itemUnit',
+            accessorKey: 'item.unitName',
+            header: t('label.unit-name'),
+            filterVariant: 'select',
+            defaultHideOnMobile: true,
+        },
+        {
+            accessorKey: 'packSize',
+            header: t('label.pack-size'),
+            columnType: ColumnType.Number,
+            enableSorting: true,
+        },
+        {
+            id: 'numberOfPacks',
+            header: t('label.pack-quantity'),
+            columnType: ColumnType.Number,
+            accessorFn: row => {
+                if ('subRows' in row)
+                return ArrayUtils.getSum(row.subRows ?? [], 'numberOfPacks');
+
+                return row.numberOfPacks;
+            },
+        },
+        {
+            id: 'unitSellPrice',
+            header: t('label.unit-sell-price'),
+            columnType: ColumnType.Currency,
+            defaultHideOnMobile: true,
+            accessorFn: rowData => {
+                if ('subRows' in rowData) {
+                return ArrayUtils.getAveragePrice(
+                    rowData.subRows ?? [],
+                    'sellPricePerPack'
+                );
+                } else {
+                if (isDefaultPlaceholderRow(rowData)) return undefined;
+                return (rowData.sellPricePerPack ?? 0) / rowData.packSize;
+                }
+            },
+        },
+]
+}, [manageVvmStatusForStock, manageVaccinesInDoses]);
+```
+
+> [!IMPORTANT]
+> Column definitions should *always* be wrapped in `useMemo` to reduce unnecessary re-renders. This is recommended by Material React Table ([docs](https://www.material-react-table.com/docs/guides/memoization#memoize-columns))
+
+### Properties
+
+#### Required
+
+A column must have at least an `accessorKey` *or* `accessorFn`, and a `header`.
+
+The `accessorKey` is a simple string representing the path to the required data from each data row — it can be a base property such as `itemName` or a nested path such as `item.code`
+
+If you require a more complex way of extracting the required data, provide an `accessorFn` instead — see the `numberOfPacks` example above.
+
+If you use an `accessorFn`, you must also provide an `id` — a unique identifier for the column. (This is not necessary with an `accessorKey`, as the `accessorKey` also serves as a unique id.)
+
+The `id` or `accessorKey` is the same key used for filtering and sort, which is updated via the URL, so ensure you use the correct key required by the API.
+
+The `header` is simply the string to display as the header row of the column.
+
+> [!TIP]
+> If you want a column header to be blank, don't set the `header` string to `""`, as that will also remove the column from the Columns popover menu. Instead, provide an empty React component `() => <></>` to the `Header` property which will be display as the column header and your `header` field will be used in the Columns menu.
+
+#### Optional
+
+You have access to the full range of [MRT column properties](https://www.material-react-table.com/docs/api/column-options) if required, but most of the time the defaults we've specified in our custom hooks will be adequate. We've also defined a handful of our own "convenience" properties which map to groups of column properties (or more complex versions) internally, or define additional functionality:
+
+- `description`: Short explanation of the column. Displays in the Column context menu (three dots), and is useful to expand on the column header, which should be kept as concise as possible.
+- `filterKey`: As explained above, the `id`/`accessorKey` will be the filter key. However, if they need to be different due to API configuration, you can specify a distinct filter key here.
+- `columnType`: `ColumnType enum` A shorthand property that maps to all the MRT properties required to properly display a certain data type. Default is `string`, but valid variants (as of 26/09/2025) are:
+  - `ColumnType.String`
+  - `ColumnType.Number` — renders a `NumericTextDisplay` component, right-aligned
+  - `ColumnType.Date` — handles conversion between ISO string and Date objects, and specifies correct filter mapping for Dates
+  - `ColumnType.Currency` — renders a `CurrencyValueCell`, which formats numbers as locale-specific currency values
+  - `ColumnType.Comment` — renders a `PopoverCell` that displays the cell value in a column of negligible width
+- `pin`: `"left" | "right"` Loads the table with the column "pinned" (i.e. it's frozen while other columns scroll sideways) to the left or the right of the table. The user can change the "pinned" settings, so this just specifies the initial state.
+- `align`: `"left" | "center" | "right"` Align the value within the cell.
+- `includeColumn`: `boolean` Can set this to `false` in order to hide certain columns under certain conditions (e.g. "VVM Status" only appears if applicable permissions are enabled). Because this is a dynamic value, we'd expect an *expression* here rather than a literal `true`/`false` (otherwise you would just not define the column), so make sure any referenced variables are included in the `useMemo` dependency array.
+- `defaultHideOnMobile`: `boolean` When the "Simplified Mobile UI" preference is enabled, this column will be hidden by default on smaller devices, but the user can manually show it via the Columns menu.
+
+> [!CAUTION]
+> Don't create new `ColumnType` variants unless it will always return a consistent set of MRT Column properties, and will be re-used throughout the app. Most of the time, you can just specify a custom `Cell` (see [below](#custom-cell-components)).
+
+
+#### Filtering & Sorting
+
+Filtering and sorting for each column is **OFF** by default, so you have to explicitly enable them using the `enableColumnFilter` and `enableSorting` props. The reason for this decision is that (for paginated tables), the GraphQL endpoint needs to have filters and sort fields specifically implemented, and we didn't want it to be possible for a column to have a filter/sort UI without being sure the functionality is available in the API.
+
+By default, enabled filters are treated as `string` values, so if another filter type is required it needs to be specified in the `filterVariant` field. MRT has [several different filters](https://www.material-react-table.com/docs/guides/column-filtering#filter-variants) available, but we have currently restricted these. This is because we store the filter state in the URL query, so we have had to write parsers and stringifiers to map between the internal filter state and the URL query string, and we're only adding these as required. So for now, the following `filterVariant`s (defined in `useTableFiltering.ts`) are available (as of 26/09/2025):
+- `date-range`
+- `select`
+- `text` (the default)
+
+##### The `select` filter
+
+The `select` filter renders a drop-down menu. The values available can be defined explicitly using the `filterSelectOptions` property — an array of objects with a `value` and `label` (the display string), such as the **Invoice Status** options:
+```ts
+filterSelectOptions: [
+    { value: InvoiceNodeStatus.New, label: t('label.new') },
+    { value: InvoiceNodeStatus.Allocated, label: t('label.allocated') },
+    { value: InvoiceNodeStatus.Picked, label: t('label.picked') },
+    { value: InvoiceNodeStatus.Shipped, label: t('label.shipped') },
+    { value: InvoiceNodeStatus.Delivered, label: t('label.delivered') },
+    { value: InvoiceNodeStatus.Received, label: t('label.received') },
+    { value: InvoiceNodeStatus.Verified, label: t('label.verified') },
+]
+```
+
+However, the `select` options can be *automatically* generated using MRT's [Faceted Values](https://www.material-react-table.com/docs/guides/column-filtering#faceted-values-for-filter-variants), where the options are generated directly from the available data. A good example of this is the "Unit Name" field of the Outbound Shipment "Detail" view. To use this feature, just specify `filterVariant: "select"` with *no* `filterSelectOptions` defined.
+
+> [!WARNING]
+> Faceted values should only be used with *non-paginated* tables, as the component requires access to *all* data to generate a complete list of available options.
+
+
+#### Custom Cell components
+
+Several types of table data require special renderers to display correctly. Some of these have been mentioned [above](#optional) and are automatically applied using the `columnType` property (such as "Date" and "Currency").
+
+However, you can specify the exact component to use via the `Cell` prop. You can either define your React component inline, or refer to one of the pre-existing "Cell" components we've started creating in the `/components` subfolder of the `material-react-table` folder. If you're defining a component that is likely to be re-used elsewhere, please add it to this components library. (As we migrate from the old tables, *all* the old table cell components should be migrated over to these Cell components.)
+
+A `Cell` component can have access to the current row/column/value data (see full API [here](https://www.material-react-table.com/docs/guides/data-columns#custom-cell-render)), so if your component needs these values as props, instead of just doing:
+```ts
+Cell: NameAndColorSetterCell
+```
+you can define it like this:
+```tsx
+Cell: ({ row }) => (
+    <NameAndColorSetterCell
+    onColorChange={onUpdate}
+    getIsDisabled={isOutboundDisabled}
+    row={row.original}
+    />
+),
+```
+
+> [!TIP]
+> To make a table **editable**, you just need to render a cell that has an event handler that calls your data update method (whether it's updating the `draft` state, or running an actual mutation directly). See the `NumberInputCell` example in the Outbound Shipment line allocation table.
+
+## Grouped rows
+
+For now, we have simply replicated the existing "Grouped Rows" functionality, which is mostly used to "Group by Item" in the Detail View. For simplicity, we're pre-processing the data rows ourselves, and rows that match on the aforementioned [`groupByField`](#input-props) are combined into a "parent" row with a special `subRows` property, which [MRT can interpret](https://www.material-react-table.com/docs/guides/expanding-sub-rows#enable-expanding-sub-rows) and display accordingly.
+
+The Material React Table library actually has sophisticated [built-in grouping/expansion functionality](https://www.material-react-table.com/docs/examples/expanding-tree), allowing grouping by any user-selected field, which we can use at some point if it becomes desirable. But for now, we thought it added unnecessary complexity to the UI when we really only need limited, specific grouping for our use cases.
+
+## Additional considerations
+
+- Most of our GraphQL **React Query** hooks need to be updated slightly to work nicely with these table elements. The `useQuery` call needs to have the `keepPreviousData` option set to `true`, and the tables `isLoading` flag should use the value from the Query hooks `isFetching` property (rather than `isLoading`). This change ensures that when a paginated table is refetching data (from a filter, sort or pagination change), we don't render the "No Results" component while loading, cos that looks fugly as. Please ensure you make these modifications when replacing an old table with a new one.
+- When defining `Cell` components, please don't add any unnecessary styling to whatever "container" you render (and don't render a container at all if you can help it!). For example, any additional `padding` will make the whole table out of whack. Also, please ensure that existing table styles "cascade" through to the cell elements as much as possible — you may need to use the `inherit` value on some properties. For example, the `ExpiryDateCell` renders text in red if expired, but it defaults to `inherit` otherwise, which ensures the colour will be the currently active text colour (which could be defined from the theme, or overridden if it's a placeholder row, say). (We've had problems in the past with Placeholder rows not being coloured correctly in some columns, and this is why.)
+- We have removed reliance on the `TableStore` provider for tables, as we manage all table state within the new abstractions or in the MRT library itself. The only downside of this is that elements that share table state (such as `Footer`) need to share a common parent. But the good thing about this library is that we can define the `table` instance at a higher level in the component tree (using the table hooks) than the `MaterialTable` component itself, so it can be passed to whichever other components need it — and the `table` instance has [loads of useful methods](https://www.material-react-table.com/docs/api/table-instance-apis) for table data and configuration info if required.
+- When migrating a table to this new structure, please look closely at all the associated utilities/helper etc. and remove as much as possible — this new library makes a *lot* of this stuff superfluous.
+- Please ensure that this documentation remains up to date as table functionality is tweaked an expanded.
+
+*Last modified: 26/09/2025 — CJS*

--- a/docs/content/patterns/unit-testing/_index.md
+++ b/docs/content/patterns/unit-testing/_index.md
@@ -1,0 +1,271 @@
++++
+title = "Unit Testing & Mocking"
+weight = 20
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Unit Testing & Mocking
+
+## Why we do them
+
+Unit test serve to validate that logic complies with specifications, they are also useful when a bug is found to quickly replicate it. Unit test are super important in managing regression, and increase confidence in doing refactor work.
+
+## Examples
+
+### Checking postgres enum vs rust enum
+
+Derive strum on the enum
+
+```rust
+#[cfg_attr(test, derive(strum::EnumIter))]
+enum MyEnum {
+```
+
+In test
+
+```rust
+#[actix_rt::test]
+async fn test_enum() {
+    let (_, connection, _, _) =
+        setup_all("test_enum", MockDataInserts::none()).await;
+
+    let repo = Repository::new(&connection);
+    // Try upsert all variants, confirm that diesel enums match postgres
+    for variant in MyEnum::iter() {
+        let id = format!("{variant:?}");
+        let result = repo.upsert_one(&Row {
+            id: id.clone(),
+            enum: variant.clone(),
+            ..Default::default()
+        });
+        assert_matches!(result, Ok(_));
+
+        assert_eq!(
+            repo.find_one_by_id(&id),
+            Ok(Some(Row {
+                id,
+                enum: variant.clone(),
+                ..Default::default()
+            }))
+        );
+    }
+}
+```
+
+## Mocking the repository layer
+
+The most confidence we can get that a piece of our app works is by testing it end to end - click some things in the UI, does it now look as I expect, all the data updated correctly? But these tests are expensive to write, run, and maintain. Whether done manually or automatically, it would be impossible to test every possible state of every area of our app in this way.
+
+Meanwhile, a small unit test is very fast to write, and easy to read and maintain. They give us confidence that each building block works as expected. But they don't ensure that the building blocks all work together for the outcome we intend.
+
+Good test coverage is best implemented with a layered testing approach. Layered testing accepts these facts, and so encourages us to write many unit tests, and then a few integration and end-to-end tests to ensure the critical paths hang together.
+
+![Testing pyramid](https://github.com/user-attachments/assets/55bb2baf-abdf-400e-a9c7-6bb3238241b7)
+
+The typical tests we write in our service layer would be considered integration tests: set up a database with some test data, call a service function, and assert that data, potentially across many tables, has been updated successfully. Many units have to work together to get the desired outcome. They're pretty time consuming to write, and often hard to read/determine was is actually being tested.
+
+Here's an example:
+
+```rs
+  #[actix_rt::test]
+    async fn update_stocktake() {
+        fn mock_stocktake_finalised() -> StocktakeRow {
+            inline_init(|r: &mut StocktakeRow| {
+                r.id = "mock_stocktake_finalised".to_string();
+                r.store_id = "store_a".to_string();
+                r.stocktake_number = 20;
+                r.created_datetime = NaiveDate::from_ymd_opt(2024, 12, 14)
+                    .unwrap()
+                    .and_hms_milli_opt(12, 33, 0, 0)
+                    .unwrap();
+                r.status = StocktakeStatus::Finalised;
+            })
+        }
+
+
+        fn mock_stocktake_finalised_line() -> StocktakeLineRow {
+            inline_init(|r: &mut StocktakeLineRow| {
+                r.id = "mock_stocktake_finalised_line".to_string();
+                r.stocktake_id = mock_stocktake_existing_line().id;
+                r.stock_line_id = Some(mock_existing_stock_line().id);
+                r.counted_number_of_packs = Some(20.0);
+                r.snapshot_number_of_packs = 20.0;
+                r.item_link_id = mock_item_a().id;
+                r.cost_price_per_pack = Some(1.0);
+                r.sell_price_per_pack = Some(2.0);
+            })
+        }
+
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "update_stocktake",
+            MockDataInserts::all(),
+            inline_init(|r: &mut MockData| {
+                r.stocktakes = vec![
+                    mock_stocktake_finalised(),
+                ];
+                r.stocktake_lines = vec![
+                    mock_stocktake_finalised_line(),
+                ];
+            }),
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let mut context = service_provider
+            .context("store_a".to_string(), "".to_string())
+            .unwrap();
+        let service = service_provider.stocktake_service;
+
+        // error: CannotEditFinalised
+        let stocktake = mock_stocktake_finalised();
+        let error = service
+            .update_stocktake(
+                &context,
+                inline_init(|i: &mut UpdateStocktake| {
+                    i.id = stocktake.id;
+                    i.comment = Some("Comment".to_string());
+                }),
+            )
+            .unwrap_err();
+        assert_eq!(error, UpdateStocktakeError::CannotEditFinalised);
+```
+
+These tests are super valuable, but we wouldn't want to have to set up every single success and error case in this manner - it's too time consuming!
+
+Enter ✨mocking✨
+
+Mocking allows us to assume that a dependency works as expected, and has been tested separately, so we can fake its responses. We can then easily provide different states to the code under test, and ensure we get the right result in each case.
+
+When I test each `validate` step in the service layer, the dependency is our database/repository layer. By comparison, we could write something like this:
+
+```rs
+ #[test]
+    fn cant_edit_verified_error() {
+        let verified_stocktake = StocktakeRow {
+            id: "verified".to_string(),
+            status: StocktakeStatus::Finalised;
+            ..Default::default()
+        };
+
+        let mock_repo = MockStocktakeRowRepository {
+            find_one_by_id_result: Some(verified_stocktake)
+        };
+
+        let input = UpdateStocktake {
+            id: "verified".to_string(),
+            ..Default::default()
+        };
+
+       let error = validate(mock_repo, input).unwrap_err();
+        assert_eq!(error, UpdateStocktakeError::CannotEditFinalised);
+    }
+```
+
+### How does it work?
+
+In Rust, mocking is made possible with traits. Traits describe the methods available on a struct (their names, input and output types) but they don't describe the internal workings. This is the trait for our Clinician Row Repository:
+
+```rs
+pub trait ClinicianRowRepositoryTrait<'a> {
+    fn find_one_by_id(&self, row_id: &str) -> Result<Option<ClinicianRow>, RepositoryError>;
+   // ... other methods as needed
+}
+```
+
+Then, our usual runtime code ClinicianRowRepository implements this trait, here is a snippet:
+
+```rs
+impl<'a> ClinicianRowRepositoryTrait<'a> for ClinicianRowRepository<'a> {
+    fn find_one_by_id(&self, row_id: &str) -> Result<Option<ClinicianRow>, RepositoryError> {
+        let result = clinician::dsl::clinician
+            .filter(clinician::dsl::id.eq(row_id))
+            .first(self.connection.lock().connection())
+            .optional()?;
+        Ok(result)
+    }
+}
+```
+
+Now, in our service layer, instead of calling `ClinicianRowRepository` directly, we can expect _something that implements the ClinicianRowRepositoryTrait_ to be passed in:
+
+```rs
+ pub fn validate<'a>(
+    clinician_repo: impl ClinicianRowRepositoryTrait<'a>,
+    input: InsertClinicianInput
+) -> Result<(), InsertClinicianError> {
+    let clinician = clinician_repo.find_one_by_id(&input.id)?;
+
+    if clinician.is_some() {
+        return Err(InsertClinicianError::ClinicianAlreadyExists);
+    }
+
+    ...
+}
+```
+
+Our runtime service code would pass in the usual repo:
+
+```rs
+ let clinician_repo = ClinicianRowRepository::new(connection);
+ validate(clinician_repo, input)?;
+```
+
+But in our tests, we can provide a different implementation! We define a `mock` clinician row repo, and implement the same trait - except this time, we just return some data, rather than accessing any database:
+
+```rs
+#[derive(Default)]
+pub struct MockClinicianRowRepository {
+    pub find_one_by_id_result: Option<ClinicianRow>,
+}
+
+
+impl<'a> ClinicianRowRepositoryTrait<'a> for MockClinicianRowRepository {
+    fn find_one_by_id(&self, _row_id: &str) -> Result<Option<ClinicianRow>, RepositoryError> {
+        Ok(self.find_one_by_id_result.clone())
+    }
+}
+```
+
+This allows our test setup to look a little more like this:
+
+```rs
+ #[test]
+    fn clinician_already_exists_error() {
+        let mock_repo = MockClinicianRowRepository {
+            find_one_by_id_result: Some(ClinicianRow::default_with_id("existing_id")), // Simulate existing clinician,
+        };
+
+        let input = InsertClinician {
+            id: "existing_id".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            validate(mock_repo, &input),
+            Err(InsertClinicianError::ClinicianAlreadyExists)
+        );
+    }
+```
+
+No in-memory database setup, no extra test data required. We used mocking to set up the exact environment we needed for the area of code under test, and nothing more.
+
+### A little deeper
+
+You'll notice the MockClinicianRowRepository has a `find_one_by_id_result` - a helper field, so we only need to set the expected value, rather implementing the whole `find_one_by_id` method for each test.
+
+Mocking gives us lots of flexibility though, if we wanted, we could have implemented the mock `find_one_by_id` as:
+
+```rs
+fn find_one_by_id(&self, row_id: &str) -> Result<Option<ClinicianRow>, RepositoryError> {
+    assert_eq!(row_id, "existing_id");
+    Some(ClinicianRow::default())
+}
+```
+
+i.e. we can do custom assertions on the thing that find_one_by_id got called with! Just think of the possibilities! 😁
+
+The actual validate function for clinicians looks slightly more complex, you can check it out [here](https://github.com/msupply-foundation/open-msupply/blob/develop/server/service/src/clinician/insert/validate.rs). It passes all required repositories in on a struct, which requires boxing. It was implemented this way to ensure this pattern was possible even with many dependent repositories, but to keep your code and tests simpler, I'd recommend avoiding the parent `Repositories` struct until necessary!

--- a/docs/content/process/_index.md
+++ b/docs/content/process/_index.md
@@ -1,0 +1,13 @@
++++
+title = "Process"
+weight = 55
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Process
+
+Team practices and development process documentation: release process, definition of done, refactoring practices, documentation standards, and notes on migrating implementations from legacy mSupply.

--- a/docs/content/process/definition-of-done/_index.md
+++ b/docs/content/process/definition-of-done/_index.md
@@ -1,0 +1,78 @@
++++
+title = "Definition of Done"
+weight = 20
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Definition of Done
+
+> This is a living document, first experimented with by Team Ruru for 2.8 release, updated as of 2.10
+
+As a team, it's important we have an agreed understanding of what it means for a piece of work to be considered "done". It defines the level of quality we commit to, and what others can expect from our software once we say something is done.
+
+## Definition
+
+For us, "development done" of an issue means:
+
+- Issue acceptance criteria have been met
+- All tests, including integration test, pass
+- All added logic has associated unit tests
+- GraphQL nodes added to an API contract test (types based - ensure stability of GQL API for 3rd party consumers)
+- No known bugs in the new area
+- Refactoring has been completed where code duplication would have been created - endeavour to introduce as little technical debt as possible
+- Any unhandled cases are apparent to user and in code (either due to out-of-scope or in-development)
+- Bullet points of the changed areas have been added to the Draft Docs Google Doc (to be written into the external docs by RC phase)
+- Internal documentation written for any patterns added (where sensible, may be comments, README, KDD...)
+- If internal docs are missing for existing pattern, context, command etc.
+  - At minimum, add a TLDR in relevant place
+  - If needed, create an issue for further context to be added by area expert
+- Testing steps have been written with PR reviewer and QA in mind, and I have gone through these steps myself
+- PR approved and merged
+
+
+And for "done" of a feature:
+
+- External docs fully written (user friendly language, screenshots, and deployed to staging)
+
+## Outcomes
+
+We expect the focus on the below practices to result in:
+
+- Increased confidence in the code released
+- Fewer bugs found during RC phase
+- Fewer regression bugs over time (due to being caught by tests)
+- Greater understanding for PMs/QA of feature implementation and its current state, due to draft documentation (& regular demos)
+  - Any misunderstandings/required rework is caught earlier
+
+
+Practices to help:
+
+- Treat `develop` branch as deployable - we should be confident that everything we merge there works
+- Test-driven development - write the tests first
+  - Proves that any code added is required, in order for a piece of logic to succeed
+  - Ensures we write testable code
+- Separate logic methods and their consumers, so tests are easier to write (e.g. a lot easier to test outputs of a function, than test a React component renders in various different ways!)
+
+
+## Ongoing discussion
+
+This understanding should be wider than the development team. The flow of value is only really complete when it is in front of a user. As such, we might only consider something done after a deployment of that feature has been rolled out.
+
+However, there can be a long time between the release of a version, and its deployment in country, so in our context, it might feel more correct for "done" to equate to "released", and deployable at any time.
+
+As such, things that should be included in done:
+
+- Feature is QA'd
+- Product documentation written (devs do reference docs, but a PM is better placed to do more of the why, the user guide)
+- New/updated translations completed across our supported languages
+- Feature released
+
+We'd love to see earlier QA (e.g. nightly builds, QA testing latest changes, rather than full features during RC phase) and PMs writing preliminary docs before/during development, describing intended workflow.
+
+These aren't within our control as a dev team though, but things to work towards as an org.
+
+Also - "treating develop as deployable" would take the full dev team agreement, and a decision on how we handle in-progress features. Feature flags, hidden pages etc. We can revisit this in future :)

--- a/docs/content/process/documentation/_index.md
+++ b/docs/content/process/documentation/_index.md
@@ -1,0 +1,68 @@
++++
+title = "Documentation"
+weight = 30
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Documentation
+
+## Public Documentation
+
+**Feature documentation should be done by the team that implemented the feature. Please also update the [Introduction](https://docs.msupply.foundation/docs/introduction/introduction/) and [Permissions](https://docs.msupply.foundation/docs/administration/permissions/) pages if needed.**
+
+Any Pull Request (PR) that has changes to the functionality or User Interface (UI) needs to be labelled with `docs: external` and the `Documentation` part of the PR needs to be filled out. You do not have to write up the whole documentation here, just a couple of bullet points or screenshots to indicate what has been changed / how it should work.
+
+Any updates to the public docs should be done in a PR branched off the current `staging` branch in the [mSupply_docs](https://github.com/msupply-foundation/msupply_docs) repository and will be merged on release cycle's PR merged date.
+
+Example:
+
+```
+## 📃 Documentation
+<!-- Note down any areas which require documentation updates -->
+
+- [ ] New `issued` column in `Requisitions` indicates stock quantity already in shipments
+```
+
+### Documentation Standards
+
+1. We use New Zealand English spelling conventions
+1. Only screenshot the `App Nav` section when screenshotting `gotos`
+1. Use a table when listing out columns with descriptions
+1. Try not to get the App Nav in screenshots or have it collapsed so that screenshots don't have to be updated when App Nav is updated
+1. You can add a callout-style section by adding a `div` with a class of `note`, `tip`, `omsupdate`, `warning` ( for Spanish and French translators, yes, you can use `nota / remarque`, `conseil / consejo`, `mise-a-jour / noticia`, `aviso / avertissement` )
+
+![Callout example](https://github.com/msupply-foundation/open-msupply/assets/9192912/ba4a3990-ef74-4e1e-87e1-af411a6db018)
+
+![Callout example 2](https://github.com/msupply-foundation/open-msupply/assets/9192912/32d2ad80-e454-49a0-8a23-81b3cfe740b8)
+
+5. You can also add an image title using a div with the `imagetitle` class
+
+![Image title example](https://github.com/msupply-foundation/open-msupply/assets/9192912/25feb6d4-012a-4419-ac6b-f6e443635993)
+
+e.g.
+
+```
+<div class="imagetitle">
+In the below example, there is the picture of a cat
+</div>
+
+![Random cat picture](/docs/catalogue/images/cat.png)
+```
+
+6. When inserting images, we prefer the syntax `![Image description](/docs/catalogue/images/image_name.png)`. You may need to use the `<img/>` tag when adding images to `<div/>` elements, such as notes, don't use them elsewhere though.
+7. Use simple language, and think carefully about how ambiguous the wording can be. Check your assumptions and tend toward being more descriptive than you might otherwise when explaining things.
+8. When writing bullet lists, these should be terminated with full stop if the line consists of multiple sentences, and not have a full stop if consisting of a single sentence
+9. Don't use gifs! The documentation is currently littered with gifs which have a huge file size, making the overall bundle of docs too big to include as offline docs. We would like to reduce the bundle size. We are also trying to produce a PDF version of the documentation and gifs are not supported.
+10. Please take screenshots of a remote site, and not the Open mSupply central server - unless explicitly describing central server functionality of course! Most users are using the remote site, and it is confusing having the screen appear differently to your screen in the documentation imagery.
+11. When annotating images with arrows or circle highlights, use the orange colour (#F09837) (side note: I see a lot of different variations here.. this is the most common) and a thick line (3rd from bottom in the preview markup tool)
+
+
+## Internal Documentation
+
+Any part of the code base that needs internal documentation needs to be labelled with `docs: internal`.
+
+**Once you have done the docs whether they be external or internal, please change the label from `docs: external` or `docs: internal` to `doc: done`**

--- a/docs/content/process/load-test/_index.md
+++ b/docs/content/process/load-test/_index.md
@@ -1,0 +1,21 @@
++++
+title = "Load Test"
+weight = 60
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Load Test
+
+Load testing was developed to benchmark our OG and OMS sync systems capabilities on a fairly standardised setup. This should inform us:
+
+* What performance we should expect
+* Where the first bottlenecks are likely to rise
+* How performance degrades over time as database size increases
+
+As for the now the docs are internal, but should be made public at some stage:
+
+https://docs.google.com/document/d/1dlITEUbRJCNUXlSLgPsRGLqqo29M6_bKA25cVqRyvfo/edit?usp=sharing

--- a/docs/content/process/migration-from-msupply/_index.md
+++ b/docs/content/process/migration-from-msupply/_index.md
@@ -1,0 +1,33 @@
++++
+title = "Migration from mSupply"
+weight = 50
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Migration from mSupply
+
+When migrating an implementation from mSupply to Open mSupply please be aware of the following:
+
+## Distribution
+
+#### Outbound Shipment
+
+- Status: **Picked**. Goods are no longer part of inventory. This was done to match mSupply's `cn` status
+
+## Replenishment
+
+## Catalogue
+
+## Inventory
+
+#### Repacks
+
+- If you have a repack in the `new` status, then this will not be transferred to Open mSupply. There is no `new` status in Open mSupply for repacks, these are saved in the system as finalised and the stock adjusted when you save.
+
+## Dispensary
+
+## Coldchain

--- a/docs/content/process/refactoring/_index.md
+++ b/docs/content/process/refactoring/_index.md
@@ -1,0 +1,93 @@
++++
+title = "Refactoring"
+weight = 40
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Refactoring code
+
+Refactoring code is an important part of the lifecycle of software.
+As we add features, or learn new techniques it often makes sense to make significant code changes to support improved maintainability in future.
+
+However, refactoring can often be a contentious area, and not everyone might agree on the best approach.
+It can also take time away from developing features, or making bug fixes.
+
+Refactors needs to be weighed up against these factors and planned in as part of the sprint planning work.
+
+## Refactor Process
+
+* Discuss with a teammate first to make sure that more than one person sees the value of the change
+* Raise a new Github Issue For Refactor (using the refactor issue template)
+> In some cases, where a small refactor is needed and is directly related to the task, the team might agree that a separate issue isn't needed
+* Discuss the issue with the wider team, if it's a small enough issue the team might agree to take it on as part of the current sprint. If not the issue can be left to be considered as part of the triage and sprint planning process.
+* If there isn't consensus with the team on the best approach for a refactor, the options might be considered in a KDD style process.
+
+## Long Term Refactoring
+
+Some refactors involve updating code in a lot of different places.
+These kinds of refactors can sometimes be done, piece by piece.
+E.g. Switching out an old table component for a new more powerful one.
+In this case it often makes sense to set a pattern on how to do the refactor, then plan in small chunks on how to refactor as we go.
+
+## Todos: tech debt to refactor!
+
+- Abstracted API hooks -> all-in-one hook
+- Github Actions: check for any depreciated actions or commands and create an issue to upgrade
+
+# Dependency upgrades
+
+A core element of code maintenance is keeping our dependencies up to date. This ensures we are getting the latest security patches, as well as new features that can improve performance and developer experience.
+
+Dependencies are easiest to keep up to date if we do so regularly. Falling behind several major versions often makes upgrading painful. It also tends to mean we can't update other packages, as they depend on newer versions of peer dependencies as well.
+
+## Our practices
+
+Patch and minor upgrades to dependencies should be applied regularly - at least every release.
+
+For major version upgrades, a refactor issue should be created. When working on this:
+
+- Changes in the major version should be reviewed
+  - Are there breaking changes for components that we use? What is the level of impact on our codebase?
+  - Are there new features that we would benefit from?
+- If either of these are significant, pair with a senior/expert in the area of the code affected, to make a plan for the upgrade. See below about ring-fencing dependenices.
+- The upgrade should be applied, and breaking changes handled. New features should be raised as a separate issue to be triaged, please use the refactor issue template to articulate the value of moving to the new features.
+
+
+### Ring-fencing dependencies
+
+To make upgrading packages easier, we should endeavour to `ring-fence our dependencies`. This is part of the intention of the `common` folder, but still needs to be worked towards. Let's take a simplified example:
+
+```ts
+// Package exposes:
+function add(a: number, b: number) {...}
+
+// Our common folder exposes:
+function add(a: number, b: number) {
+  return package.add(a, b)
+}
+
+// We use in the rest of our code
+add(15, 6)
+```
+
+After a major upgrade, the package might change the API:
+```ts
+// Package now exposes:
+function add(inputs: { first: number, second: number }) {...}
+```
+
+Because we have created our common wrapper, we can shield the rest of our codebase from having to change to support this upgrade:
+```ts
+// Our common method can continue to expose the same function signature:
+function add(a: number, b: number) {
+  return package.add({ first: a, second: b })
+}
+```
+
+We might have been using `add` in hundreds of files! But now we only need to change one place.
+
+This won't always save us from having to make sweeping changes - we might want to pass in a new type of param for example - but it does give us the option of when to do this. We can use the wrapper methods to allow upgrading dependencies quickly and access performance/security improvements, and then do a second update of the codebase to make use of new features, at a time that works for us.

--- a/docs/content/process/release-process/_index.md
+++ b/docs/content/process/release-process/_index.md
@@ -1,0 +1,216 @@
++++
+title = "Release Process"
+weight = 10
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "docs"
++++
+
+# Release Team Responsibilities
+
+One Open mSupply team will be responsible for releasing. This will be rotated every two release cycles.
+
+On top of managing the milestone and creating the release, the release team will:
+
+- Triage incoming bugs
+- Liaise with QA
+- Update docs before the release
+- Update the [release spreadsheet](https://docs.google.com/spreadsheets/d/1VmviJcym4owNtLXq2uQRG4k4PHhN3_BJA004m8l3iao) with expected release dates and status
+
+## Daily bug triage
+
+Bugs are created with the `needs daily triage` and `needs triage` labels. Each day, someone from the release team should review all bugs with the `needs daily triage` label assigned.
+
+If the bug is critical and requires a hot fix:
+- The `Severity: Hotfix` label should be assigned
+- Milestone should be assigned (either patch or current RC)
+- A team should be assigned to implement the fix immediately
+- Both the `needs daily triage` and `needs triage` labels should be removed
+
+For non-critical bugs:
+- Assign a preliminary severity label to help the triage team
+- Remove the `needs daily triage` label, keep `needs triage`
+- The bug will be properly triaged by the triage team at the next weekly meeting
+
+
+# Open mSupply Release Process
+
+On the week of the RC release, schedule a demo session with 1 person from each team and the QA team to ensure they have an idea of what they would be testing.
+
+This is the process followed when creating a release. It's written out here as a knowledge sharing process really, those of you who do the releases will know most of this, though perhaps a checklist or reference is helpful.
+
+## Checklist
+Here's an outline of the steps to take when making a release. Think of this as your cheatsheet - for more information see the sections below
+
+### RC
+
+* [ ] Check that [weblate](https://translate.msupply.org/projects/open-msupply/#repository) has pushed all changes to the repo before making the release branch!
+* [ ] Name the release branch `v*RC` to ensure branch protection e.g. v2.1.0-RC, v1.0.0-RC
+* [ ] Update package json from e.g. `2.1.0-develop` to `2.1.0-rc`
+* [ ] Publish the branch
+
+The `v*-RC` structure of the branchname will be picked up by our [nightly build process](@/github-actions/nightly-builds/_index.md). Installers for the RC will be built and published each night.
+
+#### Urgent builds
+
+If an urgent build is required, rather than waiting for nightly build, simply create a tag:
+
+- `git tag v2.1.0-rc-170125-2` (this example uses the date + `-2` to help distiguish, but you can use whatever suffix)
+- `git push origin tag v2.1.0-rc-170125-2`
+
+The `v` prefix will get picked up by our actions and kick of a build.
+
+### Release
+
+* [ ] Merge feature branch to main
+* [ ] Merge main to develop
+* [ ] Delete the release branch
+* [ ] Create a tag for the release version e.g. `v2.1.0` and push to kick of installers
+* [ ] Post in `omSupply Releases` in Telegram to announce the new release
+
+## Branches overview
+This is the branching strategy that we're using ([ref](https://github.com/mobify/branching-strategy/tree/master))
+
+![Branching strategy](https://github.com/msupply-foundation/open-msupply/assets/9192912/ddee302d-e3ff-430e-9e0a-c2c8d3cc7d32)
+
+| Branch        | Protected? | Base Branch | Description    |
+| :-------------|:-----------|:------------|:---------------|
+| `main`      | YES        | N/A         | What is live in production (**stable**).<br/>A pull request is required to merge code into `main`. |
+| `develop`     | YES        | `main`    | The latest state of development (**unstable**). |
+| feature       | NO         | `develop`   | Cutting-edge features (**unstable**). These branches are used for any maintenance features / active development. |
+| `release-vX.Y.Z` | NO      | `develop`    | A temporary release branch that follows the [semver](http://semver.org/) versioning. This is what is sent to UAT.<br/>A pull request is required to merge code into any `release-vX.Y.Z` branch. |
+| `hotfix-*`    | NO         | `main`    | These are bug fixes against production.<br/>This is used because develop might have moved on from the last published state.<br/>Remember to merge this back into develop and any release branches. |
+
+### Create and deploy a release
+When it comes to release time, the process is as follows:
+
+![Release flow](https://github.com/msupply-foundation/open-msupply/assets/9192912/0ea2699b-fe7b-4e0b-86c5-b0c71ed2cbf4)
+
+We create the release candidate branch after PR merge deadline.
+
+1. Merge `main` into `develop` to ensure the new release will contain the
+   latest production code. This reduces the chance of a merge conflict during
+   the release.
+
+   ```
+   $ git checkout develop
+   $ git merge main
+   ```
+
+1. Create a new `release-vX.Y.Z` release branch off of `develop`.
+
+   ```
+   $ git checkout -b release-vX.Y.Z
+   $ git push --set-upstream release-vX.Y.Z
+   ```
+
+
+
+1. Triage any incomplete issues - move any that won't be finished during RC phase into the Carryover milestone to be re-triaged
+
+1. When the code is ready to release, navigate to the project on
+   [Github](https://www.github.com) and open a pull request with the following branch
+   settings:
+   * Base: `main`
+   * Compare: `release-vX.Y.Z`
+   Update with details of the release
+
+1. If the version hasn't been bumped in the root `package.json` then do this now
+
+1. At some point in the checklist you will merge the release branch into `main`.
+   You can do this by using the "Merge pull request" button on the release PR.
+
+1. Add a tag, this will start a build process on Jenkins
+
+   ```
+   git tag vX.Y.Z
+   git push origin tag vX.Y.Z
+   ```
+
+   note that for the Jenkins build, the tag must start with `v`
+
+
+1. Now you are ready to create the actual release. Navigate to the [project page](https://github.com/openmsupply/open-msupply/releases)
+   on Github and draft a new release (or pre-release for RC versions)
+   * Click on the Draft a new release button:
+      ![Draft new release button](https://github.com/msupply-foundation/open-msupply/assets/9192912/a078e8d8-53e8-4e04-84d6-11b96d7f99f9)
+   * Click on Choose a tag
+      ![Choose a tag](https://github.com/msupply-foundation/open-msupply/assets/9192912/473824a5-1894-47eb-9c02-6ee34ac99f62)
+   * Select vX.Y.Z from the list
+   * This should set the 'previous tag' to 'auto'. Enter the tag as the heading of the release:
+      ![Tag heading](https://github.com/msupply-foundation/open-msupply/assets/9192912/0fff0be2-1d15-4001-8697-bf3885f3cb76)
+
+   * Edit the description. This is the format used:
+   ```
+   ### What's in this release
+   [a brief description of the highlights]
+
+   #### Features
+   - [bullet point for each feature, with a one-liner about them]
+
+   #### Bugs fixed
+   - #[issue number] [hand crafted description]
+
+   **Full Changelog**: https://github.com/openmsupply/open-msupply/compare/v1.1.14...v1.1.15
+   ```
+   You will find it helpful to click the **Generate release notes** button. This will give you a list of all PRs merged in this release. From there you can rewrite descriptions and gather up a list of changes.
+   * Upload the assets
+      * Android apk which you've just built
+      * All the assets from the jenkins build. Note that dropbox is much faster to download from!
+   * Set as latest release
+   * Click `Publish release`
+   * Post in `omSupply Releases` in Telegram to announce the new release
+
+## QA Cycle
+
+
+1. Update docs for current version (see below)
+
+1. Do daily triage for critical bugs that may stop the user from using some functionality and add them to the RCx milestone.
+
+
+### Documentation updates
+
+Public documentation for new features should be written by the team that built the feature. However, PRs for bug fixes/small enhancements throughout the cycle which have UI changes will be assigned a `docs: external` label.
+
+Once in the testing sprint, filter `Done` PRs by `docs: external`, and update any relevant screenshots/descriptions. The `docs: external` label can then be replaced with `docs: done`.
+
+Where possible, teams should write docs as they go, rather than leaving this to the end :)
+
+### QA Process
+
+**Note: QA should always be using the latest RC build for their tests. This means that they should swap to the new RC version if it is available for the rest of their testing.**
+
+1. Write up/update test suites as required
+2. Create an epic issue that links to every test suite issue.
+3. Test new features first
+4. Go through the rest of the other test suites
+5. Once the test suites have been completed, individual bug issues can be tested. QA team gets this from their tester board, so please correctly label every issue with the correct milestone.
+
+## Release
+
+1. Merge the `release-vX.Y.Z` into `develop`.
+
+    ```
+    $ git checkout develop
+    $ git merge release-vX.Y.Z
+    $ git push
+    ```
+
+2. Close the release PR.
+
+3. Delete the release branch on Github.
+
+4. Delete git tags for previous release (keep tags for this release for reference)
+
+## New Release
+
+At the start of every release:
+
+1. Create an issue describing what is in the release, and pin it to the issue board, this one as an example: https://github.com/msupply-foundation/open-msupply/issues/3840
+2. Arrange a meeting with testers and devs to talk about:
+   1. Release dates
+   2. What each team is doing
+   3. What workflows might be affected and therefore what should be prioritised for testing


### PR DESCRIPTION
Fixes #11952

# 👩🏻‍💻 What does this PR do?

Migrates non-test pages from the [open-msupply wiki](https://github.com/msupply-foundation/open-msupply/wiki) into the Zola dev docs site at `docs/content/`. The wiki has been hosting developer process documentation that's hard to maintain through PRs, hard for AI assistants to discover, and disconnected from the rest of the repo. This moves it next to the code.

**This is a lift-and-shift migration — content is moved as-is, with no rewrites or content changes.** The goal is to land the structural move first so the diff stays reviewable. Improvements, corrections (typos, outdated info, missing context, image rehosting, etc.) will follow in **separate PRs**, where the diff cleanly shows "now vs new" against the migrated baseline rather than being tangled up with the move itself.

**Test scripts stay in the wiki** (per the issue) — the `Test:-*` pages and `Test Scripts 🧪` index are QA-owned content with a different lifecycle, and a decision to move them is out of scope here.

Four new top-level sections under `docs/content/`:

| Section | Pages |
|---|---|
| `process/` | release-process, definition-of-done, documentation, refactoring, migration-from-msupply, load-test |
| `code-review/` | _index (general comments), rust, typescript, snippets |
| `patterns/` | _index (changelog & sync), feature-development, unit-testing, table-implementation, card-list-implementation |
| `github-actions/` | _index (self-hosted runner), nightly-builds, client-code-checks |

19 new `_index.md` files, all with `source = "docs"` frontmatter. Internal cross-links between migrated pages use Zola's `@/path/_index.md` syntax (e.g. the release process page links to nightly-builds).

## 💌 Any notes for the reviewer?

- **Content fidelity**: kept verbatim apart from a handful of mechanical edits that were necessary for the migration itself — replacing a `<span style="color: red">red</span>` inline-HTML usage in `patterns/table-implementation/` with plain text (to satisfy `check-docs-structure.sh`'s HTML-tag check), consolidating two near-duplicate `Nightly-Automated-Builds` wiki pages into one, and adjusting one bare anchor URL that would have failed link checking. Prose typos (e.g. "depreciated", "useage") were **deliberately preserved** — fixing them belongs in a follow-up PR so the diff is clean.
- **Image hosting**: external image URLs (mostly `github.com/.../assets/...`) are kept as-is rather than downloaded into local `images/` folders. Per the docs README the local convention is preferred — also a follow-up.
- **Wiki not touched**: the wiki pages still exist on github.com/msupply-foundation/open-msupply/wiki and aren't redirected. A follow-up can replace each migrated wiki page with a one-line pointer to the new docs URL, and update the wiki Home and sidebar.
- **Structure choice**: top-level sections rather than nesting everything under a single `contributing/` section, to match the existing pattern (each existing area — `build/`, `server/`, `client/`, etc. — is a top-level section). Weights are 55/60/70/80, fitting between `standard_reports` (50) and `tools` (90).
- **`docs/check-docs-structure.sh`** passes for all new files. The 9 pre-existing errors on develop (orphans like `docs/content/_index.md`, `search/_index.md`, the `backdating/` tree, and missing READMEs in `server/mock_msupply/`, `syncdoc/`) are unchanged by this PR. Zola is not installed locally so I couldn't run the internal-link check, but link syntax matches the existing site convention.

### Follow-up PRs (each gets a clean diff against this baseline)

In flight:
- **#11954** — Update dev docs for AI-assisted ways of working. Adds AI-aware notes across `code-review/`, `patterns/unit-testing/`, `process/refactoring/`, `process/definition-of-done/`. Stacked on this branch; GitHub will auto-retarget to `develop` when this PR merges.

Still to do:
1. Fix typos and minor prose issues across the migrated content
2. Download external images into local `images/` folders per the docs convention
3. Replace each migrated wiki page with a pointer to its new docs URL; update wiki `Home.md` and `_Sidebar.md`
4. Refresh any content that was already stale on the wiki (e.g. ESLint version notes, "Last modified" stamps)

# 🧪 Testing

- [ ] `cd docs && zola serve` and confirm the new sections appear in the sidebar
- [ ] Visit each of the 19 new pages and confirm content renders without raw markdown leaking through
- [ ] Click the cross-references (e.g. `code-review/` → `code-review/rust/`, `process/release-process/` → `github-actions/nightly-builds/`) and confirm they resolve
- [ ] Run `./docs/check-docs-structure.sh` and confirm no new errors are introduced vs `develop`
- [ ] Spot-check a few code blocks (especially the Rust ones and the bash snippets in `code-review/snippets/`) for formatting

# 📃 Documentation

- [x] **No documentation required**: this PR _is_ the documentation migration; no user-facing changes
