### PR TITLE
11971 update stock relocation

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -121,6 +121,9 @@ export enum ActivityLogNodeType {
   AssetLogReasonDeleted = 'ASSET_LOG_REASON_DELETED',
   AssetPropertyCreated = 'ASSET_PROPERTY_CREATED',
   AssetUpdated = 'ASSET_UPDATED',
+  BundledItemCreated = 'BUNDLED_ITEM_CREATED',
+  BundledItemDeleted = 'BUNDLED_ITEM_DELETED',
+  BundledItemUpdated = 'BUNDLED_ITEM_UPDATED',
   DemographicIndicatorCreated = 'DEMOGRAPHIC_INDICATOR_CREATED',
   DemographicIndicatorUpdated = 'DEMOGRAPHIC_INDICATOR_UPDATED',
   DemographicProjectionCreated = 'DEMOGRAPHIC_PROJECTION_CREATED',
@@ -139,11 +142,15 @@ export enum ActivityLogNodeType {
   InvoiceStatusVerified = 'INVOICE_STATUS_VERIFIED',
   ItemVariantCreated = 'ITEM_VARIANT_CREATED',
   ItemVariantDeleted = 'ITEM_VARIANT_DELETED',
+  ItemVariantUpdated = 'ITEM_VARIANT_UPDATED',
   ItemVariantUpdatedName = 'ITEM_VARIANT_UPDATED_NAME',
   ItemVariantUpdateDosePerUnit = 'ITEM_VARIANT_UPDATE_DOSE_PER_UNIT',
   ItemVariantUpdateLocationType = 'ITEM_VARIANT_UPDATE_LOCATION_TYPE',
   ItemVariantUpdateManufacturer = 'ITEM_VARIANT_UPDATE_MANUFACTURER',
   ItemVariantUpdateVvmType = 'ITEM_VARIANT_UPDATE_VVM_TYPE',
+  PackagingVariantCreated = 'PACKAGING_VARIANT_CREATED',
+  PackagingVariantDeleted = 'PACKAGING_VARIANT_DELETED',
+  PackagingVariantUpdated = 'PACKAGING_VARIANT_UPDATED',
   PatientCreated = 'PATIENT_CREATED',
   PatientUpdated = 'PATIENT_UPDATED',
   PrescriptionCreated = 'PRESCRIPTION_CREATED',
@@ -181,6 +188,7 @@ export enum ActivityLogNodeType {
   SensorLocationChanged = 'SENSOR_LOCATION_CHANGED',
   StocktakeCreated = 'STOCKTAKE_CREATED',
   StocktakeDeleted = 'STOCKTAKE_DELETED',
+  StocktakeEdited = 'STOCKTAKE_EDITED',
   StocktakeStatusFinalised = 'STOCKTAKE_STATUS_FINALISED',
   StockBatchChange = 'STOCK_BATCH_CHANGE',
   StockCostPriceChange = 'STOCK_COST_PRICE_CHANGE',
@@ -2090,6 +2098,8 @@ export type DeleteOutboundShipmentUnallocatedLineResponseWithId = {
   response: DeleteOutboundShipmentUnallocatedLineResponse;
 };
 
+export type DeletePluginDataResponse = DeleteResponse;
+
 export type DeletePrescriptionError = {
   __typename: 'DeletePrescriptionError';
   error: DeletePrescriptionErrorInterface;
@@ -2910,6 +2920,13 @@ export type EqualFilterStatusInput = {
   equalTo?: InputMaybe<AssetLogStatusNodeType>;
   notEqualAll?: InputMaybe<Array<AssetLogStatusNodeType>>;
   notEqualTo?: InputMaybe<AssetLogStatusNodeType>;
+};
+
+export type EqualFilterStockRelocationStatusInput = {
+  equalAny?: InputMaybe<Array<StockRelocationNodeStatus>>;
+  equalTo?: InputMaybe<StockRelocationNodeStatus>;
+  notEqualAll?: InputMaybe<Array<StockRelocationNodeStatus>>;
+  notEqualTo?: InputMaybe<StockRelocationNodeStatus>;
 };
 
 export type EqualFilterStocktakeStatusInput = {
@@ -4103,6 +4120,38 @@ export type InsertStockLineInput = {
 
 export type InsertStockLineLineResponse = InsertStockLineError | StockLineNode;
 
+export type InsertStockRelocationError = {
+  __typename: 'InsertStockRelocationError';
+  error: InsertStockRelocationErrorInterface;
+};
+
+export type InsertStockRelocationErrorInterface = {
+  description: Scalars['String']['output'];
+};
+
+export type InsertStockRelocationInput = {
+  fromLocationId?: InputMaybe<Scalars['String']['input']>;
+  lines: Array<InsertStockRelocationLineInput>;
+};
+
+export type InsertStockRelocationLineInput = {
+  fromNumberOfPacks: Scalars['Float']['input'];
+  fromStockLineId: Scalars['String']['input'];
+  id: Scalars['String']['input'];
+  toLocationId?: InputMaybe<Scalars['String']['input']>;
+  toPackSize: Scalars['Float']['input'];
+};
+
+export type InsertStockRelocationNode = {
+  __typename: 'InsertStockRelocationNode';
+  /** Ids of the created stock_relocation records. */
+  ids: Array<Scalars['String']['output']>;
+};
+
+export type InsertStockRelocationResponse =
+  | InsertStockRelocationError
+  | InsertStockRelocationNode;
+
 export type InsertStocktakeInput = {
   comment?: InputMaybe<Scalars['String']['input']>;
   createBlankStocktake?: InputMaybe<Scalars['Boolean']['input']>;
@@ -5260,6 +5309,13 @@ export type LocationNotFound = InsertOutboundShipmentLineErrorInterface &
     description: Scalars['String']['output'];
   };
 
+export type LocationOnHold = InsertStockRelocationErrorInterface &
+  UpdateStockRelocationErrorInterface & {
+    __typename: 'LocationOnHold';
+    description: Scalars['String']['output'];
+    locationId: Scalars['String']['output'];
+  };
+
 export enum LocationSortFieldInput {
   Code = 'code',
   Name = 'name',
@@ -5511,6 +5567,7 @@ export type Mutations = {
   deleteOutboundShipmentLine: DeleteOutboundShipmentLineResponse;
   deleteOutboundShipmentServiceLine: DeleteOutboundShipmentServiceLineResponse;
   deleteOutboundShipmentUnallocatedLine: DeleteOutboundShipmentUnallocatedLineResponse;
+  deletePluginData: DeletePluginDataResponse;
   deletePrescription: DeletePrescriptionResponse;
   deletePrescriptionLine: DeletePrescriptionLineResponse;
   deletePurchaseOrder: DeletePurchaseOrderResponse;
@@ -5575,6 +5632,7 @@ export type Mutations = {
   insertResponseRequisitionLine: InsertResponseRequisitionLineResponse;
   insertRnrForm: InsertRnRFormResponse;
   insertStockLine: InsertStockLineLineResponse;
+  insertStockRelocation: InsertStockRelocationResponse;
   insertStocktake: InsertStocktakeResponse;
   insertStocktakeLine: InsertStocktakeLineResponse;
   insertSupplierReturn: InsertSupplierReturnResponse;
@@ -5635,6 +5693,7 @@ export type Mutations = {
   updateRnrForm: UpdateRnRFormResponse;
   updateSensor: UpdateSensorResponse;
   updateStockLine: UpdateStockLineLineResponse;
+  updateStockRelocation: UpdateStockRelocationResponse;
   updateStocktake: UpdateStocktakeResponse;
   updateStocktakeLine: UpdateStocktakeLineResponse;
   updateSupplierReturn: UpdateSupplierReturnResponse;
@@ -5786,6 +5845,11 @@ export type MutationsDeleteOutboundShipmentServiceLineArgs = {
 
 export type MutationsDeleteOutboundShipmentUnallocatedLineArgs = {
   input: DeleteOutboundShipmentUnallocatedLineInput;
+  storeId: Scalars['String']['input'];
+};
+
+export type MutationsDeletePluginDataArgs = {
+  id: Scalars['String']['input'];
   storeId: Scalars['String']['input'];
 };
 
@@ -6060,6 +6124,11 @@ export type MutationsInsertStockLineArgs = {
   storeId: Scalars['String']['input'];
 };
 
+export type MutationsInsertStockRelocationArgs = {
+  input: InsertStockRelocationInput;
+  storeId: Scalars['String']['input'];
+};
+
 export type MutationsInsertStocktakeArgs = {
   input: InsertStocktakeInput;
   storeId: Scalars['String']['input'];
@@ -6316,6 +6385,11 @@ export type MutationsUpdateStockLineArgs = {
   storeId: Scalars['String']['input'];
 };
 
+export type MutationsUpdateStockRelocationArgs = {
+  input: UpdateStockRelocationInput;
+  storeId: Scalars['String']['input'];
+};
+
 export type MutationsUpdateStocktakeArgs = {
   input: UpdateStocktakeInput;
   storeId: Scalars['String']['input'];
@@ -6535,6 +6609,13 @@ export type NotAnOutboundShipmentError = UpdateErrorInterface &
   UpdateNameErrorInterface & {
     __typename: 'NotAnOutboundShipmentError';
     description: Scalars['String']['output'];
+  };
+
+export type NotEnoughStock = InsertStockRelocationErrorInterface &
+  UpdateStockRelocationErrorInterface & {
+    __typename: 'NotEnoughStock';
+    description: Scalars['String']['output'];
+    stockLineId: Scalars['String']['output'];
   };
 
 export type NotEnoughStockForReduction =
@@ -7776,6 +7857,8 @@ export type Queries = {
   stockCounts: StockCounts;
   /** Query for "stock_line" entries */
   stockLines: StockLinesResponse;
+  stockRelocation: StockRelocationResponse;
+  stockRelocations: StockRelocationsResponse;
   stocktake: StocktakeResponse;
   stocktakeByNumber: StocktakeResponse;
   stocktakeLines: StocktakesLinesResponse;
@@ -8253,6 +8336,7 @@ export type QueriesPeriodsArgs = {
 
 export type QueriesPluginDataArgs = {
   filter?: InputMaybe<PluginDataFilterInput>;
+  page?: InputMaybe<PaginationInput>;
   pluginCode: Scalars['String']['input'];
   sort?: InputMaybe<Array<PluginDataSortInput>>;
   storeId: Scalars['String']['input'];
@@ -8441,6 +8525,18 @@ export type QueriesStockLinesArgs = {
   filter?: InputMaybe<StockLineFilterInput>;
   page?: InputMaybe<PaginationInput>;
   sort?: InputMaybe<Array<StockLineSortInput>>;
+  storeId: Scalars['String']['input'];
+};
+
+export type QueriesStockRelocationArgs = {
+  id: Scalars['String']['input'];
+  storeId: Scalars['String']['input'];
+};
+
+export type QueriesStockRelocationsArgs = {
+  filter?: InputMaybe<StockRelocationFilterInput>;
+  page?: InputMaybe<PaginationInput>;
+  sort?: InputMaybe<Array<StockRelocationSortInput>>;
   storeId: Scalars['String']['input'];
 };
 
@@ -9590,6 +9686,13 @@ export type StockLineNodeProgramOrderTypeArgs = {
   storeId: Scalars['String']['input'];
 };
 
+export type StockLineOnHold = InsertStockRelocationErrorInterface &
+  UpdateStockRelocationErrorInterface & {
+    __typename: 'StockLineOnHold';
+    description: Scalars['String']['output'];
+    stockLineId: Scalars['String']['output'];
+  };
+
 export type StockLineReducedBelowZero =
   InsertInventoryAdjustmentErrorInterface &
     InsertRepackErrorInterface &
@@ -9633,6 +9736,68 @@ export type StockLinesReducedBelowZero = UpdateStocktakeErrorInterface & {
 };
 
 export type StockLinesResponse = StockLineConnector;
+
+export type StockRelocationConnector = {
+  __typename: 'StockRelocationConnector';
+  nodes: Array<StockRelocationNode>;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type StockRelocationFilterInput = {
+  createdDatetime?: InputMaybe<DatetimeFilterInput>;
+  finalisedDatetime?: InputMaybe<DatetimeFilterInput>;
+  fromLocationId?: InputMaybe<EqualFilterStringInput>;
+  id?: InputMaybe<EqualFilterStringInput>;
+  itemCodeOrName?: InputMaybe<StringFilterInput>;
+  status?: InputMaybe<EqualFilterStockRelocationStatusInput>;
+  storeId?: InputMaybe<EqualFilterStringInput>;
+  toLocationId?: InputMaybe<EqualFilterStringInput>;
+};
+
+export type StockRelocationNode = {
+  __typename: 'StockRelocationNode';
+  batch?: Maybe<Scalars['String']['output']>;
+  createdDatetime: Scalars['DateTime']['output'];
+  expiryDate?: Maybe<Scalars['NaiveDate']['output']>;
+  finalisedDatetime?: Maybe<Scalars['DateTime']['output']>;
+  fromLocation?: Maybe<LocationNode>;
+  fromStockLineId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  itemCode: Scalars['String']['output'];
+  itemName: Scalars['String']['output'];
+  numberOfPacks: Scalars['Float']['output'];
+  status: StockRelocationNodeStatus;
+  toLocation?: Maybe<LocationNode>;
+  toStockLineId?: Maybe<Scalars['String']['output']>;
+};
+
+export enum StockRelocationNodeStatus {
+  Finalised = 'FINALISED',
+  New = 'NEW',
+}
+
+export type StockRelocationResponse = RecordNotFound | StockRelocationNode;
+
+export enum StockRelocationSortFieldInput {
+  Batch = 'batch',
+  CreatedDatetime = 'createdDatetime',
+  ExpiryDate = 'expiryDate',
+  FinalisedDatetime = 'finalisedDatetime',
+  FromLocation = 'fromLocation',
+  ItemCode = 'itemCode',
+  ItemName = 'itemName',
+  NumberOfPacks = 'numberOfPacks',
+  Status = 'status',
+  ToLocation = 'toLocation',
+}
+
+export type StockRelocationSortInput = {
+  desc?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Sort query result by `key` */
+  key: StockRelocationSortFieldInput;
+};
+
+export type StockRelocationsResponse = StockRelocationConnector;
 
 export type StocktakeConnector = {
   __typename: 'StocktakeConnector';
@@ -11249,6 +11414,32 @@ export type UpdateStockLineInput = {
 };
 
 export type UpdateStockLineLineResponse = StockLineNode | UpdateStockLineError;
+
+export type UpdateStockRelocationError = {
+  __typename: 'UpdateStockRelocationError';
+  error: UpdateStockRelocationErrorInterface;
+};
+
+export type UpdateStockRelocationErrorInterface = {
+  description: Scalars['String']['output'];
+};
+
+export type UpdateStockRelocationInput = {
+  fromNumberOfPacks?: InputMaybe<Scalars['Float']['input']>;
+  id: Scalars['String']['input'];
+  status?: InputMaybe<StockRelocationNodeStatus>;
+  toLocationId?: InputMaybe<Scalars['String']['input']>;
+  toPackSize?: InputMaybe<Scalars['Float']['input']>;
+};
+
+export type UpdateStockRelocationNode = {
+  __typename: 'UpdateStockRelocationNode';
+  id: Scalars['String']['output'];
+};
+
+export type UpdateStockRelocationResponse =
+  | UpdateStockRelocationError
+  | UpdateStockRelocationNode;
 
 export type UpdateStocktakeError = {
   __typename: 'UpdateStocktakeError';

--- a/server/graphql/stock_relocation/src/lib.rs
+++ b/server/graphql/stock_relocation/src/lib.rs
@@ -5,7 +5,10 @@ pub mod mutations;
 pub mod queries;
 pub mod types;
 
-use mutations::{insert_stock_relocation, InsertInput, InsertResponse};
+use mutations::{
+    insert_stock_relocation, update_stock_relocation, InsertInput, InsertResponse, UpdateInput,
+    UpdateResponse,
+};
 use queries::{
     get_stock_relocation, get_stock_relocations, StockRelocationFilterInput,
     StockRelocationResponse, StockRelocationSortInput, StockRelocationsResponse,
@@ -49,5 +52,14 @@ impl StockRelocationMutations {
         input: InsertInput,
     ) -> Result<InsertResponse> {
         insert_stock_relocation(ctx, &store_id, input)
+    }
+
+    pub async fn update_stock_relocation(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+        input: UpdateInput,
+    ) -> Result<UpdateResponse> {
+        update_stock_relocation(ctx, &store_id, input)
     }
 }

--- a/server/graphql/stock_relocation/src/mutations/mod.rs
+++ b/server/graphql/stock_relocation/src/mutations/mod.rs
@@ -1,8 +1,10 @@
 use async_graphql::*;
 
 pub mod insert;
+pub mod update;
 
 pub use insert::{insert_stock_relocation, InsertInput, InsertResponse};
+pub use update::{update_stock_relocation, UpdateInput, UpdateResponse};
 
 pub struct StockLineOnHold {
     pub stock_line_id: String,

--- a/server/graphql/stock_relocation/src/mutations/update.rs
+++ b/server/graphql/stock_relocation/src/mutations/update.rs
@@ -1,0 +1,243 @@
+use async_graphql::*;
+use graphql_core::standard_graphql_error::validate_auth;
+use graphql_core::standard_graphql_error::StandardGraphqlError::{BadUserInput, InternalError};
+use graphql_core::ContextExt;
+use repository::StockRelocationRow;
+use service::auth::{Resource, ResourceAccessRequest};
+use service::stock_relocation::update::{
+    UpdateStockRelocation as UpdateServiceInput, UpdateStockRelocationError as UpdateServiceError,
+};
+
+use super::{LocationOnHold, NotEnoughStock, StockLineOnHold};
+use crate::types::StockRelocationNodeStatus;
+
+#[derive(InputObject)]
+#[graphql(name = "UpdateStockRelocationInput")]
+pub struct UpdateInput {
+    pub id: String,
+    pub from_number_of_packs: Option<f64>,
+    pub to_location_id: Option<String>,
+    pub to_pack_size: Option<f64>,
+    pub status: Option<StockRelocationNodeStatus>,
+}
+
+#[derive(SimpleObject)]
+pub struct UpdateStockRelocationNode {
+    pub id: String,
+}
+
+#[derive(SimpleObject)]
+#[graphql(name = "UpdateStockRelocationError")]
+pub struct UpdateError {
+    pub error: UpdateErrorInterface,
+}
+
+#[derive(Union)]
+#[graphql(name = "UpdateStockRelocationResponse")]
+pub enum UpdateResponse {
+    Response(UpdateStockRelocationNode),
+    Error(UpdateError),
+}
+
+#[derive(Interface)]
+#[graphql(name = "UpdateStockRelocationErrorInterface")]
+#[graphql(field(name = "description", ty = "String"))]
+pub enum UpdateErrorInterface {
+    StockLineOnHold(StockLineOnHold),
+    LocationOnHold(LocationOnHold),
+    NotEnoughStock(NotEnoughStock),
+}
+
+pub fn update_stock_relocation(
+    ctx: &Context<'_>,
+    store_id: &str,
+    input: UpdateInput,
+) -> Result<UpdateResponse> {
+    let user = validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::MutateStockLine,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context(store_id.to_string(), user.user_id)?;
+
+    let UpdateInput {
+        id,
+        from_number_of_packs,
+        to_location_id,
+        to_pack_size,
+        status,
+    } = input;
+
+    map_response(
+        service_provider
+            .stock_relocation_service
+            .update_stock_relocation(
+                &service_context,
+                store_id,
+                UpdateServiceInput {
+                    id,
+                    from_number_of_packs,
+                    to_location_id,
+                    to_pack_size,
+                    status: status.map(|status| status.into()),
+                },
+            ),
+    )
+}
+
+fn map_response(from: Result<StockRelocationRow, UpdateServiceError>) -> Result<UpdateResponse> {
+    match from {
+        Ok(row) => Ok(UpdateResponse::Response(UpdateStockRelocationNode {
+            id: row.id,
+        })),
+        Err(error) => Ok(UpdateResponse::Error(UpdateError {
+            error: map_error(error)?,
+        })),
+    }
+}
+
+fn map_error(error: UpdateServiceError) -> Result<UpdateErrorInterface> {
+    use UpdateServiceError as E;
+    let formatted_error = format!("{error:#?}");
+
+    let graphql_error = match error {
+        E::StockLineOnHold(stock_line_id) => {
+            return Ok(UpdateErrorInterface::StockLineOnHold(StockLineOnHold {
+                stock_line_id,
+            }))
+        }
+        E::LocationOnHold(location_id) => {
+            return Ok(UpdateErrorInterface::LocationOnHold(LocationOnHold {
+                location_id,
+            }))
+        }
+        E::NotEnoughStock(stock_line_id) => {
+            return Ok(UpdateErrorInterface::NotEnoughStock(NotEnoughStock {
+                stock_line_id,
+            }))
+        }
+
+        E::RelocationDoesNotExist
+        | E::NotThisStoreRelocation
+        | E::RelocationAlreadyFinalised
+        | E::StockLineDoesNotExist
+        | E::NotThisStoreStockLine
+        | E::ToLocationDoesNotExist
+        | E::NotThisStoreLocation
+        | E::InvalidNumberOfPacks
+        | E::InvalidPackSize
+        | E::CannotHaveFractionalPack => BadUserInput(formatted_error),
+        E::NewlyCreatedStockLineDoesNotExist | E::DatabaseError(_) | E::InternalError(_) => {
+            InternalError(formatted_error)
+        }
+    };
+
+    Err(graphql_error.extend())
+}
+
+#[cfg(test)]
+mod test {
+    use async_graphql::EmptyMutation;
+    use graphql_core::{assert_graphql_query, test_helpers::setup_graphql_test};
+    use repository::{
+        mock::MockDataInserts, StockRelocationRow, StockRelocationStatus, StorageConnectionManager,
+    };
+    use serde_json::json;
+    use service::{
+        service_provider::{ServiceContext, ServiceProvider},
+        stock_relocation::{
+            update::{
+                UpdateStockRelocation as UpdateServiceInput,
+                UpdateStockRelocationError as UpdateServiceError,
+            },
+            StockRelocationServiceTrait,
+        },
+    };
+
+    use crate::StockRelocationMutations;
+
+    type UpdateMethod =
+        dyn Fn(UpdateServiceInput) -> Result<StockRelocationRow, UpdateServiceError> + Sync + Send;
+
+    struct TestService(Box<UpdateMethod>);
+
+    impl StockRelocationServiceTrait for TestService {
+        fn update_stock_relocation(
+            &self,
+            _: &ServiceContext,
+            _: &str,
+            input: UpdateServiceInput,
+        ) -> Result<StockRelocationRow, UpdateServiceError> {
+            self.0(input)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
+        service_provider.stock_relocation_service = Box::new(test_service);
+        service_provider
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_update_stock_relocation_success() {
+        let (_, _, connection_manager, settings) = setup_graphql_test(
+            EmptyMutation,
+            StockRelocationMutations,
+            "test_graphql_update_stock_relocation_success",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($storeId: String!, $input: UpdateStockRelocationInput!) {
+            updateStockRelocation(storeId: $storeId, input: $input) {
+                ... on UpdateStockRelocationNode {
+                    id
+                }
+            }
+          }
+        "#;
+
+        let test_service = TestService(Box::new(|input| {
+            assert_eq!(input.id, "relocation_1");
+            assert_eq!(input.from_number_of_packs, Some(3.0));
+            assert_eq!(input.to_location_id, Some("to_location".to_string()));
+            assert_eq!(input.to_pack_size, Some(2.0));
+            assert_eq!(input.status, Some(StockRelocationStatus::Finalised));
+            Ok(StockRelocationRow {
+                id: "relocation_1".to_string(),
+                ..Default::default()
+            })
+        }));
+
+        let variables = json!({
+          "storeId": "n/a",
+          "input": {
+            "id": "relocation_1",
+            "fromNumberOfPacks": 3,
+            "toLocationId": "to_location",
+            "toPackSize": 2,
+            "status": "FINALISED"
+          }
+        });
+
+        let expected = json!({
+            "updateStockRelocation": {
+              "id": "relocation_1"
+            }
+        });
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(variables),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/server/service/src/stock_relocation/mod.rs
+++ b/server/service/src/stock_relocation/mod.rs
@@ -1,5 +1,6 @@
 use self::insert::{insert_stock_relocation, InsertStockRelocation, InsertStockRelocationError};
 use self::query::{get_stock_relocation, get_stock_relocations};
+use self::update::{update_stock_relocation, UpdateStockRelocation, UpdateStockRelocationError};
 use crate::{service_provider::ServiceContext, ListError, ListResult};
 use repository::{
     PaginationOption, RepositoryError, StockRelocation, StockRelocationFilter, StockRelocationRow,
@@ -8,6 +9,7 @@ use repository::{
 
 pub mod insert;
 pub mod query;
+pub mod update;
 pub mod validate;
 
 pub trait StockRelocationServiceTrait: Sync + Send {
@@ -38,6 +40,15 @@ pub trait StockRelocationServiceTrait: Sync + Send {
         input: InsertStockRelocation,
     ) -> Result<Vec<StockRelocationRow>, InsertStockRelocationError> {
         insert_stock_relocation(ctx, store_id, input)
+    }
+
+    fn update_stock_relocation(
+        &self,
+        ctx: &ServiceContext,
+        store_id: &str,
+        input: UpdateStockRelocation,
+    ) -> Result<StockRelocationRow, UpdateStockRelocationError> {
+        update_stock_relocation(ctx, store_id, input)
     }
 }
 

--- a/server/service/src/stock_relocation/update.rs
+++ b/server/service/src/stock_relocation/update.rs
@@ -1,0 +1,413 @@
+use chrono::Utc;
+use repository::{
+    InvoiceLineRowRepository, InvoiceLineType, RepositoryError, StockLineRow, StockRelocationRow,
+    StockRelocationRowRepository, StockRelocationStatus, StorageConnection, TransactionError,
+};
+use util::EPSILON;
+
+use crate::{
+    repack::{insert_repack, InsertRepack, InsertRepackError},
+    service_provider::ServiceContext,
+    stock_line::update::{update_stock_line, UpdateStockLine, UpdateStockLineError},
+    stock_relocation::validate::{validate_movement, RelocationMovement, ValidateMovementError},
+    NullableUpdate,
+};
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct UpdateStockRelocation {
+    pub id: String,
+    pub from_number_of_packs: Option<f64>,
+    pub to_location_id: Option<String>,
+    pub to_pack_size: Option<f64>,
+    pub status: Option<StockRelocationStatus>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum UpdateStockRelocationError {
+    RelocationDoesNotExist,
+    NotThisStoreRelocation,
+    RelocationAlreadyFinalised,
+    StockLineDoesNotExist,
+    NotThisStoreStockLine,
+    StockLineOnHold(String),
+    LocationOnHold(String),
+    ToLocationDoesNotExist,
+    NotThisStoreLocation,
+    NotEnoughStock(String),
+    InvalidNumberOfPacks,
+    InvalidPackSize,
+    CannotHaveFractionalPack,
+    NewlyCreatedStockLineDoesNotExist,
+    DatabaseError(RepositoryError),
+    InternalError(String),
+}
+
+pub fn update_stock_relocation(
+    ctx: &ServiceContext,
+    store_id: &str,
+    input: UpdateStockRelocation,
+) -> Result<StockRelocationRow, UpdateStockRelocationError> {
+    let result = ctx
+        .connection
+        .transaction_sync(|connection| {
+            let mut row = validate(connection, store_id, &input.id)?;
+
+            if let Some(from_number_of_packs) = input.from_number_of_packs {
+                row.from_number_of_packs = from_number_of_packs;
+            }
+            if let Some(to_location_id) = input.to_location_id {
+                row.to_location_id = Some(to_location_id);
+            }
+            if let Some(to_pack_size) = input.to_pack_size {
+                row.to_pack_size = Some(to_pack_size);
+            }
+
+            let stock_line = validate_movement(
+                connection,
+                store_id,
+                &RelocationMovement {
+                    from_stock_line_id: row.from_stock_line_id.clone(),
+                    from_number_of_packs: row.from_number_of_packs,
+                    to_location_id: row.to_location_id.clone(),
+                    to_pack_size: row.to_pack_size,
+                },
+            )?;
+            row.from_location_id = stock_line.location_id.clone();
+
+            let finalising = matches!(input.status, Some(StockRelocationStatus::Finalised));
+            if finalising {
+                row.to_stock_line_id = Some(apply_movement(ctx, connection, &row, &stock_line)?);
+                row.status = StockRelocationStatus::Finalised;
+                row.finalised_datetime = Some(Utc::now().naive_utc());
+            }
+
+            StockRelocationRowRepository::new(connection).upsert_one(&row)?;
+
+            Ok(row)
+        })
+        .map_err(|error: TransactionError<UpdateStockRelocationError>| error.to_inner_error())?;
+
+    Ok(result)
+}
+
+fn apply_movement(
+    ctx: &ServiceContext,
+    connection: &StorageConnection,
+    row: &StockRelocationRow,
+    stock_line: &StockLineRow,
+) -> Result<String, UpdateStockRelocationError> {
+    if is_relocation_only(stock_line, row) {
+        update_stock_line(
+            ctx,
+            UpdateStockLine {
+                id: row.from_stock_line_id.clone(),
+                location: Some(NullableUpdate {
+                    value: row.to_location_id.clone(),
+                }),
+                ..Default::default()
+            },
+        )?;
+        Ok(row.from_stock_line_id.clone())
+    } else {
+        let invoice = insert_repack(
+            ctx,
+            InsertRepack {
+                stock_line_id: row.from_stock_line_id.clone(),
+                number_of_packs: row.from_number_of_packs,
+                new_pack_size: row.to_pack_size.unwrap_or(stock_line.pack_size),
+                new_location_id: row.to_location_id.clone(),
+            },
+        )?;
+        new_stock_line_id(connection, &invoice.invoice_row.id)
+    }
+}
+
+fn is_relocation_only(stock_line: &StockLineRow, row: &StockRelocationRow) -> bool {
+    let to_pack_size = row.to_pack_size.unwrap_or(stock_line.pack_size);
+    (to_pack_size - stock_line.pack_size).abs() < EPSILON
+        && (row.from_number_of_packs - stock_line.available_number_of_packs).abs() < EPSILON
+        && (stock_line.available_number_of_packs - stock_line.total_number_of_packs).abs() < EPSILON
+}
+
+fn validate(
+    connection: &StorageConnection,
+    store_id: &str,
+    id: &str,
+) -> Result<StockRelocationRow, UpdateStockRelocationError> {
+    use UpdateStockRelocationError::*;
+
+    let row = StockRelocationRowRepository::new(connection)
+        .find_one_by_id(id)?
+        .ok_or(RelocationDoesNotExist)?;
+
+    if row.store_id != store_id {
+        return Err(NotThisStoreRelocation);
+    }
+    if row.status == StockRelocationStatus::Finalised {
+        return Err(RelocationAlreadyFinalised);
+    }
+
+    Ok(row)
+}
+
+fn new_stock_line_id(
+    connection: &StorageConnection,
+    invoice_id: &str,
+) -> Result<String, UpdateStockRelocationError> {
+    InvoiceLineRowRepository::new(connection)
+        .find_many_by_invoice_id(invoice_id)?
+        .into_iter()
+        .find(|line| line.r#type == InvoiceLineType::StockIn)
+        .and_then(|line| line.stock_line_id)
+        .ok_or(UpdateStockRelocationError::NewlyCreatedStockLineDoesNotExist)
+}
+
+impl From<RepositoryError> for UpdateStockRelocationError {
+    fn from(error: RepositoryError) -> Self {
+        UpdateStockRelocationError::DatabaseError(error)
+    }
+}
+
+impl From<ValidateMovementError> for UpdateStockRelocationError {
+    fn from(error: ValidateMovementError) -> Self {
+        use UpdateStockRelocationError as E;
+        match error {
+            ValidateMovementError::StockLineDoesNotExist => E::StockLineDoesNotExist,
+            ValidateMovementError::NotThisStoreStockLine => E::NotThisStoreStockLine,
+            ValidateMovementError::StockLineOnHold(id) => E::StockLineOnHold(id),
+            ValidateMovementError::LocationOnHold(id) => E::LocationOnHold(id),
+            ValidateMovementError::ToLocationDoesNotExist => E::ToLocationDoesNotExist,
+            ValidateMovementError::NotThisStoreLocation => E::NotThisStoreLocation,
+            ValidateMovementError::NotEnoughStock(id) => E::NotEnoughStock(id),
+            ValidateMovementError::InvalidNumberOfPacks => E::InvalidNumberOfPacks,
+            ValidateMovementError::InvalidPackSize => E::InvalidPackSize,
+            ValidateMovementError::DatabaseError(e) => E::DatabaseError(e),
+        }
+    }
+}
+
+impl From<InsertRepackError> for UpdateStockRelocationError {
+    fn from(error: InsertRepackError) -> Self {
+        use UpdateStockRelocationError as E;
+        match error {
+            InsertRepackError::StockLineDoesNotExist => E::StockLineDoesNotExist,
+            InsertRepackError::NotThisStoreStockLine => E::NotThisStoreStockLine,
+            InsertRepackError::CannotHaveFractionalPack => E::CannotHaveFractionalPack,
+            InsertRepackError::StockLineReducedBelowZero(stock_line) => {
+                E::NotEnoughStock(stock_line.stock_line_row.id)
+            }
+            InsertRepackError::DatabaseError(e) => E::DatabaseError(e),
+            InsertRepackError::NewlyCreatedInvoiceDoesNotExist => {
+                E::NewlyCreatedStockLineDoesNotExist
+            }
+            InsertRepackError::InternalError(s) => E::InternalError(s),
+        }
+    }
+}
+
+impl From<UpdateStockLineError> for UpdateStockRelocationError {
+    fn from(error: UpdateStockLineError) -> Self {
+        use UpdateStockRelocationError as E;
+        match error {
+            UpdateStockLineError::StockDoesNotExist => E::StockLineDoesNotExist,
+            UpdateStockLineError::StockDoesNotBelongToStore => E::NotThisStoreStockLine,
+            UpdateStockLineError::LocationDoesNotExist => E::ToLocationDoesNotExist,
+            UpdateStockLineError::DatabaseError(e) => E::DatabaseError(e),
+            other => E::InternalError(format!("{:?}", other)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use repository::{
+        mock::{mock_location_1, mock_location_2, MockDataInserts},
+        test_db::setup_all,
+        StockLineRow, StockLineRowRepository, StockRelocationStatus, Upsert,
+    };
+    use util::uuid::uuid;
+
+    use crate::service_provider::ServiceProvider;
+    use crate::stock_relocation::insert::{InsertStockRelocation, InsertStockRelocationLine};
+
+    use super::*;
+
+    fn whole_line(id: &str) -> StockLineRow {
+        StockLineRow {
+            id: id.to_string(),
+            item_id: "item_a".to_string(),
+            store_id: "store_a".to_string(),
+            pack_size: 1.0,
+            available_number_of_packs: 10.0,
+            total_number_of_packs: 10.0,
+            ..Default::default()
+        }
+    }
+
+    async fn setup(test: &str) -> (ServiceProvider, ServiceContext) {
+        let (_, _, connection_manager, _) = setup_all(test, MockDataInserts::all()).await;
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context("store_a".to_string(), "user_account_a".to_string())
+            .unwrap();
+        (service_provider, context)
+    }
+
+    fn insert_line(stock_line_id: &str, to_pack_size: f64) -> InsertStockRelocationLine {
+        InsertStockRelocationLine {
+            id: uuid(),
+            from_stock_line_id: stock_line_id.to_string(),
+            from_number_of_packs: 10.0,
+            to_location_id: Some(mock_location_1().id),
+            to_pack_size,
+        }
+    }
+
+    async fn insert_one(
+        service_provider: &ServiceProvider,
+        ctx: &ServiceContext,
+        line: InsertStockRelocationLine,
+    ) -> String {
+        service_provider
+            .stock_relocation_service
+            .insert_stock_relocation(
+                ctx,
+                "store_a",
+                InsertStockRelocation {
+                    from_location_id: None,
+                    lines: vec![line],
+                },
+            )
+            .unwrap()[0]
+            .id
+            .clone()
+    }
+
+    #[actix_rt::test]
+    async fn update_stock_relocation_success() {
+        let (service_provider, ctx) = setup("update_stock_relocation_success").await;
+        whole_line("repack_sl").upsert(&ctx.connection).unwrap();
+        let service = &service_provider.stock_relocation_service;
+        let stock_line_repo = StockLineRowRepository::new(&ctx.connection);
+
+        let id = insert_one(&service_provider, &ctx, insert_line("repack_sl", 1.0)).await;
+
+        // Edits values without finalising.
+        let updated = service
+            .update_stock_relocation(
+                &ctx,
+                "store_a",
+                UpdateStockRelocation {
+                    id: id.clone(),
+                    from_number_of_packs: Some(4.0),
+                    to_location_id: Some(mock_location_2().id),
+                    to_pack_size: Some(2.0),
+                    status: None,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(updated.status, StockRelocationStatus::New);
+        assert_eq!(updated.from_number_of_packs, 4.0);
+        assert_eq!(updated.to_location_id, Some(mock_location_2().id));
+        assert_eq!(updated.to_pack_size, Some(2.0));
+        assert_eq!(updated.to_stock_line_id, None);
+        assert_eq!(updated.finalised_datetime, None);
+
+        let source = stock_line_repo
+            .find_one_by_id("repack_sl")
+            .unwrap()
+            .unwrap();
+        assert_eq!(source.available_number_of_packs, 10.0);
+        assert_eq!(source.location_id, None);
+
+        // Finalises, applying the edited repack.
+        let finalised = service
+            .update_stock_relocation(
+                &ctx,
+                "store_a",
+                UpdateStockRelocation {
+                    id: id.clone(),
+                    status: Some(StockRelocationStatus::Finalised),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert_eq!(finalised.status, StockRelocationStatus::Finalised);
+        assert!(finalised.finalised_datetime.is_some());
+
+        let new_id = finalised.to_stock_line_id.clone().unwrap();
+        assert_ne!(new_id, "repack_sl");
+        let source = stock_line_repo
+            .find_one_by_id("repack_sl")
+            .unwrap()
+            .unwrap();
+        // 4 of 10 packs moved out of the source.
+        assert_eq!(source.available_number_of_packs, 6.0);
+        // 4 packs of size 1 → 2 packs of size 2 at the destination.
+        let new_line = stock_line_repo.find_one_by_id(&new_id).unwrap().unwrap();
+        assert_eq!(new_line.pack_size, 2.0);
+        assert_eq!(new_line.available_number_of_packs, 2.0);
+        assert_eq!(new_line.location_id, Some(mock_location_2().id));
+    }
+
+    #[actix_rt::test]
+    async fn update_validation_errors() {
+        let (service_provider, ctx) = setup("update_validation_errors").await;
+        whole_line("ok_sl").upsert(&ctx.connection).unwrap();
+        let service = &service_provider.stock_relocation_service;
+
+        assert_eq!(
+            service.update_stock_relocation(
+                &ctx,
+                "store_a",
+                UpdateStockRelocation {
+                    id: uuid(),
+                    ..Default::default()
+                }
+            ),
+            Err(UpdateStockRelocationError::RelocationDoesNotExist)
+        );
+
+        let id = insert_one(&service_provider, &ctx, insert_line("ok_sl", 1.0)).await;
+
+        assert_eq!(
+            service.update_stock_relocation(
+                &ctx,
+                "store_a",
+                UpdateStockRelocation {
+                    id: id.clone(),
+                    from_number_of_packs: Some(999.0),
+                    ..Default::default()
+                }
+            ),
+            Err(UpdateStockRelocationError::NotEnoughStock(
+                "ok_sl".to_string()
+            ))
+        );
+
+        service
+            .update_stock_relocation(
+                &ctx,
+                "store_a",
+                UpdateStockRelocation {
+                    id: id.clone(),
+                    status: Some(StockRelocationStatus::Finalised),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            service.update_stock_relocation(
+                &ctx,
+                "store_a",
+                UpdateStockRelocation {
+                    id,
+                    ..Default::default()
+                }
+            ),
+            Err(UpdateStockRelocationError::RelocationAlreadyFinalised)
+        );
+    }
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11971

# 👩🏻‍💻 What does this PR do?
Allows update of stock relocation and also do stock movements if finalised

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Test with GraphQL

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

