### PR TITLE
#11952 Update dev docs for AI-assisted ways of working

### DIFF
--- a/docs/content/code-review/_index.md
+++ b/docs/content/code-review/_index.md
@@ -37,6 +37,18 @@ Before submitting the PR, do a self review:
   - Ensure naming is all up to date
   - Add review comments if more context is required for a certain change (or perhaps a code comment, if the context might not be apparent when someone comes back to this code in future!)
 
+If part of the change was written with an AI assistant, the self-review bar is higher, not lower — see [Reviewing AI-assisted code](#reviewing-ai-assisted-code) below for the things to double-check before pushing.
+
+## Reviewing AI-assisted code
+
+AI assistants now author a meaningful share of the code we ship. The general code-review principles on this page still apply, but a few things shift when a human is reviewing AI-authored work (or reviewing their own changes that were drafted by an AI):
+
+- **Plausible ≠ correct.** AI-generated code often reads naturally and uses real-looking APIs that don't actually exist, or uses them with the wrong arguments. Verify imports resolve, that functions called actually exist, and that the behaviour matches the issue — don't trust by reading.
+- **Tests can codify the wrong behaviour.** AI is good at writing tests that pass, which is not the same as writing tests that prove the spec. When tests were drafted by an AI, read them as a reviewer would: do they test the *requirement*, or do they test what the implementation happens to do?
+- **Scope creep.** AI tools often touch more than asked — renaming variables, "tidying" unrelated code, adding error handling for cases that can't happen. Treat any change outside the issue's scope the same way you would a human's unrelated fix: pull it into a separate PR, or remove it.
+- **Be explicit when AI was used.** Mentioning in the PR description that AI assisted with a change (and what kind of assistance — "drafted by Claude", "Copilot autocomplete", "AI-generated tests") lets reviewers calibrate. It also makes the rest of this list cheaper to apply because reviewers know where to look.
+- **Project conventions aren't free.** The Rust and Typescript pages below capture team preferences that AI assistants won't know unless told — `.to_string()` over `.to_owned()`, no `as` casts, no `packages/...` imports, etc. If you find yourself making the same correction to AI output repeatedly, capture it in `CLAUDE.md`/equivalent so the AI catches it next time.
+
 ## Prefer a simple solution over a complex one
 Experienced Developers often argue for a simple solution rather than a complex and re-usable approach.
 **Why?**

--- a/docs/content/code-review/snippets/_index.md
+++ b/docs/content/code-review/snippets/_index.md
@@ -10,6 +10,9 @@ source = "docs"
 
 # Suggestion Snippets
 
+> [!NOTE]
+> For most of the transformations below ("add a new migration", "add a new sync table", etc.), asking an AI assistant — pointing it at the reference commit linked in each section — is now usually the lowest-friction path. The `sed` recipes here remain useful as a precise, reproducible reference: they're explicit about exactly which substitutions are being made, which is harder to verify when an AI does it.
+
 ## Summary
 
 In this page you can find common commits that can be changed and applied to help with common coding tasking.

--- a/docs/content/code-review/typescript/_index.md
+++ b/docs/content/code-review/typescript/_index.md
@@ -49,7 +49,7 @@ let translation = t("permissions", {count: permissionList.length});
 
 ## Avoid using type assertions ('as' keyword)
 
-Use of [type assertion](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions) should be avoided, it can cause runtime errors in what looks like safe code. If type assertions have to be used, the resulting type should be consumed entirely in the same scope (with maximum amount of safety checks):
+Use of [type assertion](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions) should be avoided, it can cause runtime errors in what looks like safe code. AI assistants reach for `as` readily — it's a quick way to silence a type error without solving the underlying mismatch — so this is worth watching for in AI-drafted code. If type assertions have to be used, the resulting type should be consumed entirely in the same scope (with maximum amount of safety checks):
 
 ```typescript
 const myCanvas = document.getElementById("main_canvas") as HTMLCanvasElement;
@@ -93,8 +93,7 @@ doCheck(getLooksLikeCheck() as Check) // runtime error
 
 ## Imports
 
-If using co-pilot ( and possibly other helpers 🤷 ), you may have an auto generated import appear which has the format 'packages/..'
-Do not use these! While it will work as a standard runtime import, it will cause jest tests to fail.
+AI assistants (Copilot, Claude, Cursor, etc.) frequently auto-generate imports in the form `'packages/..'`. These will run, but they break jest tests, so they need to be replaced with the package-aliased form.
 
 Prefer
 
@@ -105,6 +104,8 @@ Instead of
 `import { InternalSupplierSearchModal, InternalSupplierSearchModal, NameRowFragment, NameRowFragment } from 'packages/system/src';`
 
 You can generally find an aliased path to use instead, or a reference which is relative to the current file.
+
+If you're using an AI assistant that respects project rules (e.g. `CLAUDE.md`, `.cursorrules`, Copilot's workspace instructions), adding a one-liner about this convention there is more effective than catching it in review every time.
 
 When exporting from packages, if an item is to be used outside of the package, export it from the package itself. This may require exporting from the root `index.ts` of the package and back up the tree of index files.
 
@@ -120,7 +121,7 @@ This makes is clear exactly what is being exported, and therefore depended on, o
 
 ## Avoid nested ternary
 
-Nested ternary operators can make code difficult to read and understand, which can lead to maintenance issues and bugs.
+Nested ternary operators can make code difficult to read and understand, which can lead to maintenance issues and bugs. AI assistants tend to generate these by default when condensing logic — flag them in review and rewrite as below.
 
 Instead:
 

--- a/docs/content/patterns/unit-testing/_index.md
+++ b/docs/content/patterns/unit-testing/_index.md
@@ -14,6 +14,11 @@ source = "docs"
 
 Unit test serve to validate that logic complies with specifications, they are also useful when a bug is found to quickly replicate it. Unit test are super important in managing regression, and increase confidence in doing refactor work.
 
+> [!NOTE]
+> The economics of writing tests have shifted. AI assistants can draft both unit and integration tests cheaply, so the old trade-off ("mock heavily because integration tests are expensive to write") no longer rules out integration coverage on cost grounds — pick the layer that actually proves the behaviour you care about.
+>
+> But AI-generated tests have their own failure mode: they tend to test what the implementation *happens to do* rather than what the *spec requires*. When reviewing AI-drafted tests, ask whether each assertion would still hold if you re-implemented the function from scratch — if the test would have to change, it's testing the implementation, not the contract.
+
 ## Examples
 
 ### Checking postgres enum vs rust enum

--- a/docs/content/process/definition-of-done/_index.md
+++ b/docs/content/process/definition-of-done/_index.md
@@ -58,6 +58,15 @@ Practices to help:
 - Separate logic methods and their consumers, so tests are easier to write (e.g. a lot easier to test outputs of a function, than test a React component renders in various different ways!)
 
 
+## AI-assisted work
+
+A meaningful share of the code we ship is now drafted with AI assistance. The bar for "development done" doesn't change because of this, but a few of the existing items take a bit more care:
+
+- **All added logic has associated unit tests** — AI-drafted tests need a deliberate read to confirm they test the *spec*, not just the implementation as written (see [Unit Testing & Mocking](@/patterns/unit-testing/_index.md))
+- **No known bugs in the new area** — AI may quietly extend scope or change behaviour at edges the prompt didn't cover; widen your own testing past the happy path before calling it done
+- **Refactoring has been completed where code duplication would have been created** — the cost of mechanical refactors has dropped, so the bar for what to clean up inline (vs. leaving as tech debt) is lower than it used to be (see [Refactoring](@/process/refactoring/_index.md))
+- **PR approved and merged** — mention AI involvement in the PR description so reviewers can calibrate (see [Reviewing AI-assisted code](@/code-review/_index.md#reviewing-ai-assisted-code))
+
 ## Ongoing discussion
 
 This understanding should be wider than the development team. The flow of value is only really complete when it is in front of a user. As such, we might only consider something done after a deployment of that feature has been rolled out.

--- a/docs/content/process/refactoring/_index.md
+++ b/docs/content/process/refactoring/_index.md
@@ -18,6 +18,11 @@ It can also take time away from developing features, or making bug fixes.
 
 Refactors needs to be weighed up against these factors and planned in as part of the sprint planning work.
 
+> [!NOTE]
+> AI assistants make mechanical refactors — renames, signature changes, threading a new parameter through, applying a pattern across many call sites — substantially cheaper than they used to be. That tilts the cost/benefit calculus on smaller refactors, and some changes that would previously have been "raise an issue, prioritise later" are now reasonable to include in the current PR.
+>
+> The catch is review: AI-driven refactors can quietly change behaviour at edges the prompt didn't cover, so widen the review (and the tests) when accepting one. The bigger the blast radius, the more this matters.
+
 ## Refactor Process
 
 * Discuss with a teammate first to make sure that more than one person sees the value of the change


### PR DESCRIPTION
Relates to #11952. Stacks on top of #11953 (the migration PR) — base branch is `11952-migrate-wiki-to-docs` so the diff cleanly shows "now vs new" against the migrated baseline. GitHub will auto-retarget this PR to `develop` once #11953 merges.

> [!WARNING]
> Draft. Opinions in the prose below are mine (Claude's) drafted with Esme — please push back on tone, framing, and any team-decision-shaped claims. The intent is to seed discussion, not to land policy.

# 👩🏻‍💻 What does this PR do?

Additive edits across six migrated docs to account for the fact that AI assistants now author a meaningful share of our code. The existing guidance is preserved; new notes flag the places where AI changes the picture.

| File | What changed |
|---|---|
| `code-review/_index.md` | Adds a new **"Reviewing AI-assisted code"** subsection (plausible≠correct; tests can codify wrong behaviour; scope creep; be explicit when AI was used; capture corrections in `CLAUDE.md`). Adds a one-liner in Self review pointing to it. |
| `code-review/typescript/_index.md` | Rewrites the "co-pilot 🤷" framing in **Imports** as a first-class AI consideration, and points at project-rule files as the durable fix. Adds short AI notes to **Type assertions** and **Nested ternary** (both common AI tells). |
| `code-review/snippets/_index.md` | Adds a note at the top: for most of these `sed` recipes, asking an AI is now lower-friction; the snippets remain useful as a precise reference. |
| `patterns/unit-testing/_index.md` | Updates the **Why we do them** framing: cost of writing tests has dropped, so the old "mock heavily because integration tests are expensive" trade-off no longer rules out integration coverage on cost grounds. Flags the failure mode of AI-drafted tests (testing implementation rather than spec). |
| `process/refactoring/_index.md` | Adds a note that mechanical refactors are cheaper now, tilting the in-PR vs. raise-issue calculus — with the caveat that review and tests need to widen too. |
| `process/definition-of-done/_index.md` | Adds an **"AI-assisted work"** subsection that maps existing DoD items to AI considerations (tests for spec not impl; widen own testing; lower bar for inline tidy-up; mention AI involvement in PR description). |

## 💌 Any notes for the reviewer?

- **Tone is the main thing to push back on.** I've tried to raise considerations rather than mandate policy — "consider", "tends to", "may want to" rather than "you must". If anything reads as putting words in the team's mouth, flag it and I'll soften.
- **No content was removed.** Every change is additive — either a new subsection or a new sentence inside an existing one. The original guidance is intact, so if a note goes too far it can be pulled without losing anything.
- **The TypeScript Imports rewrite is the one substantive change** to existing prose: the original "If using co-pilot ( and possibly other helpers 🤷 )" reads as half-acknowledging AI; I've made it the default framing. Happy to revert if you'd rather keep the original tone.
- **No `CLAUDE.md` / `.cursorrules` are added** in this PR — the docs mention them as a useful place for project-specific AI rules, but actually populating them is its own decision (and would be a separate PR if the team wants to).
- Internal cross-links use Zola's `@/...` syntax and pass `zola build` (no broken links). `docs/check-docs-structure.sh` shows the same 9 pre-existing errors as `develop`, no new ones.

# 🧪 Testing

- [ ] `cd docs && zola serve` and read each of the 6 changed pages end-to-end
- [ ] Click the new cross-references in `definition-of-done` (links to unit-testing, refactoring, code-review#reviewing-ai-assisted-code) and confirm they resolve
- [ ] Sanity-check that the additions read as part of the page rather than as bolted-on commentary
- [ ] Decide which (if any) sections should be stronger or softer in tone

# 📃 Documentation

- [x] **No documentation required**: this PR _is_ the documentation update; no code or user-facing changes