### PR TITLE
#10570 Group shared DataLoaders by request-scoped keys

### DIFF
--- a/server/graphql/core/src/loader/available_volume_on_requisition.rs
+++ b/server/graphql/core/src/loader/available_volume_on_requisition.rs
@@ -36,46 +36,126 @@ impl Loader<AvailableVolumeOnRequisitionLoaderInput> for AvailableVolumeOnRequis
         let service_context = self.service_provider.basic_context()?;
         let connection = &service_context.connection;
 
-        let requisition_id =
-            if let Some(requisition_and_item_ids) = requisition_and_item_ids.first() {
-                &requisition_and_item_ids.requisition_id
-            } else {
-                return Ok(HashMap::new());
-            };
-
-        let item_ids: Vec<String> = requisition_and_item_ids
-            .iter()
-            .map(|input| input.item_id.clone())
-            .collect();
-
-        let available_volumes =
-            get_requisition_available_volume_for_items(connection, requisition_id, &item_ids)?;
+        // The loader registry is shared across all requests, so a single batch can mix
+        // inputs from different requisitions. Group item_ids by requisition_id and query
+        // each requisition separately rather than assuming a single one for the whole batch.
+        let mut requisition_item_map = HashMap::<String, Vec<String>>::new();
+        for input in requisition_and_item_ids {
+            requisition_item_map
+                .entry(input.requisition_id.clone())
+                .or_default()
+                .push(input.item_id.clone());
+        }
 
         let mut output = HashMap::<
             AvailableVolumeOnRequisitionLoaderInput,
             (Option<LocationTypeRow>, f64, f64),
         >::new();
 
-        for input in requisition_and_item_ids.iter() {
-            let item_id = &input.item_id;
+        for (requisition_id, item_ids) in requisition_item_map {
+            let available_volumes =
+                get_requisition_available_volume_for_items(connection, &requisition_id, &item_ids)?;
 
-            if let Some(volume_info) = available_volumes.get(item_id) {
-                output.insert(
-                    AvailableVolumeOnRequisitionLoaderInput::new(requisition_id, item_id),
-                    (
-                        volume_info.location_type.clone(),
-                        volume_info.available_volume,
-                        volume_info.volume_per_unit,
-                    ),
-                );
-            } else {
-                output.insert(
-                    AvailableVolumeOnRequisitionLoaderInput::new(requisition_id, item_id),
-                    (None, 0.0, 0.0),
-                );
+            for item_id in &item_ids {
+                if let Some(volume_info) = available_volumes.get(item_id) {
+                    output.insert(
+                        AvailableVolumeOnRequisitionLoaderInput::new(&requisition_id, item_id),
+                        (
+                            volume_info.location_type.clone(),
+                            volume_info.available_volume,
+                            volume_info.volume_per_unit,
+                        ),
+                    );
+                } else {
+                    output.insert(
+                        AvailableVolumeOnRequisitionLoaderInput::new(&requisition_id, item_id),
+                        (None, 0.0, 0.0),
+                    );
+                }
             }
         }
 
         Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::{
+        mock::{mock_name_a, mock_store_a, MockData, MockDataInserts},
+        test_db, ItemRow, RequisitionLineRow, RequisitionRow,
+    };
+
+    fn test_item(id: &str) -> ItemRow {
+        ItemRow {
+            id: id.to_string(),
+            name: id.to_string(),
+            code: id.to_string(),
+            // pack_size of 1 keeps volume_per_unit math clean (no division by zero)
+            default_pack_size: 1.0,
+            ..Default::default()
+        }
+    }
+
+    fn test_requisition(id: &str, number: i64) -> RequisitionRow {
+        RequisitionRow {
+            id: id.to_string(),
+            requisition_number: number,
+            name_link_id: mock_name_a().id,
+            store_id: mock_store_a().id,
+            ..Default::default()
+        }
+    }
+
+    fn test_line(id: &str, requisition_id: &str, item_id: &str, available_volume: f64) -> RequisitionLineRow {
+        RequisitionLineRow {
+            id: id.to_string(),
+            requisition_id: requisition_id.to_string(),
+            item_link_id: item_id.to_string(),
+            available_volume: Some(available_volume),
+            ..Default::default()
+        }
+    }
+
+    // The loader registry is shared across requests, so a single batch can contain inputs
+    // for multiple requisitions. Verify each (requisition, item) input resolves to its OWN
+    // requisition's available volume rather than all being looked up against the first one.
+    #[tokio::test]
+    async fn available_volume_loader_batches_across_requisitions() {
+        let (_, _, connection_manager, _) = test_db::setup_all_with_data(
+            "available_volume_loader_batches_across_requisitions",
+            MockDataInserts::all(),
+            MockData {
+                items: vec![test_item("avail_item_x"), test_item("avail_item_y")],
+                requisitions: vec![
+                    test_requisition("avail_req_1", 700001),
+                    test_requisition("avail_req_2", 700002),
+                ],
+                requisition_lines: vec![
+                    test_line("avail_line_1", "avail_req_1", "avail_item_x", 100.0),
+                    test_line("avail_line_2", "avail_req_2", "avail_item_y", 50.0),
+                ],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let loader = AvailableVolumeOnRequisitionLoader {
+            service_provider: Data::new(ServiceProvider::new(connection_manager)),
+        };
+
+        let req1_input = AvailableVolumeOnRequisitionLoaderInput::new("avail_req_1", "avail_item_x");
+        let req2_input = AvailableVolumeOnRequisitionLoaderInput::new("avail_req_2", "avail_item_y");
+
+        let result = loader
+            .load(&[req1_input.clone(), req2_input.clone()])
+            .await
+            .unwrap();
+
+        // req2's input resolves to req2's own volume (previously absent: the batch used
+        // req1 as the only requisition and looked up item_y within req1).
+        assert_eq!(result.get(&req1_input).unwrap().1, 100.0);
+        assert_eq!(result.get(&req2_input).unwrap().1, 50.0);
     }
 }

--- a/server/graphql/core/src/loader/item_stats.rs
+++ b/server/graphql/core/src/loader/item_stats.rs
@@ -53,31 +53,20 @@ impl Loader<ItemStatsLoaderInput> for ItemsStatsForItemLoader {
     ) -> Result<HashMap<ItemStatsLoaderInput, Self::Value>, Self::Error> {
         let service_context = self.service_provider.basic_context()?;
 
-        // Validate all same store
-        let store_id = match loader_inputs.first() {
-            Some(input) => &input.store_id,
-            None => return Ok(HashMap::new()),
-        };
-        if loader_inputs.iter().any(|i| &i.store_id != store_id) {
-            return Err(StandardGraphqlError::BadUserInput(
-                "Cannot batch item stats across multiple stores".to_string(),
-            )
-            .into());
-        }
-        let store_id = store_id.clone();
+        // The loader registry is shared across all requests, so a single batch can mix
+        // inputs from different stores. Group by (store_id, payload) and query each group
+        // separately rather than assuming a single store/payload for the whole batch.
+        let mut map = HashMap::<(String, ItemStatsLoaderInputPayload), Vec<String>>::new();
 
-        let mut map = HashMap::<ItemStatsLoaderInputPayload, Vec<String>>::new();
-
-        // Group by payload -> Vec<item_id>
         for input in loader_inputs {
-            map.entry(input.payload.clone())
+            map.entry((input.store_id.clone(), input.payload.clone()))
                 .or_default()
                 .push(input.item_id.clone());
         }
 
         let mut out = HashMap::<ItemStatsLoaderInput, Self::Value>::new();
 
-        for (payload, item_ids) in map {
+        for ((store_id, payload), item_ids) in map {
             let item_stats = self
                 .service_provider
                 .item_stats_service
@@ -103,5 +92,52 @@ impl Loader<ItemStatsLoaderInput> for ItemsStatsForItemLoader {
             }
         }
         Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::{
+        mock::{mock_store_a, mock_store_b, test_item_stats, MockDataInserts},
+        test_db,
+    };
+
+    // The loader registry is shared across requests, so a single batch can contain inputs
+    // for multiple stores. Verify each (store, item) input resolves to its OWN store's
+    // stats rather than erroring or cross-contaminating.
+    #[tokio::test]
+    async fn item_stats_loader_batches_across_stores() {
+        let (_, _, connection_manager, _) = test_db::setup_all_with_data(
+            "item_stats_loader_batches_across_stores",
+            MockDataInserts::all(),
+            test_item_stats::mock_item_stats(),
+        )
+        .await;
+
+        let loader = ItemsStatsForItemLoader {
+            service_provider: Data::new(ServiceProvider::new(connection_manager)),
+        };
+
+        let item_id = test_item_stats::item().id;
+        // Same item, two different stores, in a single batch.
+        let store_a_input = ItemStatsLoaderInput::new(&mock_store_a().id, &item_id, None, None);
+        let store_b_input = ItemStatsLoaderInput::new(&mock_store_b().id, &item_id, None, None);
+
+        let result = loader
+            .load(&[store_a_input.clone(), store_b_input.clone()])
+            .await
+            .unwrap();
+
+        // Both stores resolved (previously this errored with BadUserInput).
+        assert_eq!(result.len(), 2);
+        assert_eq!(
+            result.get(&store_a_input).unwrap().available_stock_on_hand,
+            test_item_stats::item_1_soh()
+        );
+        assert_eq!(
+            result.get(&store_b_input).unwrap().available_stock_on_hand,
+            test_item_stats::item_1_store_b_soh()
+        );
     }
 }

--- a/server/graphql/core/src/loader/requisition_indicator_information.rs
+++ b/server/graphql/core/src/loader/requisition_indicator_information.rs
@@ -36,35 +36,109 @@ impl Loader<RequisitionIndicatorInfoLoaderInput> for RequisitionIndicatorInfoLoa
     ) -> Result<HashMap<RequisitionIndicatorInfoLoaderInput, Self::Value>, Self::Error> {
         let service_context = self.service_provider.basic_context()?;
 
-        let line_ids = util::dedup_iter(loader_inputs.iter().map(|input| input.line_id.clone()));
-
-        let Some(RequisitionIndicatorInfoLoaderInput {
-            store_id,
-            period_id,
-            ..
-        }) = loader_inputs.first()
-        else {
-            return Ok(HashMap::new());
-        };
-
-        let indicator_info_rows = self
-            .service_provider
-            .requisition_service
-            .get_indicator_information(&service_context, line_ids, &store_id, &period_id)?;
+        // The loader registry is shared across all requests, so a single batch can mix
+        // inputs from different (store, period) combinations. Group line_ids by
+        // (store_id, period_id) and query each group separately rather than assuming a
+        // single store/period for the whole batch.
+        let mut group_line_map = HashMap::<(String, String), Vec<String>>::new();
+        for input in loader_inputs {
+            group_line_map
+                .entry((input.store_id.clone(), input.period_id.clone()))
+                .or_default()
+                .push(input.line_id.clone());
+        }
 
         let mut result: HashMap<_, Self::Value> = HashMap::new();
 
-        for indicator_info in indicator_info_rows {
-            result
-                .entry(RequisitionIndicatorInfoLoaderInput::new(
-                    &indicator_info.indicator_line_id,
-                    store_id,
-                    period_id,
-                ))
-                .or_default()
-                .push(indicator_info);
+        for ((store_id, period_id), line_ids) in group_line_map {
+            let line_ids = util::dedup_iter(line_ids);
+
+            let indicator_info_rows = self
+                .service_provider
+                .requisition_service
+                .get_indicator_information(&service_context, line_ids, &store_id, &period_id)?;
+
+            for indicator_info in indicator_info_rows {
+                result
+                    .entry(RequisitionIndicatorInfoLoaderInput::new(
+                        &indicator_info.indicator_line_id,
+                        &store_id,
+                        &period_id,
+                    ))
+                    .or_default()
+                    .push(indicator_info);
+            }
         }
 
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::{
+        mock::{
+            mock_name_store_b, mock_period, mock_period_2_a, mock_store_a, MockData,
+            MockDataInserts,
+        },
+        test_db, NameRow, StorePreferenceRow,
+    };
+
+    // The loader registry is shared across requests, so a single batch can contain inputs
+    // for multiple (store, period) combinations. Verify each input resolves to its OWN
+    // period rather than all being looked up against the first period in the batch.
+    #[tokio::test]
+    async fn requisition_indicator_info_loader_batches_across_periods() {
+        let (_, _, connection_manager, _) = test_db::setup_all_with_data(
+            "requisition_indicator_info_loader_batches_across_periods",
+            MockDataInserts::all(),
+            MockData {
+                // store_b is already a customer of store_a (mock_name_store_join), but the
+                // customer query also requires its name to be supplied by store_a.
+                names: vec![NameRow {
+                    supplying_store_id: Some(mock_store_a().id),
+                    ..mock_name_store_b()
+                }],
+                // Indicator info is only returned when extra fields are enabled for the store.
+                store_preferences: vec![StorePreferenceRow {
+                    id: mock_store_a().id,
+                    extra_fields_in_requisition: true,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let loader = RequisitionIndicatorInfoLoader {
+            service_provider: Data::new(ServiceProvider::new(connection_manager)),
+        };
+
+        let line_id = "test_indicator_line";
+        // Same store + line, two different periods, in a single batch.
+        let period_1_input =
+            RequisitionIndicatorInfoLoaderInput::new(line_id, &mock_store_a().id, &mock_period().id);
+        let period_2_input = RequisitionIndicatorInfoLoaderInput::new(
+            line_id,
+            &mock_store_a().id,
+            &mock_period_2_a().id,
+        );
+
+        let result = loader
+            .load(&[period_1_input.clone(), period_2_input.clone()])
+            .await
+            .unwrap();
+
+        // Each period's input resolves to its OWN period's data. Previously period 2's input
+        // was absent (the batch queried only the first period and keyed everything under it).
+        let period_1_info = result.get(&period_1_input).unwrap();
+        let period_2_info = result.get(&period_2_input).unwrap();
+        assert!(period_1_info
+            .iter()
+            .all(|info| info.datetime.date() == mock_period().end_date));
+        assert!(period_2_info
+            .iter()
+            .all(|info| info.datetime.date() == mock_period_2_a().end_date));
     }
 }

--- a/server/graphql/core/src/loader/stock_line.rs
+++ b/server/graphql/core/src/loader/stock_line.rs
@@ -71,32 +71,38 @@ impl Loader<StockLineByItemAndStoreIdLoaderInput> for StockLineByItemAndStoreIdL
         let connection = self.connection_manager.connection()?;
         let repo = StockLineRepository::new(&connection);
 
-        let store_id = if let Some(item_and_store_ids) = item_and_store_ids.first() {
-            &item_and_store_ids.store_id
-        } else {
-            return Ok(HashMap::new());
-        };
-
-        let item_ids =
-            util::dedup_iter(item_and_store_ids.iter().map(|input| input.item_id.clone()));
-
-        let result = repo.query_by_filter(
-            StockLineFilter::new()
-                .item_id(EqualFilter::equal_any(item_ids))
-                .store_id(EqualFilter::equal_to(store_id.to_string()))
-                .has_packs_in_store(true),
-            None,
-        )?;
+        // The loader registry is shared across all requests, so a single batch can mix
+        // inputs from different stores. Group item_ids by store_id and query each store
+        // separately rather than assuming a single store for the whole batch.
+        let mut store_item_map = HashMap::<String, Vec<String>>::new();
+        for input in item_and_store_ids {
+            store_item_map
+                .entry(input.store_id.clone())
+                .or_default()
+                .push(input.item_id.clone());
+        }
 
         let mut result_map = HashMap::new();
-        for stock_line in result {
-            result_map
-                .entry(StockLineByItemAndStoreIdLoaderInput::new(
-                    store_id,
-                    &stock_line.item_row.id,
-                ))
-                .or_insert(Vec::new())
-                .push(stock_line);
+        for (store_id, item_ids) in store_item_map {
+            let item_ids = util::dedup_iter(item_ids);
+
+            let result = repo.query_by_filter(
+                StockLineFilter::new()
+                    .item_id(EqualFilter::equal_any(item_ids))
+                    .store_id(EqualFilter::equal_to(store_id.to_string()))
+                    .has_packs_in_store(true),
+                None,
+            )?;
+
+            for stock_line in result {
+                result_map
+                    .entry(StockLineByItemAndStoreIdLoaderInput::new(
+                        &store_id,
+                        &stock_line.item_row.id,
+                    ))
+                    .or_insert(Vec::new())
+                    .push(stock_line);
+            }
         }
         Ok(result_map)
     }
@@ -123,5 +129,60 @@ impl Loader<String> for StockLineByIdLoader {
             .into_iter()
             .map(|stock_line| (stock_line.stock_line_row.id.clone(), stock_line))
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::{
+        mock::{
+            mock_item_a, mock_item_a_lines, mock_item_b, mock_item_b_lines, mock_store_a,
+            mock_store_b, MockData, MockDataInserts,
+        },
+        test_db,
+    };
+
+    // The loader registry is shared across requests, so a single batch can contain inputs
+    // for multiple stores. Verify each (store, item) input resolves to its OWN store's
+    // stock lines and does not get the previous store's results (the .first() bug).
+    #[tokio::test]
+    async fn stock_line_by_item_and_store_loader_batches_across_stores() {
+        let (_, _, connection_manager, _) = test_db::setup_all_with_data(
+            "stock_line_by_item_and_store_loader_batches_across_stores",
+            MockDataInserts::none().units().items().names().stores(),
+            MockData {
+                // item_a lines live in store_a, item_b lines live in store_b
+                stock_lines: mock_item_a_lines()
+                    .into_iter()
+                    .chain(mock_item_b_lines())
+                    .collect(),
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let loader = StockLineByItemAndStoreIdLoader { connection_manager };
+
+        let store_a_input =
+            StockLineByItemAndStoreIdLoaderInput::new(&mock_store_a().id, &mock_item_a().id);
+        let store_b_input =
+            StockLineByItemAndStoreIdLoaderInput::new(&mock_store_b().id, &mock_item_b().id);
+
+        let result = loader
+            .load(&[store_a_input.clone(), store_b_input.clone()])
+            .await
+            .unwrap();
+
+        // store_b's input resolves to store_b's lines (previously empty: the batch took
+        // store_a as the only store and looked up item_b within store_a).
+        assert_eq!(result.get(&store_a_input).unwrap().len(), 2);
+        assert_eq!(result.get(&store_b_input).unwrap().len(), 2);
+        // No cross-contamination: store_a's lines are all in store_a.
+        assert!(result
+            .get(&store_a_input)
+            .unwrap()
+            .iter()
+            .all(|sl| sl.stock_line_row.store_id == mock_store_a().id));
     }
 }


### PR DESCRIPTION
Fixes #10570

# 👩🏻‍💻 What does this PR do?

The `LoaderRegistry` is built **once at server startup** and shared across every HTTP request (`server/server/src/lib.rs`). async-graphql's `DataLoader` coalesces concurrent `load_one` calls — including calls from *different* requests — into a single `load()` batch. So one `load()` slice can mix inputs from different stores, requisitions, periods and users.

Several loaders assumed a batch was homogeneous on a request-scoped field: they took `loader_inputs.first()` and applied that one value to the whole batch (or rejected mixed batches outright). Under concurrent multi-store load this either **errors** or **silently returns data keyed to the wrong store/requisition/period**.

This PR fixes the four affected loaders by grouping each batch by its request-scoped key(s) and querying per group, mirroring the pattern already used correctly in `clinician`/`name`/`master_list` loaders. Each fix adds a `#[tokio::test]` that drives a heterogeneous batch and asserts every input resolves to its own value.

## 🔍 Loader review — which loaders needed fixing

I audited every loader in `server/graphql/core/src/loader/` that keys on a request-scoped field (`store_id`, `requisition_id`, `period_id`, `customer_name_id`, …). Categories:
- **A — errors**: rejects a mixed batch with an error.
- **B — silently wrong**: applies `.first()`'s value to the whole batch, returning wrong/missing data with no error.
- **C — safe**: groups by all scoped keys (or keys results by a composite key), so mixed batches resolve correctly.

| Loader | Scoped field(s) | Before | Fixed here? |
|--------|-----------------|--------|-------------|
| `item_stats.rs` · `ItemsStatsForItemLoader` | `store_id` (+ payload) | **A** — returned `BadUserInput` "Cannot batch item stats across multiple stores" (the load-test symptom) | ✅ |
| `stock_line.rs` · `StockLineByItemAndStoreIdLoader` | `store_id` | **B** — `.first()` store; other stores' inputs resolved empty | ✅ |
| `available_volume_on_requisition.rs` | `requisition_id` | **B** — `.first()` requisition; other requisitions' inputs resolved empty | ✅ |
| `requisition_indicator_information.rs` | `store_id` + `period_id` | **B** — `.first()` store/period; other periods' inputs resolved empty | ✅ |
| `program_indicator_value.rs` · `IndicatorValueLoader` | `store_id` + `period_id` + `customer_name_id` | **B** (had a `TODO`) | ⏩ already fixed on `develop` (PR #11278), not in this RC base |
| `clinician.rs`, `name.rs`, `master_list.rs`, `program.rs`, `program_order_types.rs`, `item_store_join.rs` | `store_id` | **C** — already group by store / key compositely | — no change |
| `item_stock_on_hand.rs` | `store_id` | **C** — `equal_any(store_ids)`, keyed by `(store, item)` | — no change |
| `previous_encounter.rs` | per-input | **C** — queries each input individually | — no change |

## 💌 Any notes for the reviewer?

- **Behaviour change for `ItemsStatsForItemLoader`**: it previously returned a `BadUserInput` error for a multi-store batch; it now resolves all stores correctly. No more cross-store batching error.
- The grouping key for `item_stats` is `(store_id, payload)` where payload already covers `amc_lookback_months` + `period_end` — exactly the grouping the issue's example called for.
- `program_indicator_value` (the fifth loader from the same family) is intentionally **not** touched here: it was already corrected on `develop` and is out of scope for this `v2.16.05-RC` branch.
- Root cause not addressed here: the registry is still global, so a future loader could reintroduce this. A per-request `LoaderRegistry` would prevent the class of bug entirely — flagging as a possible follow-up rather than expanding this PR's scope.

# 🧪 Testing

Automated (run from `server/`):

- [ ] `cargo nextest run -p graphql_core loader::` → 5 pass, including the 4 new heterogeneous-batch tests:
  - `item_stats::tests::item_stats_loader_batches_across_stores`
  - `stock_line::tests::stock_line_by_item_and_store_loader_batches_across_stores`
  - `available_volume_on_requisition::tests::available_volume_loader_batches_across_requisitions`
  - `requisition_indicator_information::tests::requisition_indicator_info_loader_batches_across_periods`

Each test would fail on the old `.first()` code: the second store/requisition/period's input was absent (or the batch errored), so its `.unwrap()` would panic.

Manual (optional, reproduces the original report): drive concurrent `itemStockOnHand` queries against two different stores on a busy server and confirm no `Bad user input` responses.

# 📃 Documentation

- [x] **No documentation required**: internal performance/correctness fix, no user-facing behaviour change (besides removing an error that only occurred under concurrent multi-store load).
