### PR TITLE
#11958 Keep item_link_id JSON key for requisition line plugins

### DIFF
--- a/client/packages/plugins/backendCommon/generated/RequisitionLineRow.ts
+++ b/client/packages/plugins/backendCommon/generated/RequisitionLineRow.ts
@@ -3,7 +3,6 @@
 export type RequisitionLineRow = {
   id: string;
   requisition_id: string;
-  item_link_id: string;
   item_name: string;
   requested_quantity: number;
   suggested_quantity: number;
@@ -25,4 +24,8 @@ export type RequisitionLineRow = {
   expiring_units: number;
   days_out_of_stock: number;
   option_id: string | null;
+  forecast_total_units: number | null;
+  forecast_total_doses: number | null;
+  vaccine_courses: string | null;
+  item_link_id: string;
 };

--- a/server/repository/src/db_diesel/requisition_line/requisition_line_row.rs
+++ b/server/repository/src/db_diesel/requisition_line/requisition_line_row.rs
@@ -89,7 +89,10 @@ pub struct RequisitionLineRow {
     pub forecast_total_units: Option<f64>,
     pub forecast_total_doses: Option<f64>,
     pub vaccine_courses: Option<String>,
-    // Resolved from item_link - must be last to match view column order
+    // Resolved from item_link - must be last to match view column order.
+    // Serialized as `item_link_id` to preserve the backend plugin JSON contract
+    // (e.g. TransformRequestRequisitionLines) after the #11668 item_link rename.
+    #[serde(rename = "item_link_id")]
     pub item_id: String,
 }
 
@@ -227,5 +230,31 @@ impl Upsert for RequisitionLineRow {
             RequisitionLineRowRepository::new(con).find_one_by_id(&self.id),
             Ok(Some(self.clone()))
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RequisitionLineRow;
+
+    // The backend plugin contract (e.g. TransformRequestRequisitionLines) serializes
+    // RequisitionLineRow to/from JSON. The #11668 item_link refactor renamed the Rust
+    // field item_link_id -> item_id; a #[serde(rename)] keeps the JSON key as
+    // `item_link_id` so existing plugins don't break. This test pins that contract.
+    #[test]
+    fn requisition_line_row_serializes_item_link_id_key() {
+        let row = RequisitionLineRow {
+            id: "line".to_string(),
+            item_id: "item".to_string(),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_value(&row).unwrap();
+        assert_eq!(json.get("item_link_id").and_then(|v| v.as_str()), Some("item"));
+        assert!(json.get("item_id").is_none());
+
+        // And it round-trips back from the `item_link_id` key.
+        let parsed: RequisitionLineRow = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.item_id, "item");
     }
 }


### PR DESCRIPTION
Fixes #11958

# 👩🏻‍💻 What does this PR do?

PR #11668 (the `item_link` abstraction refactor) renamed the Rust field `item_link_id` → `item_id` on `RequisitionLineRow`. That struct is serialized to JSON and handed to backend plugins via the `transform_request_requisition_lines` hook (`lines: Vec<RequisitionLineRow>` in, `transformed_lines` out — see `server/service/src/backend_plugin/types/transform_request_requisition_lines.rs`). Serde field names *are* the plugin wire contract, so the rename silently changed the JSON key from `item_link_id` to `item_id` and broke every plugin reading `line.item_link_id`.

This restores the contract by adding `#[serde(rename = "item_link_id")]` to the field, keeping the key stable in both directions (serialize + deserialize). A regression test pins the serialized shape.

#11668 already used this exact approach for the 5 sync-serialized rows (`RnRFormRow`, `RnRFormLineRow`, `VaccinationRow`, `ItemVariantRow`, `VaccineCourseItemRow`); `RequisitionLineRow` was simply missed because it's plugin-facing rather than sync-facing.

## 💌 Any notes for the reviewer?

- **Single-field, low-risk change.** No serializer in the codebase produced `item_id` for this field before #11668, so this purely restores the pre-#11668 wire key — no API/sync version bump needed.
- **Value semantics:** the field now carries the resolved canonical `item_id` (via the view) rather than the raw `item_link` FK. These are identical for unmerged items; for merged items the plugins that consume it map `item_link_id → item_id` and still resolve correctly (the self-link `item_link.id == item.id`). So the key is restored and behaviour is preserved.
- **Divergence from the issue:** the issue floated also adding `#[serde(alias = "item_id")]` to accept both keys on input. I deliberately left the alias off — a symmetric `item_link_id`-only contract (plugins always receive *and* send `item_link_id`) is less confusing than receiving one key but accepting two on the way back.
- **Verified against real plugins.** A cross-repo scan of all `msupply-foundation/*plugins` repos (see [issue comment](https://github.com/msupply-foundation/open-msupply/issues/11958#issuecomment-4627363184)) found 5 deployed plugins reading `line.item_link_id`; all are covered by this fix. I also built a throwaway `item_link_compat_check` backend plugin and installed it on a running central server — it logged `PASS: 'item_link_id' present on all 49 requisition line(s)`.

# 🧪 Testing

- [x] `cargo nextest run -p repository requisition_line_row_serializes_item_link_id_key` — passes (asserts the JSON key is `item_link_id`, not `item_id`, and round-trips)
- [x] Built + installed a backend `transform_request_requisition_lines` plugin reading `line.item_link_id` against a running central server; observed `PASS` in the server log
- [ ] Postgres / SQLite full suite in CI

# 📃 Documentation

- [ ] **No documentation required**: bug fix restoring a previously-working plugin wire contract; no user-facing behaviour change


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [ ] No Breaking Changes in the Graphql API

**Issue Review**
- [ ] All requirements in original issue have been covered

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend