### PR TITLE
10538 Fields not fully visible for volume/weight data when small values are entered

### DIFF
--- a/client/packages/common/src/ui/layout/tables/types.ts
+++ b/client/packages/common/src/ui/layout/tables/types.ts
@@ -10,6 +10,9 @@ export type ColumnDef<T extends MRT_RowData> = MRT_ColumnDef<T> & {
    * alignment & rounding for numbers). Defaults to string.*/
   columnType?: ColumnType;
 
+  /** The number of decimal places to display. Defaults to 2. */
+  decimalLimit?: number;
+
   /** Display the column in the table. Use to handle columns only included for
    * certain preferences or permissions. Defaults to true */
   includeColumn?: boolean;

--- a/client/packages/common/src/ui/layout/tables/useGetColumnDefDefaults.tsx
+++ b/client/packages/common/src/ui/layout/tables/useGetColumnDefDefaults.tsx
@@ -120,6 +120,7 @@ export const useGetColumnTypeDefaults = () => {
               <NumericTextDisplay
                 value={typeof value === 'number' ? value : undefined}
                 defaultValue={UNDEFINED_STRING_VALUE}
+                decimalLimit={column.decimalLimit}
               />
             );
           },

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.tsx
@@ -8,6 +8,7 @@ import {
   ExpiryDateCell,
   Box,
   weightedAverageByUnits,
+  NumericTextDisplay,
 } from '@openmsupply-client/common';
 import { StockOutLineFragment } from '../../StockOut';
 
@@ -153,6 +154,7 @@ export const useOutboundColumns = () => {
         header: t('label.volume'),
         size: 100,
         columnType: ColumnType.Number,
+        decimalLimit: 5,
         accessorFn: row =>
           (row.stockLine?.volumePerPack ?? 0) * row.numberOfPacks,
         aggregationFn: 'sum',
@@ -173,7 +175,7 @@ export const useOutboundColumns = () => {
                 width: '100%',
               }}
             >
-              {totalVolume}
+              <NumericTextDisplay value={totalVolume} decimalLimit={5} />
             </Box>
           );
         },

--- a/client/packages/system/src/Item/DetailView/Tabs/General.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/General.tsx
@@ -153,6 +153,7 @@ export const GeneralTab = ({ item, isLoading }: GeneralTabProps) => {
               <NumericTextInput
                 value={item?.volumePerPack}
                 disabled={isDisabled}
+                decimalLimit={5}
                 fullWidth
               />
             }
@@ -163,6 +164,7 @@ export const GeneralTab = ({ item, isLoading }: GeneralTabProps) => {
               <NumericTextInput
                 value={item?.volumePerOuterPack}
                 disabled={isDisabled}
+                decimalLimit={5}
                 fullWidth
               />
             }
@@ -173,6 +175,7 @@ export const GeneralTab = ({ item, isLoading }: GeneralTabProps) => {
               <NumericTextInput
                 value={item?.weight}
                 disabled={isDisabled}
+                decimalLimit={5}
                 fullWidth
               />
             }

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemPackagingVariantsTable.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemPackagingVariantsTable.tsx
@@ -77,7 +77,7 @@ export const ItemPackagingVariantsTable = ({
                   updatePackaging({ id: row.id, volumePerUnit: value })
                 }
                 error={cell.getValue() === 0}
-                decimalLimit={4}
+                decimalLimit={5}
               />
             )
           : TextWithTooltipCell,

--- a/client/packages/system/src/Location/ListView/ListView.tsx
+++ b/client/packages/system/src/Location/ListView/ListView.tsx
@@ -75,6 +75,7 @@ export const LocationListView = () => {
         accessorKey: 'volume',
         header: t('label.volume'),
         columnType: ColumnType.Number,
+        decimalLimit: 5,
       },
       {
         id: 'volumeUsed',


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #10538

# 👩🏻‍💻 What does this PR do?
Make volume & weight fields display up to 5 dp

<img width="540" height="310" alt="Screenshot 2026-06-10 at 13 08 58" src="https://github.com/user-attachments/assets/e713e4e5-23f3-4daf-b93d-bdfefaa52ddf" />


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set packaging volume, weight etc in OG 
- [ ] Sync
- [ ] Go to Item > Click on item 
- [ ] Should see up to 5 dp for those fields

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

