### PR TITLE
Port changelog lock removal (ChangelogCursorTracker) to develop

### DIFF
--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -1,7 +1,7 @@
 use crate::{
     db_diesel::store_row::store, diesel_macros::apply_equal_filter,
-    name_store_join::name_store_join, vaccination_row::vaccination, DBType, EqualFilter,
-    LockedConnection, RepositoryError, StorageConnection, TransactionNotification,
+    name_store_join::name_store_join, vaccination_row::vaccination, ChangelogCursorTracker, DBType,
+    EqualFilter, RepositoryError, StorageConnection, TransactionNotification,
 };
 use diesel::{helper_types::IntoBoxed, prelude::*};
 use serde::{Deserialize, Serialize};
@@ -280,20 +280,19 @@ impl<'a> ChangelogRepository<'a> {
         limit: u32,
         filter: Option<ChangelogFilter>,
     ) -> Result<Vec<ChangelogRow>, RepositoryError> {
-        let result = with_locked_changelog_table(self.connection, |locked_con| {
-            let query = create_filtered_query(earliest, filter)
-                .order(changelog_deduped::dsl::cursor.asc())
-                .limit(limit.into());
+        let mut query = create_filtered_query(earliest, filter);
+        query = clamp_to_safe_cursor(self.connection, query);
+        let query = query
+            .order(changelog_deduped::dsl::cursor.asc())
+            .limit(limit.into());
 
-            // // Debug diesel query
-            // println!(
-            //     "{}",
-            //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
-            // );
+        // // Debug diesel query
+        // println!(
+        //     "{}",
+        //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
+        // );
 
-            let result: Vec<ChangelogRow> = query.load(locked_con.connection())?;
-            Ok(result)
-        })?;
+        let result: Vec<ChangelogRow> = query.load(self.connection.lock().connection())?;
         Ok(result)
     }
 
@@ -302,7 +301,12 @@ impl<'a> ChangelogRepository<'a> {
         earliest: u64,
         filter: Option<ChangelogFilter>,
     ) -> Result<u64, RepositoryError> {
-        let result = create_filtered_query(earliest, filter)
+        // Clamp identically to the row reader so callers that drive a push/processor loop off
+        // `count` (e.g. the `_ => continue` termination check) stay consistent with `changelogs()`
+        // while a tx is in flight — otherwise count could report rows the clamped reader won't
+        // return, spinning the loop.
+        let query = clamp_to_safe_cursor(self.connection, create_filtered_query(earliest, filter));
+        let result = query
             .count()
             .get_result::<i64>(self.connection.lock().connection())?;
         Ok(result as u64)
@@ -315,20 +319,19 @@ impl<'a> ChangelogRepository<'a> {
         sync_site_id: i32,
         is_initialized: bool,
     ) -> Result<Vec<ChangelogRow>, RepositoryError> {
-        let result = with_locked_changelog_table(self.connection, |locked_con| {
-            let query = create_filtered_outgoing_sync_query(earliest, sync_site_id, is_initialized)
-                .order(changelog_deduped::cursor.asc())
-                .limit(batch_size.into());
+        let mut query = create_filtered_outgoing_sync_query(earliest, sync_site_id, is_initialized);
+        query = clamp_to_safe_cursor(self.connection, query);
+        let query = query
+            .order(changelog_deduped::cursor.asc())
+            .limit(batch_size.into());
 
-            // Debug diesel query
-            // println!(
-            //     "{}",
-            //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
-            // );
+        // Debug diesel query
+        // println!(
+        //     "{}",
+        //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
+        // );
 
-            let result: Vec<ChangelogRow> = query.load(locked_con.connection())?;
-            Ok(result)
-        })?;
+        let result: Vec<ChangelogRow> = query.load(self.connection.lock().connection())?;
         Ok(result)
     }
 
@@ -339,24 +342,20 @@ impl<'a> ChangelogRepository<'a> {
         sync_site_id: i32,
         fetch_patient_id: String,
     ) -> Result<Vec<ChangelogRow>, RepositoryError> {
-        let result = with_locked_changelog_table(self.connection, |locked_con| {
-            let query = create_filtered_outgoing_patient_sync_query(
-                earliest,
-                sync_site_id,
-                fetch_patient_id,
-            )
+        let mut query =
+            create_filtered_outgoing_patient_sync_query(earliest, sync_site_id, fetch_patient_id);
+        query = clamp_to_safe_cursor(self.connection, query);
+        let query = query
             .order(changelog_deduped::cursor.asc())
             .limit(batch_size.into());
 
-            // Debug diesel query
-            // println!(
-            //     "{}",
-            //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
-            // );
+        // Debug diesel query
+        // println!(
+        //     "{}",
+        //     diesel::debug_query::<crate::DBType, _>(&query).to_string()
+        // );
 
-            let result: Vec<ChangelogRow> = query.load(locked_con.connection())?;
-            Ok(result)
-        })?;
+        let result: Vec<ChangelogRow> = query.load(self.connection.lock().connection())?;
         Ok(result)
     }
 
@@ -369,7 +368,11 @@ impl<'a> ChangelogRepository<'a> {
         sync_site_id: i32,
         is_initialized: bool,
     ) -> Result<u64, RepositoryError> {
-        let result = create_filtered_outgoing_sync_query(earliest, sync_site_id, is_initialized)
+        let query = clamp_to_safe_cursor(
+            self.connection,
+            create_filtered_outgoing_sync_query(earliest, sync_site_id, is_initialized),
+        );
+        let result = query
             .count()
             .get_result::<i64>(self.connection.lock().connection())?;
         Ok(result as u64)
@@ -381,20 +384,37 @@ impl<'a> ChangelogRepository<'a> {
         sync_site_id: i32,
         fetch_patient_id: String,
     ) -> Result<u64, RepositoryError> {
-        let result =
-            create_filtered_outgoing_patient_sync_query(earliest, sync_site_id, fetch_patient_id)
-                .count()
-                .get_result::<i64>(self.connection.lock().connection())?;
+        let query = clamp_to_safe_cursor(
+            self.connection,
+            create_filtered_outgoing_patient_sync_query(earliest, sync_site_id, fetch_patient_id),
+        );
+        let result = query
+            .count()
+            .get_result::<i64>(self.connection.lock().connection())?;
         Ok(result as u64)
     }
 
     /// Returns latest change log
     /// After initial sync we use this method to get the latest cursor to make sure we don't try to push any records that were synced to this site on initialisation
-    pub fn latest_cursor(&self) -> Result<u64, RepositoryError> {
+    pub fn absolute_latest_cursor(&self) -> Result<u64, RepositoryError> {
         let result = changelog::table
             .select(diesel::dsl::max(changelog::cursor))
             .first::<Option<i64>>(self.connection.lock().connection())?;
         Ok(result.unwrap_or(0) as u64)
+    }
+
+    /// Like [`absolute_latest_cursor`], but clamped to the max safe cursor while another connection has an
+    /// in-flight changelog tx (see [`ChangelogCursorTracker`]). Use this for sync push cursor
+    /// advancement so we never advance past an in-flight (uncommitted, lower) cursor.
+    ///
+    /// Note: `absolute_latest_cursor` itself is deliberately left un-clamped — migration bookkeeping
+    /// (`run_without_change_log_updates`) inserts changelog rows then reads the cursor on the same
+    /// connection, where a clamp would return the pre-insert max.
+    pub fn latest_cursor(&self) -> Result<u64, RepositoryError> {
+        match ChangelogCursorTracker::max_safe_cursor(self.connection) {
+            Some(safe) => Ok(safe),
+            None => self.absolute_latest_cursor(),
+        }
     }
 
     // Delete all change logs with cursor greater-equal cursor_ge
@@ -434,6 +454,10 @@ impl<'a> ChangelogRepository<'a> {
     /// Inserts a changelog record, and returns the cursor of the inserted record
     #[cfg(feature = "postgres")]
     pub fn insert(&self, row: &ChangeLogInsertRow) -> Result<i64, RepositoryError> {
+        // Register this connection's in-flight cursor boundary before the insert so concurrent
+        // readers clamp below it (see ChangelogCursorTracker).
+        ChangelogCursorTracker::track(self.connection)?;
+
         // Insert the record, and then return the cursor of the inserted record
         // Using a returning clause makes this thread safe
         let cursor_id = diesel::insert_into(changelog::table)
@@ -443,12 +467,17 @@ impl<'a> ChangelogRepository<'a> {
             .pop()
             .unwrap_or_default(); // This shouldn't happen, maybe should unwrap or panic?
 
-        self.connection.notify(TransactionNotification::ChangelogInsert);
+        self.connection
+            .notify(TransactionNotification::ChangelogInsert);
         Ok(cursor_id)
     }
 
     #[cfg(not(feature = "postgres"))]
     pub fn insert(&self, row: &ChangeLogInsertRow) -> Result<i64, RepositoryError> {
+        // Register this connection's in-flight cursor boundary before the insert so concurrent
+        // readers clamp below it (see ChangelogCursorTracker).
+        ChangelogCursorTracker::track(self.connection)?;
+
         // Insert the record, and then return the cursor of the inserted record
         // SQLite docs say this is safe if you don't have different threads sharing a single connection
         diesel::insert_into(changelog::table)
@@ -456,7 +485,8 @@ impl<'a> ChangelogRepository<'a> {
             .execute(self.connection.lock().connection())?;
         let cursor_id = diesel::select(last_insert_rowid())
             .get_result::<i64>(self.connection.lock().connection())?;
-        self.connection.notify(TransactionNotification::ChangelogInsert);
+        self.connection
+            .notify(TransactionNotification::ChangelogInsert);
         Ok(cursor_id)
     }
 }
@@ -618,8 +648,9 @@ fn create_filtered_outgoing_patient_sync_query(
     query
 }
 
-/// Runs some DB operation with a fully locked `changelog` table.
-/// This only applies for for Postgres and does nothing for Sqlite.
+/// Clamps a changelog query to the max safe cursor reported by the
+/// `ChangelogCursorTracker`, so reads never advance past an in-flight
+/// (uncommitted, lower) changelog cursor on another connection.
 ///
 /// Motivation:
 /// When querying changelog entries, ongoing transactions might continue adding changelog entries
@@ -630,37 +661,21 @@ fn create_filtered_outgoing_patient_sync_query(
 ///
 /// For example, a changelog may contain [1, 3, 4, 5] while another (slow) tx is about to commit a
 /// changelog row with cursor = 2.
-/// We need to wait for this changelog 2 to be added before doing the changelogs() query, otherwise
-/// we might update the latest changelog cursor to 5 and the changelog with cursor = 2 will be left
+/// If we update the latest changelog cursor to 5, the changelog with cursor = 2 will be left
 /// unhandled when continuing from the latest cursor position.
 ///
-/// Locking the changelog table will wait for ongoing writers and will prevent new writers while
-/// reading the changelog.
-fn with_locked_changelog_table<T, F>(
+/// While that tx is in flight the tracker reports a safe cursor below 2, so this filter caps the
+/// query at that boundary. The ceiling comes from the raw `changelog` table and is conservative vs
+/// the `changelog_deduped` view (`MAX(deduped) <= MAX(raw)`). When no tx is in flight the tracker
+/// returns `None` and the query is unchanged. This replaces the previous `LOCK TABLE` approach,
+/// which blocked concurrent readers under load.
+fn clamp_to_safe_cursor(
     connection: &StorageConnection,
-    f: F,
-) -> Result<T, RepositoryError>
-where
-    F: FnOnce(&mut LockedConnection) -> Result<T, RepositoryError>,
-{
-    if cfg!(feature = "postgres") {
-        use diesel::connection::SimpleConnection;
-        let result = connection.transaction_sync_etc(
-            |con| {
-                let mut locked_con = con.lock();
-                locked_con
-                    .connection()
-                    .batch_execute("LOCK TABLE ONLY changelog IN ACCESS EXCLUSIVE MODE")?;
-
-                f(&mut locked_con)
-            },
-            false,
-        )?;
-
-        Ok(result)
-    } else {
-        let mut locked_con = connection.lock();
-        f(&mut locked_con)
+    query: BoxedChangelogQuery,
+) -> BoxedChangelogQuery {
+    match ChangelogCursorTracker::max_safe_cursor(connection) {
+        Some(safe) => query.filter(changelog_deduped::cursor.le(safe as i64)),
+        None => query,
     }
 }
 
@@ -734,70 +749,137 @@ impl RowActionType {
 mod test {
     use super::*;
     use strum::IntoEnumIterator;
-    use tokio::sync::oneshot;
     use util::assert_matches;
 
+    use crate::{mock::MockDataInserts, test_db::setup_all};
+    #[cfg(feature = "postgres")]
     use crate::{
-        mock::MockDataInserts, test_db::setup_all, ClinicianRow, ClinicianRowRepository,
-        ClinicianRowRepositoryTrait, RepositoryError, TransactionError,
+        ClinicianRow, ClinicianRowRepository, ClinicianRowRepositoryTrait, RepositoryError,
+        TransactionError,
     };
 
-    /// Example from with_locked_changelog_table() comment
+    /// Concurrent-tx race (the scenario the `ChangelogCursorTracker` guards): while connection A
+    /// holds an in-flight (uncommitted, lower) changelog cursor, connection B commits a *higher*
+    /// cursor. Without clamping, a reader on a third connection would return the higher committed
+    /// row and advance its push cursor past A's in-flight row, skipping it forever. The tracker
+    /// caps reads at A's tracked boundary until A commits.
+    ///
+    /// Postgres-only: SQLite serialises writers under `BEGIN IMMEDIATE`, so a concurrent in-flight
+    /// tx on a separate connection cannot be reproduced (and the channel handshake below would
+    /// deadlock on the single writer).
+    #[cfg(feature = "postgres")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_late_changelog_rows() {
-        let (_, connection, connection_manager, _) =
-            setup_all("test_late_changelog_rows", MockDataInserts::none()).await;
+    async fn test_changelog_clamped_by_in_flight_tx() {
+        let (_, connection, connection_manager, _) = setup_all(
+            "test_changelog_clamped_by_in_flight_tx",
+            MockDataInserts::none(),
+        )
+        .await;
 
-        ClinicianRowRepository::new(&connection)
-            .upsert_one(&ClinicianRow {
-                id: String::from("1"),
-                is_active: true,
-                ..Default::default()
-            })
+        let not_system_log = || {
+            Some(
+                ChangelogFilter::new()
+                    .table_name(EqualFilter::not_equal_to(ChangelogTableName::SystemLog)),
+            )
+        };
+
+        let observer = connection_manager.connection().unwrap();
+        let cursor_before = ChangelogRepository::new(&observer)
+            .absolute_latest_cursor()
             .unwrap();
 
-        let (sender, receiver) = oneshot::channel::<()>();
-        let manager_2 = connection_manager.clone();
-        let process_2 = tokio::spawn(async move {
-            let connection = manager_2.connection().unwrap();
-            let result: Result<(), TransactionError<RepositoryError>> = connection
-                .transaction_sync(|con| {
-                    ClinicianRowRepository::new(con)
-                        .upsert_one(&ClinicianRow {
-                            id: String::from("2"),
-                            is_active: true,
-                            ..Default::default()
-                        })
-                        .unwrap();
-                    sender.send(()).unwrap();
-                    std::thread::sleep(core::time::Duration::from_millis(100));
+        // Channels to drive connection A: signal it has registered an in-flight cursor, then
+        // signal it to commit.
+        let (registered_tx, registered_rx) = std::sync::mpsc::channel::<()>();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+
+        let manager_a = connection_manager.clone();
+        let slow_tx = tokio::task::spawn_blocking(move || {
+            let conn = manager_a.connection().unwrap();
+            let _: Result<(), TransactionError<RepositoryError>> =
+                conn.transaction_sync(|con| -> Result<(), RepositoryError> {
+                    ClinicianRowRepository::new(con).upsert_one(&ClinicianRow {
+                        id: "clinician_in_flight".to_string(),
+                        is_active: true,
+                        ..Default::default()
+                    })?;
+                    registered_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
                     Ok(())
                 });
-            result
         });
-        receiver.await.unwrap();
+
+        registered_rx.recv().unwrap();
+
+        // Connection B commits a higher changelog cursor while A's lower cursor is still in flight.
         ClinicianRowRepository::new(&connection)
             .upsert_one(&ClinicianRow {
-                id: String::from("3"),
+                id: "clinician_committed_after".to_string(),
                 is_active: true,
                 ..Default::default()
             })
             .unwrap();
 
-        let changelogs = ChangelogRepository::new(&connection)
-            .changelogs(
-                0,
-                10,
-                Some(
-                    ChangelogFilter::new()
-                        .table_name(EqualFilter::not_equal_to(ChangelogTableName::SystemLog)),
-                ),
-            )
+        // The clamp is active: safe cursor is pegged below the (now higher) raw max.
+        assert!(ChangelogCursorTracker::max_safe_cursor(&observer).is_some());
+        let safe_during = ChangelogRepository::new(&observer).latest_cursor().unwrap();
+        let raw_during = ChangelogRepository::new(&observer)
+            .absolute_latest_cursor()
             .unwrap();
-        assert_eq!(changelogs.len(), 3);
+        assert!(
+            safe_during <= cursor_before && safe_during < raw_during,
+            "expected safe cursor clamped (<= {}, < raw {}), got {}",
+            cursor_before,
+            raw_during,
+            safe_during
+        );
 
-        // being good and awaiting the task to finish orderly and check it did run fine
-        process_2.await.unwrap().unwrap();
+        // The reader must not return the committed-after row past the clamp.
+        let rows_during = ChangelogRepository::new(&observer)
+            .changelogs(0, 100, not_system_log())
+            .unwrap();
+        assert!(
+            !rows_during
+                .iter()
+                .any(|r| r.record_id == "clinician_committed_after"),
+            "reader returned a row past the in-flight clamp"
+        );
+
+        // `count` must clamp identically to the row reader, otherwise a push/processor loop that
+        // continues while `count > 0` but the clamped reader returns nothing would spin until the
+        // in-flight tx commits. (Fails if `count` is left un-clamped — it would include the
+        // committed-after row.)
+        let count_during = ChangelogRepository::new(&observer)
+            .count(0, not_system_log())
+            .unwrap();
+        assert_eq!(
+            count_during as usize,
+            rows_during.len(),
+            "count must clamp identically to changelogs() while a tx is in flight"
+        );
+
+        // Release A; once it commits the tracker entry is removed and the clamp lifts.
+        release_tx.send(()).unwrap();
+        slow_tx.await.unwrap();
+
+        assert_eq!(ChangelogCursorTracker::max_safe_cursor(&observer), None);
+        let safe_after = ChangelogRepository::new(&observer).latest_cursor().unwrap();
+        assert!(
+            safe_after > cursor_before,
+            "expected cursor to advance past {} after commit, got {}",
+            cursor_before,
+            safe_after
+        );
+
+        let rows_after = ChangelogRepository::new(&observer)
+            .changelogs(0, 100, not_system_log())
+            .unwrap();
+        assert!(rows_after
+            .iter()
+            .any(|r| r.record_id == "clinician_in_flight"));
+        assert!(rows_after
+            .iter()
+            .any(|r| r.record_id == "clinician_committed_after"));
     }
 
     #[actix_rt::test]

--- a/server/repository/src/db_diesel/changelog/changelog_cursor_tracker.rs
+++ b/server/repository/src/db_diesel/changelog/changelog_cursor_tracker.rs
@@ -1,0 +1,196 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use diesel::prelude::*;
+
+use crate::{repository_error::RepositoryError, StorageConnection};
+
+use super::changelog::changelog;
+
+/// Per-`StorageConnectionManager` tracker of in-flight (uncommitted) changelog
+/// boundaries. Each `StorageConnection` registers a single entry on its first
+/// changelog insert of a transaction: the value is `MAX(cursor)` at the
+/// time of that first insert, i.e. a lower bound on the cursors this
+/// transaction will produce.
+///
+/// Readers compute `max_safe_cursor = min(values)` to avoid advancing past
+/// any in-flight cursor.
+///
+/// Crash-safe: on process crash the in-memory map is lost, but the database
+/// rolls back all in-flight transactions, so an empty tracker on restart is
+/// consistent with the database.
+#[derive(Default)]
+pub struct ChangelogCursorTracker {
+    inner: Mutex<HashMap<String, u64>>,
+}
+
+impl ChangelogCursorTracker {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Register the connection's lower-bound tracked cursor for its current
+    /// transaction. No-op if the connection's uuid is already present
+    /// (idempotent across multiple inserts in the same tx) or if the
+    /// connection is in autocommit (no transaction).
+    pub fn track(connection: &StorageConnection) -> Result<(), RepositoryError> {
+        let tracker = connection.changelog_cursor_tracker();
+
+        if tracker.contains(connection.uuid()) {
+            return Ok(());
+        }
+
+        let in_transaction = connection
+            .lock()
+            .transaction_level::<RepositoryError>()
+            .map_err(RepositoryError::from)?
+            > 0;
+        if !in_transaction {
+            return Ok(());
+        }
+
+        let max_cursor = changelog::table
+            .select(diesel::dsl::max(changelog::cursor))
+            .first::<Option<i64>>(connection.lock().connection())?
+            .unwrap_or(0) as u64;
+
+        tracker
+            .inner
+            .lock()
+            .unwrap()
+            .insert(connection.uuid().to_string(), max_cursor);
+
+        Ok(())
+    }
+
+    /// Returns the maximum cursor that is currently safe to read up to. If any
+    /// transaction is mid-flight, returns `Some(min(registered))`; if not,
+    /// returns `None` (no clamp).
+    pub fn max_safe_cursor(connection: &StorageConnection) -> Option<u64> {
+        let tracker = connection.changelog_cursor_tracker();
+        let guard = tracker.inner.lock().unwrap();
+        guard.values().min().copied()
+    }
+
+    /// Remove the connection's entry. Called from the outermost
+    /// commit/rollback path of `transaction_sync_etc`.
+    pub fn untrack(connection: &StorageConnection) {
+        let tracker = connection.changelog_cursor_tracker();
+        tracker.inner.lock().unwrap().remove(connection.uuid());
+    }
+
+    fn contains(&self, uuid: &str) -> bool {
+        self.inner.lock().unwrap().contains_key(uuid)
+    }
+}
+
+impl std::fmt::Debug for ChangelogCursorTracker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let guard = self.inner.lock().unwrap();
+        f.debug_struct("ChangelogCursorTracker")
+            .field("in_flight", &*guard)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{test_db, TransactionError};
+
+    #[actix_rt::test]
+    async fn empty_tracker_returns_none() {
+        let settings = test_db::get_test_db_settings("tracker_empty");
+        let manager = test_db::setup(&settings).await;
+        let connection = manager.connection().unwrap();
+
+        assert_eq!(ChangelogCursorTracker::max_safe_cursor(&connection), None);
+    }
+
+    #[actix_rt::test]
+    async fn track_outside_transaction_is_noop() {
+        let settings = test_db::get_test_db_settings("tracker_autocommit_noop");
+        let manager = test_db::setup(&settings).await;
+        let connection = manager.connection().unwrap();
+
+        ChangelogCursorTracker::track(&connection).unwrap();
+        assert_eq!(ChangelogCursorTracker::max_safe_cursor(&connection), None);
+    }
+
+    #[actix_rt::test]
+    async fn track_is_idempotent_within_a_transaction() {
+        let settings = test_db::get_test_db_settings("tracker_idempotent");
+        let manager = test_db::setup(&settings).await;
+        let connection = manager.connection().unwrap();
+
+        let _: Result<_, TransactionError<RepositoryError>> =
+            connection.transaction_sync(|con| -> Result<(), RepositoryError> {
+                ChangelogCursorTracker::track(con)?;
+                let first = ChangelogCursorTracker::max_safe_cursor(con);
+                ChangelogCursorTracker::track(con)?;
+                let second = ChangelogCursorTracker::max_safe_cursor(con);
+                assert_eq!(first, second);
+                assert!(first.is_some());
+                Ok(())
+            });
+    }
+
+    #[actix_rt::test]
+    async fn untrack_after_outermost_commit() {
+        let settings = test_db::get_test_db_settings("tracker_untrack_on_commit");
+        let manager = test_db::setup(&settings).await;
+        let connection = manager.connection().unwrap();
+
+        let _: Result<_, TransactionError<RepositoryError>> =
+            connection.transaction_sync(|con| -> Result<(), RepositoryError> {
+                ChangelogCursorTracker::track(con)?;
+                assert!(ChangelogCursorTracker::max_safe_cursor(con).is_some());
+                Ok(())
+            });
+
+        assert_eq!(ChangelogCursorTracker::max_safe_cursor(&connection), None);
+    }
+
+    #[actix_rt::test]
+    async fn untrack_after_outermost_rollback() {
+        let settings = test_db::get_test_db_settings("tracker_untrack_on_rollback");
+        let manager = test_db::setup(&settings).await;
+        let connection = manager.connection().unwrap();
+
+        let _: Result<(), TransactionError<RepositoryError>> =
+            connection.transaction_sync(|con| -> Result<(), RepositoryError> {
+                ChangelogCursorTracker::track(con)?;
+                assert!(ChangelogCursorTracker::max_safe_cursor(con).is_some());
+                Err(RepositoryError::NotFound)
+            });
+
+        assert_eq!(ChangelogCursorTracker::max_safe_cursor(&connection), None);
+    }
+
+    #[actix_rt::test]
+    async fn min_of_two_connections() {
+        let settings = test_db::get_test_db_settings("tracker_min_of_two");
+        let manager = test_db::setup(&settings).await;
+        let connection_a = manager.connection().unwrap();
+        let connection_b = manager.connection().unwrap();
+        let observer = manager.connection().unwrap();
+
+        let _: Result<_, TransactionError<RepositoryError>> =
+            connection_a.transaction_sync(|con_a| -> Result<(), RepositoryError> {
+                ChangelogCursorTracker::track(con_a)?;
+                let _: Result<_, TransactionError<RepositoryError>> = connection_b
+                    .transaction_sync(|con_b| -> Result<(), RepositoryError> {
+                        ChangelogCursorTracker::track(con_b)?;
+                        // Both registered — observer should see a clamp.
+                        assert!(ChangelogCursorTracker::max_safe_cursor(&observer).is_some());
+                        Ok(())
+                    });
+                Ok(())
+            });
+
+        // Both should be untracked after their outer commits
+        assert_eq!(ChangelogCursorTracker::max_safe_cursor(&observer), None);
+    }
+}

--- a/server/repository/src/db_diesel/changelog/mod.rs
+++ b/server/repository/src/db_diesel/changelog/mod.rs
@@ -1,5 +1,8 @@
 pub mod changelog;
 pub use self::changelog::*;
 
+pub mod changelog_cursor_tracker;
+pub use self::changelog_cursor_tracker::*;
+
 #[cfg(test)]
 mod test;

--- a/server/repository/src/db_diesel/changelog/test.rs
+++ b/server/repository/src/db_diesel/changelog/test.rs
@@ -25,7 +25,7 @@ async fn test_changelog() {
     let location_repo = LocationRowRepository::new(&connection);
     let repo = ChangelogRepository::new(&connection);
     // Clear change log and get starting cursor
-    let starting_cursor = repo.latest_cursor().unwrap();
+    let starting_cursor = repo.absolute_latest_cursor().unwrap();
     repo.delete(0).unwrap();
     // single entry:
     location_repo.upsert_one(&mock_location_1()).unwrap();
@@ -154,7 +154,7 @@ async fn test_changelog_iteration() {
     let location_repo = LocationRowRepository::new(&connection);
     let repo = ChangelogRepository::new(&connection);
     // Clear change log and get starting cursor
-    let starting_cursor = repo.latest_cursor().unwrap();
+    let starting_cursor = repo.absolute_latest_cursor().unwrap();
     repo.delete(0).unwrap();
 
     location_repo.upsert_one(&mock_location_1()).unwrap();

--- a/server/repository/src/db_diesel/storage_connection.rs
+++ b/server/repository/src/db_diesel/storage_connection.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 
 use super::{get_connection, DBBackendConnection, DBConnection};
 
+use crate::db_diesel::changelog::ChangelogCursorTracker;
 use crate::repository_error::RepositoryError;
 
 use diesel::{
@@ -10,6 +11,7 @@ use diesel::{
     r2d2::{ConnectionManager, Pool},
 };
 use log::error;
+use util::uuid::uuid;
 
 // feature sqlite
 #[cfg(not(feature = "postgres"))]
@@ -67,6 +69,10 @@ pub struct StorageConnection {
     raw_connection: Mutex<DBConnection>,
     on_commit: Option<Arc<dyn Fn(&TransactionNotification) + Send + Sync>>,
     pending_notifications: RwLock<HashSet<TransactionNotification>>,
+    /// Identifies this connection in the `ChangelogCursorTracker`. Generated once at
+    /// construction; reused across transactions on the same connection.
+    uuid: String,
+    changelog_cursor_tracker: Arc<ChangelogCursorTracker>,
 }
 
 impl StorageConnection {
@@ -74,6 +80,14 @@ impl StorageConnection {
         LockedConnection {
             raw_connection: self.raw_connection.lock().unwrap(),
         }
+    }
+
+    pub fn uuid(&self) -> &str {
+        &self.uuid
+    }
+
+    pub fn changelog_cursor_tracker(&self) -> &ChangelogCursorTracker {
+        &self.changelog_cursor_tracker
     }
 
     /// Execute a raw SQL statement (or batch of statements) directly against the underlying
@@ -146,12 +160,25 @@ impl From<TransactionError<RepositoryError>> for RepositoryError {
     }
 }
 
+impl Drop for StorageConnection {
+    /// Safety net: ensure this connection is removed from the cursor tracker even if a
+    /// transaction path missed the explicit untrack (e.g. early return, panic).
+    fn drop(&mut self) {
+        ChangelogCursorTracker::untrack(self);
+    }
+}
+
 impl StorageConnection {
-    pub fn new(connection: DBConnection) -> StorageConnection {
+    pub fn new(
+        connection: DBConnection,
+        changelog_cursor_tracker: Arc<ChangelogCursorTracker>,
+    ) -> StorageConnection {
         StorageConnection {
             raw_connection: Mutex::new(connection),
             on_commit: None,
             pending_notifications: RwLock::new(HashSet::new()),
+            uuid: uuid(),
+            changelog_cursor_tracker,
         }
     }
 
@@ -183,17 +210,21 @@ impl StorageConnection {
     where
         F: FnOnce(&StorageConnection) -> Result<T, E>,
     {
-        let current_level = {
-            let mut guard = self.lock();
-            let current_level = guard.transaction_level()?;
-            if current_level > 0 && reuse_tx {
-                drop(guard);
-                return match f(self) {
-                    Ok(ok) => Ok(ok),
-                    Err(err) => Err(TransactionError::Inner(err)),
-                };
-            }
+        // Lock is dropped in this line
+        let current_level = self.lock().transaction_level()?;
 
+        // If we are re-using transaction just call the underlying function, error will propagate
+        // to the original closure for the transaction.
+        if current_level > 0 && reuse_tx {
+            return match f(self) {
+                Ok(ok) => Ok(ok),
+                Err(err) => Err(TransactionError::Inner(err)),
+            };
+        }
+
+        // Start a new outer or inner transaction, acquire lock that will be dropped when block exits
+        {
+            let mut guard = self.lock();
             let con: &mut DBBackendConnection = guard.connection();
             if current_level == 0 {
                 // sqlite can only have 1 writer, so to avoid concurrency issues,
@@ -203,41 +234,54 @@ impl StorageConnection {
                 AnsiTransactionManager::begin_transaction(con)
             }
             .map_err(|e| map_begin_transaction_error(e, current_level))?;
-            current_level
         };
 
-        let result = f(self);
+        let inner_result = f(self);
 
-        match result {
+        // Commit or rollback based on the inner result.
+        let result = match inner_result {
             Ok(value) => {
                 let mut guard = self.raw_connection.lock().unwrap();
                 let con: &mut DBBackendConnection = &mut guard;
-                AnsiTransactionManager::commit_transaction(con).map_err(|err| {
-                    error!("Failed to end tx: {err:?}");
-                    TransactionError::Transaction {
-                        msg: format!("Failed to end tx: {err}"),
-                        level: current_level + 1,
+                match AnsiTransactionManager::commit_transaction(con) {
+                    Ok(_) => Ok(value),
+                    Err(err) => {
+                        error!("Failed to end tx: {err:?}");
+                        Err(TransactionError::Transaction {
+                            msg: format!("Failed to end tx: {err}"),
+                            level: current_level + 1,
+                        })
                     }
-                })?;
-                // Fire pending notifications after outermost transaction commits
-                if current_level == 0 {
-                    self.flush_notifications();
                 }
-                Ok(value)
             }
             Err(e) => {
                 let mut guard = self.raw_connection.lock().unwrap();
                 let con: &mut DBBackendConnection = &mut guard;
-                AnsiTransactionManager::rollback_transaction(con).map_err(|err| {
-                    error!("Failed to rollback tx: {err:?}");
-                    TransactionError::Transaction {
-                        msg: format!("Failed to rollback tx: {err}"),
-                        level: current_level + 1,
+                match AnsiTransactionManager::rollback_transaction(con) {
+                    Ok(_) => Err(TransactionError::Inner(e)),
+                    Err(err) => {
+                        error!("Failed to rollback tx: {err:?}");
+                        Err(TransactionError::Transaction {
+                            msg: format!("Failed to rollback tx: {err}"),
+                            level: current_level + 1,
+                        })
                     }
-                })?;
-                Err(TransactionError::Inner(e))
+                }
+            }
+        };
+
+        // When closing off the outermost transaction, untrack this connection's in-flight
+        // changelog cursor and then fire pending notifications. Untrack runs first (on both
+        // commit and rollback) so a processor task woken by the on-commit hook sees the
+        // just-committed rows with an un-clamped tracker.
+        if current_level == 0 {
+            ChangelogCursorTracker::untrack(self);
+            if result.is_ok() {
+                self.flush_notifications();
             }
         }
+
+        result
     }
 }
 
@@ -256,6 +300,8 @@ fn map_begin_transaction_error<T>(
 pub struct StorageConnectionManager {
     pool: Pool<ConnectionManager<DBBackendConnection>>,
     on_commit: Option<Arc<dyn Fn(&TransactionNotification) + Send + Sync>>,
+    /// Shared with every `StorageConnection` produced by this manager.
+    changelog_cursor_tracker: Arc<ChangelogCursorTracker>,
 }
 
 impl StorageConnectionManager {
@@ -263,6 +309,7 @@ impl StorageConnectionManager {
         StorageConnectionManager {
             pool,
             on_commit: None,
+            changelog_cursor_tracker: ChangelogCursorTracker::new(),
         }
     }
 
@@ -271,7 +318,10 @@ impl StorageConnectionManager {
     }
 
     pub fn connection(&self) -> Result<StorageConnection, RepositoryError> {
-        let conn = StorageConnection::new(get_connection(&self.pool)?);
+        let conn = StorageConnection::new(
+            get_connection(&self.pool)?,
+            self.changelog_cursor_tracker.clone(),
+        );
         match &self.on_commit {
             Some(callback) => Ok(conn.with_on_commit(callback.clone())),
             None => Ok(conn),

--- a/server/repository/src/migrations/helpers.rs
+++ b/server/repository/src/migrations/helpers.rs
@@ -11,11 +11,11 @@ pub(crate) fn run_without_change_log_updates<
 ) -> anyhow::Result<u64> {
     // Remember the current changelog cursor in order to be able to delete all changelog entries
     // triggered by the merge migrations.
-    let cursor_before_job = ChangelogRepository::new(connection).latest_cursor()?;
+    let cursor_before_job = ChangelogRepository::new(connection).absolute_latest_cursor()?;
 
     job(connection)?;
 
-    let cursor_after_job = ChangelogRepository::new(connection).latest_cursor()?;
+    let cursor_after_job = ChangelogRepository::new(connection).absolute_latest_cursor()?;
     // Revert changelog to the state before the merge migrations
     ChangelogRepository::new(connection).delete((cursor_before_job + 1).try_into()?)?;
     Ok(cursor_after_job)
@@ -40,7 +40,7 @@ async fn check_change_log_update() {
 
     // First insert
     let cursor = ChangelogRepository::new(&connection)
-        .latest_cursor()
+        .absolute_latest_cursor()
         .unwrap();
     NameRowRepository::new(&connection)
         .upsert_one(&name_row)
@@ -48,12 +48,12 @@ async fn check_change_log_update() {
     assert!(
         cursor
             < ChangelogRepository::new(&connection)
-                .latest_cursor()
+                .absolute_latest_cursor()
                 .unwrap()
     );
     // Now update
     let cursor = ChangelogRepository::new(&connection)
-        .latest_cursor()
+        .absolute_latest_cursor()
         .unwrap();
     NameRowRepository::new(&connection)
         .upsert_one(&name_row)
@@ -61,13 +61,13 @@ async fn check_change_log_update() {
     assert!(
         cursor
             < ChangelogRepository::new(&connection)
-                .latest_cursor()
+                .absolute_latest_cursor()
                 .unwrap()
     );
 
     // Now update with run_without_change_log_updates
     let cursor = ChangelogRepository::new(&connection)
-        .latest_cursor()
+        .absolute_latest_cursor()
         .unwrap();
     run_without_change_log_updates(&connection, |connection| {
         NameRowRepository::new(connection).upsert_one(&name_row)?;
@@ -77,7 +77,7 @@ async fn check_change_log_update() {
     assert_eq!(
         cursor,
         ChangelogRepository::new(&connection)
-            .latest_cursor()
+            .absolute_latest_cursor()
             .unwrap()
     );
 }

--- a/server/repository/src/migrations/v2_00_00/mod.rs
+++ b/server/repository/src/migrations/v2_00_00/mod.rs
@@ -81,12 +81,12 @@ async fn migration_2_00_00() {
 
     insert_merge_test_data(&connection);
     let changelog_repo = ChangelogRepository::new(&connection);
-    let cursor_before = changelog_repo.latest_cursor().unwrap();
+    let cursor_before = changelog_repo.absolute_latest_cursor().unwrap();
 
     migrate(&connection, Some(version.clone())).unwrap();
     assert_eq!(get_database_version(&connection), version);
 
-    let cursor_after = changelog_repo.latest_cursor().unwrap();
+    let cursor_after = changelog_repo.absolute_latest_cursor().unwrap();
 
     assert_eq!(cursor_before, cursor_after);
 }

--- a/server/service/src/processors/mod.rs
+++ b/server/service/src/processors/mod.rs
@@ -31,6 +31,13 @@ pub(crate) mod transfer;
 
 const CHANNEL_BUFFER_SIZE: usize = 30;
 
+/// Number of re-trigger/re-drain attempts `await_events_processed` makes so processors converge
+/// past the `ChangelogCursorTracker` clamp (see `await_events_processed` for details).
+const AWAIT_EVENTS_DRAIN_ATTEMPTS: usize = 10;
+/// Pause between drain attempts, giving an in-flight sibling transaction time to commit and lift
+/// its changelog cursor clamp before the next re-read.
+const AWAIT_EVENTS_DRAIN_INTERVAL: std::time::Duration = std::time::Duration::from_millis(20);
+
 #[derive(Clone)]
 pub struct ProcessorsTrigger {
     requisition_transfer: Sender<()>,
@@ -152,13 +159,35 @@ impl ProcessorsTrigger {
     /// this method are handled when this method returns.
     /// However, new events might have been added while this method was running.
     pub async fn await_events_processed(&self) {
-        let (sender, receiver) = oneshot::channel();
-        if let Err(error) = self.await_process_queue.send(sender).await {
-            log::error!("Problem sending the await_events_processed queue {error:#?}");
-        }
+        // A single drain is no longer sufficient since the changelog read race is guarded by the
+        // in-memory `ChangelogCursorTracker` (replacing the old `LOCK TABLE` approach). Under that
+        // clamp a changelog reader no longer blocks on an in-flight writer on another connection;
+        // it returns immediately with rows above the in-flight cursor hidden. So a processor drain
+        // can finish having skipped a record that is committed-but-clamped behind a concurrent
+        // transaction (e.g. one of the sibling instances in the concurrent transfer tests). The
+        // skipped record is not lost - the processor cursor is not advanced past it, so the next
+        // trigger re-reads it once the clamp clears. In production that next trigger arrives with
+        // ordinary activity; tests need to drive it here.
+        //
+        // Re-trigger the transfer processors and re-drain a few times, with a short pause for any
+        // in-flight sibling transaction to commit and lift its clamp, so the processors converge
+        // before this method returns - matching the eventual consistency a running system has.
+        for iteration in 0..AWAIT_EVENTS_DRAIN_ATTEMPTS {
+            self.trigger_requisition_transfer_processors();
+            self.trigger_invoice_transfer_processors();
 
-        if let Err(error) = receiver.await {
-            log::error!("Problem receiving the await_events_processed response {error:#?}");
+            let (sender, receiver) = oneshot::channel();
+            if let Err(error) = self.await_process_queue.send(sender).await {
+                log::error!("Problem sending the await_events_processed queue {error:#?}");
+            }
+
+            if let Err(error) = receiver.await {
+                log::error!("Problem receiving the await_events_processed response {error:#?}");
+            }
+
+            if iteration + 1 < AWAIT_EVENTS_DRAIN_ATTEMPTS {
+                tokio::time::sleep(AWAIT_EVENTS_DRAIN_INTERVAL).await;
+            }
         }
     }
 

--- a/server/service/src/sync/test/integration/mod.rs
+++ b/server/service/src/sync/test/integration/mod.rs
@@ -143,7 +143,7 @@ pub(crate) fn integrate_with_is_sync_reset(
     integrations: Vec<IntegrationOperation>,
 ) -> Vec<IntegrationOperation> {
     let changelog_repo = ChangelogRepository::new(&connection);
-    let cursor = changelog_repo.latest_cursor().unwrap();
+    let cursor = changelog_repo.absolute_latest_cursor().unwrap();
     // Need to reset is_sync_update since we've inserted test data with sync methods
     // they need to sync to central (if is_sync_update is set to true they will not sync to central)
     let integrations: Vec<(Option<_>, IntegrationOperation)> =

--- a/server/service/src/sync/test/pull_and_push.rs
+++ b/server/service/src/sync/test/pull_and_push.rs
@@ -48,7 +48,7 @@ async fn test_sync_pull_and_push() {
 
     // Get push cursor before inserting pull data (so that we can test push, excluding inserted mock data)
     let push_cursor = ChangelogRepository::new(&connection)
-        .latest_cursor()
+        .absolute_latest_cursor()
         .unwrap()
         + 1;
 

--- a/server/service/src/sync/translations/encounter_legacy.rs
+++ b/server/service/src/sync/translations/encounter_legacy.rs
@@ -124,7 +124,7 @@ mod tests {
             setup_all("test_translate_encounter_to_legacy", MockDataInserts::all()).await;
 
         let cursor = ChangelogRepository::new(&connection)
-            .latest_cursor()
+            .absolute_latest_cursor()
             .unwrap_or(0);
 
         // Create a new EncounterRow (this will get a changelog entry created automatically)

--- a/server/service/src/sync/translations/vaccination_legacy.rs
+++ b/server/service/src/sync/translations/vaccination_legacy.rs
@@ -167,7 +167,7 @@ mod tests {
 
         // Get the current cursor value
         let cursor = ChangelogRepository::new(&connection)
-            .latest_cursor()
+            .absolute_latest_cursor()
             .unwrap();
 
         // Create a new VaccinationRow (this will get a changelog entry created automatically)

--- a/server/service/src/sync/translations/vaccine_course_dose_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_dose_legacy.rs
@@ -124,7 +124,7 @@ mod tests {
 
         // Get the current cursor value
         let cursor = ChangelogRepository::new(&connection)
-            .latest_cursor()
+            .absolute_latest_cursor()
             .unwrap();
 
         // Create a new VaccineCourseDoseRow (this will get a changelog entry created automatically)

--- a/server/service/src/sync/translations/vaccine_course_item_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_item_legacy.rs
@@ -116,7 +116,7 @@ mod tests {
 
         // Get the current cursor value
         let cursor = ChangelogRepository::new(&connection)
-            .latest_cursor()
+            .absolute_latest_cursor()
             .unwrap();
 
         // Create a new VaccineCourseItemRow (this will get a changelog entry created automatically)

--- a/server/service/src/sync/translations/vaccine_course_legacy.rs
+++ b/server/service/src/sync/translations/vaccine_course_legacy.rs
@@ -125,7 +125,7 @@ mod tests {
 
         // Get the current cursor value
         let cursor = ChangelogRepository::new(&connection)
-            .latest_cursor()
+            .absolute_latest_cursor()
             .unwrap();
 
         // Create a new VaccineCourseRow (this will get a changelog entry created automatically)


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Ports the changelog lock removal to develop (v2.20), as deferred in #12023's follow-ups. No linked issue — the work is tracked only as the deferred item in #12023 (#11940 covered the 2.16 backport and is closed; the race itself is #11087).

Changelog locking was identified in load testing as a performance problem: develop guards the changelog read race (#11087) with `LOCK TABLE ONLY changelog IN ACCESS EXCLUSIVE MODE` (`with_locked_changelog_table`), which blocks readers too and stalls GraphQL list queries under load. #11492 fixed this on 3.0 with a lightweight in-memory `ChangelogCursorTracker`, and #11947 backported it to 2.16 — but the #12023 RC→develop merge had to drop that backport because develop's changelog schema had diverged. This PR re-applies it to develop's schema.

How the tracker closes the race: each `StorageConnection` records `MAX(changelog.cursor)` on the first changelog insert of a transaction; cursor-based readers clamp to `min(in-flight)` so they never advance past an uncommitted, lower cursor. No table lock — non-blocking.

- Add `ChangelogCursorTracker` (`Arc` owned by `StorageConnectionManager`, keyed by per-connection uuid), and plumb it through `StorageConnection`/`StorageConnectionManager` with a `Drop` safety net. Untrack on the outermost commit **and** rollback, before `flush_notifications`.
- Hook `track()` into both `ChangelogRepository::insert` cfg variants.
- Remove `with_locked_changelog_table`; clamp the 3 row readers (`changelogs`, `outgoing_sync_records_from_central`, `outgoing_patient_sync_records_from_central`) and the 3 `count` functions via `clamp_to_safe_cursor`.
- `latest_cursor()` is now the **clamped** variant (used by the push-cursor-advance sites: `advance_push_cursor`, v6 push, `sync_on_central` empty-batch fallbacks); the raw max moves to `absolute_latest_cursor()` for migration bookkeeping (`run_without_change_log_updates`) and tests.
- Re-trigger/re-drain loop in `await_events_processed` so test processor drains converge past a clamp held by a concurrent sibling transaction (port of the #11947 transfer-test fix).
- Replace the lock-specific `test_late_changelog_rows` with a deterministic, Postgres-only `test_changelog_clamped_by_in_flight_tx`, plus the 6 tracker unit tests.

## 💌 Any notes for the reviewer?

**This is a port of #11947 (which itself reimplemented #11492), kept as close to that diff as possible.** Most hunks apply verbatim; `migrations/helpers.rs` is byte-identical to #11947's version. Review #11947 side-by-side if useful.

Differences from a literal #11947 diff, all forced by develop:

- develop's readers load `ChangelogRow` directly from the `changelog_deduped` view (no `ChangelogJoin`/`from_join` — the view resolves name links), so the clamped readers are simpler than the 2.16 versions.
- The repository crate is **edition 2018**, where inline-captured `assert!` placeholders don't format — the two assert messages in the new test use explicit format args instead.
- The test-mod imports for the Postgres-only clamp test are cfg-gated to avoid the unused-import warning #11947 shipped with on SQLite.
- Not needed here (already on develop via #12023): the `sync_on_central` clamp comments, the CI rust-toolchain pin, and `await_process_queue.send().await`.

Carried over from #11947, worth re-reading there: why the 3 `count` functions must clamp identically to the readers (a `count > 0` loop would otherwise spin against a clamped reader), why `absolute_latest_cursor()` is deliberately un-clamped for migration bookkeeping, and the `transaction_sync_etc` refactor (untrack on commit+rollback before flush).

Confirmed develop has no live DB-trigger path writing to `changelog` (dropped by `v2_00_00`), so the `track()` hook in `ChangelogRepository::insert` covers every runtime changelog row.

# 🧪 Testing

Ran locally on this branch:

- [x] `cargo check --workspace --tests` — clean (lone pre-existing `util` warning)
- [x] `cargo nextest run -p repository` (SQLite) — 183/183
- [x] `cargo nextest run -p repository --features postgres --test-threads=3` — 184/184, including the new `test_changelog_clamped_by_in_flight_tx`: while a slow tx holds an in-flight lower cursor and another connection commits a higher one, the reader **and** `count` clamp below the in-flight cursor; after commit the clamp lifts and both rows are visible
- [x] `cargo nextest run -p service -E 'test(sync) | test(transfer) | test(processor)'` (SQLite) — 167/167
- [x] same with `--features repository/postgres --test-threads=3` — 166/167; the one failure (`test_fall_through_inner_transaction`) fails identically on clean develop (verified in a baseline worktree), pre-existing and unrelated
- [ ] Load test: confirm changelog reads/GraphQL list queries no longer stall behind changelog writers

# 📃 Documentation

- [x] **No documentation required**: performance fix, no change in user-facing behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
