### PR TITLE
test(sync): fix name_store_join inactive translation test

### DIFF
--- a/server/service/src/sync/translations/name_store_join.rs
+++ b/server/service/src/sync/translations/name_store_join.rs
@@ -220,7 +220,7 @@ mod tests {
 
         let (_, connection, _, _) = setup_all(
             "test_name_store_join_translation",
-            MockDataInserts::none().names(),
+            MockDataInserts::none().names().stores(),
         )
         .await;
 
@@ -232,6 +232,18 @@ mod tests {
 
             assert_eq!(translation_result, record.translated_record);
         }
+
+        // The inactive (soft-delete) record translates to a delete only if the row
+        // already exists locally, so insert it first (it's ignored otherwise).
+        NameStoreJoinRepository::new(&connection)
+            .upsert_one_without_changelog(&NameStoreJoinRow {
+                id: "BE65A4A05E4D47E88303D6105A7872CC".to_string(),
+                store_id: "store_b".to_string(),
+                name_id: "name_store_a".to_string(),
+                name_is_customer: false,
+                name_is_supplier: true,
+            })
+            .unwrap();
 
         for record in test_data::test_pull_upsert_inactive_records() {
             let translation_result = translator


### PR DESCRIPTION
## What

Fixes the `test_name_store_join_translation` test, which fails on this branch.

## Why

The new behavior makes the inactive (soft-delete) translation return `Ignored("Is inactive and not found")` when the `name_store_join` row doesn't exist locally. The existing test runs the inactive record against a DB with no `name_store_join` rows (`MockDataInserts::none().names()`) and asserts it translates to a `Delete`, so it now fails:

```
left:  Ignored("Is inactive and not found")
right: IntegrationOperations([Delete(NameStoreJoinRowDelete("BE65A4A05E4D47E88303D6105A7872CC"))])
```

## Change

- Add `.stores()` to the mock inserts (satisfies the `store_id` FK).
- Insert the `name_store_join` row before the inactive loop so the existing assertion (→ `Delete`) holds and continues to exercise the soft-delete path.

Verified: `cargo nextest run -p service test_name_store_join_translation` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)