### PR TITLE
Pin Android/Backend CI cargo builds to server/rust-toolchain.toml

### DIFF
--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -39,10 +39,21 @@ jobs:
           cp "$HOME/android/local.properties" ./client/packages/android
           cp "$HOME/android/release.keystore" ./client/packages/android/app
 
+      - name: Read Rust toolchain channel
+        id: rust_toolchain
+        # Scope the toolchain to this job only via RUSTUP_TOOLCHAIN; do NOT set a
+        # global rustup default/override on the shared self-hosted runner, or it
+        # would leak into develop builds (which pin a different channel).
+        run: |
+          CHANNEL=$(grep '^channel' server/rust-toolchain.toml | cut -d '"' -f2)
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "RUSTUP_TOOLCHAIN=$CHANNEL" >> "$GITHUB_ENV"
       - name: Set Up Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+          override: false
+          default: false
           targets: aarch64-linux-android
             armv7-linux-androideabi
         # Targets need to match in the config.toml of the self-hosted machine

--- a/.github/workflows/server-tests.yaml
+++ b/.github/workflows/server-tests.yaml
@@ -21,9 +21,20 @@ jobs:
       - name: Update PATH
         run: echo "$HOME/.cargo/bin:/opt/homebrew/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v4
+      - name: Read Rust toolchain channel
+        id: rust_toolchain
+        # Scope the toolchain to this job only via RUSTUP_TOOLCHAIN; do NOT set a
+        # global rustup default/override on the shared self-hosted runner, or it
+        # would leak into develop builds (which pin a different channel).
+        run: |
+          CHANNEL=$(grep '^channel' server/rust-toolchain.toml | cut -d '"' -f2)
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "RUSTUP_TOOLCHAIN=$CHANNEL" >> "$GITHUB_ENV"
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+          override: false
+          default: false
       - name: Install cargo-nextest
         run: command -v cargo-nextest || cargo install cargo-nextest --locked
       - uses: actions-rs/cargo@v1
@@ -61,9 +72,20 @@ jobs:
       - name: Update PATH
         run: echo "$HOME/.cargo/bin/:/opt/homebrew/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v4
+      - name: Read Rust toolchain channel
+        id: rust_toolchain
+        # Scope the toolchain to this job only via RUSTUP_TOOLCHAIN; do NOT set a
+        # global rustup default/override on the shared self-hosted runner, or it
+        # would leak into develop builds (which pin a different channel).
+        run: |
+          CHANNEL=$(grep '^channel' server/rust-toolchain.toml | cut -d '"' -f2)
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "RUSTUP_TOOLCHAIN=$CHANNEL" >> "$GITHUB_ENV"
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
+          override: false
+          default: false
       - name: Install cargo-nextest
         run: command -v cargo-nextest || cargo install cargo-nextest --locked
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

The **Android Build** and **Backend Tests** jobs invoke `cargo` from outside `server/` — the android build from `client/packages/android/` (via `build_remote_server_libs.sh`), the backend tests from the repo root (via `--manifest-path server/Cargo.toml`). rustup resolves the toolchain from the *working directory*, not the manifest, so neither job sees `server/rust-toolchain.toml` and both fall back to the runner's default `stable`.

That newer default rustc promotes diesel 2.3.2's ambiguous `max` glob import (`use diesel::dsl::max;`) to a hard error, so these jobs fail even though everything compiles under the pinned 1.88 (and the released 2.16.0x builds did).

Each affected job now reads the channel from `server/rust-toolchain.toml` and exports it as `RUSTUP_TOOLCHAIN` for that job only.

## 💌 Any notes for the reviewer?

- `RUSTUP_TOOLCHAIN` (via `$GITHUB_ENV`) is used deliberately instead of `rustup default`/`override` — it scopes the toolchain to the job's processes and leaves **no persistent state** on the shared self-hosted runner, so develop builds (pinned to a different channel) are unaffected. `default: false` / `override: false` are set explicitly for the same reason.
- Other cargo workflows (`server-build`, `validate-db-migration`, `build-mac-demo`) already run `cargo` inside `server/`, so they pick up the pin and were left untouched.
- Not touched here: the `Dockerise` failure is unrelated (fails in the `yarn` stage; its rust step uses the pinned `rust:1.88-slim` image). The deeper fix — dropping the ambiguous `use diesel::dsl::max;` imports as `develop` already did — is left for the RC line to decide separately.

# 🧪 Testing

- [ ] Push to a branch with `server/**` changes and confirm **Backend Tests** (sqlite + postgres) compile and pass.
- [ ] Trigger **Android Build** (tag push / `workflow_dispatch`) and confirm the rust lib compiles without the `max` ambiguity error.
- [ ] Confirm a concurrent/subsequent develop build on the same self-hosted runner still uses its own pinned channel.

# 📃 Documentation

- [ ] **No documentation required**: CI-only change, no user facing behaviour change.
