### PR TITLE
11653 Move volume information out of else statement

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseStats/RequestStoreStats.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseStats/RequestStoreStats.tsx
@@ -226,14 +226,14 @@ export const RequestStoreStats = ({
               colour="primary.light"
             />
           </Box>
-
-          {!!availableVolumeAtLocationType && (
-            <VolumeInformation
-              availableVolumeAtLocationType={availableVolumeAtLocationType}
-              itemVolume={itemVolume}
-            />
-          )}
         </>
+      )}
+
+      {!!availableVolumeAtLocationType && (
+        <VolumeInformation
+          availableVolumeAtLocationType={availableVolumeAtLocationType}
+          itemVolume={itemVolume}
+        />
       )}
     </Box>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11653

# 👩🏻‍💻 What does this PR do?
Move volume information out of else statement so it will show regardless of forecasting

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up location types in OG
- [ ] Set up storage requirements for item (restricted to type, preferred pack size & volume per pack) in OG
- [ ] Make sure stock lines are associated with location types in your store to get accurate storage volumes
- [ ] enable population forecasting, define a population, safety stock buffer and supply interval
- [ ] Create an Internal Order from Store A to Store B with items set up above, then finalise
- [ ]  Go to Store B and click on created Requisition
- [ ] Click on line, go to customer tab
- [ ] You should see volumes for storage types

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

