### PR TITLE
#11978 Add CLI script to tag the current branch

### DIFF
--- a/build/create-tag-for-current-branch.sh
+++ b/build/create-tag-for-current-branch.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -e
+
+# Create a nightly-style tag for the CURRENT branch, from the CLI (no GitHub Action).
+#
+# Mirrors .github/scripts/create-nightly-tags.sh, but:
+# - Operates only on the branch you currently have checked out (RC or not).
+# - The version always comes from package.json; the branch name only decides the label:
+#     - RC branch  -> label "RC"          (same as nightly)
+#     - otherwise  -> first 6 chars of the branch name
+#   Tag shape: v<version>-<label>-<MMDDHHMM>, e.g. v3.00.00-RC-06081530
+# - Bumps package.json + commits on a throwaway temp branch, tags it, then returns to your
+#   branch and deletes the temp branch. Your branch's package.json is left untouched; the tag
+#   keeps the bump commit reachable.
+# - Prompts before pushing the tag (and only the tag, never the temp branch) to origin.
+
+# Run from the repo root so ./package.json resolves regardless of where this is invoked from.
+cd "$(git rev-parse --show-toplevel)"
+
+ORIGINAL_BRANCH=""
+TEMP_BRANCH=""
+
+cleanup() {
+    # Always return to the original branch and remove the temp branch (idempotent, never fails).
+    if [[ -n "$ORIGINAL_BRANCH" ]]; then
+        git checkout "$ORIGINAL_BRANCH" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "$TEMP_BRANCH" ]] && git show-ref --verify --quiet "refs/heads/$TEMP_BRANCH"; then
+        git branch -D "$TEMP_BRANCH" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
+ORIGINAL_BRANCH=$(git branch --show-current)
+if [[ -z "$ORIGINAL_BRANCH" ]]; then
+    echo "Not on a branch (detached HEAD). Check out a branch and try again." >&2
+    exit 1
+fi
+
+# --- Version (from package.json) ---
+PKG_VERSION=$(cat ./package.json | grep 'version":' | sed 's/.*"version":[ \t]*"\([^"]*\)".*/\1/')
+CLEAN_VERSION=$(echo "$PKG_VERSION" | sed -E 's/-(develop|rc)$//i')
+
+# --- Label (from branch name) ---
+if [[ "$ORIGINAL_BRANCH" =~ (R|r)(C|c) ]]; then
+    LABEL="RC"
+    LABEL_NOTE="RC branch"
+else
+    # First 6 chars of the branch name, with '/' replaced by '-' to avoid nested ref paths.
+    LABEL=$(echo "$ORIGINAL_BRANCH" | tr '/' '-' | cut -c1-6)
+    LABEL_NOTE="first 6 chars of branch name; not an RC branch"
+fi
+
+# --- Timestamp (from current HEAD, before the temp commit) ---
+TIMESTAMP=$(git log -1 --format=%cd --date=format:%m%d%H%M)
+
+if [[ -z "$CLEAN_VERSION" || -z "$LABEL" || -z "$TIMESTAMP" ]]; then
+    echo "Failed to build tag (version: '$PKG_VERSION', label: '$LABEL', timestamp: '$TIMESTAMP')." >&2
+    exit 1
+fi
+
+NEW_VERSION="$CLEAN_VERSION-$LABEL-$TIMESTAMP"
+if [[ "$CLEAN_VERSION" == v* ]]; then
+    TAG_NAME="$NEW_VERSION"
+else
+    TAG_NAME="v$NEW_VERSION"
+fi
+
+echo "Branch:    $ORIGINAL_BRANCH"
+echo "Version:   $CLEAN_VERSION            (from package.json \"$PKG_VERSION\")"
+echo "Label:     $LABEL                 ($LABEL_NOTE)"
+echo "Tag:       $TAG_NAME"
+
+# --- Duplicate check (before creating the temp branch) ---
+if git tag -l | grep -q "^${TAG_NAME}$"; then
+    echo "Tag $TAG_NAME already exists locally, skipping."
+    exit 0
+fi
+if git ls-remote --tags origin | grep -q "refs/tags/${TAG_NAME}$"; then
+    echo "Tag $TAG_NAME already exists on origin, skipping."
+    exit 0
+fi
+
+# --- Temp branch: bump package.json, commit, tag ---
+TEMP_BRANCH="tmp-tag-$TAG_NAME"
+git checkout -b "$TEMP_BRANCH" >/dev/null
+
+sed 's/"version":[ \t]*"[^"]*"/"version": "'"$NEW_VERSION"'"/' ./package.json > ./package.json.tmp && mv ./package.json.tmp ./package.json
+git add ./package.json
+git commit -m "Update package.json version to $NEW_VERSION for tag $TAG_NAME" >/dev/null
+git tag "$TAG_NAME"
+echo "On temp branch $TEMP_BRANCH: package.json version -> $NEW_VERSION, tagged."
+
+# --- Push with confirmation (tag only) ---
+read -r -p "Push tag $TAG_NAME to origin? [y/N] " ANSWER
+if [[ "$ANSWER" =~ ^[Yy]$ ]]; then
+    git push origin "$TAG_NAME"
+    echo "Pushed tag $TAG_NAME."
+else
+    echo "Skipped push. Tag $TAG_NAME created locally — push later with:"
+    echo "  git push origin $TAG_NAME"
+fi
+
+# cleanup() runs on EXIT: returns to $ORIGINAL_BRANCH and deletes $TEMP_BRANCH.
+echo "Returning to $ORIGINAL_BRANCH and removing temp branch ($ORIGINAL_BRANCH's package.json is untouched)."

--- a/build/create-tag-for-current-branch.sh
+++ b/build/create-tag-for-current-branch.sh
@@ -42,7 +42,7 @@ PKG_VERSION=$(cat ./package.json | grep 'version":' | sed 's/.*"version":[ \t]*"
 CLEAN_VERSION=$(echo "$PKG_VERSION" | sed -E 's/-(develop|rc)$//i')
 
 # --- Label (from branch name) ---
-if [[ "$ORIGINAL_BRANCH" =~ (R|r)(C|c) ]]; then
+if [[ "$ORIGINAL_BRANCH" =~ -[Rr][Cc]$ ]]; then
     LABEL="RC"
     LABEL_NOTE="RC branch"
 else

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "3.00.00-RC-06080920",
+  "version": "3.00.00-RC",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "3.00.00-develop",
+  "version": "3.00.00-RC-06080920",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",


### PR DESCRIPTION
Fixes #11978

# 👩🏻‍💻 What does this PR do?

Adds `build/create-tag-for-current-branch.sh`, a manual companion to the nightly tag Action ([.github/scripts/create-nightly-tags.sh](.github/scripts/create-nightly-tags.sh)). The nightly Action only tags the known RC/`develop` branches and can only run inside CI; this lets you produce a tag in the **same style** for whatever branch you currently have checked out, straight from the CLI.

Use case (from the issue): a fix made during the day while testing that you want to deploy and test overnight (e.g. sync v7 migration fixes), without waiting for the nightly run.

What it does:
- Version comes from `package.json`; the branch name only decides the label — `RC` for RC branches, otherwise the first 6 chars of the branch name. Tag shape: `v<version>-<label>-<MMDDHHMM>` (e.g. `v3.00.00-RC-06081530`), matching the nightly format.
- Bumps `package.json` + commits on a throwaway temp branch, tags that commit, then returns to your branch and deletes the temp branch — so **your branch's `package.json` is left untouched** while the tag keeps the bump commit reachable.
- Prompts `[y/N]` before pushing, and pushes **only the tag** (never the temp branch). On `n` it leaves the tag locally with the manual push command.
- Skips cleanly if the tag already exists (local or remote); aborts on detached HEAD.

# 💌 Any notes for the reviewer?

- The nightly script (`create-nightly-tags.sh`) and its Action are **left untouched** — this is a separate, standalone script, placed in `build/` alongside the other build scripts.
- **Difference vs the issue / nightly:** the issue asks for "very similar" behaviour. The main divergences, chosen deliberately for safe local use, are: (1) it operates on the *current* branch only rather than iterating all RC/`develop` branches; (2) the version bump commit lives on a temp branch that's deleted afterward, so it never dirties your working branch; (3) it prompts before pushing instead of pushing unconditionally; (4) for non-RC branches the label is the first 6 chars of the branch name (the nightly only ever labels `RC`/`develop`).
- `cd "$(git rev-parse --show-toplevel)"` at the top lets it run from any subdirectory of the repo; it must still be run from inside the checkout.
- No application code is touched — this is purely a developer/build tooling script.

# 🧪 Testing

- [ ] Check out an RC branch (e.g. `v3.0.0-RC`) and run `bash build/create-tag-for-current-branch.sh`
- [ ] Confirm it proposes `v<version>-RC-<MMDDHHMM>` with the version taken from `package.json`
- [ ] Answer `n` at the prompt → verify the tag exists locally (`git tag -l`), you're back on your original branch, `package.json` is unchanged, and no `tmp-tag-*` branch remains
- [ ] Re-run → confirm it detects the existing tag and skips without creating a temp branch
- [ ] (Optional) On a non-RC branch, confirm the label is the first 6 chars of the branch name
- [ ] (Optional, real) Answer `y` → confirm only the tag is pushed to origin

# 📃 Documentation

- [x] **No documentation required**: developer tooling only, no user facing changes

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Breaking Changes**
- [x] No Breaking Changes in the Graphql API

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend