### PR TITLE
12001 In a cancelled prescription, you can interact with the Next button

### DIFF
--- a/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
+++ b/client/packages/invoices/src/Prescriptions/LineEditView/LineEditView.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import {
   BasicSpinner,
-  InvoiceNodeStatus,
   NothingHere,
   RouteBuilder,
   useBreadcrumbs,
@@ -67,8 +66,6 @@ export const PrescriptionLineEditView = () => {
 
   const lines =
     data?.lines.nodes.sort((a, b) => a.id.localeCompare(b.id)) ?? [];
-
-  const status = data?.status;
 
   // Future TODO: expose on Prescription/Invoice query - items, and whether they have
   // any packs allocated or not!
@@ -155,7 +152,7 @@ export const PrescriptionLineEditView = () => {
   if (!data) return <NothingHere />;
 
   const itemIdList = items.map(item => item.id);
-  if (status !== InvoiceNodeStatus.Verified) itemIdList.push('new');
+  if (!isDisabled) itemIdList.push('new');
 
   return (
     <>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12001

# 👩🏻‍💻 What does this PR do?
Don't allow pressing of next button in line edit if prescription cancelled

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have a verified/cancelled prescription
- [ ] Click no line edit
- [ ] See next button disabled

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

