### PR TITLE
Prevent the cold chain unauthenticated warning message

### DIFF
--- a/client/packages/coldchain/src/Monitoring/api/TemperatureNotification/hooks/useTemperatureNotificationList.ts
+++ b/client/packages/coldchain/src/Monitoring/api/TemperatureNotification/hooks/useTemperatureNotificationList.ts
@@ -1,4 +1,6 @@
+import { useEffect } from 'react';
 import {
+  AuthError,
   LIST_KEY,
   useNotification,
   useQuery,
@@ -23,28 +25,20 @@ export const useTemperatureNotificationList = (queryParams?: ListParams) => {
   const { warning } = useNotification();
   const { temperatureNotificationApi, storeId } =
     useTemperatureNotificationGraphQL();
-  const { userHasPermission } = useAuthContext();
+  const { userHasPermission, error: authError } = useAuthContext();
 
   const canViewSensorDetails = userHasPermission(UserPermission.SensorQuery);
   const queryKey = [TEMPERATURE_NOTIFICATION, storeId, LIST_KEY, queryParams];
 
   const queryFn = async () => {
-    try {
-      const { first, offset } = queryParams ?? {};
+    const { first, offset } = queryParams ?? {};
 
-      const result = await temperatureNotificationApi.temperatureNotifications({
-        storeId,
-        page: { offset, first },
-      });
+    const result = await temperatureNotificationApi.temperatureNotifications({
+      storeId,
+      page: { offset, first },
+    });
 
-      return result?.temperatureNotifications;
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      warning(`${t('error.fetch-notifications')}: ${errorMessage}`)();
-
-      throw error;
-    }
+    return result?.temperatureNotifications;
   };
 
   const query = useQuery({
@@ -55,6 +49,24 @@ export const useTemperatureNotificationList = (queryParams?: ListParams) => {
     staleTime: STALE_TIME_MS,
     enabled: !!storeId && canViewSensorDetails,
   });
+
+  const { isError, error } = query;
+
+  useEffect(() => {
+    // Notify on the error state rather than inside queryFn, so the toast is
+    // shown once per failure instead of once per (retried) request.
+    // Skip when the user is no longer authenticated (e.g. logged out due to
+    // inactivity) - a failed background poll isn't actionable for them. A
+    // stale token may still be present, so gate on the auth error instead.
+    const isLoggedOut =
+      authError === AuthError.Unauthenticated ||
+      authError === AuthError.Timeout;
+    if (!isError || isLoggedOut) return;
+
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error';
+    warning(`${t('error.fetch-notifications')}: ${errorMessage}`)();
+  }, [isError, error, authError, warning, t]);
 
   return query;
 };

--- a/client/packages/common/src/hooks/useNotification/useNotification.tsx
+++ b/client/packages/common/src/hooks/useNotification/useNotification.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { IconButton, Typography } from '@mui/material';
 import { CloseIcon, InfoIcon } from '../../ui/icons';
 import { OptionsObject, SnackbarKey, useSnackbar } from 'notistack';
@@ -17,72 +17,96 @@ export const useNotification = (): NotificationHook => {
   const t = useTranslation();
   const { closeSnackbar, enqueueSnackbar } = useSnackbar();
 
-  const action = (key: SnackbarKey) => (
-    <IconButton
-      size="small"
-      sx={{ marginInlineStart: 2 }}
-      onClick={() => {
-        closeSnackbar(key);
-      }}
-    >
-      <CloseIcon style={{ color: '#fff' }} />
-    </IconButton>
-  );
-
-  const actionWithDetail = (key: SnackbarKey, message: string) => (
-    <>
-      <PaperPopover
-        mode="click"
-        width={300}
-        Content={
-          <PaperPopoverSection>
-            <Typography variant="body1">{message}</Typography>
-          </PaperPopoverSection>
-        }
+  const action = useCallback(
+    (key: SnackbarKey) => (
+      <IconButton
+        size="small"
+        sx={{ marginInlineStart: 2 }}
+        onClick={() => {
+          closeSnackbar(key);
+        }}
       >
-        <IconButton size="small">
-          <InfoIcon style={{ color: '#fff' }} />
-        </IconButton>
-      </PaperPopover>
-      {action(key)}
-    </>
+        <CloseIcon style={{ color: '#fff' }} />
+      </IconButton>
+    ),
+    [closeSnackbar]
   );
 
-  const error = (message: string, options?: OptionsObject) => () =>
-    enqueueSnackbar(message, {
-      variant: 'error',
-      action,
-      ...options,
-    });
+  const actionWithDetail = useCallback(
+    (key: SnackbarKey, message: string) => (
+      <>
+        <PaperPopover
+          mode="click"
+          width={300}
+          Content={
+            <PaperPopoverSection>
+              <Typography variant="body1">{message}</Typography>
+            </PaperPopoverSection>
+          }
+        >
+          <IconButton size="small">
+            <InfoIcon style={{ color: '#fff' }} />
+          </IconButton>
+        </PaperPopover>
+        {action(key)}
+      </>
+    ),
+    [action]
+  );
 
-  const errorWithDetail = (message: string, options?: OptionsObject) => () =>
-    enqueueSnackbar(t('error.something-wrong-info-icon'), {
-      variant: 'error',
-      action: key => actionWithDetail(key, message),
-      autoHideDuration: 10000,
-      ...options,
-    });
+  const error = useCallback(
+    (message: string, options?: OptionsObject) => () =>
+      enqueueSnackbar(message, {
+        variant: 'error',
+        action,
+        ...options,
+      }),
+    [enqueueSnackbar, action]
+  );
 
-  const info = (message: string, options?: OptionsObject) => () =>
-    enqueueSnackbar(message, {
-      variant: 'info',
-      action,
-      ...options,
-    });
+  const errorWithDetail = useCallback(
+    (message: string, options?: OptionsObject) => () =>
+      enqueueSnackbar(t('error.something-wrong-info-icon'), {
+        variant: 'error',
+        action: key => actionWithDetail(key, message),
+        autoHideDuration: 10000,
+        ...options,
+      }),
+    [enqueueSnackbar, t, actionWithDetail]
+  );
 
-  const success = (message: string, options?: OptionsObject) => () =>
-    enqueueSnackbar(message, {
-      variant: 'success',
-      action,
-      ...options,
-    });
+  const info = useCallback(
+    (message: string, options?: OptionsObject) => () =>
+      enqueueSnackbar(message, {
+        variant: 'info',
+        action,
+        ...options,
+      }),
+    [enqueueSnackbar, action]
+  );
 
-  const warning = (message: string, options?: OptionsObject) => () =>
-    enqueueSnackbar(message, {
-      variant: 'warning',
-      action,
-      ...options,
-    });
+  const success = useCallback(
+    (message: string, options?: OptionsObject) => () =>
+      enqueueSnackbar(message, {
+        variant: 'success',
+        action,
+        ...options,
+      }),
+    [enqueueSnackbar, action]
+  );
 
-  return { error, errorWithDetail, info, success, warning };
+  const warning = useCallback(
+    (message: string, options?: OptionsObject) => () =>
+      enqueueSnackbar(message, {
+        variant: 'warning',
+        action,
+        ...options,
+      }),
+    [enqueueSnackbar, action]
+  );
+
+  return useMemo(
+    () => ({ error, errorWithDetail, info, success, warning }),
+    [error, errorWithDetail, info, success, warning]
+  );
 };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11987

# 👩🏻‍💻 What does this PR do?
The notification came in with the upgrade to tanstack. `useQuery` will retry three times a failed query and the toast was called in the query method.

I've moved into an effect which has a dependency of the error and will only fire once. Have also excluded unauthenticated errors from calling the toast, as we don't need to inform users of this error state.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Log in, wait for an hour, or
- [ ] Log in, use developer tools to delete the auth cookie and refresh token cookie

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

