### PR TITLE
feat(cli): add progress bar to reintegrate-buffer

### DIFF
--- a/docs/content/server/cli/reintegrate_buffer/_index.md
+++ b/docs/content/server/cli/reintegrate_buffer/_index.md
@@ -73,7 +73,7 @@ correctly.
 
 **3. Reintegrate**
 
-Reset the buffer's integration state and re-run integration:
+Reset the buffer's integration state and re-run integration, with a progress bar:
 
 `NOTE` need to pass `APP__DATABASE__DATABASE_NAME=my_replay` before the command if you don't want it to pickup db name from yaml
 ```
@@ -114,4 +114,8 @@ cargo run --bin remote_server_cli --features postgres -- reintegrate-buffer --mi
 
 - The reset (when not `--skip-buffer-reset`) drops null-data upsert rows and marks every
   `sync_buffer` row pending again, so integration reprocesses the whole buffer.
-- The integrator logs per-batch progress at `info` level as it works through the buffer.
+- The progress bar reflects live progress even with `--use-transaction`, where the integration's
+  DB writes aren't committed until the end — it reads the same in-memory sync log the API/UI uses.
+- **Logging vs. the bar:** the integrator still logs per-batch progress at `info` level, and those
+  lines share stderr with the progress bar, so they scroll the bar as they print. Run with
+  `RUST_LOG=warn` for a clean bar, or leave it at `info` to see both the log lines and the bar.

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2086,6 +2086,7 @@ dependencies = [
  "egui",
  "egui_extras",
  "graphql",
+ "indicatif",
  "log",
  "machine-uid",
  "report_builder",
@@ -2214,6 +2215,19 @@ dependencies = [
  "toml 1.0.7+spec-1.1.0",
  "winnow 1.0.0",
  "yaml-rust2",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3417,6 +3431,12 @@ checksum = "491bdf728bf25ddd9ad60d4cf1c48588fa82c013a2440b91aa7fc43e34a07c32"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -6118,6 +6138,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7261,6 +7294,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc"

--- a/server/cli/Cargo.toml
+++ b/server/cli/Cargo.toml
@@ -45,6 +45,7 @@ copy_dir = "0.1.3"
 shellexpand = "3.1.2"
 serde_yml = "0.0.12"
 colored = "3.1.1"
+indicatif = "0.17"
 
 
 [dev-dependencies]

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -405,7 +405,8 @@ async fn main() -> anyhow::Result<()> {
                 use_transaction,
                 should_migrate,
                 skip_buffer_reset,
-            )?;
+            )
+            .await?;
         }
         Action::InitialiseFromCentral { users } => {
             initialise_from_central(settings, &users).await?;

--- a/server/cli/src/reintegrate_buffer.rs
+++ b/server/cli/src/reintegrate_buffer.rs
@@ -1,20 +1,25 @@
 use anyhow::anyhow;
+use indicatif::{ProgressBar, ProgressStyle};
 use log::info;
 use repository::{
     get_storage_connection_manager,
     migrations::{migrate, MigrationConfig},
-    SyncBufferRepository, SyncVersion,
+    Pagination, SyncBufferRepository, SyncLogV5V6Repository, SyncLogV5V6Sort, SyncLogV5V6SortField,
+    SyncVersion,
 };
 use service::{
     settings::Settings,
     sync::{sync_status::logger::SyncLogger, synchroniser::integrate_and_translate_sync_buffer},
 };
+use std::time::Duration;
+use tokio::task::spawn_blocking;
 
-/// Re-runs sync buffer translation + integration against the `sync_buffer` already in the database.
+/// Re-runs sync buffer translation + integration against the `sync_buffer` already in the database,
+/// showing a live progress bar.
 ///
 /// Optionally migrates the database first, resets the buffer's integration state, then translates
-/// and integrates every pending row. The integrator logs per-batch progress at `info` level.
-pub fn reintegrate_buffer(
+/// and integrates every pending row.
+pub async fn reintegrate_buffer(
     settings: &Settings,
     source_site_id: i32,
     use_transaction: bool,
@@ -58,21 +63,80 @@ pub fn reintegrate_buffer(
         )?;
     }
 
-    let connection = connection_manager.connection()?;
-    let total_pending = SyncBufferRepository::new(&connection)
+    // Count what's about to be integrated so the progress bar has a total.
+    let total_pending = SyncBufferRepository::new(&connection_manager.connection()?)
         .count_pending(source_site_id, SyncVersion::V5V6, None)?;
     info!("Starting reintegration for source_site_id={source_site_id} ({total_pending} pending)");
 
-    // The integrator logs per-batch progress at `info` level as it goes.
+    // Run integration on a blocking thread so the async runtime stays free to
+    // drive the progress bar.
+    let integrate_cm = connection_manager.clone();
     let start = std::time::Instant::now();
-    let mut logger =
-        SyncLogger::start(&connection).map_err(|e| anyhow!("failed to start sync logger: {e:?}"))?;
-    let (upserts, deletes, merges) = integrate_and_translate_sync_buffer(
-        &connection,
-        Some(&mut logger),
-        source_site_id,
-        use_transaction,
-    )?;
+    let integration = spawn_blocking(move || -> anyhow::Result<_> {
+        let connection = integrate_cm.connection()?;
+        let mut logger = SyncLogger::start(&connection)
+            .map_err(|e| anyhow!("failed to start sync logger: {e:?}"))?;
+        Ok(integrate_and_translate_sync_buffer(
+            &connection,
+            Some(&mut logger),
+            source_site_id,
+            use_transaction,
+        )?)
+    });
+
+    // Progress: poll the latest sync_log row via the repository. Its query applies
+    // `or_latest_row`, overlaying the in-memory cached row that the integration updates
+    // on every batch — so progress is visible even with --use-transaction, where the
+    // DB updates aren't committed until the end (same mechanism the API/UI uses).
+    //
+    // Logging note: the integrator still emits its per-batch progress at `info` level.
+    // Those lines and the progress bar share stderr, so info logs will scroll the bar.
+    // Run with `RUST_LOG=warn` for a clean bar, or at `info` to see both.
+    let pb = ProgressBar::new(total_pending as u64);
+    pb.set_style(
+        ProgressStyle::with_template(
+            "[{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({percent}%) {msg}",
+        )
+        .unwrap()
+        .progress_chars("=>-"),
+    );
+    pb.set_message("integrating");
+    // indicatif's own redraw thread: keeps elapsed time / bar animation smooth between
+    // the slower (1s) data polls below. Independent of how often we re-query the DB.
+    pb.enable_steady_tick(Duration::from_millis(120));
+
+    while !integration.is_finished() {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let poll_cm = connection_manager.clone();
+        let done = spawn_blocking(move || -> Option<i32> {
+            let connection = poll_cm.connection().ok()?;
+            // `query` with an explicit descending sort, not `query_one`: query_one
+            // passes no sort, which `query` defaults to started_datetime ASC — i.e. the
+            // oldest row. We want the latest (current) run's row.
+            SyncLogV5V6Repository::new(&connection)
+                .query(
+                    Pagination::one(),
+                    None,
+                    Some(SyncLogV5V6Sort {
+                        key: SyncLogV5V6SortField::StartedDatetime,
+                        desc: Some(true),
+                    }),
+                )
+                .ok()?
+                .into_iter()
+                .next()
+                .and_then(|log| log.sync_log_row.integration_progress_done)
+        })
+        .await
+        .ok()
+        .flatten();
+        if let Some(done) = done {
+            pb.set_position(done as u64);
+        }
+    }
+
+    let (upserts, deletes, merges) = integration.await??;
+    pb.finish_and_clear();
 
     info!("Reintegration complete in {:?}", start.elapsed());
     info!("Upsert results: {upserts:#?}");


### PR DESCRIPTION

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->
Follow up from #11998 

# 👩🏻‍💻 What does this PR do?

Adds a progress bar for quick at a glance progress tracking during sync-buffer reintegration runs from cli

If yaml settings have console logging enabled, they will log as usual and progress bar will continue to be shown interspersed with logs. 

<img width="932" height="112" alt="image" src="https://github.com/user-attachments/assets/a6704d00-5be9-4dda-b885-9c03f04a4cf4" />

For long runs you probably want to have those log to a file (All / File in yaml settings) . When running without console logs you will see just the progress bar

<img width="581" height="38" alt="image" src="https://github.com/user-attachments/assets/65a00c5b-3b14-48a0-b196-a7ebe028be65" />


## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

