### PR TITLE
11212 no 'cancel' button in store tab 'preferences' (unlike 'properties' tab)

### DIFF
--- a/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
+++ b/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
@@ -35,6 +35,7 @@ interface EditPreferenceProps {
   label?: string;
   isLast?: boolean;
   disabled?: boolean;
+  isAutoSave?: boolean; // Global Prefs auto-save instead of using draft
 }
 
 export const EditPreference = ({
@@ -43,6 +44,7 @@ export const EditPreference = ({
   label,
   isLast = false,
   disabled: disabledProp,
+  isAutoSave = true,
 }: EditPreferenceProps) => {
   const t = useTranslation();
   const { error } = useNotification();
@@ -69,23 +71,24 @@ export const EditPreference = ({
   const [value, setValue] = useState(preference.value);
   const [hasError, setHasError] = useState(false);
 
-  const debouncedUpdate = useDebouncedValueCallback(
-    async value => {
-      const success = await update(value);
-      setHasError(!success);
+  const onUpdate = async (newValue: PreferenceDescriptionNode['value']) => {
+    const success = await update(newValue);
+    setHasError(!success);
 
-      if (!success) {
-        // If update fails, revert to original value
-        setValue(preference.value);
-      }
-    },
-    [],
-    350
-  );
+    if (!success) {
+      setValue(preference.value);
+    }
+  };
+
+  const debouncedUpdate = useDebouncedValueCallback(onUpdate, [], 350);
 
   const handleChange = (newValue: PreferenceDescriptionNode['value']) => {
     setValue(newValue);
-    debouncedUpdate(newValue);
+    if (isAutoSave) {
+      debouncedUpdate(newValue);
+    } else {
+      onUpdate(newValue);
+    }
   };
 
   switch (preference.valueType) {
@@ -119,7 +122,7 @@ export const EditPreference = ({
             <NumericTextInput
               value={value}
               onChange={handleChange}
-              onBlur={() => {}}
+              onBlur={() => { }}
               disabled={disabled}
               decimalLimit={
                 preference.valueType === PreferenceValueNodeType.Float
@@ -143,16 +146,16 @@ export const EditPreference = ({
             <BasicTextInput
               value={value}
               onChange={e => handleChange(e.target.value)}
-              onBlur={() => {}}
+              onBlur={() => { }}
               disabled={disabled}
               sx={
                 hasError
                   ? {
-                      borderColor: theme => theme.palette.error.main,
-                      borderWidth: '2px',
-                      borderStyle: 'solid',
-                      borderRadius: '8px',
-                    }
+                    borderColor: theme => theme.palette.error.main,
+                    borderWidth: '2px',
+                    borderStyle: 'solid',
+                    borderRadius: '8px',
+                  }
                   : undefined
               }
             />

--- a/client/packages/system/src/Manage/Preferences/api/useEditPreference.ts
+++ b/client/packages/system/src/Manage/Preferences/api/useEditPreference.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import {
   isEmpty,
   PreferenceNodeType,
@@ -5,6 +6,7 @@ import {
   UpsertPreferencesInput,
   useMutation,
   useNotification,
+  usePatchState,
   useTranslation,
 } from '@openmsupply-client/common';
 import { usePreferencesGraphQL } from './usePreferencesGraphQL';
@@ -34,9 +36,26 @@ export const useEditPreferences = (
     }
   };
 
+  const { patch, updatePatch, resetDraft, isDirty } =
+    usePatchState<UpsertPreferencesInput>({});
+
+  useEffect(() => {
+    resetDraft();
+  }, [storeId, resetDraft]);
+
+  const saveDraft = async (): Promise<boolean> => {
+    if (isEmpty(patch)) return true;
+    return update(patch);
+  };
+
   return {
     preferences: data ?? [],
     update,
+    draft: patch,
+    updateDraft: updatePatch,
+    resetDraft,
+    saveDraft,
+    isDirty,
   };
 };
 
@@ -63,13 +82,8 @@ const useUpsertPref = () => {
         queryKey: [PREFERENCE_DESCRIPTION_QUERY_KEY],
       });
       queryClient.invalidateQueries({
-        queryKey: [
-          'dashboard',
-          'count',
-          requestStoreId,
-          'stock',
-        ]
+        queryKey: ['dashboard', 'count', requestStoreId, 'stock'],
       });
-    }
+    },
   });
 };

--- a/client/packages/system/src/Name/ListView/Stores/EditStorePreferences.tsx
+++ b/client/packages/system/src/Name/ListView/Stores/EditStorePreferences.tsx
@@ -1,27 +1,27 @@
 import React from 'react';
 import {
   NothingHere,
-  PreferenceNodeType,
+  PreferenceDescriptionNode,
   PreferenceValueNodeType,
+  UpsertPreferencesInput,
 } from '@openmsupply-client/common';
 import {
   EditPreference,
   PreferenceSearchInput,
-  useEditPreferences,
   usePreferenceSearch,
 } from '../../../Manage/Preferences';
 
 interface EditStorePreferencesProps {
   storeId: string;
+  preferences: PreferenceDescriptionNode[];
+  update: (input: Partial<UpsertPreferencesInput>) => void;
 }
 
 export const EditStorePreferences = ({
   storeId,
+  preferences,
+  update,
 }: EditStorePreferencesProps) => {
-  const { update, preferences } = useEditPreferences(
-    PreferenceNodeType.Store,
-    storeId
-  );
   const { searchTerm, setSearchTerm, filteredPreferences, hasSearchTerm } =
     usePreferenceSearch(preferences);
 
@@ -39,15 +39,18 @@ export const EditStorePreferences = ({
             <EditPreference
               key={pref.key}
               preference={pref}
-              update={value => {
+              isAutoSave={false}
+              update={async value => {
                 const finalValue =
-                  ((pref.valueType === PreferenceValueNodeType.Integer || pref.valueType === PreferenceValueNodeType.Float) &&
-                    value === undefined)
+                  (pref.valueType === PreferenceValueNodeType.Integer ||
+                    pref.valueType === PreferenceValueNodeType.Float) &&
+                    value === undefined
                     ? 0
                     : value;
-                return update({
+                update({
                   [pref.key]: [{ storeId, value: finalValue }],
                 });
+                return true;
               }}
               isLast={isLast}
             />

--- a/client/packages/system/src/Name/ListView/Stores/StoreEditModal.tsx
+++ b/client/packages/system/src/Name/ListView/Stores/StoreEditModal.tsx
@@ -12,6 +12,9 @@ import {
   TabContext,
   TabPanel,
   NamePropertyNode,
+  PreferenceDescriptionNode,
+  PreferenceNodeType,
+  UpsertPreferencesInput,
 } from '@openmsupply-client/common';
 import { useName } from '../../api';
 import { NameRenderer } from '../..';
@@ -22,6 +25,7 @@ import {
   useDraftStoreProperties,
 } from './useDraftStoreProperties';
 import { EditStorePreferences } from './EditStorePreferences';
+import { useEditPreferences } from '../../../Manage/Preferences';
 
 interface StoreEditModalProps {
   nameId: string;
@@ -48,13 +52,21 @@ export const StoreEditModal = ({
   const { draftProperties, setDraftProperties } = useDraftStoreProperties(
     data?.properties
   );
+  const {
+    preferences,
+    updateDraft: update,
+    saveDraft: savePreferences,
+  } = useEditPreferences(PreferenceNodeType.Store, data?.store?.id);
   const [currentTab, setCurrentTab] = useState(Tabs.Properties);
 
   const save = async () => {
-    mutateAsync({
-      id: nameId,
-      properties: JSON.stringify(draftProperties),
-    });
+    if (draftProperties && Object.keys(draftProperties).length > 0) {
+      await mutateAsync({
+        id: nameId,
+        properties: JSON.stringify(draftProperties),
+      });
+    }
+    await savePreferences();
   };
 
   if (isLoading || propertiesLoading) return <BasicSpinner />;
@@ -62,18 +74,12 @@ export const StoreEditModal = ({
   return !!data ? (
     <Modal
       title=""
-      cancelButton={
-        currentTab !== Tabs.Preferences ? (
-          <DialogButton variant="cancel" onClick={onClose} />
-        ) : undefined
-      }
+      cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
       okButton={
         <DialogButton
-          variant="ok"
+          variant="save"
           onClick={async () => {
-            if (draftProperties && Object.keys(draftProperties).length > 0) {
-              await save();
-            }
+            await save();
             onClose();
           }}
         />
@@ -133,6 +139,8 @@ export const StoreEditModal = ({
             updateProperty={patch =>
               setDraftProperties({ ...draftProperties, ...patch })
             }
+            preferences={preferences}
+            update={update}
             currentTab={currentTab}
             setCurrentTab={setCurrentTab}
           />
@@ -152,6 +160,8 @@ interface ModalTabProps {
   propertyConfigs: NamePropertyNode[];
   draftProperties: DraftProperties;
   updateProperty: (update: DraftProperties) => void;
+  preferences: PreferenceDescriptionNode[];
+  update: (input: Partial<UpsertPreferencesInput>) => void;
   currentTab: Tabs;
   setCurrentTab: (tab: Tabs) => void;
 }
@@ -161,6 +171,8 @@ const ModalTabs = ({
   propertyConfigs,
   draftProperties,
   updateProperty,
+  preferences,
+  update,
   currentTab,
   setCurrentTab,
 }: ModalTabProps) => {
@@ -199,7 +211,11 @@ const ModalTabs = ({
             height: '100%',
           }}
         >
-          <EditStorePreferences storeId={storeId} />
+          <EditStorePreferences
+            storeId={storeId}
+            preferences={preferences}
+            update={update}
+          />
         </TabPanel>
       )}
     </TabContext>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11212

# 👩🏻‍💻 What does this PR do?
Change the store pref edit modal to draft then save. This means the user has to click the save button to actually apply preferences
<img width="797" height="1179" alt="pref modal" src="https://github.com/user-attachments/assets/62009725-2b47-43ce-8a0a-4a996d8262d1" />

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to store preferences
- [ ] See save button
- [ ] Try changing preferences click cancel
- [ ] Go back to modal, preferences should have reset to before changes
- [ ] Now change some and click save
- [ ] Should save 
- [ ] Global preferences should still be auto-save situation

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

