### PR TITLE
11928 fix: disable cost price field for internal supplier and PO inbound shipments

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -754,6 +754,7 @@
   "info.automatic-shipment": "This shipment was created automatically, as the result of an outbound shipment in another store.",
   "info.automatic-shipment-no-edit": "You are unable to edit details until the status is confirmed as Delivered.",
   "info.cannot-edit-program-requisition": "Cannot edit supplier, reorder threshold MOS, target MOS or add items in a program requisition.",
+  "info.cost-price-not-editable": "Cost price is controlled by the supplying store or purchase order and cannot be edited here.",
   "info.manual-return": "This return was created manually. The delivery status will not be automatically updated.",
   "info.manual-shipment": "This shipment was created manually. The delivery status will not be automatically updated.",
   "info.no-shipment": "Finalising this requisition will prevent you from creating a shipment for it.",

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -29,7 +29,7 @@ import {
   InfoIcon,
   useSimplifiedTabletUI,
 } from '@openmsupply-client/common';
-import { Select, MenuItem } from '@mui/material';
+import { Select, MenuItem, Tooltip } from '@mui/material';
 import { DraftInboundLine } from '../../../../types';
 import {
   CampaignOrProgramCell,
@@ -108,7 +108,9 @@ export const InboundLineEditCards = ({
     isExternal,
   } = useInboundShipment();
   const isManualShipment =
-    !inboundData?.purchaseOrder && !inboundData?.linkedShipment;
+    !inboundData?.purchaseOrder &&
+    !inboundData?.linkedShipment &&
+    !inboundData?.otherParty?.store;
 
   const showLineStatus =
     lines.some(line => line.status != null) ||
@@ -418,14 +420,21 @@ export const InboundLineEditCards = ({
         columnGroup: 'moreInfo',
         defaultHideOnMobile: true,
         Cell: ({ cell, row }) => (
-          <CurrencyInputCell
-            cell={cell}
-            disabled={isDisabled || !isManualShipment}
-            decimalsLimit={5}
-            updateFn={value =>
-              updateDraftLine({ id: row.original.id, costPricePerPack: value })
-            }
-          />
+          <Tooltip
+            title={!isManualShipment ? t('info.cost-price-not-editable') : ''}
+            placement="top"
+          >
+            <span style={{ display: 'inline-block', width: '100%' }}>
+              <CurrencyInputCell
+                cell={cell}
+                disabled={isDisabled || !isManualShipment}
+                decimalsLimit={5}
+                updateFn={value =>
+                  updateDraftLine({ id: row.original.id, costPricePerPack: value })
+                }
+              />
+            </span>
+          </Tooltip>
         ),
       },
       {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11928

# 👩🏻‍💻 What does this PR do?
Fixes a bug where the cost price field on an inbound shipment line could not be edited with clicking OK throwing a CannotEditCostPrice error.

Root cause: The frontend's isManualShipment condition only checked for a linked shipment or purchase order, but missed the case where the supplier is an internal store (otherParty.store is set). This meant the cost price field appeared editable but the server correctly rejected the change because name_store_id was set on the invoice.
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Create an inbound shipment from an internal supplier store (not via a purchase order)
- [ ] Open the line edit modal — confirm the cost price field is greyed out and not editable
- [ ] Hover over the cost price field — confirm the tooltip reads "Cost price is controlled by the 
supplying store or purchase order and cannot be edited here."
- [ ] Create an inbound shipment from an external supplier (manual, no PO) — confirm cost price is
editable
- [ ] Create an inbound shipment linked to a purchase order — confirm cost price is greyed out with
tooltip
- [ ] Create an inbound shipment from an internal store with a linked shipment — confirm cost price is
greyed out with tooltip

# 📃 Documentation

- [ ] No documentation required: bug fix restoring expected behaviour, tooltip provides inline guidance

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

