### PR TITLE
11873 fix CampaignDoesNotExist error when inserting stocktake line with soft-deleted campaign

### DIFF
--- a/server/service/src/campaign/mod.rs
+++ b/server/service/src/campaign/mod.rs
@@ -11,7 +11,7 @@ use repository::{
     PaginationOption,
 };
 pub use upsert::{upsert_campaign, UpsertCampaign, UpsertCampaignError};
-pub use validate::check_campaign_exists;
+pub use validate::{check_campaign_exists, check_campaign_exists_including_deleted};
 
 pub trait CampaignServiceTrait: Send + Sync {
     fn get_campaigns(

--- a/server/service/src/campaign/validate.rs
+++ b/server/service/src/campaign/validate.rs
@@ -1,5 +1,8 @@
 use repository::{
-    campaign::campaign::{CampaignFilter, CampaignRepository},
+    campaign::{
+        campaign::{CampaignFilter, CampaignRepository},
+        campaign_row::CampaignRowRepository,
+    },
     EqualFilter, RepositoryError, StorageConnection,
 };
 
@@ -11,4 +14,18 @@ pub fn check_campaign_exists(
         CampaignFilter::new().id(EqualFilter::equal_to(campaign_id.to_string())),
     ))?;
     Ok(count > 0)
+}
+
+/// Checks whether a campaign row exists, including soft-deleted campaigns.
+///
+/// Campaigns are soft-deleted (`deleted_datetime` is set), but their id stays
+/// referenced on stock lines. When such a stock line is carried forward onto a
+/// stocktake/invoice line, the (now soft-deleted) campaign id must still pass
+/// validation - the user cannot newly assign a deleted campaign, so any
+/// soft-deleted id reaching these mutations is a legitimate carry-forward.
+pub fn check_campaign_exists_including_deleted(
+    connection: &StorageConnection,
+    campaign_id: &str,
+) -> Result<bool, RepositoryError> {
+    CampaignRowRepository::new(connection).check_exists_by_id(campaign_id)
 }

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -1,7 +1,7 @@
 use crate::common::check_program_exists;
 use crate::invoice::inbound_shipment::InboundShipmentType;
 use crate::{
-    campaign::check_campaign_exists,
+    campaign::check_campaign_exists_including_deleted,
     check_item_variant_exists, check_location_exists, check_location_type_is_valid,
     check_vvm_status_exists,
     invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
@@ -133,7 +133,7 @@ pub fn validate(
         value: Some(campaign_id),
     }) = &input.campaign_id
     {
-        if !check_campaign_exists(connection, campaign_id)? {
+        if !check_campaign_exists_including_deleted(connection, campaign_id)? {
             return Err(CampaignDoesNotExist);
         }
     }

--- a/server/service/src/stocktake_line/insert/mod.rs
+++ b/server/service/src/stocktake_line/insert/mod.rs
@@ -126,6 +126,7 @@ mod stocktake_line_test {
             mock_stocktake_finalised, mock_stocktake_line_a, mock_store_a,
             program_master_list_store, MockData, MockDataInserts,
         },
+        campaign::campaign_row::CampaignRow,
         test_db::{setup_all, setup_all_with_data},
         EqualFilter, ReasonOptionRow, ReasonOptionType, StockLineFilter, StockLineRepository,
         StockLineRow, StockLineRowRepository, StocktakeLineRow, StocktakeRow,
@@ -450,6 +451,97 @@ mod stocktake_line_test {
             .unwrap()
             .unwrap();
         assert_eq!(stock_line_row.donor_id, Some(donor_id));
+    }
+
+    #[actix_rt::test]
+    async fn insert_stocktake_line_with_soft_deleted_campaign() {
+        // A campaign that has been soft-deleted, but is still referenced by a
+        // stock line. Carrying this campaign_id forward onto a stocktake line
+        // must not fail validation (regression for CampaignDoesNotExist).
+        fn soft_deleted_campaign() -> CampaignRow {
+            CampaignRow {
+                id: String::from("soft_deleted_campaign"),
+                name: String::from("Soft Deleted Campaign"),
+                deleted_datetime: Some(
+                    NaiveDate::from_ymd_opt(2024, 1, 1)
+                        .unwrap()
+                        .and_hms_opt(0, 0, 0)
+                        .unwrap(),
+                ),
+                ..Default::default()
+            }
+        }
+
+        fn mock_stock_line_with_campaign() -> StockLineRow {
+            StockLineRow {
+                id: String::from("mock_stock_line_with_campaign"),
+                item_id: String::from("item_a"),
+                store_id: String::from("store_a"),
+                available_number_of_packs: 20.0,
+                pack_size: 1.0,
+                total_number_of_packs: 30.0,
+                campaign_id: Some(soft_deleted_campaign().id),
+                ..Default::default()
+            }
+        }
+
+        // The campaign is inserted via MockData, but the stock line referencing
+        // it is created after setup - the mock data inserter adds stock lines
+        // before campaigns, so the foreign key would otherwise fail.
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "insert_stocktake_line_with_soft_deleted_campaign",
+            MockDataInserts::all(),
+            MockData {
+                campaigns: vec![soft_deleted_campaign()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, "".to_string())
+            .unwrap();
+        let service = service_provider.stocktake_line_service;
+
+        StockLineRowRepository::new(&context.connection)
+            .upsert_one(&mock_stock_line_with_campaign())
+            .unwrap();
+
+        // success: a soft-deleted campaign carried forward from the stock line
+        let stocktake_a = mock_stocktake_a();
+        let stock_line = mock_stock_line_with_campaign();
+        service
+            .insert_stocktake_line(
+                &context,
+                InsertStocktakeLine {
+                    id: uuid(),
+                    stocktake_id: stocktake_a.id.clone(),
+                    stock_line_id: Some(stock_line.id.clone()),
+                    campaign_id: Some(soft_deleted_campaign().id),
+                    counted_number_of_packs: Some(17.0),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        // regression: a campaign id that does not exist at all still errors
+        // (use a different stock line, the one above is now in the stocktake)
+        let other_stock_line = mock_new_stock_line_for_stocktake_a();
+        let error = service
+            .insert_stocktake_line(
+                &context,
+                InsertStocktakeLine {
+                    id: uuid(),
+                    stocktake_id: stocktake_a.id,
+                    stock_line_id: Some(other_stock_line.id),
+                    campaign_id: Some("nonexistent_campaign_id".to_string()),
+                    counted_number_of_packs: Some(17.0),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert_eq!(error, InsertStocktakeLineError::CampaignDoesNotExist);
     }
 
     #[actix_rt::test]

--- a/server/service/src/stocktake_line/insert/validate.rs
+++ b/server/service/src/stocktake_line/insert/validate.rs
@@ -1,6 +1,6 @@
 use super::{InsertStocktakeLine, InsertStocktakeLineError};
 use crate::{
-    campaign::check_campaign_exists,
+    campaign::check_campaign_exists_including_deleted,
     check_location_exists, check_location_type_is_valid, check_vvm_status_exists,
     common::{check_program_exists, check_stock_line_exists, CommonStockLineError},
     stocktake::{check_stocktake_exist, check_stocktake_not_finalised},
@@ -175,7 +175,7 @@ pub fn validate(
     };
 
     if let Some(campaign_id) = &input.campaign_id {
-        if !check_campaign_exists(connection, campaign_id)? {
+        if !check_campaign_exists_including_deleted(connection, campaign_id)? {
             return Err(InsertStocktakeLineError::CampaignDoesNotExist);
         }
     }

--- a/server/service/src/stocktake_line/update/validate.rs
+++ b/server/service/src/stocktake_line/update/validate.rs
@@ -1,5 +1,5 @@
 use crate::{
-    campaign::check_campaign_exists,
+    campaign::check_campaign_exists_including_deleted,
     check_location_exists, check_location_type_is_valid, check_vvm_status_exists,
     common::{check_program_exists, check_stock_line_exists, CommonStockLineError},
     stocktake::{check_stocktake_exist, check_stocktake_not_finalised},
@@ -156,7 +156,7 @@ pub fn validate(
         value: Some(ref campaign_id),
     }) = &input.campaign_id
     {
-        if !check_campaign_exists(connection, campaign_id)? {
+        if !check_campaign_exists_including_deleted(connection, campaign_id)? {
             return Err(CampaignDoesNotExist);
         }
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11870 

# 👩🏻‍💻 What does this PR do?
Fixes a CampaignDoesNotExist error that occurs when adding an item to a stocktake where the underlying stock line references a soft-deleted campaign.

Root cause: When a campaign is deleted in open-mSupply, it is soft-deleted (deleted_datetime is set on the row). However, existing stock lines still hold the old campaign_id. When a user adds an item with such a stock line to a stocktake, the campaign id is carried forward onto the new stocktake line. On save, the insert/update validation calls check_campaign_exists, which filters out soft-deleted campaigns — so the validation rejects a campaign id the stock line legitimately already had, returning CampaignDoesNotExist.

Fix: Added check_campaign_exists_including_deleted in service/src/campaign/validate.rs, which checks row existence without filtering on deleted_datetime. This is used at the three carry-forward validation sites (stocktake line insert, stocktake line update, inbound shipment stock-in line update). The existing check_campaign_exists (used by the campaign delete logic itself) is untouched.

A user can never newly assign a soft-deleted campaign — the search dropdown only lists live ones — so any soft-deleted id at these mutation sites is always a legitimate carry-forward from an existing stock line. A genuinely non-existent campaign id still returns CampaignDoesNotExist.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

To reproduce the bug:

1. Run this SQL to soft-delete a campaign that is still referenced by a stock line:
-- Find stock lines with a (potentially soft-deleted) campaign
```sql
SELECT sl.id, sl.batch, il.name AS item_name, c.id AS campaign_id, c.name, c.deleted_datetime
FROM stock_line sl
JOIN item_link ilnk ON ilnk.id = sl.item_link_id
JOIN item il ON il.id = ilnk.item_id
JOIN campaign c ON c.id = sl.campaign_id
WHERE sl.campaign_id IS NOT NULL AND c.deleted_datetime IS NULL;
```

-- Soft-delete one of those campaigns
UPDATE campaign SET deleted_datetime = datetime('now') WHERE id = '<campaign_id>';
2. Navigate to a stocktake and add the item whose stock line references the now-deleted campaign
3. In the stocktake line modal, enter a value in "Packs counted" and click OK
4. Before fix: CampaignDoesNotExist error appears in the snackbar
5. After fix: line saves successfully

- [ ] Reproduce the bug using the SQL steps above, confirm the fix resolves it
- [ ] Confirm that entering an entirely invalid (non-existent) campaign id via direct API call still returns CampaignDoesNotExist
- [ ] Confirm stocktake finalisation correctly carries the soft-deleted campaign_id back to the stock line

# 📃 Documentation

- [x] No documentation required: bug fix, no change in user-facing behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

