### PR TITLE
 11135 [Store dashboard] 'Emergency' requisitions are displayed even if store is not using program orders 

### DIFF
--- a/client/packages/requisitions/src/ResponseRequisition/ListView/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/ListView/Toolbar.tsx
@@ -5,10 +5,53 @@ import {
   Box,
   useTranslation,
   RequisitionNodeStatus,
+  FilterDefinition,
+  useAuthContext,
 } from '@openmsupply-client/common';
 
 const ToolbarComponent = () => {
   const t = useTranslation();
+  const { store } = useAuthContext();
+
+  const filters: FilterDefinition[] = [
+    {
+      type: 'text',
+      name: t('label.name'),
+      urlParameter: 'otherPartyName',
+      placeholder: t('placeholder.search-by-name'),
+    },
+    {
+      type: 'number',
+      name: t('label.requisition-number'),
+      urlParameter: 'requisitionNumber',
+      wide: true,
+    },
+    {
+      type: 'enum',
+      name: t('label.status'),
+      urlParameter: 'status',
+      options: [
+        { label: t('label.new'), value: RequisitionNodeStatus.New },
+        {
+          label: t('label.finalised'),
+          value: RequisitionNodeStatus.Finalised,
+        },
+      ],
+    },
+    {
+      type: 'boolean',
+      name: t('label.shipment-created'),
+      urlParameter: 'aShipmentHasBeenCreated',
+    },
+  ];
+
+  if (store?.preferences.omProgramModule) {
+    filters.push({
+      type: 'boolean',
+      name: t('label.emergency'),
+      urlParameter: 'isEmergency',
+    });
+  }
 
   return (
     <AppBarContentPortal
@@ -20,44 +63,7 @@ const ToolbarComponent = () => {
       }}
     >
       <Box display="flex" gap={1}>
-        <FilterMenu
-          filters={[
-            {
-              type: 'text',
-              name: t('label.name'),
-              urlParameter: 'otherPartyName',
-              placeholder: t('placeholder.search-by-name'),
-            },
-            {
-              type: 'number',
-              name: t('label.requisition-number'),
-              urlParameter: 'requisitionNumber',
-              wide: true,
-            },
-            {
-              type: 'enum',
-              name: t('label.status'),
-              urlParameter: 'status',
-              options: [
-                { label: t('label.new'), value: RequisitionNodeStatus.New },
-                {
-                  label: t('label.finalised'),
-                  value: RequisitionNodeStatus.Finalised,
-                },
-              ],
-            },
-            {
-              type: 'boolean',
-              name: t('label.shipment-created'),
-              urlParameter: 'aShipmentHasBeenCreated',
-            },
-            {
-              type: 'boolean',
-              name: t('label.emergency'),
-              urlParameter: 'isEmergency',
-            },
-          ]}
-        />
+        <FilterMenu filters={filters} />
       </Box>
     </AppBarContentPortal>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11135

# 👩🏻‍💻 What does this PR do?

<!-- Explain the changes you made -->
Hide is emergency filter behind program preference

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Don't have program store preference on in OG
- [ ] Go to requisition
- [ ] Click filters
- [ ] Shouldn't see is emergency filter
- [ ] Turn pref on -> go through steps 2 & 3 
- [ ] See emergency filter

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

