### PR TITLE
11950 Show table settings menu on line edit modal tables

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/SettingsMenu.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/SettingsMenu.tsx
@@ -39,6 +39,7 @@ export const SettingsMenu = ({
   resetTableState,
   onSaveAsGlobalDefault,
   globalDefaults,
+  showDensityToggle = true,
 }: {
   table: MRT_TableInstance<any>;
   tableId: string;
@@ -50,6 +51,8 @@ export const SettingsMenu = ({
   resetTableState: () => void;
   onSaveAsGlobalDefault?: () => void;
   globalDefaults?: ManagedTableState;
+  /** Hide the density toggle for tables with a fixed density (e.g. simple modal tables) */
+  showDensityToggle?: boolean;
 }) => {
   const t = useTranslation();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -175,11 +178,16 @@ export const SettingsMenu = ({
           </ListItemIcon>
           <ListItemText>{t('label.reset-pinned-columns')}</ListItemText>
         </MenuItem>
-        <Divider />
-        <MenuItem onClick={() => density.update(nextDensity)}>
-          <ListItemIcon>{densityIcon()}</ListItemIcon>
-          <ListItemText> {t('label.toggle-density')}</ListItemText>
-        </MenuItem>
+        {showDensityToggle && [
+          <Divider key="density-divider" />,
+          <MenuItem
+            key="density-toggle"
+            onClick={() => density.update(nextDensity)}
+          >
+            <ListItemIcon>{densityIcon()}</ListItemIcon>
+            <ListItemText> {t('label.toggle-density')}</ListItemText>
+          </MenuItem>,
+        ]}
         {onSaveAsGlobalDefault && [
           <Divider key="save-default-divider" />,
           <MenuItem

--- a/client/packages/common/src/ui/layout/tables/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/useBaseMaterialTable.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   MRT_Row,
   MRT_RowData,
+  MRT_TableInstance,
   MRT_TableOptions,
   useMaterialReactTable,
 } from 'material-react-table';
@@ -23,6 +24,7 @@ import {
   useColumnGrouping,
 } from './tableState';
 import { clearSavedState, getSavedState } from './tableState/utils';
+import { SettingsMenu } from './components/SettingsMenu';
 import { DataError, NothingHere } from '@common/components';
 import {
   useIsCentralServerApi,
@@ -50,6 +52,16 @@ export interface BaseTableConfig<T extends MRT_RowData> extends Omit<
     onToggle?: (isGrouped: boolean) => void;
   };
   columns: ColumnDef<T>[];
+  /** Renders a custom bottom toolbar. Receives the settings menu render fn so
+   * tables without a top toolbar (e.g. simple modal tables) can still show the
+   * table settings menu (reset state, save as global default for central
+   * server admins). */
+  bottomToolbar?: (params: {
+    table: MRT_TableInstance<T>;
+    renderSettingsMenu: (opts?: {
+      showDensityToggle?: boolean;
+    }) => React.ReactNode;
+  }) => React.ReactNode;
   /** Keep sorting and filtering in local component state instead of syncing to URL query params. Use for tables in modals, popovers, or anywhere the table state shouldn't affect the URL. */
   localStateOnly?: boolean;
   initialSort?: { key: string; dir: 'asc' | 'desc' };
@@ -67,6 +79,7 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
   getIsRestrictedRow,
   columns: omsColumns,
   data,
+  bottomToolbar,
   grouping: groupingInput,
   enableColumnResizing = true,
   manualFiltering = false,
@@ -163,14 +176,27 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     ? () => saveGlobalTableConfig(tableId, getSavedState(tableId) ?? {})
     : undefined;
 
+  const renderSettingsMenu = (
+    table: MRT_TableInstance<T>,
+    opts?: { showDensityToggle?: boolean }
+  ) => (
+    <SettingsMenu
+      table={table}
+      tableId={tableId}
+      density={density}
+      columnSizing={columnSizing}
+      columnVisibility={columnVisibility}
+      columnPinning={columnPinning}
+      columnOrder={columnOrder}
+      resetTableState={resetTableState}
+      onSaveAsGlobalDefault={onSaveAsGlobalDefault}
+      globalDefaults={resetDefaults}
+      showDensityToggle={opts?.showDensityToggle}
+    />
+  );
+
   const displayOptions = useTableDisplayOptions({
-    tableId,
-    density,
-    columnSizing,
-    columnVisibility,
-    columnPinning,
-    columnOrder,
-    resetTableState,
+    renderSettingsMenu,
     hasColumnFilters,
     onRowClick,
     isGrouped: !!grouping.state.length,
@@ -185,8 +211,6 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     getIsRestrictedRow,
     muiTableBodyRowProps,
     isMobile,
-    onSaveAsGlobalDefault,
-    globalDefaults: resetDefaults,
   });
 
   const table = useMaterialReactTable<T>({
@@ -217,6 +241,13 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
 
     // Disable bottom footer - use OMS custom action footer instead
     enableBottomToolbar: false,
+    renderBottomToolbar: bottomToolbar
+      ? ({ table }) =>
+          bottomToolbar({
+            table,
+            renderSettingsMenu: opts => renderSettingsMenu(table, opts),
+          })
+      : undefined,
 
     // Grouping options
     enableGrouping: true,

--- a/client/packages/common/src/ui/layout/tables/useSimpleMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/useSimpleMaterialTable.tsx
@@ -31,7 +31,7 @@ export const useSimpleMaterialTable = <T extends MRT_RowData>({
       sorting: [],
     },
     ...tableOptions,
-    renderBottomToolbar: ({ table }) => (
+    bottomToolbar: ({ table, renderSettingsMenu }) => (
       <Box
         sx={{
           display: 'flex',
@@ -40,6 +40,8 @@ export const useSimpleMaterialTable = <T extends MRT_RowData>({
         }}
       >
         <MRT_ShowHideColumnsButton table={table} />
+        {/* Density is pinned to compact for simple tables, so hide the toggle */}
+        {renderSettingsMenu({ showDensityToggle: false })}
         {bottomToolbarContent && (
           <Box sx={{ marginLeft: 'auto' }}>{bottomToolbarContent}</Box>
         )}

--- a/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
@@ -3,6 +3,7 @@ import {
   MRT_Row,
   MRT_RowData,
   MRT_ShowHideColumnsButton,
+  MRT_TableInstance,
   MRT_TableOptions,
   MRT_ToggleFiltersButton,
   MRT_ToggleFullScreenButton,
@@ -19,25 +20,10 @@ import { ColumnDef } from './types';
 import { IconButton } from '@common/components';
 import { useTranslation } from '@common/intl';
 import { EnvUtils } from '@common/utils';
-import { SettingsMenu } from './components/SettingsMenu';
-import { ManagedTableState } from './tableState/utils';
-import {
-  useColumnDensity,
-  useColumnOrder,
-  useColumnPinning,
-  useColumnSizing,
-  useColumnVisibility,
-} from './tableState';
 import { useTableKeyboardNavigation } from './useTableKeyboardNavigation';
 
 export const useTableDisplayOptions = <T extends MRT_RowData>({
-  tableId,
-  density,
-  columnSizing,
-  columnVisibility,
-  columnPinning,
-  columnOrder,
-  resetTableState,
+  renderSettingsMenu,
   onRowClick,
   isGrouped,
   toggleGrouped,
@@ -47,16 +33,8 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
   getIsRestrictedRow = () => false,
   muiTableBodyRowProps = {},
   isMobile = false,
-  onSaveAsGlobalDefault,
-  globalDefaults,
 }: {
-  tableId: string;
-  density: ReturnType<typeof useColumnDensity>;
-  columnSizing: ReturnType<typeof useColumnSizing>;
-  columnVisibility: ReturnType<typeof useColumnVisibility>;
-  columnPinning: ReturnType<typeof useColumnPinning>;
-  columnOrder: ReturnType<typeof useColumnOrder>;
-  resetTableState: () => void;
+  renderSettingsMenu: (table: MRT_TableInstance<T>) => React.ReactNode;
   onRowClick?: (row: T, isCtrlClick: boolean) => void;
   isGrouped: boolean;
   hasColumnFilters: boolean;
@@ -65,8 +43,6 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
   getIsPlaceholderRow?: (row: MRT_Row<T>) => boolean;
   getIsRestrictedRow?: (row: MRT_Row<T>) => boolean;
   isMobile?: boolean;
-  onSaveAsGlobalDefault?: () => void;
-  globalDefaults?: ManagedTableState;
 
   // This object is merged with the default row props in muiTableBodyRowProps
   // below. We can do the same for other muiTable props if needed in future.
@@ -138,18 +114,7 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
         {hasColumnFilters && <MRT_ToggleFiltersButton table={table} />}
         <MRT_ShowHideColumnsButton table={table} />
         {!isMobile && <MRT_ToggleFullScreenButton table={table} />}
-        <SettingsMenu
-          table={table}
-          tableId={tableId}
-          density={density}
-          columnSizing={columnSizing}
-          columnVisibility={columnVisibility}
-          columnPinning={columnPinning}
-          columnOrder={columnOrder}
-          resetTableState={resetTableState}
-          onSaveAsGlobalDefault={onSaveAsGlobalDefault}
-          globalDefaults={globalDefaults}
-        />
+        {renderSettingsMenu(table)}
       </>
     ),
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Related to #11950 — stacked on #11951 (base branch is `11950-add-manufacturer-column-to-outbound-shipment-line-edit-modal`).

# 👩🏻‍💻 What does this PR do?

Adds the table **settings menu** (gear icon) to the bottom toolbar of "simple" tables — the line edit modal style tables — next to the existing show/hide columns button.

Simple tables disable MRT's top toolbar, which is where the settings menu lived, so there was no way to reach **"Save table config as global default"** on them. That matters for #11951: the manufacturer column in the outbound shipment line edit modal is hidden by default, and the intended way to enable it deployment-wide is the global table config — which central server admins simply couldn't set on that table. The tables already *honoured* a global config for their `tableId`; there was just no UI to save one.

Implementation:
- `useBaseMaterialTable` now builds the `SettingsMenu` render function (it owns all the column-state hooks) and exposes it via a new `bottomToolbar` option
- `useTableDisplayOptions` receives the render function for the top toolbar instead of constructing the menu itself (no behaviour change for full tables)
- `useSimpleMaterialTable` renders the gear next to the eye button in its bottom toolbar
- `SettingsMenu` gains a `showDensityToggle` prop — hidden for simple tables since they pin density to `compact`, so the toggle would silently do nothing there

## 💌 Any notes for the reviewer?

- This is a refactor of where `SettingsMenu` gets constructed, but full (paginated/non-paginated) tables are visually and behaviourally unchanged.
- The gear appears on **every** `useSimpleMaterialTable` usage (~24 call sites: outbound/prescription/stocktake line edit, repack, returns, item variants, history modal, etc.). All users get the reset options; only central server admins with the Edit Central Data permission see "Save table config as global default" — same gating as full tables.
- Manually verified in-app on: prescription line edit (Batches), outbound line edit modal (menu renders correctly above the dialog), stocktake add-item modal, repack modal, item packaging variants, prescription history modal (including hide column → "Show all columns" restore). Screenshots to be attached.

# 🧪 Testing

- [ ] Open an outbound shipment line edit modal — confirm the gear icon shows next to the show/hide columns (eye) button below the table
- [ ] Hide a column via the eye button, then open the gear — "Show all columns" should be enabled and restore the column
- [ ] Confirm the gear menu has **no** "Toggle density" item on modal tables (density is fixed to compact there)
- [ ] As an admin on the central server: hide a column (e.g. Manufacturer), gear → "Save table config as global default", then log in as a non-admin user / other site and confirm the column is hidden by default on that table
- [ ] Spot-check a few other simple tables (stocktake line edit, repack modal, prescription history, item packaging variants) — gear present, menu works
- [ ] Confirm full tables (e.g. outbound shipment list) look and behave exactly as before, including the density toggle in their settings menu

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1. Table settings menu (reset/save global config) is now also available on line edit modal tables via the gear in the bottom toolbar

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

