### PR TITLE
#11922 Fix backdated positive inventory adjustment shown at 23:59

### DIFF
--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/AdjustmentForm.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/AdjustmentForm.tsx
@@ -35,6 +35,19 @@ export const AdjustmentForm = ({
   const isInventoryReduction =
     draft.adjustmentType === AdjustmentTypeInput.Reduction;
 
+  // Reductions are stamped at end of day, additions at start of day, so the
+  // ledger entry sorts correctly within the backdated day. Today's date is not
+  // backdated, so it yields null.
+  const toBackdatedDatetime = (
+    date: Date | null | undefined,
+    isReduction: boolean
+  ) =>
+    date && !DateUtils.isToday(date)
+      ? Formatter.toIsoString(
+          isReduction ? DateUtils.endOfDayOrNull(date) : DateUtils.startOfDay(date)
+        )
+      : null;
+
   // +1 day buffer so the boundary date isn't rejected by server UTC check
   const minDate =
     backdating?.maxDays && backdating?.maxDays > 0
@@ -66,10 +79,19 @@ export const AdjustmentForm = ({
           <InventoryAdjustmentDirectionInput
             value={draft.adjustmentType}
             onChange={adjustmentType => {
+              const type = adjustmentType ?? AdjustmentTypeInput.Addition;
               setDraft(state => ({
                 ...state,
-                adjustmentType: adjustmentType ?? AdjustmentTypeInput.Addition,
+                adjustmentType: type,
                 reason: null,
+                // Recompute the time component so it matches the new direction,
+                // rather than keeping whatever was set when the date was picked.
+                backdatedDatetime: state.backdatedDatetime
+                  ? toBackdatedDatetime(
+                      new Date(state.backdatedDatetime),
+                      type === AdjustmentTypeInput.Reduction
+                    )
+                  : null,
               }));
             }}
           />
@@ -103,14 +125,10 @@ export const AdjustmentForm = ({
               onChange={date =>
                 setDraft(state => ({
                   ...state,
-                  backdatedDatetime:
-                    date && !DateUtils.isToday(date)
-                      ? Formatter.toIsoString(
-                          isInventoryReduction
-                            ? DateUtils.endOfDayOrNull(date)
-                            : DateUtils.startOfDay(date)
-                        )
-                      : null,
+                  backdatedDatetime: toBackdatedDatetime(
+                    date,
+                    isInventoryReduction
+                  ),
                 }))
               }
               maxDate={new Date()}


### PR DESCRIPTION
Fixes #11922

# 👩🏻‍💻 What does this PR do?

A backdated **positive** inventory adjustment could appear in the stock ledger at `23:59` of the backdated day instead of `00:00`.

The backdated datetime's time-of-day is chosen by direction so the ledger entry sorts correctly within the day: reductions are stamped end-of-day (`23:59`), additions start-of-day (`00:00`). But this was only computed in the date picker's `onChange` — **not** when the adjustment direction toggled. So picking a date while the direction was *Reduction* (stored as `23:59`) and then switching to *Addition* left the stale `23:59` stamp on the positive adjustment.

This PR extracts the time-stamping logic into a small `toBackdatedDatetime(date, isReduction)` helper and calls it from the direction toggle as well, recomputing the time component from the already-selected date so it always matches the current adjustment type.

Touches only `client/packages/system/src/Stock/Components/InventoryAdjustment/AdjustmentForm.tsx`.

## 💌 Any notes for the reviewer?

- This is a **display/ordering** correctness fix, not a data-integrity one. An addition can never drive the ledger running balance below zero, so the stored stock totals were always correct — only the displayed timestamp (and thus intra-day sort position) was wrong. Despite the "Severity: Hotfix" label on the issue, there's no corruption risk.
- The server is unchanged; the draft shape (`backdatedDatetime` as an ISO string) is unchanged. No GraphQL/codegen impact.
- The reverse path is also covered: picking a date as *Addition* then toggling to *Reduction* now correctly re-stamps to `23:59`.

# 🧪 Testing

- [ ] Enable backdated inventory adjustments preference for the store
- [ ] Open Stock → select a stock line → Adjust
- [ ] Set direction to **Reduction**, pick a past date, then toggle direction to **Addition**
- [ ] Save and confirm the ledger entry shows at **00:00** of that day, not 23:59
- [ ] Reverse: pick the date as **Addition**, toggle to **Reduction** → entry shows at **23:59**
- [ ] Select today's date → confirm no backdating is applied (datetime stays current)

# 📃 Documentation

- [x] **No documentation required**: bug fix, not a change in intended behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
