### PR TITLE
11988 fix: plugin deletions not syncing from central to remote sites

### DIFF
--- a/server/repository/src/db_diesel/plugin_data_row.rs
+++ b/server/repository/src/db_diesel/plugin_data_row.rs
@@ -3,7 +3,7 @@ use super::{
     StorageConnection,
 };
 
-use crate::{repository_error::RepositoryError, Upsert};
+use crate::{repository_error::RepositoryError, Delete, Upsert};
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -106,6 +106,26 @@ impl Upsert for PluginDataRow {
         assert_eq!(
             PluginDataRowRepository::new(con).find_one_by_id(&self.id),
             Ok(Some(self.clone()))
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PluginDataRowDelete(pub String);
+impl Delete for PluginDataRowDelete {
+    fn delete(&self, con: &StorageConnection) -> Result<Option<i64>, RepositoryError> {
+        let repo = PluginDataRowRepository::new(con);
+        // Look up the existing row to preserve its store_id on the delete changelog,
+        // so the delete is routed to the same sites the upsert was synced to.
+        let store_id = repo.find_one_by_id(&self.0)?.and_then(|row| row.store_id);
+        let change_log_id = repo.delete(&self.0, store_id)?;
+        Ok(Some(change_log_id))
+    }
+    // Test only
+    fn assert_deleted(&self, con: &StorageConnection) {
+        assert_eq!(
+            PluginDataRowRepository::new(con).find_one_by_id(&self.0),
+            Ok(None)
         )
     }
 }

--- a/server/service/src/sync/test/test_data/backend_plugin.rs
+++ b/server/service/src/sync/test/test_data/backend_plugin.rs
@@ -1,4 +1,6 @@
-use repository::{BackendPluginRow, PluginType, PluginTypes, PluginVariantType};
+use repository::{
+    BackendPluginRow, BackendPluginRowDelete, PluginType, PluginTypes, PluginVariantType,
+};
 use serde_json::json;
 
 // Data in this file is used in "test_backend_plugin_translation" and "test_sync_pull_and_push"
@@ -34,6 +36,14 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
         TABLE_NAME,
         BACKEND_PLUGIN,
         backend_plugin(),
+    )]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
+        TABLE_NAME,
+        BACKEND_PLUGIN.0,
+        BackendPluginRowDelete(BACKEND_PLUGIN.0.to_string()),
     )]
 }
 

--- a/server/service/src/sync/test/test_data/frontend_plugin.rs
+++ b/server/service/src/sync/test/test_data/frontend_plugin.rs
@@ -1,4 +1,7 @@
-use repository::{FrontendPluginFile, FrontendPluginFiles, FrontendPluginRow, FrontendPluginTypes};
+use repository::{
+    FrontendPluginFile, FrontendPluginFiles, FrontendPluginRow, FrontendPluginRowDelete,
+    FrontendPluginTypes,
+};
 use serde_json::json;
 
 // Data in this file is used in "test_frontend_plugin_translation" and "test_sync_pull_and_push"
@@ -40,6 +43,14 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
         TABLE_NAME,
         FRONTEND_PLUGIN,
         frontend_plugin(),
+    )]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
+        TABLE_NAME,
+        FRONTEND_PLUGIN.0,
+        FrontendPluginRowDelete(FRONTEND_PLUGIN.0.to_string()),
     )]
 }
 

--- a/server/service/src/sync/test/test_data/mod.rs
+++ b/server/service/src/sync/test/test_data/mod.rs
@@ -217,6 +217,11 @@ pub(crate) fn get_all_pull_delete_central_test_records() -> Vec<TestSyncIncoming
     test_records.append(&mut rnr_form_line::test_pull_delete_records());
     test_records.append(&mut rnr_form::test_pull_delete_records());
 
+    // Open mSupply central
+    test_records.append(&mut backend_plugin::test_pull_delete_records());
+    test_records.append(&mut frontend_plugin::test_pull_delete_records());
+    test_records.append(&mut plugin_data::test_pull_delete_records());
+
     test_records
 }
 

--- a/server/service/src/sync/test/test_data/plugin_data.rs
+++ b/server/service/src/sync/test/test_data/plugin_data.rs
@@ -1,7 +1,7 @@
 use crate::sync::test::TestSyncOutgoingRecord;
 
 use super::TestSyncIncomingRecord;
-use repository::PluginDataRow;
+use repository::{PluginDataRow, PluginDataRowDelete};
 use serde_json::json;
 
 const TABLE_NAME: &str = "plugin_data";
@@ -34,6 +34,14 @@ pub(crate) fn test_pull_upsert_records() -> Vec<TestSyncIncomingRecord> {
         TABLE_NAME,
         PLUGIN_DATA,
         plugin_data(),
+    )]
+}
+
+pub(crate) fn test_pull_delete_records() -> Vec<TestSyncIncomingRecord> {
+    vec![TestSyncIncomingRecord::new_pull_delete(
+        TABLE_NAME,
+        PLUGIN_DATA.0,
+        PluginDataRowDelete(PLUGIN_DATA.0.to_string()),
     )]
 }
 

--- a/server/service/src/sync/translations/backend_plugin.rs
+++ b/server/service/src/sync/translations/backend_plugin.rs
@@ -80,6 +80,14 @@ impl SyncTranslation for BackendPluginTranslator {
             sync_record.record_id.clone(),
         )))
     }
+
+    fn try_translate_to_delete_sync_record(
+        &self,
+        _: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        Ok(PushTranslateResult::delete(changelog, self.table_name()))
+    }
 }
 
 #[cfg(test)]
@@ -99,6 +107,15 @@ mod tests {
             assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_from_upsert_sync_record(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+
+        for record in test_data::test_pull_delete_records() {
+            assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
+            let translation_result = translator
+                .try_translate_from_delete_sync_record(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/frontend_plugin.rs
+++ b/server/service/src/sync/translations/frontend_plugin.rs
@@ -80,6 +80,14 @@ impl SyncTranslation for FrontendPluginTranslator {
             sync_record.record_id.clone(),
         )))
     }
+
+    fn try_translate_to_delete_sync_record(
+        &self,
+        _: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        Ok(PushTranslateResult::delete(changelog, self.table_name()))
+    }
 }
 
 #[cfg(test)]
@@ -99,6 +107,15 @@ mod tests {
             assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_from_upsert_sync_record(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+
+        for record in test_data::test_pull_delete_records() {
+            assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
+            let translation_result = translator
+                .try_translate_from_delete_sync_record(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);

--- a/server/service/src/sync/translations/plugin_data.rs
+++ b/server/service/src/sync/translations/plugin_data.rs
@@ -1,6 +1,6 @@
 use repository::{
-    ChangelogRow, ChangelogTableName, PluginDataRow, PluginDataRowRepository, StorageConnection,
-    SyncBufferRow,
+    ChangelogRow, ChangelogTableName, PluginDataRow, PluginDataRowDelete, PluginDataRowRepository,
+    StorageConnection, SyncBufferRow,
 };
 
 use crate::sync::translations::store::StoreTranslation;
@@ -74,6 +74,24 @@ impl SyncTranslation for PluginDataTranslator {
             serde_json::to_value(row)?,
         ))
     }
+
+    fn try_translate_to_delete_sync_record(
+        &self,
+        _: &StorageConnection,
+        changelog: &ChangelogRow,
+    ) -> Result<PushTranslateResult, anyhow::Error> {
+        Ok(PushTranslateResult::delete(changelog, self.table_name()))
+    }
+
+    fn try_translate_from_delete_sync_record(
+        &self,
+        _: &StorageConnection,
+        sync_record: &SyncBufferRow,
+    ) -> Result<PullTranslateResult, anyhow::Error> {
+        Ok(PullTranslateResult::delete(PluginDataRowDelete(
+            sync_record.record_id.clone(),
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -93,6 +111,15 @@ mod tests {
             assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
             let translation_result = translator
                 .try_translate_from_upsert_sync_record(&connection, &record.sync_buffer_row)
+                .unwrap();
+
+            assert_eq!(translation_result, record.translated_record);
+        }
+
+        for record in test_data::test_pull_delete_records() {
+            assert!(translator.should_translate_from_sync_record(&record.sync_buffer_row));
+            let translation_result = translator
+                .try_translate_from_delete_sync_record(&connection, &record.sync_buffer_row)
                 .unwrap();
 
             assert_eq!(translation_result, record.translated_record);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11988

# 👩🏻‍💻 What does this PR do?
Fixes plugin deletions not syncing from the omSupply central server to remote sites.

When a plugin (`backend_plugin`, `frontend_plugin`) or plugin data record (`plugin_data`) was deleted on central (via Manage > Plugins), a delete changelog entry was correctly written locally, but the sync translation layer never converted it into a delete sync record to send to remote sites. The delete was silently dropped because none of the three plugin translators implemented `try_translate_to_delete_sync_record` — they fell through to the trait default (`NotMatched`).

A second gap existed for `plugin_data` specifically: there was no `PluginDataRowDelete` type or receive-side delete translation (`try_translate_from_delete_sync_record`), so even if a delete record arrived at a remote site it could not be applied.

Changes:
- Added `try_translate_to_delete_sync_record` to `BackendPluginTranslator`, `FrontendPluginTranslator`, and `PluginDataTranslator` so central correctly emits `SyncAction::Delete` records during pull
- Added `PluginDataRowDelete` struct (implementing the `Delete` trait) to the repository layer, preserving `store_id` on the delete changelog so store-scoped plugin data deletes are routed to the correct sites only
- Added `try_translate_from_delete_sync_record` to `PluginDataTranslator` so remote sites can apply incoming plugin data deletes
- Added `test_pull_delete_records()` to all three plugin test-data modules and wired them into the central pull-delete
integration test (`get_all_pull_delete_central_test_records`)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Run `cargo nextest run -p service sync::test::pull_and_push` — confirms delete records translate and integrate correctly
- [ ] Run `cargo nextest run -p service plugin` — confirms all plugin unit tests pass
- [ ] Central omSupply server + 1 omSupply remote site:
  1. On central: install a backend plugin and a frontend plugin via Manage > Plugins
  2. Sync down to remote — confirm plugins appear on the remote
  3. On central: delete the backend plugin and frontend plugin
  4. Sync again — confirm the plugins are gone on the remote
  5. (For `plugin_data`) Create a plugin data record via a plugin that produces them, sync down, delete on central, sync again — confirm it is removed on the remote

# 📃 Documentation

 - [ ] **No documentation required**: bug fix, no user-facing behaviour change (deletes now work as expected)

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

