### PR TITLE
#11267 Fix New Item zero-qty placeholder and stuck modal

### DIFF
--- a/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
+++ b/client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts
@@ -52,6 +52,11 @@ export const useBlockNavigation = () => {
   const blockers: BlockingState[] = Array.from(blocking.values());
 
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
+    // Same-pathname "navigations" are re-render artifacts, not real navigations.
+    // React Router fires them on the destination after a proceed() completes, which
+    // would re-block before the destination component has reset its dirty state.
+    if (currentLocation.pathname === nextLocation.pathname) return false;
+
     for (const b of blockers) {
       if (b.options?.disabled) {
         return false;
@@ -62,7 +67,7 @@ export const useBlockNavigation = () => {
         return b.options.customCheck.navigate(currentLocation, nextLocation);
       }
 
-      if (b.shouldBlock && currentLocation.pathname !== nextLocation.pathname) {
+      if (b.shouldBlock) {
         // Set the blocker that is blocking navigation, so we can show the correct modal content
         setActiveBlocker(b);
         return true;

--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -157,6 +157,11 @@ export const PrescriptionLineEditView = () => {
   const itemIdList = items.map(item => item.id);
   if (status !== InvoiceNodeStatus.Verified) itemIdList.push('new');
 
+  const canSave =
+    !!item?.id &&
+    allocationIsDirty &&
+    !(allocatedQuantity === 0 && prescribedUnits === 0);
+
   return (
     <>
       <AppBarButtons invoiceId={data?.id} />
@@ -170,7 +175,7 @@ export const PrescriptionLineEditView = () => {
               .addPart(invoiceId)}
             enteredLineIds={enteredLineIds}
             showNew={!isDisabled}
-            isDirty={isDirty.current}
+            isDirty={canSave}
             handleSaveNew={onSave}
             scrollRef={scrollRef}
           />
@@ -203,11 +208,7 @@ export const PrescriptionLineEditView = () => {
       />
       <Footer
         isSaving={isSavingLines}
-        disabled={
-          !item?.id ||
-          !allocationIsDirty ||
-          (allocatedQuantity === 0 && prescribedUnits === 0)
-        }
+        disabled={!canSave}
         handleSave={onSave}
         handleCancel={() =>
           navigate(

--- a/client/packages/system/src/Item/Components/ListItems/ListItems.tsx
+++ b/client/packages/system/src/Item/Components/ListItems/ListItems.tsx
@@ -52,6 +52,7 @@ export const ListItems = ({
   }
 
   const changeItem = (id: string) => {
+    if (id === currentItemId) return;
     if (currentItemId === 'new' && isDirty) {
       showSaveNewConfirmation();
     } else navigate(route.addPart(id).build());


### PR DESCRIPTION
Fixes #11267

Addresses the follow-up reported in [this comment](https://github.com/msupply-foundation/open-msupply/issues/11267#issuecomment-4654280976): the original render-loop fix (#11756) didn't fully resolve the "placeholder zero-quantity line" path through the New Item flow.

# 👩🏻‍💻 What does this PR do?

Three small fixes that together resolve the remaining symptoms when adding a prescription line, leaving the quantity at zero, and clicking "New Item" (or footer Cancel) to leave.

**1. Save-confirmation modal no longer fires for zero-qty placeholders** ([LineEditView.tsx](client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx), [ListItems.tsx](client/packages/system/src/Item/Components/ListItems/ListItems.tsx))

The Footer "Save" button already encoded `disabled = !item?.id || !allocationIsDirty || (allocatedQuantity === 0 && prescribedUnits === 0)`. The sidebar's "Save new item?" modal trigger only checked `isDirty.current`, so it could fire even when there was nothing savable. OK then called `onSave` which would `navigate(..., { replace: true })` to the picked item's URL despite no line ever persisting — leaving the URL claiming you were viewing an item that didn't exist in the DB.

Extract `canSave` as a single source of truth and pass it both to the Footer (`disabled={!canSave}`) and `ListItems` (`isDirty={canSave}`). The two save-trigger paths can no longer drift.

**2. Clicking the row you're already on is a no-op** ([ListItems.tsx](client/packages/system/src/Item/Components/ListItems/ListItems.tsx))

Added `if (id === currentItemId) return` at the top of `changeItem`. Stops a redundant `navigate('/.../new')` to the same URL — which was tripping `useConfirmOnLeaving` and showing a confusing "Are you sure?" prompt for an empty placeholder.

**3. `useConfirmOnLeaving` no longer re-opens the modal after `proceed()`** ([useConfirmOnLeaving.ts](client/packages/common/src/hooks/useConfirmOnLeaving/useConfirmOnLeaving.ts))

When the user clicked OK on the leave prompt, the modal would visually linger and need a second click to dismiss. Verified with instrumentation: after `blocker.proceed()` completes, React Router fires the `useBlocker` callback again on the destination URL (e.g. `curr=/<id> -> next=/<id>`). The default path already filtered same-pathname navigations; the `customCheck` path didn't, so it would re-evaluate against still-dirty state from the just-departed item and re-block, re-opening the modal.

Hoist the same-pathname guard to the top of the blocker callback so it applies to all paths.

## 💌 Any notes for the reviewer?

**Shared hook change**: the `useConfirmOnLeaving` change affects every consumer of the hook. Impact analysis:

| Consumer | Path | Effect |
|---|---|---|
| `LineEditView.tsx` | customCheck | **Fixes** the lingering modal |
| `RnRForms/AutoSave.tsx` | customCheck | Skips redundant `saveLines()` on same-pathname re-renders. `setInterval(saveLines, 10s)` already covers any window. Benign. |
| All other consumers (Inbound shipment, ColdChain Equipment, Encounter, Stock detail, JsonForms, IndicatorsDemographics, ImportFridgeTag) | default | **Equivalent** — the old default path already required pathname differs to block; I just hoisted that check. |

Encounter uses `customConfirmation` (different option — only replaces the modal UI, not the block decision). Unaffected.

**Other notes:**
- No backend changes.
- No new dependencies.
- The `canSave` extraction in LineEditView de-duplicates the disabled expression between the Footer and the sidebar modal trigger; intentional small refactor to prevent the two from drifting again.

# 🧪 Testing

`develop` branch with PostgreSQL central server.

**Primary fix — zero-quantity placeholder**
- [ ] Dispensary → Prescriptions → new prescription, pick a patient
- [ ] Add an item
- [ ] Click **New Item** in the left list, select an item from the dropdown, leave quantity at 0
- [ ] Click **New Item** again → confirm no save-confirmation modal appears (you're already on the new slot); no URL change, no toast
- [ ] Enter a quantity, click footer **Save** → confirm the line saves to the DB and the URL updates to `/<itemId>`
- [ ] After saving, click **New Item** → confirm clean navigation to `/new` with a fresh empty form
- [ ] Repeat the New Item / pick / New Item cycle several more times rapidly → confirm no infinite-render error, no permanently spinning OK button, and no "Invalid blocker state transition" red error banner

**Secondary fix — leave-blocker modal dismisses on a single OK click**
- [ ] On `/dispensary/prescription/<id>/new` with an item picked (qty 0 is fine), click footer **Cancel**
- [ ] Confirm "Are you sure?" modal appears
- [ ] Click **OK** once → confirm modal dismisses and URL goes to `/<id>` (prescription detail) — no second click needed
- [ ] Repeat with: click sidebar **Aspirin** row instead of Cancel; click **Prescriptions** breadcrumb; both should also dismiss on a single OK

**Regression sanity-checks (other `useConfirmOnLeaving` consumers)**
- [ ] **Inbound shipment** line edit — make dirty, click breadcrumb away → expect prompt, OK proceeds
- [ ] **Stock detail** — make dirty, navigate away → expect prompt, OK proceeds
- [ ] **Encounter detail (pending status)** — touch a JSON form field, navigate away → expect the custom "mark as visited" prompt (uses `customConfirmation`, not `customCheck`)
- [ ] **RnRForms** — edit a line, navigate away → expect `saveLines()` to run (no prompt — that consumer never blocks)

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in user-facing behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)