### PR TITLE
Translations update from mSupply Foundation Translation Server

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1479,7 +1479,7 @@
   "label.po-sent": "PO sent",
   "label.policy-number": "Policy number",
   "label.policy-number-family": "Family policy number",
-  "label.policy-number-person": "Personal Policy number",
+  "label.policy-number-person": "Personal policy number",
   "label.policy-type": "Policy type",
   "label.population-forecast-calculation": "Population forecast calculation",
   "label.position": "Position",


### PR DESCRIPTION
Translations update from [mSupply Foundation Translation Server](https://translate.msupply.org) for [Open mSupply/Common](https://translate.msupply.org/projects/open-msupply/common/).



Current translation status:

![Weblate translation status](https://translate.msupply.org/widget/open-msupply/common/horizontal-auto.svg)