### PR TITLE
11673 back date audit history shows one date less than the order received back dated date

### DIFF
--- a/client/packages/common/src/utils/formatters/formatters.ts
+++ b/client/packages/common/src/utils/formatters/formatters.ts
@@ -20,6 +20,13 @@ export const Formatter = {
     if (date && isValid(date)) return date.toISOString();
     else return null;
   },
+  // RFC3339 datetime that preserves the local UTC offset (e.g. 2024-12-10T00:00:00+13:00),
+  // unlike toIsoString which always emits UTC ("Z"). Use when the server needs the calendar
+  // date as the user sees it (e.g. backdating, where the audit log records the picked date).
+  localIsoString: (date?: Date | null): string | null => {
+    if (date && isValid(date)) return format(date, "yyyy-MM-dd'T'HH:mm:ssxxx");
+    else return null;
+  },
   dateTime: (date?: Date | null): string =>
     date && isValid(date)
       ? format(date, "dd/MM/yyyy' 'HH:mm:ss")

--- a/client/packages/invoices/src/InboundShipment/DetailView/ReceivedDateInput.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ReceivedDateInput.tsx
@@ -109,9 +109,11 @@ export const ReceivedDateInput = () => {
     // other same-day transactions and is available all day. For today, send the
     // actual moment — startOfDay would be in the past beyond the max-backdating
     // window in some timezones, and we want today to mean "now".
+    // Send the local offset (not UTC "Z") so the server's backdating audit log records the
+    // calendar date the user picked rather than the UTC date, which can be a day earlier.
     const receivedDatetime = DateUtils.isToday(newDate)
-      ? newDate.toISOString()
-      : Formatter.toIsoString(DateUtils.startOfDay(newDate));
+      ? Formatter.localIsoString(newDate)
+      : Formatter.localIsoString(DateUtils.startOfDay(newDate));
 
     const doUpdate = async () => {
       const hasStocktakeAfter = await checkStocktakeAfterDate(newDate);

--- a/docs/content/server/service/backdating/inbound_shipments/_index.md
+++ b/docs/content/server/service/backdating/inbound_shipments/_index.md
@@ -24,8 +24,8 @@ Allow users to backdate the **received date** on an inbound shipment that has al
 - Location movements belonging to stock lines from this invoice have their `enter_datetime` updated to the new received date; if `exit_datetime` was set, it is also updated.
 - Only editable when the shipment is in `Received` or `Verified` status.
 - Gated by the global `Backdating` preference (`enabled` + `max_days`).
-- The frontend sends `DateTime<Utc>` (full ISO datetime with timezone via `.toISOString()`) so there is no naive-date timezone ambiguity.
-- On backdating, an `InvoiceDateBackdated` activity log entry is written with the old and new received dates.
+- The frontend sends a full RFC3339 datetime **carrying the client's UTC offset** (e.g. `2024-12-10T00:00:00+13:00`), parsed server-side as `DateTime<FixedOffset>`. Storage and validation use `.naive_utc()`; the offset is retained only so the audit log can record the calendar date the user actually picked.
+- On backdating, an `InvoiceDateBackdated` activity log entry is written with the old and new received dates, **formatted in the client's offset** (not raw UTC) so they match the date the user selected — otherwise a user east of UTC picking local midnight would see the previous day in the log (issue [#11673](https://github.com/msupply-foundation/open-msupply/issues/11673)).
 - The user is shown a confirmation warning that the change is one-way before it is applied.
 - A stocktake warning is shown if a stocktake exists after the selected date.
 
@@ -46,7 +46,7 @@ From [inbound_shipment/update/generate.rs](https://github.com/msupply-foundation
 - All stock lines linked to invoice lines of this invoice (StockIn lines) are queried, and every `location_movement` for those stock lines has its `enter_datetime` (and `exit_datetime`, when set) updated to the new received date. These are returned as `backdate_location_movements` and upserted in the transaction.
 - `shipped_datetime`, `delivered_datetime`, and `created_datetime` are **not** modified.
 
-The `InvoiceDateBackdated` activity log entry is written at the top-level update in [inbound_shipment/update/mod.rs](https://github.com/msupply-foundation/open-msupply/blob/develop/server/service/src/invoice/inbound_shipment/update/mod.rs), capturing the pre-update `received_datetime` and the new value (both formatted as `%Y-%m-%d`).
+The `InvoiceDateBackdated` activity log entry is written at the top-level update in [inbound_shipment/update/mod.rs](https://github.com/msupply-foundation/open-msupply/blob/develop/server/service/src/invoice/inbound_shipment/update/mod.rs), capturing the pre-update `received_datetime` and the new value. Both are formatted as `%Y-%m-%d` after converting the stored naive-UTC datetime into the client's offset, so the logged dates match what the user picked.
 
 ## Key files
 
@@ -54,19 +54,19 @@ The `InvoiceDateBackdated` activity log entry is written at the top-level update
 
 | File | Change |
 |------|--------|
-| `server/service/src/invoice/inbound_shipment/update/mod.rs` | `received_datetime: Option<DateTime<Utc>>` field; new error variants; upsert of `backdate_location_movements`; `InvoiceDateBackdated` activity log entry |
+| `server/service/src/invoice/inbound_shipment/update/mod.rs` | `received_datetime: Option<DateTime<FixedOffset>>` field; new error variants; upsert of `backdate_location_movements`; `InvoiceDateBackdated` activity log entry (dates formatted in the client's offset) |
 | `server/service/src/invoice/inbound_shipment/update/validate.rs` | Validation: preference enabled, received/verified status, strictly earlier (UTC datetime comparison), within `max_days` |
 | `server/service/src/invoice/inbound_shipment/update/generate.rs` | Updates `received_datetime` via `.naive_utc()`; collects location movement rows to update `enter_datetime` / `exit_datetime` |
 | `server/repository/src/db_diesel/activity_log_row.rs` | `InvoiceDateBackdated` activity log type |
 | `server/graphql/types/src/types/activity_log.rs` | `InvoiceDateBackdated` GraphQL enum variant |
-| `server/graphql/invoice/src/mutations/inbound_shipment/update.rs` | `receivedDatetime: DateTime<Utc>` on the GraphQL input; error mapping |
+| `server/graphql/invoice/src/mutations/inbound_shipment/update.rs` | `receivedDatetime: DateTime<FixedOffset>` on the GraphQL input (preserves the client's UTC offset); error mapping |
 | `server/repository/src/migrations/v2_18_00/add_invoice_date_backdated_activity_log_type.rs` | Postgres migration for the `InvoiceDateBackdated` enum value |
 
 ### Frontend (TypeScript)
 
 | File | Change |
 |------|--------|
-| `client/packages/invoices/src/InboundShipment/DetailView/ReceivedDateInput.tsx` | Received date picker in the toolbar; sends `DateTime` via `.toISOString()`; `maxDate` is the current received date (server-side check enforces strictly earlier) |
+| `client/packages/invoices/src/InboundShipment/DetailView/ReceivedDateInput.tsx` | Received date picker in the toolbar; sends `DateTime` via `Formatter.localIsoString` (RFC3339 with the local offset, so the audit log shows the picked date); `maxDate` is the current received date (server-side check enforces strictly earlier) |
 | `client/packages/invoices/src/InboundShipment/api/api.ts` | `receivedDatetime` in `toUpdate` |
 | `client/packages/invoices/src/InboundShipment/api/operations.graphql` | `stocktakeCountAfterDate` query for the stocktake warning |
 | `client/packages/common/src/authentication/api/operations.graphql` | `backdating` preference query (combined struct) |

--- a/server/graphql/invoice/src/mutations/inbound_shipment/update.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/update.rs
@@ -4,7 +4,7 @@ use crate::mutations::{
 };
 use async_graphql::*;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, FixedOffset};
 use graphql_core::generic_inputs::{InboundShipmentType, TaxInput};
 use graphql_core::simple_generic_errors::{
     CannotEditInvoice, OtherPartyNotASupplier, OtherPartyNotVisible,
@@ -51,7 +51,7 @@ pub struct UpdateInput {
     pub charges_local_currency: Option<f64>,
     pub charges_foreign_currency: Option<f64>,
     pub default_donor: Option<UpdateDonorInput>,
-    pub received_datetime: Option<DateTime<Utc>>,
+    pub received_datetime: Option<DateTime<FixedOffset>>,
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq, Debug)]
@@ -226,9 +226,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         | ServiceError::CannotMoveReceivedDateForward
         | ServiceError::ExceedsMaximumBackdatingDays
         | ServiceError::CannotSetShippedStatusOnManualInboundShipment
-        | ServiceError::CurrencyRateMustBePositive => {
-            BadUserInput(formatted_error)
-        }
+        | ServiceError::CurrencyRateMustBePositive => BadUserInput(formatted_error),
         ServiceError::PreferenceError(_) => InternalError(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::UpdatedInvoiceDoesNotExist => InternalError(formatted_error),

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -1,7 +1,7 @@
 use crate::activity_log::{activity_log_entry_with_store, log_type_from_invoice_status};
 use crate::invoice_line::ShipmentTaxUpdate;
 use crate::{invoice::query::get_invoice, service_provider::ServiceContext, WithDBError};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, FixedOffset};
 use repository::vvm_status::vvm_status_log_row::VVMStatusLogRowRepository;
 use repository::{
     ActivityLogType, InvoiceLineRowRepository, InvoiceRowRepository, InvoiceStatus,
@@ -56,7 +56,7 @@ pub struct UpdateInboundShipment {
     pub charges_local_currency: Option<f64>,
     pub charges_foreign_currency: Option<f64>,
     pub default_donor: Option<UpdateDefaultDonor>,
-    pub received_datetime: Option<DateTime<Utc>>,
+    pub received_datetime: Option<DateTime<FixedOffset>>,
 }
 
 type OutError = UpdateInboundShipmentError;
@@ -180,15 +180,20 @@ pub fn update_inbound_shipment(
                 )?;
             }
 
-            if patch.received_datetime.is_some() {
+            if let Some(received_datetime) = patch.received_datetime {
+                let offset = received_datetime.offset();
+                let local_date = |d: chrono::NaiveDateTime| {
+                    d.and_utc()
+                        .with_timezone(offset)
+                        .format("%Y-%m-%d")
+                        .to_string()
+                };
                 activity_log_entry_with_store(
                     ctx,
                     ActivityLogType::InvoiceDateBackdated,
                     Some(update_invoice.id.to_string()),
-                    old_received_datetime.map(|d| d.format("%Y-%m-%d").to_string()),
-                    update_invoice
-                        .received_datetime
-                        .map(|d| d.format("%Y-%m-%d").to_string()),
+                    old_received_datetime.map(local_date),
+                    update_invoice.received_datetime.map(local_date),
                     store_id.map(|id| id.to_string()),
                 )?;
             }
@@ -2015,9 +2020,9 @@ mod test {
 
     #[actix_rt::test]
     async fn update_inbound_shipment_backdate_received_errors() {
-        use chrono::DateTime;
+        use chrono::{DateTime, FixedOffset};
 
-        let now = Utc::now();
+        let now = Utc::now().fixed_offset();
         let two_days_ago = now - Duration::days(2);
         fn new_inbound() -> InvoiceRow {
             InvoiceRow {
@@ -2030,7 +2035,7 @@ mod test {
             }
         }
 
-        fn received_inbound(received_datetime: DateTime<Utc>) -> InvoiceRow {
+        fn received_inbound(received_datetime: DateTime<FixedOffset>) -> InvoiceRow {
             let naive = received_datetime.naive_utc();
             InvoiceRow {
                 id: "received_inbound_backdate".to_string(),
@@ -2080,7 +2085,9 @@ mod test {
             .upsert_one(&PreferenceRow {
                 id: "backdating_global".to_string(),
                 key: "backdating".to_string(),
-                value: r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":0}"#.to_string(),
+                value:
+                    r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":0}"#
+                        .to_string(),
                 store_id: None,
             })
             .unwrap();
@@ -2154,7 +2161,9 @@ mod test {
             .upsert_one(&PreferenceRow {
                 id: "backdating_global".to_string(),
                 key: "backdating".to_string(),
-                value: r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":1}"#.to_string(),
+                value:
+                    r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":1}"#
+                        .to_string(),
                 store_id: None,
             })
             .unwrap();
@@ -2176,16 +2185,16 @@ mod test {
 
     #[actix_rt::test]
     async fn update_inbound_shipment_backdate_received_success() {
-        use chrono::DateTime;
+        use chrono::{DateTime, FixedOffset};
         use repository::{
             location_movement::{LocationMovementFilter, LocationMovementRepository},
             LocationMovementRow, LocationMovementRowRepository,
         };
 
-        let now = Utc::now();
+        let now = Utc::now().fixed_offset();
         let three_days_ago = now - Duration::days(3);
 
-        fn received_inbound(received_datetime: DateTime<Utc>) -> InvoiceRow {
+        fn received_inbound(received_datetime: DateTime<FixedOffset>) -> InvoiceRow {
             let naive = received_datetime.naive_utc();
             InvoiceRow {
                 id: "received_inbound_backdate_success".to_string(),
@@ -2274,7 +2283,9 @@ mod test {
             .upsert_one(&PreferenceRow {
                 id: "backdating_global".to_string(),
                 key: "backdating".to_string(),
-                value: r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":0}"#.to_string(),
+                value:
+                    r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":0}"#
+                        .to_string(),
                 store_id: None,
             })
             .unwrap();
@@ -2303,10 +2314,7 @@ mod test {
             .unwrap()
             .unwrap();
 
-        assert_eq!(
-            updated.received_datetime,
-            Some(three_days_ago.naive_utc())
-        );
+        assert_eq!(updated.received_datetime, Some(three_days_ago.naive_utc()));
 
         // delivered_datetime and created_datetime are intentionally left untouched
         // so the resulting out-of-order dates make backdating visible.
@@ -2368,5 +2376,91 @@ mod test {
         );
         assert!(logs[0].activity_log_row.changed_from.is_some());
         assert!(logs[0].activity_log_row.changed_to.is_some());
+    }
+
+    #[actix_rt::test]
+    async fn update_inbound_shipment_backdate_received_log_uses_local_timezone() {
+        use chrono::{FixedOffset, TimeZone};
+        use repository::activity_log::{ActivityLogFilter, ActivityLogRepository};
+        use repository::{PreferenceRow, PreferenceRowRepository};
+
+        let now = Utc::now().fixed_offset();
+
+        fn received_inbound(received_datetime: chrono::NaiveDateTime) -> InvoiceRow {
+            InvoiceRow {
+                id: "received_inbound_backdate_tz".to_string(),
+                name_id: mock_name_a().id,
+                store_id: mock_store_a().id,
+                r#type: InvoiceType::InboundShipment,
+                status: InvoiceStatus::Received,
+                received_datetime: Some(received_datetime),
+                ..Default::default()
+            }
+        }
+
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "update_inbound_shipment_backdate_received_log_uses_local_timezone",
+            MockDataInserts::all(),
+            MockData {
+                invoices: vec![received_inbound(now.naive_utc())],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        PreferenceRowRepository::new(&connection)
+            .upsert_one(&PreferenceRow {
+                id: "backdating_global".to_string(),
+                key: "backdating".to_string(),
+                value:
+                    r#"{"shipmentsEnabled":true,"inventoryAdjustmentsEnabled":false,"maxDays":0}"#
+                        .to_string(),
+                store_id: None,
+            })
+            .unwrap();
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, "".to_string())
+            .unwrap();
+        let service = &service_provider.invoice_service;
+
+        // User in UTC+13 picks local midnight on 2024-12-10. As a UTC instant this is
+        // 2024-12-09T11:00:00, so the naive (UTC) date is the 9th
+        let plus_13 = FixedOffset::east_opt(13 * 60 * 60).unwrap();
+        let backdate = plus_13.with_ymd_and_hms(2024, 12, 10, 0, 0, 0).unwrap();
+        assert_eq!(
+            backdate.naive_utc().format("%Y-%m-%d").to_string(),
+            "2024-12-09"
+        );
+
+        service
+            .update_inbound_shipment(
+                &context,
+                UpdateInboundShipment {
+                    id: received_inbound(now.naive_utc()).id,
+                    received_datetime: Some(backdate),
+                    ..Default::default()
+                },
+                InboundShipmentType::InboundShipment,
+            )
+            .unwrap();
+
+        let logs = ActivityLogRepository::new(&connection)
+            .query(
+                Default::default(),
+                Some(
+                    ActivityLogFilter::new()
+                        .r#type(ActivityLogType::InvoiceDateBackdated.equal_to()),
+                ),
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(logs.len(), 1);
+        assert_eq!(
+            logs[0].activity_log_row.changed_to,
+            Some("2024-12-10".to_string())
+        );
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11673

# 👩🏻‍💻 What does this PR do?
Sends the offset for received backdate to backend to save in from and to log entries. The date being different from what is being displayed in frontend is because the UTC was being saved and isn't being parsed to be displayed in the user's local time

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have backdating global pref on for invoices
- [ ] Create an inbound shipment 
- [ ] Add lines, change status to received
- [ ] Back date
- [ ] Check log date same as toolbar date

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

