### PR TITLE
Ignore deleting name store join when inactive if it doesnt exist

### DIFF
--- a/server/repository/src/db_diesel/changelog/generate_changelog.rs
+++ b/server/repository/src/db_diesel/changelog/generate_changelog.rs
@@ -169,6 +169,7 @@ impl NameStoreJoinRow {
             record_id: row.id.clone(),
             row_action: action,
             store_id: Some(row.store_id.clone()),
+            // TODO does this need to be here
             transfer_store_id: transfer_store_id_for_name(con, &row.name_id)?,
             source_site_id: source_site_id.get_id(con)?,
             ..Default::default()

--- a/server/repository/src/db_diesel/name_store_join.rs
+++ b/server/repository/src/db_diesel/name_store_join.rs
@@ -89,6 +89,15 @@ impl<'a> NameStoreJoinRepository<'a> {
         Ok(result)
     }
 
+    pub fn check_exists_by_id(&self, id: &str) -> Result<bool, RepositoryError> {
+        let id: Option<String> = name_store_join::table
+            .filter(name_store_join::id.eq(id))
+            .select(name_store_join::id)
+            .first(self.connection.lock().connection())
+            .optional()?;
+        Ok(id.is_some())
+    }
+
     pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
         let changelog = NameStoreJoinRow::generate_changelog(
             RowOrId::Id(id),
@@ -122,7 +131,10 @@ impl<'a> NameStoreJoinRepository<'a> {
         Ok(result.into_iter().map(to_domain).collect())
     }
 
-    pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<NameStoreJoinRow>, RepositoryError> {
+    pub fn find_many_by_id(
+        &self,
+        ids: &[String],
+    ) -> Result<Vec<NameStoreJoinRow>, RepositoryError> {
         Ok(name_store_join::table
             .filter(name_store_join::id.eq_any(ids))
             .load(self.connection.lock().connection())?)

--- a/server/service/src/sync/translations/name_store_join.rs
+++ b/server/service/src/sync/translations/name_store_join.rs
@@ -94,6 +94,11 @@ impl SyncTranslation for NameStoreJoinTranslation {
         // given that we don't handle soft deletes, translate to a hard-delete
         if let Some(inactive) = data.inactive {
             if inactive {
+                if !NameStoreJoinRepository::new(connection).check_exists_by_id(&data.id)? {
+                    return Ok(PullTranslateResult::Ignored(
+                        "Is inactive and not found".to_string(),
+                    ));
+                }
                 return self.try_translate_from_delete_sync_record(connection, sync_record);
             }
         }

--- a/server/service/src/sync/translations/name_store_join.rs
+++ b/server/service/src/sync/translations/name_store_join.rs
@@ -220,7 +220,7 @@ mod tests {
 
         let (_, connection, _, _) = setup_all(
             "test_name_store_join_translation",
-            MockDataInserts::none().names(),
+            MockDataInserts::none().names().stores(),
         )
         .await;
 
@@ -232,6 +232,18 @@ mod tests {
 
             assert_eq!(translation_result, record.translated_record);
         }
+
+        // The inactive (soft-delete) record translates to a delete only if the row
+        // already exists locally, so insert it first (it's ignored otherwise).
+        NameStoreJoinRepository::new(&connection)
+            .upsert_one_without_changelog(&NameStoreJoinRow {
+                id: "BE65A4A05E4D47E88303D6105A7872CC".to_string(),
+                store_id: "store_b".to_string(),
+                name_id: "name_store_a".to_string(),
+                name_is_customer: false,
+                name_is_supplier: true,
+            })
+            .unwrap();
 
         for record in test_data::test_pull_upsert_inactive_records() {
             let translation_result = translator


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

relates to: https://github.com/msupply-foundation/open-msupply-internal/issues/147

# 👩🏻‍💻 What does this PR do?

When name store join is inactive during translation we try to delete it, when it can't be found in generating change log not found error is thrown. 

We now check for name_store_join existing before creating delete integration operation

## 💌 Any notes for the reviewer?

The query seems to be super fast, no concern with performance atm, we will review performance of each table integration

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

