### PR TITLE
11878 Cannot get back to store selector page on login if opted out

### DIFF
--- a/client/packages/host/src/components/Footer/StoreSelector.tsx
+++ b/client/packages/host/src/components/Footer/StoreSelector.tsx
@@ -1,10 +1,13 @@
 import React, { FC, useState, useMemo } from 'react';
 import {
   Box,
+  Checkbox,
   CircularProgress,
   FlatButton,
   PaperPopoverSection,
+  Typography,
   useAuthContext,
+  useLocalStorage,
   useTranslation,
   useNavigate,
   useUserDetails,
@@ -12,14 +15,26 @@ import {
   useRootNavigationPath,
   PaperPopover,
 } from '@openmsupply-client/common';
+import { FormControlLabel } from '@mui/material';
 import { PropsWithChildrenOnly, UserStoreNodeFragment } from '@common/types';
 
 export const StoreSelector: FC<PropsWithChildrenOnly> = ({ children }) => {
   const t = useTranslation();
   const navigate = useNavigate();
-  const { store, setStore, token } = useAuthContext();
+  const { store, setStore, token, mostRecentUsername } = useAuthContext();
   const { data, isLoading } = useUserDetails(token);
   const [popoverAnchor, setPopoverAnchor] = useState<HTMLElement | null>(null);
+  const [skipPrefs, setSkipPrefs] = useLocalStorage(
+    '/login/skip-store-selector',
+    {}
+  );
+
+  // For store selector on login
+  const skipKey = (mostRecentUsername ?? '').toLowerCase();
+  const rememberChoice = !!(skipPrefs ?? {})[skipKey];
+  const setRememberChoice = (checked: boolean) => {
+    if (skipKey) setSkipPrefs({ ...(skipPrefs ?? {}), [skipKey]: checked });
+  };
 
   const rootNavigationPath = useRootNavigationPath();
 
@@ -102,13 +117,30 @@ export const StoreSelector: FC<PropsWithChildrenOnly> = ({ children }) => {
                 ) : (
                   <FlatButton
                     label={t('control.search.no-results-label')}
-                    onClick={() => {}}
+                    onClick={() => { }}
                     disabled={true}
                     key="no-results"
                     sx={buttonStyle}
                   />
                 )}
               </Box>
+              <FormControlLabel
+                sx={{ marginTop: 1 }}
+                control={
+                  <Checkbox
+                    checked={rememberChoice}
+                    onChange={e => setRememberChoice(e.target.checked)}
+                    size="small"
+                  />
+                }
+                label={
+                  <Typography
+                    sx={{ fontSize: '14px', color: 'text.secondary' }}
+                  >
+                    {t('message.remember-store-choice')}
+                  </Typography>
+                }
+              />
             </>
           )}
         </PaperPopoverSection>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11878

# 👩🏻‍💻 What does this PR do?
Allow the user to clear "remember my choice" selection for login store selector through the store popover in the footer.


There is a lozenge in the screenshot in issue, but think that should be implemented once we decide what login behaviour should be, i.e. should the user be logged into default store, or last logged in? 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have more than 2 stores for a user
- [ ] Login -> Select "Remember my choice"
- [ ] Logout -> Shouldn't see store selector when logging in 
- [ ] Login again and click store popover in the footer
- [ ] Untick "Remember my choice"
- [ ] Logout -> Login
- [ ] See store selector again 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

