### PR TITLE
#11936 Consistent add/delete line rules for received inbound shipments

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/AppBarButtons.tsx
@@ -29,7 +29,7 @@ export const AppBarButtonsComponent = ({
   const { store } = useAuthContext();
   const {
     query: { data },
-    isDisabled,
+    isAddOrDeleteLinesDisabled,
   } = useInboundShipment();
   const { OpenButton } = useDetailPanel();
   const {
@@ -56,7 +56,7 @@ export const AppBarButtonsComponent = ({
     // We just want to show the scan button for mobile users to use the scanner approach.
     return (
       <AppBarButtonsPortal>
-        <AddFromScannerButton disabled={isDisabled} />
+        <AddFromScannerButton disabled={isAddOrDeleteLinesDisabled} />
       </AppBarButtonsPortal>
     );
   }
@@ -74,12 +74,12 @@ export const AppBarButtonsComponent = ({
           openUploadModal={openUploadModal}
           requisitionId={data?.requisition?.id ?? ''}
           invoice={data}
-          disable={isDisabled}
+          disable={isAddOrDeleteLinesDisabled}
           disableAddFromMasterListButton={!!data?.linkedShipment || !!data?.purchaseOrder}
           disableAddFromInternalOrderButton={disableInternalOrderButton}
           allPurchaseOrderItemsAdded={allPurchaseOrderItemsAdded}
         />
-        <AddFromScannerButton disabled={isDisabled} />
+        <AddFromScannerButton disabled={isAddOrDeleteLinesDisabled} />
         {data && (
           <>
             {plugins.inboundShipmentAppBar?.map((Plugin, index) => (

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -17,6 +17,7 @@ import {
   InvoiceLineStatusType,
   InvoiceNodeStatus,
   ModalMode,
+  usePreferences,
   useSimplifiedTabletUI,
   Box,
   ButtonWithIcon,
@@ -91,9 +92,18 @@ export const InboundLineEdit = ({
   const permissionDeniedNotification = useDisabledNotificationToast(
     t('auth.permission-denied')
   );
+  const { externalInboundShipmentLinesMustBeAuthorised } = usePreferences();
   const isReceived =
     data?.status === InvoiceNodeStatus.Received ||
     data?.status === InvoiceNodeStatus.Verified;
+  // A shipment with line authorisation can only be received once every line is
+  // approved/rejected, so adding/duplicating/deleting batches (which changes
+  // the line set) is locked once received. Shipments without line
+  // authorisation can still add/delete batches while received (#11936).
+  const requiresLineAuthorisation =
+    data?.lines.nodes.some(line => line.status != null) ||
+    (isExternal && !!externalInboundShipmentLinesMustBeAuthorised);
+  const batchEditLocked = isReceived && !!requiresLineAuthorisation;
   const purchaseOrder = data?.purchaseOrder;
   const hasPurchaseOrder = !!purchaseOrder;
 
@@ -330,7 +340,7 @@ export const InboundLineEdit = ({
       duplicateDraftLine={duplicateDraftLine}
       removeDraftLine={removeDraftLine}
       isDisabled={isDisabled}
-      isReceived={isReceived}
+      batchEditLocked={batchEditLocked}
       foreignCurrency={foreignCurrency}
       isExternalSupplier={isExternalSupplier}
       item={effectiveItem}
@@ -376,7 +386,7 @@ export const InboundLineEdit = ({
       }
       headerActions={
         <ButtonWithIcon
-          disabled={isDisabled || isReceived}
+          disabled={isDisabled || batchEditLocked}
           color="primary"
           variant="outlined"
           onClick={handleAddBatch}

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEdit.tsx
@@ -15,9 +15,7 @@ import {
   useNotification,
   useDisabledNotificationToast,
   InvoiceLineStatusType,
-  InvoiceNodeStatus,
   ModalMode,
-  usePreferences,
   useSimplifiedTabletUI,
   Box,
   ButtonWithIcon,
@@ -88,22 +86,11 @@ export const InboundLineEdit = ({
     query: { data },
     hasAuthorisePermission,
     isExternal,
+    isAddOrDeleteLinesDisabled,
   } = useInboundShipment();
   const permissionDeniedNotification = useDisabledNotificationToast(
     t('auth.permission-denied')
   );
-  const { externalInboundShipmentLinesMustBeAuthorised } = usePreferences();
-  const isReceived =
-    data?.status === InvoiceNodeStatus.Received ||
-    data?.status === InvoiceNodeStatus.Verified;
-  // A shipment with line authorisation can only be received once every line is
-  // approved/rejected, so adding/duplicating/deleting batches (which changes
-  // the line set) is locked once received. Shipments without line
-  // authorisation can still add/delete batches while received (#11936).
-  const requiresLineAuthorisation =
-    data?.lines.nodes.some(line => line.status != null) ||
-    (isExternal && !!externalInboundShipmentLinesMustBeAuthorised);
-  const batchEditLocked = isReceived && !!requiresLineAuthorisation;
   const purchaseOrder = data?.purchaseOrder;
   const hasPurchaseOrder = !!purchaseOrder;
 
@@ -340,7 +327,6 @@ export const InboundLineEdit = ({
       duplicateDraftLine={duplicateDraftLine}
       removeDraftLine={removeDraftLine}
       isDisabled={isDisabled}
-      batchEditLocked={batchEditLocked}
       foreignCurrency={foreignCurrency}
       isExternalSupplier={isExternalSupplier}
       item={effectiveItem}
@@ -386,7 +372,7 @@ export const InboundLineEdit = ({
       }
       headerActions={
         <ButtonWithIcon
-          disabled={isDisabled || batchEditLocked}
+          disabled={isDisabled || isAddOrDeleteLinesDisabled}
           color="primary"
           variant="outlined"
           onClick={handleAddBatch}

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -63,8 +63,6 @@ interface CardProps {
 interface InboundLineEditCardsProps extends CardProps {
   duplicateDraftLine: (id: string) => void;
   removeDraftLine: (id: string) => void;
-  /** Locks adding/duplicating/deleting batches (line authorisation, once received) */
-  batchEditLocked?: boolean;
   lastCardRef?: React.RefObject<HTMLDivElement | null>;
   actions?: React.ReactNode;
   /** The specific line ID to scroll into view when the modal opens */
@@ -77,7 +75,6 @@ export const InboundLineEditCards = ({
   duplicateDraftLine,
   removeDraftLine,
   isDisabled = false,
-  batchEditLocked = false,
   foreignCurrency,
   isExternalSupplier,
   hasItemVariantsEnabled,
@@ -107,6 +104,7 @@ export const InboundLineEditCards = ({
     query: { data: inboundData },
     hasAuthorisePermission,
     isExternal,
+    isAddOrDeleteLinesDisabled,
   } = useInboundShipment();
   const isManualShipment =
     !inboundData?.purchaseOrder && !inboundData?.linkedShipment;
@@ -710,7 +708,7 @@ export const InboundLineEditCards = ({
         pin: 'right',
         Cell: ({ row }) => (
           <IconButton
-            disabled={isDisabled || batchEditLocked}
+            disabled={isDisabled || isAddOrDeleteLinesDisabled}
             label={t('label.duplicate-batch')}
             showLabel={!simplified}
             onClick={() => {
@@ -733,7 +731,7 @@ export const InboundLineEditCards = ({
         pin: 'right',
         Cell: ({ row }) => (
           <IconButton
-            disabled={isDisabled || batchEditLocked}
+            disabled={isDisabled || isAddOrDeleteLinesDisabled}
             label={t('label.delete-batch')}
             showLabel={!simplified}
             color="error"
@@ -753,7 +751,7 @@ export const InboundLineEditCards = ({
     hasItemVariantsEnabled,
     hasVvmStatusesEnabled,
     isDisabled,
-    batchEditLocked,
+    isAddOrDeleteLinesDisabled,
     isExternalSupplier,
     isManualShipment,
     item?.isVaccine,

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -63,7 +63,8 @@ interface CardProps {
 interface InboundLineEditCardsProps extends CardProps {
   duplicateDraftLine: (id: string) => void;
   removeDraftLine: (id: string) => void;
-  isReceived?: boolean;
+  /** Locks adding/duplicating/deleting batches (line authorisation, once received) */
+  batchEditLocked?: boolean;
   lastCardRef?: React.RefObject<HTMLDivElement | null>;
   actions?: React.ReactNode;
   /** The specific line ID to scroll into view when the modal opens */
@@ -76,7 +77,7 @@ export const InboundLineEditCards = ({
   duplicateDraftLine,
   removeDraftLine,
   isDisabled = false,
-  isReceived = false,
+  batchEditLocked = false,
   foreignCurrency,
   isExternalSupplier,
   hasItemVariantsEnabled,
@@ -709,7 +710,7 @@ export const InboundLineEditCards = ({
         pin: 'right',
         Cell: ({ row }) => (
           <IconButton
-            disabled={isDisabled || isReceived}
+            disabled={isDisabled || batchEditLocked}
             label={t('label.duplicate-batch')}
             showLabel={!simplified}
             onClick={() => {
@@ -732,7 +733,7 @@ export const InboundLineEditCards = ({
         pin: 'right',
         Cell: ({ row }) => (
           <IconButton
-            disabled={isDisabled || isReceived}
+            disabled={isDisabled || batchEditLocked}
             label={t('label.delete-batch')}
             showLabel={!simplified}
             color="error"
@@ -752,7 +753,7 @@ export const InboundLineEditCards = ({
     hasItemVariantsEnabled,
     hasVvmStatusesEnabled,
     isDisabled,
-    isReceived,
+    batchEditLocked,
     isExternalSupplier,
     isManualShipment,
     item?.isVaccine,

--- a/client/packages/invoices/src/InboundShipment/api/hooks/document/useInboundShipment.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/document/useInboundShipment.ts
@@ -1,6 +1,7 @@
 import {
   RecordPatch,
   UpdateInboundShipmentInput,
+  InvoiceNodeStatus,
   InvoiceTypeInput,
   useMutation,
   useQuery,
@@ -56,6 +57,19 @@ export const useInboundShipment = (id?: string) => {
     : userHasPermission(UserPermission.InboundShipmentVerify);
   const isDisabled = isInboundDisabled(data) || !hasMutatePermission;
   const isStatusChangeDisabled = isInboundStatusChangeDisabled(data);
+  // A shipment that went through line authorisation (any line has an auth
+  // status) can only be received once every line is approved or rejected, so
+  // its set of lines is locked from then on — lines/batches cannot be added
+  // or deleted, though other line details remain editable. The server
+  // enforces the same lock via the externalInboundShipmentLinesMustBeAuthorised
+  // preference (check_lines_locked_by_authorisation).
+  const requiresLineAuthorisation =
+    data?.lines.nodes.some(line => line.status != null) ?? false;
+  const isAddOrDeleteLinesDisabled =
+    isDisabled ||
+    (requiresLineAuthorisation &&
+      (data?.status === InvoiceNodeStatus.Received ||
+        data?.status === InvoiceNodeStatus.Verified));
 
   const rows = useMemo(() => {
     const lines = data?.lines?.nodes ?? [];
@@ -158,6 +172,7 @@ export const useInboundShipment = (id?: string) => {
     draft,
     isExternal,
     isDisabled,
+    isAddOrDeleteLinesDisabled,
     hasMutatePermission,
     isHoldable,
     isStatusChangeDisabled,

--- a/client/packages/invoices/src/InboundShipment/api/hooks/line/useDeleteSelectedLines.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/line/useDeleteSelectedLines.ts
@@ -13,7 +13,7 @@ export const useInboundDeleteSelectedLines = (
   resetRowSelection: () => void
 ): (() => void) => {
   const t = useTranslation();
-  const { isDisabled, isExternal } = useInboundShipment();
+  const { isAddOrDeleteLinesDisabled, isExternal } = useInboundShipment();
   const { mutateAsync } = useDeleteInboundLines(isExternal);
   const errorsContext = useInboundShipmentLineErrorContext();
 
@@ -49,7 +49,7 @@ export const useInboundDeleteSelectedLines = (
   const confirmAndDelete = useDeleteConfirmation({
     selectedRows: rowsToDelete,
     deleteAction: onDelete,
-    canDelete: !isDisabled,
+    canDelete: !isAddOrDeleteLinesDisabled,
     messages: {
       confirmMessage: t('messages.confirm-delete-shipment-lines', {
         count: rowsToDelete.length,
@@ -57,7 +57,7 @@ export const useInboundDeleteSelectedLines = (
       deleteSuccess: t('messages.deleted-lines', {
         count: rowsToDelete.length,
       }),
-      cantDelete: handleCantDelete({ isDisabled }),
+      cantDelete: handleCantDelete({ isDisabled: isAddOrDeleteLinesDisabled }),
     },
   });
 

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/delete.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/delete.rs
@@ -49,11 +49,11 @@ pub fn delete(
     let service_provider = ctx.service_provider();
     let service_context = service_provider.context(store_id.to_string(), user.user_id)?;
 
-    map_response(
-        service_provider
-            .invoice_line_service
-            .delete_stock_in_line(&service_context, input.to_domain(), Some(r#type.to_domain())),
-    )
+    map_response(service_provider.invoice_line_service.delete_stock_in_line(
+        &service_context,
+        input.to_domain(),
+        Some(r#type.to_domain()),
+    ))
 }
 
 #[derive(Interface)]
@@ -97,7 +97,8 @@ fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
         ServiceError::LineDoesNotExist => {
             return Ok(DeleteErrorInterface::RecordNotFound(RecordNotFound {}))
         }
-        ServiceError::CannotEditFinalised => {
+        ServiceError::CannotEditFinalised
+        | ServiceError::CannotDeleteLinesOfAuthorisedReceivedInvoice => {
             return Ok(DeleteErrorInterface::CannotEditInvoice(
                 CannotEditInvoice {},
             ))

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
@@ -74,11 +74,11 @@ pub fn insert(
     let service_provider = ctx.service_provider();
     let service_context = service_provider.context(store_id.to_string(), user.user_id)?;
 
-    map_response(
-        service_provider
-            .invoice_line_service
-            .insert_stock_in_line(&service_context, input.to_domain(), Some(r#type.to_domain())),
-    )
+    map_response(service_provider.invoice_line_service.insert_stock_in_line(
+        &service_context,
+        input.to_domain(),
+        Some(r#type.to_domain()),
+    ))
 }
 
 #[derive(Interface)]
@@ -177,7 +177,8 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
             )))
         }
 
-        ServiceError::CannotEditFinalised => {
+        ServiceError::CannotEditFinalised
+        | ServiceError::CannotAddLinesToAuthorisedReceivedInvoice => {
             return Ok(InsertErrorInterface::CannotEditInvoice(
                 CannotEditInvoice {},
             ))

--- a/server/service/src/invoice_line/stock_in_line/delete/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/delete/mod.rs
@@ -67,6 +67,7 @@ pub enum DeleteStockInLineError {
     NotAStockIn,
     NotThisStoreInvoice,
     CannotEditFinalised,
+    CannotDeleteLinesOfAuthorisedReceivedInvoice,
     BatchIsReserved,
     NotThisInvoiceLine(String),
     LineUsedInStocktake,
@@ -97,15 +98,16 @@ mod test {
     use repository::{
         mock::{
             mock_customer_return_a, mock_customer_return_a_invoice_line_a,
-            mock_customer_return_a_invoice_line_b, mock_item_a, mock_name_store_b, mock_store_a,
-            mock_store_b, mock_supplier_return_b_invoice_line_a,
-            mock_transferred_inbound_shipment_a, mock_transferred_inbound_shipment_a_line_b,
-            mock_user_account_a, mock_vaccine_item_a, mock_vvm_status_a, MockData, MockDataInserts,
+            mock_customer_return_a_invoice_line_b, mock_item_a, mock_name_store_b,
+            mock_purchase_order_a, mock_store_a, mock_store_b,
+            mock_supplier_return_b_invoice_line_a, mock_transferred_inbound_shipment_a,
+            mock_transferred_inbound_shipment_a_line_b, mock_user_account_a, mock_vaccine_item_a,
+            mock_vvm_status_a, MockData, MockDataInserts,
         },
         test_db::setup_all_with_data,
         vvm_status::vvm_status_log::{VVMStatusLogFilter, VVMStatusLogRepository},
         EqualFilter, InvoiceLineRow, InvoiceLineRowRepository, InvoiceLineType, InvoiceRow,
-        InvoiceStatus, InvoiceType, StockLineRow, StockLineRowRepository,
+        InvoiceStatus, InvoiceType, PreferenceRow, StockLineRow, StockLineRowRepository,
     };
 
     use crate::{
@@ -161,7 +163,8 @@ mod test {
                 DeleteStockInLine {
                     id: "invalid".to_string(),
                     r#type: StockInType::CustomerReturn,
-                }, None
+                },
+                None
             ),
             Err(ServiceError::LineDoesNotExist)
         );
@@ -173,7 +176,8 @@ mod test {
                 DeleteStockInLine {
                     id: mock_supplier_return_b_invoice_line_a().id,
                     r#type: StockInType::CustomerReturn,
-                }, None
+                },
+                None
             ),
             Err(ServiceError::NotAStockIn)
         );
@@ -185,7 +189,8 @@ mod test {
                 DeleteStockInLine {
                     id: verified_return_line().id,
                     r#type: StockInType::CustomerReturn,
-                }, None
+                },
+                None
             ),
             Err(ServiceError::CannotEditFinalised)
         );
@@ -197,7 +202,8 @@ mod test {
                 DeleteStockInLine {
                     id: mock_customer_return_a_invoice_line_b().id, // line number_of_packs and stock_line available_number_of_packs are different
                     r#type: StockInType::CustomerReturn,
-                }, None
+                },
+                None
             ),
             Err(ServiceError::BatchIsReserved)
         );
@@ -209,7 +215,8 @@ mod test {
                 DeleteStockInLine {
                     id: mock_transferred_inbound_shipment_a_line_b().id,
                     r#type: StockInType::InboundShipment,
-                }, None
+                },
+                None
             ),
             Err(ServiceError::LineLinkedToTransferredInvoice)
         );
@@ -222,9 +229,72 @@ mod test {
                 DeleteStockInLine {
                     id: mock_customer_return_a_invoice_line_a().id,
                     r#type: StockInType::CustomerReturn,
-                }, None
+                },
+                None
             ),
             Err(ServiceError::NotThisStoreInvoice)
+        );
+    }
+
+    #[actix_rt::test]
+    async fn delete_stock_in_line_authorised_received_invoice() {
+        fn authorised_received_inbound() -> InvoiceRow {
+            InvoiceRow {
+                id: "authorised_received_inbound".to_string(),
+                store_id: mock_store_a().id,
+                name_id: mock_name_store_b().id,
+                r#type: InvoiceType::InboundShipment,
+                status: InvoiceStatus::Received,
+                purchase_order_id: Some(mock_purchase_order_a().id),
+                ..Default::default()
+            }
+        }
+
+        fn line_to_delete() -> InvoiceLineRow {
+            InvoiceLineRow {
+                id: "authorised_received_inbound_line".to_string(),
+                invoice_id: authorised_received_inbound().id,
+                item_id: mock_item_a().id,
+                r#type: InvoiceLineType::StockIn,
+                number_of_packs: 10.0,
+                pack_size: 1.0,
+                ..Default::default()
+            }
+        }
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "delete_stock_in_line_authorised_received_invoice",
+            MockDataInserts::all(),
+            MockData {
+                invoices: vec![authorised_received_inbound()],
+                invoice_lines: vec![line_to_delete()],
+                preferences: vec![PreferenceRow {
+                    id: "ext_auth_pref_received_delete_test".to_string(),
+                    key: "external_inbound_shipment_lines_must_be_authorised".to_string(),
+                    value: "true".to_string(),
+                    store_id: Some(mock_store_a().id),
+                }],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+
+        // Lines cannot be deleted once an authorised shipment is received
+        assert_eq!(
+            delete_stock_in_line(
+                &context,
+                DeleteStockInLine {
+                    id: line_to_delete().id,
+                    r#type: StockInType::InboundShipment,
+                },
+                None
+            ),
+            Err(ServiceError::CannotDeleteLinesOfAuthorisedReceivedInvoice)
         );
     }
 
@@ -269,7 +339,8 @@ mod test {
             DeleteStockInLine {
                 id: return_line().id,
                 r#type: StockInType::CustomerReturn,
-            }, None
+            },
+            None,
         )
         .unwrap();
 
@@ -302,7 +373,8 @@ mod test {
                 r#type: StockInType::InboundShipment,
                 vvm_status_id: Some(mock_vvm_status_a().id),
                 ..Default::default()
-            }, None
+            },
+            None,
         )
         .unwrap();
 
@@ -326,7 +398,8 @@ mod test {
                 id: "delivered_invoice_line_with_vvm_status".to_string(),
                 r#type: StockInType::InboundShipment,
                 ..Default::default()
-            }, None
+            },
+            None,
         )
         .unwrap();
 

--- a/server/service/src/invoice_line/stock_in_line/delete/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/delete/validate.rs
@@ -1,14 +1,14 @@
+use crate::invoice::inbound_shipment::InboundShipmentType;
 use crate::{
     invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
     invoice_line::{
-        stock_in_line::check_batch,
+        stock_in_line::{check_batch, check_lines_locked_by_authorisation},
         validate::{
             check_line_belongs_to_invoice, check_line_not_associated_with_stocktake,
             check_line_row_exists,
         },
     },
 };
-use crate::invoice::inbound_shipment::InboundShipmentType;
 use repository::{InvoiceLineRow, InvoiceRow, StorageConnection};
 
 use super::{DeleteStockInLine, DeleteStockInLineError};
@@ -37,6 +37,9 @@ pub fn validate(
     }
     if !check_invoice_is_editable(&invoice) {
         return Err(CannotEditFinalised);
+    }
+    if check_lines_locked_by_authorisation(connection, &invoice) {
+        return Err(CannotDeleteLinesOfAuthorisedReceivedInvoice);
     }
     if !check_batch(&line, connection)? {
         return Err(BatchIsReserved);

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -109,6 +109,7 @@ pub enum InsertStockInLineError {
     DonorNotVisible,
     SelectedDonorPartyIsNotADonor,
     CannotEditFinalised,
+    CannotAddLinesToAuthorisedReceivedInvoice,
     LocationDoesNotExist,
     ItemVariantDoesNotExist,
     ItemNotFound,
@@ -511,6 +512,91 @@ mod test {
                 invoice_id: mock_inbound_shipment_e().id,
                 r#type: StockInType::InboundShipment,
                 program_id: Some(mock_immunisation_program_a().id),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+    }
+
+    #[actix_rt::test]
+    async fn insert_stock_in_line_authorised_received_invoice() {
+        fn authorised_received_inbound() -> InvoiceRow {
+            InvoiceRow {
+                id: "authorised_received_inbound".to_string(),
+                store_id: mock_store_a().id,
+                name_id: mock_name_store_b().id,
+                r#type: InvoiceType::InboundShipment,
+                status: InvoiceStatus::Received,
+                purchase_order_id: Some(mock_purchase_order_a().id),
+                ..Default::default()
+            }
+        }
+
+        // Received inbound in the same store but not linked to a purchase
+        // order, so not subject to line authorisation
+        fn received_inbound() -> InvoiceRow {
+            InvoiceRow {
+                id: "received_inbound_without_auth".to_string(),
+                store_id: mock_store_a().id,
+                name_id: mock_name_store_b().id,
+                r#type: InvoiceType::InboundShipment,
+                status: InvoiceStatus::Received,
+                ..Default::default()
+            }
+        }
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "insert_stock_in_line_authorised_received_invoice",
+            MockDataInserts::all(),
+            MockData {
+                invoices: vec![authorised_received_inbound(), received_inbound()],
+                preferences: vec![PreferenceRow {
+                    id: "ext_auth_pref_received_insert_test".to_string(),
+                    key: "external_inbound_shipment_lines_must_be_authorised".to_string(),
+                    value: "true".to_string(),
+                    store_id: Some(mock_store_a().id),
+                }],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+
+        // Lines cannot be added once an authorised shipment is received
+        assert_eq!(
+            insert_stock_in_line(
+                &context,
+                InsertStockInLine {
+                    id: "new_line_authorised_received".to_string(),
+                    invoice_id: authorised_received_inbound().id,
+                    item_id: mock_item_a().id,
+                    pack_size: 1.0,
+                    number_of_packs: 1.0,
+                    r#type: StockInType::InboundShipment,
+                    purchase_order_line_id: Some(mock_purchase_order_a_line_1().id),
+                    ..Default::default()
+                },
+                None
+            ),
+            Err(ServiceError::CannotAddLinesToAuthorisedReceivedInvoice)
+        );
+
+        // A received shipment not subject to line authorisation still accepts
+        // new lines
+        insert_stock_in_line(
+            &context,
+            InsertStockInLine {
+                id: "new_line_received_no_auth".to_string(),
+                invoice_id: received_inbound().id,
+                item_id: mock_item_a().id,
+                pack_size: 1.0,
+                number_of_packs: 1.0,
+                r#type: StockInType::InboundShipment,
                 ..Default::default()
             },
             None,

--- a/server/service/src/invoice_line/stock_in_line/insert/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/validate.rs
@@ -5,7 +5,7 @@ use crate::{
     check_vvm_status_exists,
     invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
     invoice_line::{
-        stock_in_line::check_pack_size,
+        stock_in_line::{check_lines_locked_by_authorisation, check_pack_size},
         validate::{check_item_exists, check_line_exists, check_number_of_packs},
     },
     validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors},
@@ -77,6 +77,9 @@ pub fn validate(
     }
     if !check_invoice_is_editable(&invoice) {
         return Err(CannotEditFinalised);
+    }
+    if check_lines_locked_by_authorisation(connection, &invoice) {
+        return Err(CannotAddLinesToAuthorisedReceivedInvoice);
     }
 
     if let Some(donor_id) = &input.donor_id {

--- a/server/service/src/invoice_line/stock_in_line/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/mod.rs
@@ -1,6 +1,8 @@
+use crate::preference::{ExternalInboundShipmentLinesMustBeAuthorised, Preference};
 use repository::InvoiceRow;
 use repository::InvoiceStatus;
 use repository::InvoiceType;
+use repository::StorageConnection;
 
 pub mod generate;
 pub mod validate;
@@ -31,6 +33,29 @@ impl StockInType {
             StockInType::InboundShipment => InvoiceType::InboundShipment,
         }
     }
+}
+
+/// An external inbound shipment subject to line authorisation can only be
+/// received once every line is approved or rejected, so its set of lines is
+/// locked from then on — lines cannot be added or deleted, though other line
+/// details remain editable.
+pub fn check_lines_locked_by_authorisation(
+    connection: &StorageConnection,
+    invoice: &InvoiceRow,
+) -> bool {
+    // Only external inbound shipments (linked to a purchase order) are
+    // subject to line authorisation
+    if invoice.purchase_order_id.is_none()
+        || !matches!(
+            invoice.status,
+            InvoiceStatus::Received | InvoiceStatus::Verified
+        )
+    {
+        return false;
+    }
+    ExternalInboundShipmentLinesMustBeAuthorised
+        .load(connection, Some(invoice.store_id.clone()))
+        .unwrap_or(false)
 }
 
 pub fn should_update_stock(invoice: &InvoiceRow) -> bool {


### PR DESCRIPTION
Fixes #11936

# 👩🏻‍💻 What does this PR do?

On an inbound shipment in `Received` status, the line edit modal's "Add batch", duplicate and delete batch buttons were disabled — while the toolbar "Add item" and footer "Delete lines" buttons remained enabled. So you could add a whole new item but not a second batch of it, with no workaround.

The blanket lock came from #10907 (issue #10929 — line authorisation in external inbound shipments), where the rule is deliberate: an authorised shipment can only be received once every line is approved/rejected, so the set of lines must not change afterwards. But it was applied to **all** inbound shipments (too strict for ordinary shipments), only to the modal's batch buttons (toolbar/footer still allowed adding/deleting lines on authorised received shipments — too loose), and never enforced server-side.

This PR makes one rule, applied everywhere and enforced on both ends:

> Lines can be added/deleted while the shipment is editable, **unless** the shipment is subject to line authorisation and has been received — then the line set is locked.

**Client** — new `isAddOrDeleteLinesDisabled` flag in `useInboundShipment`, used by all entry points that change the line set:

- Toolbar `AddButton` (add item / add from master list / add from internal order) and `AddFromScannerButton`
- Footer "Delete lines" (`useInboundDeleteSelectedLines`)
- Line edit modal "Add batch" + per-batch duplicate/delete buttons (`InboundLineEdit` / `InboundLineEditCards`)

**Server** — new `check_lines_locked_by_authorisation` check in `insert_stock_in_line` and `delete_stock_in_line` validation: the shipment is external (linked to a purchase order), received/verified, and the `externalInboundShipmentLinesMustBeAuthorised` preference is on for the store. Returns `CannotAddLinesToAuthorisedReceivedInvoice` / `CannotDeleteLinesOfAuthorisedReceivedInvoice`, mapped to the structured `CannotEditInvoice` GraphQL error (same as `CannotEditFinalised`). Cheap: the preference is only loaded after the status and purchase-order-id checks short-circuit. Service tests added for both, including the positive case (received shipment not subject to authorisation still accepts new lines).

Resulting behaviour:

- Manual / internal / non-authorised external shipments at `Received`: add/duplicate/delete batch now enabled — consistent with "Add item" / "Delete lines", and matching what the server has always allowed (stock is correctly introduced/removed for changes at `Received`).
- Authorised shipments at `Received`: adding/deleting lines now blocked everywhere — modal, toolbar, footer, scanner — and rejected by the server even if attempted via the API.
- `Verified`: unchanged, fully locked via `isInboundDisabled`. The line-status dropdown lock at `Received` is also unchanged.

## 💌 Any notes for the reviewer?

- Detection differs slightly by side, intentionally: the client disables buttons based on the data (`lines.some(line => line.status != null)`, the same signal used to show the auth status column), while the server enforces based on the preference (external shipment + pref on + received). The data-based check handles display for shipments received before a preference change; the pref-based check keeps validation to a single preference load with no extra line query.
- The toolbar AddButton's "upload document" option shares the SplitButton's disabled state, so it's also disabled on an authorised received shipment. Shout if documents should still be uploadable there and I'll split the disable per-option.
- `update_stock_in_line` is intentionally untouched: editing line *details* after receiving is still allowed for users with authorise permission (per #10929).

# 🧪 Testing

Without line authorisation (#11936 repro):

- [ ] Create a manual inbound shipment, add an item with a batch, set status to `Received`
- [ ] Open the item line → "Add batch", duplicate and delete batch are now enabled; add a batch, save, and confirm stock is introduced for it (item ledger)
- [ ] Delete a batch line and confirm its stock line is removed
- [ ] Set the shipment to `Verified` → all batch editing is disabled

With line authorisation:

- [ ] Turn on the `Lines must be authorised on external inbound shipments` preference, create an external inbound shipment (from a purchase order), approve/reject all lines and receive it
- [ ] Confirm "Add item", scanner, footer "Delete lines", "Add batch" and per-batch duplicate/delete are ALL disabled
- [ ] Confirm the line edit modal still opens and other details remain editable with authorise permission

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
