### PR TITLE
11885 Fix sync initialisation failing on multiple-site central servers

### DIFF
--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -365,41 +365,6 @@ impl<'a> ChangelogRepository<'a> {
         Ok(result)
     }
 
-    /// This returns the number of changelog records that should be evaluated to send to the remote site when doing a v6_pull
-    /// This looks up associated records to decide if change log should be sent to the site or not
-    /// Update this method when adding new record types to the system
-    pub fn count_outgoing_sync_records_from_central(
-        &self,
-        earliest: u64,
-        sync_site_id: i32,
-        is_initialized: bool,
-    ) -> Result<u64, RepositoryError> {
-        let query = clamp_to_safe_cursor(
-            self.connection,
-            create_filtered_outgoing_sync_query(earliest, sync_site_id, is_initialized),
-        );
-        let result = query
-            .count()
-            .get_result::<i64>(self.connection.lock().connection())?;
-        Ok(result as u64)
-    }
-
-    pub fn count_outgoing_patient_sync_records_from_central(
-        &self,
-        earliest: u64,
-        sync_site_id: i32,
-        fetch_patient_id: String,
-    ) -> Result<u64, RepositoryError> {
-        let query = clamp_to_safe_cursor(
-            self.connection,
-            create_filtered_outgoing_patient_sync_query(earliest, sync_site_id, fetch_patient_id),
-        );
-        let result = query
-            .count()
-            .get_result::<i64>(self.connection.lock().connection())?;
-        Ok(result as u64)
-    }
-
     /// Returns latest change log
     /// After initial sync we use this method to get the latest cursor to make sure we don't try to push any records that were synced to this site on initialisation
     pub fn absolute_latest_cursor(&self) -> Result<u64, RepositoryError> {

--- a/server/repository/src/migrations/views/changelog_deduped.rs
+++ b/server/repository/src/migrations/views/changelog_deduped.rs
@@ -19,11 +19,12 @@ impl ViewMigrationFragment for ViewMigration {
         sql!(
             connection,
             r#"
-                -- View of the changelog that only contains the most recent changes to a row, i.e. previous row
-    -- edits are removed.
-    -- Note, an insert + delete will show up as an orphaned delete.
-    -- For records that can be transferred between stores (like assets), we need to group by both
-    -- record_id and store_id to ensure changes are not lost when an asset is moved.
+                -- Most recent change per row only (an insert + delete shows as an orphaned delete).
+    -- Dedupe by (record_id, store_id) so store transfers (e.g. assets) aren't lost.
+    -- "Keep the row with no newer row for the same key" (NOT EXISTS anti-join) is equivalent to the
+    -- old GROUP BY MAX(cursor) self-join (cursor is unique), but lets the planner push a
+    -- `WHERE cursor >= ?` down to the cursor index instead of deduping the whole changelog first -
+    -- turning per-batch sync queries on a large changelog from a full scan into a tail scan.
   CREATE VIEW changelog_deduped AS
     SELECT c.cursor,
         c.table_name,
@@ -34,16 +35,15 @@ impl ViewMigrationFragment for ViewMigration {
         c.store_id,
         c.is_sync_update,
         c.source_site_id
-    FROM (
-        SELECT record_id, store_id, MAX(cursor) AS max_cursor
-        FROM changelog
-        GROUP BY record_id, store_id
-    ) grouped
-    INNER JOIN changelog c
-        ON c.record_id = grouped.record_id 
-        AND (c.store_id = grouped.store_id OR (c.store_id IS NULL AND grouped.store_id IS NULL))
-        AND c.cursor = grouped.max_cursor
+    FROM changelog c
     LEFT JOIN name_link ON c.name_link_id = name_link.id
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM changelog newer
+        WHERE newer.record_id = c.record_id
+            AND (newer.store_id = c.store_id OR (newer.store_id IS NULL AND c.store_id IS NULL))
+            AND newer.cursor > c.cursor
+    )
     ORDER BY c.cursor;            "#
         )?;
 

--- a/server/service/src/ledger_fix/ledger_fix_driver.rs
+++ b/server/service/src/ledger_fix/ledger_fix_driver.rs
@@ -61,18 +61,29 @@ impl LedgerFixDriver {
 }
 
 async fn ledger_fix(service_provider: Arc<ServiceProvider>) {
-    let ctx = service_provider.basic_context().unwrap();
+    // Runs on the main loop, so never panic: a transient pool-exhaustion failure here would crash
+    // the server. Log and skip; the loop retries next interval.
+    let ctx = match service_provider.basic_context() {
+        Ok(ctx) => ctx,
+        Err(error) => {
+            log::error!(
+                "Ledger fix: skipping run, could not acquire DB context (DB unavailable?): {error:?}"
+            );
+            return;
+        }
+    };
 
     let stock_line_ids = match find_stock_line_ledger_discrepancies(&ctx.connection, None) {
         Ok(stock_line_ids) => stock_line_ids,
         Err(e) => {
-            system_error_log(
+            if let Err(log_error) = system_error_log(
                 &ctx.connection,
                 SystemLogType::LedgerFixError,
                 &e,
                 "Error while finding stock line ledger discrepancies",
-            )
-            .unwrap();
+            ) {
+                log::error!("Ledger fix: failed to write system log: {log_error:?}");
+            }
             return;
         }
     };
@@ -83,7 +94,9 @@ async fn ledger_fix(service_provider: Arc<ServiceProvider>) {
         stock_line_ids
     );
 
-    system_log(&ctx.connection, SystemLogType::LedgerFixError, &error_msg).unwrap()
+    if let Err(log_error) = system_log(&ctx.connection, SystemLogType::LedgerFixError, &error_msg) {
+        log::error!("Ledger fix: failed to write system log: {log_error:?}");
+    }
 }
 
 impl LedgerFixTrigger {
@@ -105,8 +118,14 @@ impl LedgerFixTrigger {
 async fn delay(service_provider: Arc<ServiceProvider>, duration: Duration) -> bool {
     tokio::time::sleep(duration).await;
 
-    let last_ledger_fix_run = get_last_ledger_fix_run(&service_provider)
-        .expect("Repository error while getting last ledger fix run");
+    let last_ledger_fix_run = match get_last_ledger_fix_run(&service_provider) {
+        Ok(value) => value,
+        Err(error) => {
+            // Don't panic the main loop on a transient DB error - skip and retry next interval.
+            log::error!("Ledger fix: skipping run, could not read last run (DB unavailable?): {error:?}");
+            return false;
+        }
+    };
 
     // Do ledger fix if date is not set yet
     let Some(last_ledger_fix_run) = last_ledger_fix_run else {
@@ -122,7 +141,7 @@ async fn delay(service_provider: Arc<ServiceProvider>, duration: Duration) -> bo
 fn get_last_ledger_fix_run(
     service_provider: &ServiceProvider,
 ) -> Result<Option<NaiveDateTime>, RepositoryError> {
-    let ctx = service_provider.basic_context().unwrap();
+    let ctx = service_provider.basic_context()?;
     let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
 
     // Get and parse last ledger fix run, if not set or filed to parse return epoch
@@ -145,14 +164,22 @@ fn get_last_ledger_fix_run(
 }
 
 fn set_last_ledger_fix_run(service_provider: &ServiceProvider) {
-    let ctx = service_provider.basic_context().unwrap();
+    let ctx = match service_provider.basic_context() {
+        Ok(ctx) => ctx,
+        Err(error) => {
+            log::error!(
+                "Ledger fix: could not record last run, DB context unavailable: {error:?}"
+            );
+            return;
+        }
+    };
     let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
 
     let now = Utc::now().naive_utc();
     let now_string =
         serde_json::to_string(&now).expect("Failed to serialize last ledger fix run datetime");
 
-    key_value_store
-        .set_string(KeyType::LastLedgerFixRun, Some(now_string))
-        .expect("Database error while setting last ledger fix run");
+    if let Err(error) = key_value_store.set_string(KeyType::LastLedgerFixRun, Some(now_string)) {
+        log::error!("Ledger fix: failed to persist last run datetime: {error:?}");
+    }
 }

--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -202,18 +202,33 @@ impl SyncApiV5 {
     /// Poll `/sync/v5/site_status` until central reports `Idle`. Used to wait out a
     /// "central busy" response (another sync session for this site is in progress;
     /// legacy central gates sync per-site) before retrying. Errors on timeout.
-    pub(crate) async fn wait_until_central_idle(&self) -> Result<(), SyncApiError> {
+    pub(crate) async fn wait_until_central_idle(
+        &self,
+        poll_period_seconds: u64,
+        timeout_seconds: u64,
+    ) -> Result<(), SyncApiError> {
         let route = "/sync/v5/site_status";
         let start = std::time::SystemTime::now();
-        let poll_period = std::time::Duration::from_secs(CENTRAL_BUSY_POLL_PERIOD_SECONDS);
-        let timeout = std::time::Duration::from_secs(CENTRAL_BUSY_TIMEOUT_SECONDS);
+        let poll_period = std::time::Duration::from_secs(poll_period_seconds);
+        let timeout = std::time::Duration::from_secs(timeout_seconds);
         log::info!("Central server busy with another sync session for this site; waiting for it to become idle...");
         loop {
             tokio::time::sleep(poll_period).await;
 
-            if self.get_site_status().await?.code == SiteStatusCodeV5::Idle {
-                log::info!("Central server is idle; retrying request");
-                return Ok(());
+            match self.get_site_status().await {
+                Ok(status) if status.code == SiteStatusCodeV5::Idle => {
+                    log::info!("Central server is idle; retrying request");
+                    return Ok(());
+                }
+                Ok(_) => {}
+                // Transient poll failures don't mean central is still busy; retry until timeout.
+                Err(error) if error.is_transient() => {
+                    log::warn!(
+                        "Polling central site status failed while waiting for idle (will retry): {:#?}",
+                        error
+                    );
+                }
+                Err(error) => return Err(error),
             }
 
             if start.elapsed().unwrap_or(timeout) >= timeout {
@@ -230,8 +245,8 @@ impl SyncApiV5 {
 
 // When central is busy with another sync session for this site, poll site status
 // this often, up to this long, before giving up.
-const CENTRAL_BUSY_POLL_PERIOD_SECONDS: u64 = 15;
-const CENTRAL_BUSY_TIMEOUT_SECONDS: u64 = 30 * 60;
+pub(crate) const CENTRAL_BUSY_POLL_PERIOD_SECONDS: u64 = 15;
+pub(crate) const CENTRAL_BUSY_TIMEOUT_SECONDS: u64 = 30 * 60;
 
 #[derive(Error, Debug)]
 pub enum ParsingResponseError {
@@ -323,6 +338,7 @@ pub async fn validate_site_auth(
 mod tests {
     use httpmock::{Method::POST, MockServer};
     use reqwest::header::AUTHORIZATION;
+    use util::assert_matches;
 
     use super::*;
 
@@ -379,5 +395,25 @@ mod tests {
             .await;
 
         assert!(result_with_auth.is_err());
+    }
+
+    /// A transient (connection) failure polling `/sync/v5/site_status` must not abort the wait
+    /// outright - it should be tolerated and retried until the timeout below, same as central
+    /// genuinely still being busy. (Old behaviour: a bare `?` on the failing poll would return
+    /// `Err` immediately here, on the very first iteration, well before the 1s timeout - this is
+    /// the regression this PR followup fixes.)
+    #[actix_rt::test]
+    async fn test_wait_until_central_idle_tolerates_transient_poll_errors() {
+        let api = SyncApiV5::new_test("http://localhost:9999", "", "", "site_id");
+
+        let result = api.wait_until_central_idle(0, 1).await;
+
+        assert_matches!(
+            result,
+            Err(SyncApiError {
+                source: SyncApiErrorVariantV5::Other(_),
+                ..
+            })
+        );
     }
 }

--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -11,7 +11,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
 use thiserror::Error;
 use url::ParseError;
-use util::{format_error, with_retries, RetrySeconds};
+use util::{format_error, with_retries_opts, RetrySeconds};
 
 use super::*;
 
@@ -132,7 +132,10 @@ impl SyncApiV5 {
             .join(route)
             .map_err(|error| self.api_error(route, error.into()))?;
 
-        let result = with_retries(RetrySeconds::default(), |client| {
+        // Don't retry idle-timeouts: legacy sync v5 requests can run for minutes server-side
+        // and continue after the client gives up; retrying would overlap the same site's
+        // in-flight request and trip `sync_is_running`. Connect errors are still retried.
+        let result = with_retries_opts(RetrySeconds::default(), false, |client| {
             client
                 .get(url.clone())
                 .headers(tuple_vec_to_header(vec![
@@ -170,7 +173,8 @@ impl SyncApiV5 {
             .join(route)
             .map_err(|error| self.api_error(route, error.into()))?;
 
-        let result = with_retries(RetrySeconds::default(), |client| {
+        // See `do_get`: don't retry idle-timeouts for sync v5 (avoids same-site self-overlap).
+        let result = with_retries_opts(RetrySeconds::default(), false, |client| {
             client
                 .post(url.clone())
                 .headers(tuple_vec_to_header(vec![
@@ -194,7 +198,40 @@ impl SyncApiV5 {
     pub(crate) async fn do_empty_post(&self, route: &str) -> Result<Response, SyncApiError> {
         self.do_post(route, &json!({})).await
     }
+
+    /// Poll `/sync/v5/site_status` until central reports `Idle`. Used to wait out a
+    /// "central busy" response (another sync session for this site is in progress;
+    /// legacy central gates sync per-site) before retrying. Errors on timeout.
+    pub(crate) async fn wait_until_central_idle(&self) -> Result<(), SyncApiError> {
+        let route = "/sync/v5/site_status";
+        let start = std::time::SystemTime::now();
+        let poll_period = std::time::Duration::from_secs(CENTRAL_BUSY_POLL_PERIOD_SECONDS);
+        let timeout = std::time::Duration::from_secs(CENTRAL_BUSY_TIMEOUT_SECONDS);
+        log::info!("Central server busy with another sync session for this site; waiting for it to become idle...");
+        loop {
+            tokio::time::sleep(poll_period).await;
+
+            if self.get_site_status().await?.code == SiteStatusCodeV5::Idle {
+                log::info!("Central server is idle; retrying request");
+                return Ok(());
+            }
+
+            if start.elapsed().unwrap_or(timeout) >= timeout {
+                return Err(self.api_error(
+                    route,
+                    SyncApiErrorVariantV5::Other(anyhow::anyhow!(
+                        "Timed out waiting for central server to become idle"
+                    )),
+                ));
+            }
+        }
+    }
 }
+
+// When central is busy with another sync session for this site, poll site status
+// this often, up to this long, before giving up.
+const CENTRAL_BUSY_POLL_PERIOD_SECONDS: u64 = 15;
+const CENTRAL_BUSY_TIMEOUT_SECONDS: u64 = 30 * 60;
 
 #[derive(Error, Debug)]
 pub enum ParsingResponseError {

--- a/server/service/src/sync/api/error.rs
+++ b/server/service/src/sync/api/error.rs
@@ -134,13 +134,19 @@ impl SyncApiError {
         matches!(self.source, SyncApiErrorVariantV5::Other(_))
     }
 
-    /// Central is still building the initial sync queue (common for large
-    /// legacy datasets); caller should poll instead of failing the sync.
-    pub(crate) fn is_initialisation_in_progress(&self) -> bool {
+    /// Central is busy with another session for this site (sync / integration / initialisation in
+    /// progress). Caller should wait for central to be idle and retry.
+    pub(crate) fn is_central_busy(&self) -> bool {
         matches!(
             &self.source,
             SyncApiErrorVariantV5::ParsedError { source, .. }
-                if matches!(&source.code, SyncErrorCodeV5::Other(code) if code == "initialisation_in_progress")
+                if matches!(
+                    &source.code,
+                    SyncErrorCodeV5::Other(code)
+                        if code == "sync_is_running"
+                            || code == "integration_in_progress"
+                            || code == "initialisation_in_progress"
+                )
         )
     }
 }
@@ -338,33 +344,41 @@ mod test {
         );
     }
 
-    /// `503 initialisation_in_progress` must be classified as benign so
-    /// `request_initialisation` polls instead of failing; others must not be.
+    /// The three transient "central busy" codes must classify as busy (so callers poll and
+    /// retry instead of failing). Connection / unrelated errors must not.
     #[actix_rt::test]
-    async fn test_is_initialisation_in_progress() {
-        // 503 with `initialisation_in_progress` code -> classified as in-progress
-        let mock_server = MockServer::start();
-        let url = mock_server.base_url();
-
-        mock_server.mock(|when, then| {
-            when.method(POST).path("/sync/v5/initialise");
-            then.status(503).body(
-                r#"{
-                    "error": {
-                        "code": "initialisation_in_progress",
-                        "message": "Initialisation in progress",
-                        "data": null
-                    }
-                }"#,
+    async fn test_central_busy_classification() {
+        // Helper: stand up a mock that returns `code` with 503 on /initialise, and return
+        // the resulting parsed error.
+        async fn busy_error(code: &str) -> SyncApiError {
+            let mock_server = MockServer::start();
+            let url = mock_server.base_url();
+            let body = format!(
+                r#"{{ "error": {{ "code": "{}", "message": "busy", "data": null }} }}"#,
+                code
             );
-        });
+            mock_server.mock(|when, then| {
+                when.method(POST).path("/sync/v5/initialise");
+                then.status(503).body(body);
+            });
+            create_api(&url, "", "")
+                .post_initialise()
+                .await
+                .expect_err("Should result in error")
+        }
 
-        let result = create_api(&url, "", "")
-            .post_initialise()
-            .await
-            .expect_err("Should result in error");
+        // All three transient codes must classify as central-busy.
+        for code in [
+            "initialisation_in_progress",
+            "sync_is_running",
+            "integration_in_progress",
+        ] {
+            let result = busy_error(code).await;
+            assert!(result.is_central_busy(), "{} should be central-busy", code);
+        }
 
-        // Sanity check it parsed into the expected `Other` code...
+        // `initialisation_in_progress` parses as an `Other` 503 code.
+        let result = busy_error("initialisation_in_progress").await;
         assert_matches!(
             &result,
             SyncApiError {
@@ -379,41 +393,16 @@ mod test {
             }
         );
 
-        assert!(result.is_initialisation_in_progress());
-        assert!(!result.is_connection());
-        assert!(!result.is_unknown());
+        // An unrelated 503 code must NOT be treated as busy.
+        let result = busy_error("some_other_error").await;
+        assert!(!result.is_central_busy());
 
-        // A different 503 error code must NOT be treated as in-progress.
-        let mock_server = MockServer::start();
-        let url = mock_server.base_url();
-
-        mock_server.mock(|when, then| {
-            when.method(POST).path("/sync/v5/initialise");
-            then.status(503).body(
-                r#"{
-                    "error": {
-                        "code": "sync_is_running",
-                        "message": "Sync is already running - try again later",
-                        "data": null
-                    }
-                }"#,
-            );
-        });
-
-        let result = create_api(&url, "", "")
-            .post_initialise()
-            .await
-            .expect_err("Should result in error");
-
-        assert!(!result.is_initialisation_in_progress());
-
-        // A connection error must NOT be treated as in-progress either.
+        // A connection error must NOT be treated as busy.
         let result = create_api("http://localhost:9999", "", "")
             .post_initialise()
             .await
             .expect_err("Should result in error");
-
-        assert!(!result.is_initialisation_in_progress());
+        assert!(!result.is_central_busy());
         assert!(result.is_connection());
     }
 }

--- a/server/service/src/sync/api/error.rs
+++ b/server/service/src/sync/api/error.rs
@@ -134,6 +134,12 @@ impl SyncApiError {
         matches!(self.source, SyncApiErrorVariantV5::Other(_))
     }
 
+    /// Transient transport-level failure (dropped connection, unknown/unparseable error).
+    /// Safe to retry within a bounded polling loop rather than aborting it outright.
+    pub(crate) fn is_transient(&self) -> bool {
+        self.is_connection() || self.is_unknown()
+    }
+
     /// Central is busy with another session for this site (sync / integration / initialisation in
     /// progress). Caller should wait for central to be idle and retry.
     pub(crate) fn is_central_busy(&self) -> bool {
@@ -404,5 +410,32 @@ mod test {
             .expect_err("Should result in error");
         assert!(!result.is_central_busy());
         assert!(result.is_connection());
+    }
+
+    #[actix_rt::test]
+    async fn test_is_transient() {
+        // Connection error - transient (safe to retry within a poll loop).
+        let connection_error = create_api("http://localhost:9999", "", "")
+            .post_initialise()
+            .await
+            .expect_err("Should result in error");
+        assert!(connection_error.is_transient());
+
+        // Unknown error - also transient.
+        let unknown_error =
+            SyncApiError::new_test(SyncApiErrorVariantV5::Other(anyhow::anyhow!("boom")));
+        assert!(unknown_error.is_transient());
+
+        // A parsed business error (e.g. central-busy) is not transient - it's an authoritative
+        // response, not a transport failure, so it shouldn't be silently retried as such.
+        let parsed_error = SyncApiError::new_test(SyncApiErrorVariantV5::ParsedError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            source: ParsedError {
+                code: SyncErrorCodeV5::Other("initialisation_in_progress".to_string()),
+                message: "busy".to_string(),
+                data: None,
+            },
+        });
+        assert!(!parsed_error.is_transient());
     }
 }

--- a/server/service/src/sync/api/error.rs
+++ b/server/service/src/sync/api/error.rs
@@ -133,6 +133,16 @@ impl SyncApiError {
     pub(crate) fn is_unknown(&self) -> bool {
         matches!(self.source, SyncApiErrorVariantV5::Other(_))
     }
+
+    /// Central is still building the initial sync queue (common for large
+    /// legacy datasets); caller should poll instead of failing the sync.
+    pub(crate) fn is_initialisation_in_progress(&self) -> bool {
+        matches!(
+            &self.source,
+            SyncApiErrorVariantV5::ParsedError { source, .. }
+                if matches!(&source.code, SyncErrorCodeV5::Other(code) if code == "initialisation_in_progress")
+        )
+    }
 }
 
 #[cfg(test)]
@@ -326,5 +336,84 @@ mod test {
                 ..
             }
         );
+    }
+
+    /// `503 initialisation_in_progress` must be classified as benign so
+    /// `request_initialisation` polls instead of failing; others must not be.
+    #[actix_rt::test]
+    async fn test_is_initialisation_in_progress() {
+        // 503 with `initialisation_in_progress` code -> classified as in-progress
+        let mock_server = MockServer::start();
+        let url = mock_server.base_url();
+
+        mock_server.mock(|when, then| {
+            when.method(POST).path("/sync/v5/initialise");
+            then.status(503).body(
+                r#"{
+                    "error": {
+                        "code": "initialisation_in_progress",
+                        "message": "Initialisation in progress",
+                        "data": null
+                    }
+                }"#,
+            );
+        });
+
+        let result = create_api(&url, "", "")
+            .post_initialise()
+            .await
+            .expect_err("Should result in error");
+
+        // Sanity check it parsed into the expected `Other` code...
+        assert_matches!(
+            &result,
+            SyncApiError {
+                source: SyncApiErrorVariantV5::ParsedError {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    source: ParsedError {
+                        code: SyncErrorCodeV5::Other(_),
+                        ..
+                    }
+                },
+                ..
+            }
+        );
+
+        assert!(result.is_initialisation_in_progress());
+        assert!(!result.is_connection());
+        assert!(!result.is_unknown());
+
+        // A different 503 error code must NOT be treated as in-progress.
+        let mock_server = MockServer::start();
+        let url = mock_server.base_url();
+
+        mock_server.mock(|when, then| {
+            when.method(POST).path("/sync/v5/initialise");
+            then.status(503).body(
+                r#"{
+                    "error": {
+                        "code": "sync_is_running",
+                        "message": "Sync is already running - try again later",
+                        "data": null
+                    }
+                }"#,
+            );
+        });
+
+        let result = create_api(&url, "", "")
+            .post_initialise()
+            .await
+            .expect_err("Should result in error");
+
+        assert!(!result.is_initialisation_in_progress());
+
+        // A connection error must NOT be treated as in-progress either.
+        let result = create_api("http://localhost:9999", "", "")
+            .post_initialise()
+            .await
+            .expect_err("Should result in error");
+
+        assert!(!result.is_initialisation_in_progress());
+        assert!(result.is_connection());
     }
 }

--- a/server/service/src/sync/api/get_site_info.rs
+++ b/server/service/src/sync/api/get_site_info.rs
@@ -8,6 +8,10 @@ pub struct SiteInfoV5 {
     pub(crate) id: String,
     pub(crate) site_id: i32,
     pub(crate) initialisation_status: InitialisationStatus,
+    /// Live count of `sync_out` records queued for this site on central (an init progress signal).
+    /// Optional: older central versions may omit it.
+    #[serde(default)]
+    pub(crate) queue_length: Option<i64>,
     #[serde(rename = "omSupplyCentralServerUrl")]
     pub(crate) central_server_url: String,
     #[serde(rename = "isOmSupplyCentralServer")]
@@ -73,6 +77,7 @@ mod test {
                 id: "abc123".to_string(),
                 site_id: 123,
                 initialisation_status: InitialisationStatus::New,
+                queue_length: None,
                 is_central_server: false,
                 central_server_url: "http://localhost:2000".to_string(),
                 msupply_central_site_id: 1,

--- a/server/service/src/sync/api/post_initialise.rs
+++ b/server/service/src/sync/api/post_initialise.rs
@@ -1,15 +1,13 @@
 use super::*;
 
 impl SyncApiV5 {
-    // Initialize remote sync queue.
-    // Should only be called on initial sync or when re-initialising an existing data file.
-    pub(crate) async fn post_initialise(&self) -> Result<RemoteSyncBatchV5, SyncApiError> {
+    // Request remote sync queue (re)initialisation (initial sync, or re-initialising a data file).
+    // Central generates the queue asynchronously and responds 202 (older central: 200). We ignore the
+    // body and just confirm the POST was accepted; the caller polls /sync/v5/site for progress.
+    pub(crate) async fn post_initialise(&self) -> Result<(), SyncApiError> {
         let route = "/sync/v5/initialise";
-        let response = self.do_empty_post(route).await?;
-
-        to_json(response)
-            .await
-            .map_err(|error| self.api_error(route, error.into()))
+        self.do_empty_post(route).await?;
+        Ok(())
     }
 }
 
@@ -18,8 +16,31 @@ mod test {
     use super::*;
     use httpmock::{Method::POST, MockServer};
 
+    // New central: 202 Accepted with an initialisationStatus body (body ignored, status is what matters).
     #[actix_rt::test]
-    async fn test_initialise_remote_records() {
+    async fn test_initialise_accepts_202() {
+        let mock_server = MockServer::start();
+        let url = mock_server.base_url();
+
+        let mock = mock_server.mock(|when, then| {
+            when.method(POST).path("/sync/v5/initialise");
+            then.status(202).body(
+                r#"{
+                    "initialisationStatus": "started"
+                }"#,
+            );
+        });
+
+        let result = create_api(&url, "", "").post_initialise().await;
+
+        mock.assert();
+
+        assert!(result.is_ok());
+    }
+
+    // Older central: `200` with a `queueLength` body. Still accepted (backward compatible).
+    #[actix_rt::test]
+    async fn test_initialise_accepts_legacy_200() {
         let mock_server = MockServer::start();
         let url = mock_server.base_url();
 

--- a/server/service/src/sync/central_data_synchroniser.rs
+++ b/server/service/src/sync/central_data_synchroniser.rs
@@ -49,10 +49,22 @@ impl CentralDataSynchroniser {
         loop {
             let start_cursor = cursor_controller.get(connection)?;
 
-            let CentralSyncBatchV5 { max_cursor, data } = self
-                .sync_api_v5
-                .get_central_records(start_cursor, batch_size)
-                .await?;
+            // Retry while central is busy with another sync session for this site
+            // (legacy central gates sync per-site); wait for idle then re-request the
+            // same cursor.
+            let CentralSyncBatchV5 { max_cursor, data } = loop {
+                match self
+                    .sync_api_v5
+                    .get_central_records(start_cursor, batch_size)
+                    .await
+                {
+                    Ok(batch) => break batch,
+                    Err(error) if error.is_central_busy() => {
+                        self.sync_api_v5.wait_until_central_idle().await?;
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            };
             let batch_length = data.len();
 
             logger.progress(SyncStepProgress::PullCentral, max_cursor - start_cursor)?;

--- a/server/service/src/sync/central_data_synchroniser.rs
+++ b/server/service/src/sync/central_data_synchroniser.rs
@@ -1,7 +1,10 @@
 use std::cmp;
 
 use super::{
-    api::{CommonSyncRecord, ParsingSyncRecordError, SyncApiError, SyncApiV5},
+    api::{
+        CommonSyncRecord, ParsingSyncRecordError, SyncApiError, SyncApiV5,
+        CENTRAL_BUSY_POLL_PERIOD_SECONDS, CENTRAL_BUSY_TIMEOUT_SECONDS,
+    },
     sync_status::logger::{SyncLogger, SyncLoggerError, SyncStepProgress},
 };
 use crate::{cursor_controller::CursorController, sync::api::CentralSyncBatchV5};
@@ -60,7 +63,12 @@ impl CentralDataSynchroniser {
                 {
                     Ok(batch) => break batch,
                     Err(error) if error.is_central_busy() => {
-                        self.sync_api_v5.wait_until_central_idle().await?;
+                        self.sync_api_v5
+                            .wait_until_central_idle(
+                                CENTRAL_BUSY_POLL_PERIOD_SECONDS,
+                                CENTRAL_BUSY_TIMEOUT_SECONDS,
+                            )
+                            .await?;
                     }
                     Err(error) => return Err(error.into()),
                 }

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -97,6 +97,12 @@ impl RemoteDataSynchroniser {
     /// gate the POST on live worker status (`site_status`), not the persisted `initialisation_status`:
     /// a crashed worker leaves status stuck at `started`, and gating on liveness lets it self-heal on
     /// the next cycle while still avoiding a duplicate POST when a worker is genuinely running.
+    ///
+    /// Known compatibility gap: this liveness gating only helps clients running this code. An old
+    /// (pre-#12068) OMS client treats `/sync/v5/initialise` returning as "queue ready" (the previous
+    /// blocking semantics) and will pull before the queue exists if talking to an upgraded,
+    /// asynchronously-behaving 4D central - that can only be closed by 4D-side version gating (see
+    /// 4D PR msupply-foundation/msupply#18406), not from here.
     pub(crate) async fn request_initialisation(
         &self,
         _site_info: &SiteInfoV5,
@@ -148,7 +154,7 @@ impl RemoteDataSynchroniser {
             let site_info = match self.sync_api_v5.get_site_info().await {
                 Ok(info) => info,
                 // Transient poll failures don't affect the worker; retry until the stall timeout.
-                Err(error) if error.is_connection() || error.is_unknown() => {
+                Err(error) if error.is_transient() => {
                     log::warn!("Polling central site info failed (will retry): {:#?}", error);
                     if last_progress.elapsed() >= stall_timeout {
                         return Err(WaitForInitialisationError::TimeoutReached);
@@ -170,12 +176,27 @@ impl RemoteDataSynchroniser {
                 InitialisationStatus::New | InitialisationStatus::Started => {}
             }
 
-            let worker_alive = matches!(
-                self.sync_api_v5.get_site_status().await?.code,
-                SiteStatusCodeV5::InitialisationInProgress
-                    | SiteStatusCodeV5::SyncIsRunning
-                    | SiteStatusCodeV5::IntegrationInProgress
-            );
+            let worker_alive = match self.sync_api_v5.get_site_status().await {
+                Ok(status) => matches!(
+                    status.code,
+                    SiteStatusCodeV5::InitialisationInProgress
+                        | SiteStatusCodeV5::SyncIsRunning
+                        | SiteStatusCodeV5::IntegrationInProgress
+                ),
+                // Transient poll failures don't affect the worker; retry until the stall timeout,
+                // same as the get_site_info poll above.
+                Err(error) if error.is_transient() => {
+                    log::warn!(
+                        "Polling central site status failed (will retry): {:#?}",
+                        error
+                    );
+                    if last_progress.elapsed() >= stall_timeout {
+                        return Err(WaitForInitialisationError::TimeoutReached);
+                    }
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
 
             let queue_length = site_info.queue_length.unwrap_or(0);
             let progressing =
@@ -235,7 +256,12 @@ impl RemoteDataSynchroniser {
                 match self.sync_api_v5.get_queued_records(batch_size).await {
                     Ok(batch) => break batch,
                     Err(error) if error.is_central_busy() => {
-                        self.sync_api_v5.wait_until_central_idle().await?;
+                        self.sync_api_v5
+                            .wait_until_central_idle(
+                                CENTRAL_BUSY_POLL_PERIOD_SECONDS,
+                                CENTRAL_BUSY_TIMEOUT_SECONDS,
+                            )
+                            .await?;
                     }
                     Err(error) => return Err(error.into()),
                 }
@@ -318,7 +344,12 @@ impl RemoteDataSynchroniser {
                 // (legacy central gates sync per-site). Cursor hasn't advanced, so wait
                 // for idle then rebuild this batch.
                 Err(error) if error.is_central_busy() => {
-                    self.sync_api_v5.wait_until_central_idle().await?;
+                    self.sync_api_v5
+                        .wait_until_central_idle(
+                            CENTRAL_BUSY_POLL_PERIOD_SECONDS,
+                            CENTRAL_BUSY_TIMEOUT_SECONDS,
+                        )
+                        .await?;
                     continue;
                 }
                 Err(error) => return Err(error.into()),
@@ -352,11 +383,20 @@ impl RemoteDataSynchroniser {
         loop {
             tokio::time::sleep(poll_period).await;
 
-            let response = self.sync_api_v5.get_site_status().await?;
-
-            if response.code == SiteStatusCodeV5::Idle {
-                info!("Central server operation finished");
-                break;
+            match self.sync_api_v5.get_site_status().await {
+                Ok(response) if response.code == SiteStatusCodeV5::Idle => {
+                    info!("Central server operation finished");
+                    break;
+                }
+                Ok(_) => {}
+                // Transient poll failures don't mean the operation failed; retry until timeout.
+                Err(error) if error.is_transient() => {
+                    log::warn!(
+                        "Polling central site status failed (will retry): {:#?}",
+                        error
+                    );
+                }
+                Err(error) => return Err(error.into()),
             }
 
             let elapsed = start.elapsed().unwrap_or(timeout);
@@ -516,6 +556,31 @@ mod test {
             .wait_for_initialisation(0, 0)
             .await;
         assert_matches!(result, Err(WaitForInitialisationError::TimeoutReached));
+    }
+
+    /// A transient (connection) failure polling central must not abort the wait outright - it
+    /// should be tolerated and retried until the stall timeout, same as a genuine stall.
+    /// (Old behaviour: a bare `?` on the failing poll would return `Err` immediately here, on the
+    /// very first iteration, well before the 1s stall timeout below - this is the regression this
+    /// PR followup fixes. No mock server is registered at all, so every poll - both `get_site_info`
+    /// and `get_site_status` - hits a real connection-refused error.)
+    #[actix_rt::test]
+    async fn test_wait_for_initialisation_tolerates_transient_poll_errors() {
+        let result = synchroniser("http://localhost:9999")
+            .wait_for_initialisation(0, 1)
+            .await;
+        assert_matches!(result, Err(WaitForInitialisationError::TimeoutReached));
+    }
+
+    /// Same regression as above, isolated to the `get_site_status` poll specifically:
+    /// `wait_for_sync_operation` only ever calls `get_site_status`, so a transient failure here
+    /// can only be tolerated by the fix in that function's own match arm, not by `get_site_info`'s.
+    #[actix_rt::test]
+    async fn test_wait_for_sync_operation_tolerates_transient_poll_errors() {
+        let result = synchroniser("http://localhost:9999")
+            .wait_for_sync_operation(0, 1)
+            .await;
+        assert_matches!(result, Err(WaitForSyncOperationError::TimeoutReached));
     }
 
     /// No live worker (idle) -> `request_initialisation` re-POSTs `/sync/v5/initialise`.

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use crate::{
     cursor_controller::CursorController,
@@ -26,15 +26,16 @@ use repository::{
 use thiserror::Error;
 
 const INITIALISATION_POLL_PERIOD_SECONDS: u64 = 15;
-// 30 minutes
-const INITIALISATION_TIMEOUT_SECONDS: u64 = 30 * 60;
+// Stall timeout, not a run-length cap: fail only after this long with no forward progress (no live
+// worker and the queue not growing). A large initial sync can run for hours as long as it progresses.
+const INITIALISATION_STALL_TIMEOUT_SECONDS: u64 = 20 * 60;
 
 #[derive(Error, Debug)]
 pub(crate) enum PostInitialisationError {
     #[error(transparent)]
     SyncApiError(#[from] SyncApiError),
     #[error("Error while waiting for initialisation")]
-    WaitForInitialisationError(#[from] WaitForSyncOperationError),
+    WaitForInitialisationError(#[from] WaitForInitialisationError),
 }
 
 #[derive(Error, Debug)]
@@ -75,45 +76,126 @@ pub(crate) enum WaitForSyncOperationError {
     TimeoutReached,
 }
 
+#[derive(Error, Debug)]
+pub(crate) enum WaitForInitialisationError {
+    #[error(transparent)]
+    SyncApiError(#[from] SyncApiError),
+    #[error("Timeout was reached while waiting for central server initialisation")]
+    TimeoutReached,
+    #[error("Central server reported an error while generating the initial sync queue")]
+    InitialisationFailed,
+}
+
 pub struct RemoteDataSynchroniser {
     pub(crate) sync_api_v5: SyncApiV5,
 }
 
 impl RemoteDataSynchroniser {
-    /// Request initialisation
-    /// This api call is blocking, and will wait while central server adds relevant records to sync queue.
-    /// If there is a connection problem while initialisation is happening, we don't want to restart initialisation on next sync
-    /// thus polling and a check for initialisation status was introduced. When initialisation is in progress,
-    /// api will return `initialisation_in_progress` and `get_site_info` will return `initialisationStatus` = `started`
+    /// Request initialisation, then poll until central finishes generating the queue.
+    ///
+    /// `post_initialise` returns immediately (central generates the queue in a worker process). We
+    /// gate the POST on live worker status (`site_status`), not the persisted `initialisation_status`:
+    /// a crashed worker leaves status stuck at `started`, and gating on liveness lets it self-heal on
+    /// the next cycle while still avoiding a duplicate POST when a worker is genuinely running.
     pub(crate) async fn request_initialisation(
         &self,
-        site_info: &SiteInfoV5,
+        _site_info: &SiteInfoV5,
     ) -> Result<(), PostInitialisationError> {
-        // First check if already initialising
-        let should_post_initialise =
-            site_info.initialisation_status != InitialisationStatus::Started;
+        // Only POST if there isn't already a live worker generating the queue.
+        let worker_running = matches!(
+            self.sync_api_v5.get_site_status().await?.code,
+            SiteStatusCodeV5::InitialisationInProgress
+        );
 
-        if should_post_initialise {
-            let Err(error) = self.sync_api_v5.post_initialise().await else {
-                return Ok(());
-            };
-            // Ignore connection/unknown errors (post_initialise is blocking and can time out)
-            // and `initialisation_in_progress` (central already building the queue) - just poll.
-            if !(error.is_connection()
-                || error.is_unknown()
-                || error.is_initialisation_in_progress())
-            {
-                return Err(error.into());
+        if !worker_running {
+            if let Err(error) = self.sync_api_v5.post_initialise().await {
+                // Tolerate transient errors (connection/unknown) and "central busy" codes, then poll.
+                if !(error.is_connection() || error.is_unknown() || error.is_central_busy()) {
+                    return Err(error.into());
+                }
             }
         }
-        // Wait for initialisation to finish
-        self.wait_for_sync_operation(
+        self.wait_for_initialisation(
             INITIALISATION_POLL_PERIOD_SECONDS,
-            INITIALISATION_TIMEOUT_SECONDS,
+            INITIALISATION_STALL_TIMEOUT_SECONDS,
         )
         .await?;
 
         Ok(())
+    }
+
+    /// Wait for central to finish generating the initial sync queue.
+    ///
+    /// No fixed wall-clock cap: we wait while central makes progress and only give up after
+    /// `stall_timeout_seconds` of none. `site_info.initialisation_status` is the authoritative outcome
+    /// (`completed`/`error`, set before the worker exits); `site_status` (worker alive) and a growing
+    /// `queue_length` are the progress signals. `TimeoutReached` only fires when genuinely stalled
+    /// (worker died, or alive but queue not growing) - recoverable via a re-POST next cycle.
+    pub(crate) async fn wait_for_initialisation(
+        &self,
+        poll_period_seconds: u64,
+        stall_timeout_seconds: u64,
+    ) -> Result<(), WaitForInitialisationError> {
+        let poll_period = Duration::from_secs(poll_period_seconds);
+        let stall_timeout = Duration::from_secs(stall_timeout_seconds);
+        let mut last_progress = Instant::now();
+        let mut previous_queue_length: Option<i64> = None;
+        info!("Awaiting central server initialisation...");
+        loop {
+            tokio::time::sleep(poll_period).await;
+
+            // Outcome first - authoritative, set before the worker exits.
+            let site_info = match self.sync_api_v5.get_site_info().await {
+                Ok(info) => info,
+                // Transient poll failures don't affect the worker; retry until the stall timeout.
+                Err(error) if error.is_connection() || error.is_unknown() => {
+                    log::warn!("Polling central site info failed (will retry): {:#?}", error);
+                    if last_progress.elapsed() >= stall_timeout {
+                        return Err(WaitForInitialisationError::TimeoutReached);
+                    }
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
+
+            match site_info.initialisation_status {
+                InitialisationStatus::Completed => {
+                    info!("Central server initialisation finished");
+                    return Ok(());
+                }
+                InitialisationStatus::Error => {
+                    return Err(WaitForInitialisationError::InitialisationFailed);
+                }
+                // `New` / `Started`: still in progress - assess liveness and progress below.
+                InitialisationStatus::New | InitialisationStatus::Started => {}
+            }
+
+            let worker_alive = matches!(
+                self.sync_api_v5.get_site_status().await?.code,
+                SiteStatusCodeV5::InitialisationInProgress
+                    | SiteStatusCodeV5::SyncIsRunning
+                    | SiteStatusCodeV5::IntegrationInProgress
+            );
+
+            let queue_length = site_info.queue_length.unwrap_or(0);
+            let progressing =
+                is_initialisation_progressing(worker_alive, queue_length, previous_queue_length);
+            previous_queue_length = Some(queue_length);
+
+            if progressing {
+                last_progress = Instant::now();
+            }
+
+            log::info!(
+                "Central still initialising: queue_length = {}, worker_alive = {}",
+                queue_length,
+                worker_alive,
+            );
+
+            if last_progress.elapsed() >= stall_timeout {
+                return Err(WaitForInitialisationError::TimeoutReached);
+            }
+        }
     }
 
     /// Update push cursor after initial sync, i.e. set it to the end of the just received data
@@ -147,7 +229,17 @@ impl RemoteDataSynchroniser {
         );
 
         loop {
-            let sync_batch = self.sync_api_v5.get_queued_records(batch_size).await?;
+            // Retry while central is busy with another sync session for this site
+            // (legacy central gates sync per-site); wait for idle then re-request.
+            let sync_batch = loop {
+                match self.sync_api_v5.get_queued_records(batch_size).await {
+                    Ok(batch) => break batch,
+                    Err(error) if error.is_central_busy() => {
+                        self.sync_api_v5.wait_until_central_idle().await?;
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            };
 
             // queued_length is number of remote pull records awaiting acknowledgement
             // at this point it's number of records waiting to be pulled including records in this pull batch
@@ -216,10 +308,21 @@ impl RemoteDataSynchroniser {
             .map(RemoteSyncRecordV5::from)
             .collect();
 
-            let response = self
+            let response = match self
                 .sync_api_v5
                 .post_queued_records(change_logs_total, records)
-                .await?;
+                .await
+            {
+                Ok(response) => response,
+                // Retry while central is busy with another sync session for this site
+                // (legacy central gates sync per-site). Cursor hasn't advanced, so wait
+                // for idle then rebuild this batch.
+                Err(error) if error.is_central_busy() => {
+                    self.sync_api_v5.wait_until_central_idle().await?;
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
 
             // Update cursor only if record for that cursor has been pushed/processed
             if let Some(last_pushed_cursor_id) = last_pushed_cursor {
@@ -272,6 +375,212 @@ impl From<PushSyncRecord> for RemoteSyncRecordV5 {
         RemoteSyncRecordV5 {
             sync_id: cursor.to_string(),
             record,
+        }
+    }
+}
+
+/// Forward progress (refreshes the stall clock): a live worker that's either still pre-generation
+/// (`queue_length == 0`) or growing the queue. A dead worker, or a live worker whose non-empty queue
+/// has stopped growing (a wedge), is not progress and eventually trips the stall timeout.
+fn is_initialisation_progressing(
+    worker_alive: bool,
+    queue_length: i64,
+    previous_queue_length: Option<i64>,
+) -> bool {
+    let queue_grew = previous_queue_length.map_or(false, |prev| queue_length > prev);
+    worker_alive && (queue_length == 0 || queue_grew)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::sync::api::SyncApiV5;
+    use httpmock::{
+        Method::{GET, POST},
+        MockServer,
+    };
+    use std::time::Duration;
+    use util::assert_matches;
+
+    fn synchroniser(url: &str) -> RemoteDataSynchroniser {
+        RemoteDataSynchroniser {
+            sync_api_v5: SyncApiV5::new_test(url, "", "", "site"),
+        }
+    }
+
+    /// Body for `GET /sync/v5/site`. `queue_length` of `None` omits the field (older central).
+    fn site_info_body(status: &str, queue_length: Option<i64>) -> String {
+        let queue = queue_length
+            .map(|q| format!(r#""queueLength": {},"#, q))
+            .unwrap_or_default();
+        format!(
+            r#"{{
+                "id": "abc",
+                "siteId": 1,
+                "initialisationStatus": "{}",
+                {}
+                "isOmSupplyCentralServer": false,
+                "omSupplyCentralServerUrl": "http://localhost",
+                "mSupplyCentralSiteId": 1
+            }}"#,
+            status, queue
+        )
+    }
+
+    fn site_status_body(code: &str) -> String {
+        format!(r#"{{ "code": "{}", "message": "", "data": null }}"#, code)
+    }
+
+    /// The pure progress predicate that decides whether the stall clock is refreshed.
+    #[test]
+    fn test_is_initialisation_progressing() {
+        // Live worker, no records yet (prep/delete phase) -> progressing.
+        assert!(is_initialisation_progressing(true, 0, None));
+        assert!(is_initialisation_progressing(true, 0, Some(0)));
+        // Live worker, queue grew -> progressing.
+        assert!(is_initialisation_progressing(true, 10, Some(5)));
+        // Live worker, non-empty queue not growing (wedge) -> NOT progressing.
+        assert!(!is_initialisation_progressing(true, 5, Some(5)));
+        assert!(!is_initialisation_progressing(true, 5, None));
+        // Dead worker is never progress, regardless of queue.
+        assert!(!is_initialisation_progressing(false, 0, None));
+        assert!(!is_initialisation_progressing(false, 10, Some(5)));
+    }
+
+    /// `completed` returns Ok before the stall clock is ever consulted.
+    #[actix_rt::test]
+    async fn test_wait_for_initialisation_completed() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site");
+            then.status(200).body(site_info_body("completed", Some(42)));
+        });
+
+        let result = synchroniser(&server.base_url())
+            .wait_for_initialisation(0, 600)
+            .await;
+        assert_matches!(result, Ok(()));
+    }
+
+    /// `error` fails fast with `InitialisationFailed`.
+    #[actix_rt::test]
+    async fn test_wait_for_initialisation_error() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site");
+            then.status(200).body(site_info_body("error", None));
+        });
+
+        let result = synchroniser(&server.base_url())
+            .wait_for_initialisation(0, 600)
+            .await;
+        assert_matches!(result, Err(WaitForInitialisationError::InitialisationFailed));
+    }
+
+    /// Worker gone (idle) but not completed -> no progress -> stall timeout (recoverable).
+    #[actix_rt::test]
+    async fn test_wait_for_initialisation_crashed_worker_times_out() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site");
+            then.status(200).body(site_info_body("started", None));
+        });
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site_status");
+            then.status(200).body(site_status_body("idle"));
+        });
+
+        // stall = 0 -> trips on the first observation with no progress.
+        let result = synchroniser(&server.base_url())
+            .wait_for_initialisation(0, 0)
+            .await;
+        assert_matches!(result, Err(WaitForInitialisationError::TimeoutReached));
+    }
+
+    /// Worker alive but its non-empty queue is not growing (wedge) -> stall timeout.
+    #[actix_rt::test]
+    async fn test_wait_for_initialisation_wedged_worker_times_out() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site");
+            then.status(200)
+                .body(site_info_body("started", Some(5)));
+        });
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site_status");
+            then.status(200)
+                .body(site_status_body("initialisation_in_progress"));
+        });
+
+        let result = synchroniser(&server.base_url())
+            .wait_for_initialisation(0, 0)
+            .await;
+        assert_matches!(result, Err(WaitForInitialisationError::TimeoutReached));
+    }
+
+    /// No live worker (idle) -> `request_initialisation` re-POSTs `/sync/v5/initialise`.
+    /// (POST is made to return a non-tolerated error so the call returns immediately.)
+    #[actix_rt::test]
+    async fn test_request_initialisation_reposts_when_no_worker() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site_status");
+            then.status(200).body(site_status_body("idle"));
+        });
+        let post = server.mock(|when, then| {
+            when.method(POST).path("/sync/v5/initialise");
+            then.status(401).body(
+                r#"{ "error": { "code": "site_incorrect_hardware_id", "message": "x", "data": null } }"#,
+            );
+        });
+
+        let result = synchroniser(&server.base_url())
+            .request_initialisation(&dummy_site_info())
+            .await;
+
+        post.assert(); // the re-POST happened (crash recovery)
+        assert_matches!(result, Err(_));
+    }
+
+    /// A live worker (initialisation_in_progress) must NOT trigger a duplicate POST; we just wait.
+    #[actix_rt::test]
+    async fn test_request_initialisation_skips_post_when_worker_running() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site_status");
+            then.status(200)
+                .body(site_status_body("initialisation_in_progress"));
+        });
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site");
+            then.status(200).body(site_info_body("started", Some(1)));
+        });
+        let post = server.mock(|when, then| {
+            when.method(POST).path("/sync/v5/initialise");
+            then.status(200).body(r#"{ "queueLength": 0 }"#);
+        });
+
+        // request_initialisation uses the real 15s poll period before its first site check, so
+        // it's still sleeping after a short wait - long enough to prove no POST was made.
+        let result = tokio::time::timeout(
+            Duration::from_millis(300),
+            synchroniser(&server.base_url()).request_initialisation(&dummy_site_info()),
+        )
+        .await;
+
+        assert!(result.is_err(), "should still be waiting, not returned");
+        post.assert_calls(0); // no duplicate POST while a worker is running
+    }
+
+    fn dummy_site_info() -> SiteInfoV5 {
+        SiteInfoV5 {
+            id: "abc".to_string(),
+            site_id: 1,
+            initialisation_status: InitialisationStatus::Started,
+            queue_length: None,
+            central_server_url: "http://localhost".to_string(),
+            is_central_server: false,
+            msupply_central_site_id: 1,
         }
     }
 }

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -97,9 +97,12 @@ impl RemoteDataSynchroniser {
             let Err(error) = self.sync_api_v5.post_initialise().await else {
                 return Ok(());
             };
-            // Ignore connection or unknown error. There is high chance of connection error
-            // on post_initialise end point (since it's blocking and can take awhile).
-            if !(error.is_connection() || error.is_unknown()) {
+            // Ignore connection/unknown errors (post_initialise is blocking and can time out)
+            // and `initialisation_in_progress` (central already building the queue) - just poll.
+            if !(error.is_connection()
+                || error.is_unknown()
+                || error.is_initialisation_in_progress())
+            {
                 return Err(error.into());
             }
         }

--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 // See README.md for description of when this API version needs to be updated
-pub(crate) static SYNC_V5_VERSION: u32 = 15; // bumped for 2.20.0 OG v9.0.X?
+pub(crate) static SYNC_V5_VERSION: u32 = 16; // bumped for 2.21.0 OG v9.01.X: client handles the non-blocking (202) initialise + /sync/v5/site polling
 pub(crate) static SYNC_V6_VERSION: u32 = 5; // bumped for 2.9.02 (adding new types to system log)
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -85,11 +85,9 @@ pub async fn pull(
         response.site_id,
         is_initialised,
     )?;
-    let total_records = changelog_repo.count_outgoing_sync_records_from_central(
-        cursor,
-        response.site_id,
-        is_initialised,
-    )?;
+    // A short batch means the changelog tail is exhausted (= last batch). Avoids a full count, which
+    // scans the changelog on every pull and exhausts the DB pool under concurrent multi-site init.
+    let num_changelogs = changelogs.len();
     // Clamp the empty-batch fallback so we don't advance past an in-flight (uncommitted, lower)
     // changelog cursor. The non-empty path is already safe because the query is clamped.
     let max_cursor = changelog_repo.latest_cursor()?;
@@ -116,7 +114,9 @@ pub async fn pull(
     );
     log::debug!("Sending records as central server: {records:#?}");
 
-    let is_last_batch = total_records <= batch_size as u64;
+    let is_last_batch = num_changelogs < batch_size as usize;
+    // Cheap progress-bar estimate (over-estimates, but monotonic and snaps to done on the last batch).
+    let total_records = max_cursor.saturating_sub(cursor);
 
     Ok(SyncBatchV6 {
         total_records,
@@ -240,11 +240,8 @@ pub async fn patient_pull(
         response.site_id,
         fetch_patient_id.clone(),
     )?;
-    let total_records = changelog_repo.count_outgoing_patient_sync_records_from_central(
-        cursor,
-        response.site_id,
-        fetch_patient_id,
-    )?;
+    // See `pull`: short batch = last batch; avoids a full count and uses a cheap progress estimate.
+    let num_changelogs = changelogs.len();
     // Clamp the empty-batch fallback so we don't advance past an in-flight (uncommitted, lower)
     // changelog cursor. The non-empty path is already safe because the query is clamped.
     let max_cursor = changelog_repo.latest_cursor()?;
@@ -271,7 +268,8 @@ pub async fn patient_pull(
     );
     log::debug!("Patient Pull: Sending records as central server: {records:#?}");
 
-    let is_last_batch = total_records <= batch_size as u64;
+    let is_last_batch = num_changelogs < batch_size as usize;
+    let total_records = max_cursor.saturating_sub(cursor);
 
     Ok(SyncBatchV6 {
         total_records,

--- a/server/service/src/sync/sync_status/logger.rs
+++ b/server/service/src/sync/sync_status/logger.rs
@@ -14,7 +14,8 @@ use crate::sync::{
         CentralPullErrorV6, RemotePushErrorV6, WaitForSyncOperationErrorV6,
     },
     remote_data_synchroniser::{
-        PostInitialisationError, RemotePullError, RemotePushError, WaitForSyncOperationError,
+        PostInitialisationError, RemotePullError, RemotePushError, WaitForInitialisationError,
+        WaitForSyncOperationError,
     },
     synchroniser::SyncError,
 };
@@ -400,7 +401,7 @@ impl SyncLogError {
             | SyncError::WaitForIntegrationError(WaitForSyncOperationError::SyncApiError(error))
             | SyncError::PostInitialisationError(
                 PostInitialisationError::WaitForInitialisationError(
-                    WaitForSyncOperationError::SyncApiError(error),
+                    WaitForInitialisationError::SyncApiError(error),
                 ),
             ) => Self::from_sync_api_error(SyncApiErrorVariant::V5(&error.source), sync_error),
 

--- a/server/service/src/sync/sync_status/test.rs
+++ b/server/service/src/sync/sync_status/test.rs
@@ -209,6 +209,9 @@ fn get_initialisation_sync_status_tester(
                  ..
              }| {
                 let mut new_status = previous_status.clone();
+                // summary.duration_in_seconds advances during the init poll wait; reconcile it (like
+                // the `initialise` handler) - this assertion checks pull_central progress, not summary.
+                new_status.summary.clone_from(&current_status.summary);
                 if iteration == 0 {
                     new_status
                         .prepare_initial
@@ -358,7 +361,9 @@ fn get_initialisation_sync_status_tester(
             let site_info = SiteInfoV5 {
                 id: "abc123".to_string(),
                 site_id: 123,
-                initialisation_status: crate::sync::api::InitialisationStatus::New,
+                // `wait_for_initialisation` finishes when `/site` reports completed.
+                initialisation_status: crate::sync::api::InitialisationStatus::Completed,
+                queue_length: None,
                 central_server_url: format!("http://127.0.0.1:{}", ctx.open_msupply_central_port),
                 is_central_server: false,
                 msupply_central_site_id: 1,
@@ -508,7 +513,9 @@ fn get_push_and_error_sync_status_tester(
             let site_info = SiteInfoV5 {
                 id: "abc123".to_string(),
                 site_id: 123,
-                initialisation_status: crate::sync::api::InitialisationStatus::New,
+                // `wait_for_initialisation` finishes when `/site` reports completed.
+                initialisation_status: crate::sync::api::InitialisationStatus::Completed,
+                queue_length: None,
                 central_server_url: format!("http://127.0.0.1:{}", ctx.open_msupply_central_port),
                 is_central_server: false,
                 msupply_central_site_id: 1,

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -34,6 +34,22 @@ pub async fn with_retries<F>(connection_timeouts: RetrySeconds, f: F) -> Result<
 where
     F: Fn(Client) -> RequestBuilder,
 {
+    with_retries_opts(connection_timeouts, true, f).await
+}
+
+/// As [`with_retries`], but `retry_on_idle_timeout` controls whether an idle read timeout
+/// (or 408) triggers a retry. Pass `false` for long-running endpoints whose server-side
+/// work continues after the client gives up (e.g. legacy sync v5): retrying there spawns
+/// an overlapping server-side request for the same site, which the central then rejects as
+/// "sync already running". Connect errors are always retried (no server-side work began).
+pub async fn with_retries_opts<F>(
+    connection_timeouts: RetrySeconds,
+    retry_on_idle_timeout: bool,
+    f: F,
+) -> Result<Response>
+where
+    F: Fn(Client) -> RequestBuilder,
+{
     let mut index = 0;
     loop {
         let client = https_client_builder()
@@ -60,20 +76,23 @@ where
         };
         let elapsed = started.elapsed();
 
-        let (status, is_connect_error, is_timeout_error, url) = match result.as_ref() {
-            Ok(r) => (
-                Some(r.status()),
-                false,
-                false,
-                Some(redact_url_for_log(r.url())),
-            ),
-            Err(e) => (
-                e.status(),
-                e.is_connect(),
-                e.is_timeout(),
-                e.url().map(redact_url_for_log),
-            ),
-        };
+        let (status, is_connect_error, is_timeout_error, is_dropped_connection, url) =
+            match result.as_ref() {
+                Ok(r) => (
+                    Some(r.status()),
+                    false,
+                    false,
+                    false,
+                    Some(redact_url_for_log(r.url())),
+                ),
+                Err(e) => (
+                    e.status(),
+                    e.is_connect(),
+                    e.is_timeout(),
+                    is_connection_dropped(e),
+                    e.url().map(redact_url_for_log),
+                ),
+            };
 
         // Surface the status code (or transport error) for any failed attempt so
         // proxy/upstream errors like 502/503/504 — which we do not currently retry —
@@ -87,6 +106,8 @@ where
                     "connection error"
                 } else if is_timeout_error {
                     "idle timeout"
+                } else if is_dropped_connection {
+                    "connection dropped"
                 } else {
                     "request error"
                 };
@@ -94,9 +115,13 @@ where
             }
         };
 
-        let will_retry =
-            (is_connect_error || is_timeout_error || status == Some(StatusCode::REQUEST_TIMEOUT))
-                && (index + 1) < connection_timeouts.0.len();
+        let idle_timeout = is_timeout_error || status == Some(StatusCode::REQUEST_TIMEOUT);
+        // A mid-flight connection drop (e.g. hyper `IncompleteMessage`) is retried only for endpoints
+        // opting in via `retry_on_idle_timeout` (idempotent reads/upserts like v6); v5 keeps it off to
+        // avoid overlapping an in-flight server-side request. Connect errors are always retried.
+        let will_retry = (is_connect_error
+            || (retry_on_idle_timeout && (idle_timeout || is_dropped_connection)))
+            && (index + 1) < connection_timeouts.0.len();
 
         if let Ok(response) = result.as_ref() {
             let content_length_display = response
@@ -143,5 +168,101 @@ where
         }
 
         break result;
+    }
+}
+
+/// True if the server dropped an established connection mid-response (hyper `IncompleteMessage`,
+/// reset, broken pipe) - distinct from `is_connect`/`is_timeout`, and safe to retry for idempotent
+/// requests.
+fn is_connection_dropped(error: &reqwest::Error) -> bool {
+    // Only request-phase transport errors; never status / decode / body errors.
+    error.is_request() && chain_contains_transient_drop(error)
+}
+
+/// Walk the error's source chain looking for a transient transport-drop signature.
+fn chain_contains_transient_drop(error: &(dyn std::error::Error + 'static)) -> bool {
+    // hyper renders `IncompleteMessage` as "connection closed before message completed".
+    const SIGNATURES: [&str; 5] = [
+        "connection closed before message completed",
+        "incompletemessage",
+        "connection reset",
+        "broken pipe",
+        "unexpected end of file",
+    ];
+
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(error);
+    while let Some(err) = current {
+        let message = err.to_string().to_lowercase();
+        if SIGNATURES.iter().any(|signature| message.contains(signature)) {
+            return true;
+        }
+        current = err.source();
+    }
+    false
+}
+
+#[cfg(test)]
+mod test {
+    use super::chain_contains_transient_drop;
+    use std::error::Error;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct ChainError {
+        message: String,
+        source: Option<Box<ChainError>>,
+    }
+
+    impl fmt::Display for ChainError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.message)
+        }
+    }
+
+    impl Error for ChainError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            self.source
+                .as_ref()
+                .map(|boxed| boxed.as_ref() as &(dyn Error + 'static))
+        }
+    }
+
+    fn chain(messages: &[&str]) -> ChainError {
+        // Build innermost-first so the outer error's source points inward.
+        let mut current: Option<Box<ChainError>> = None;
+        for message in messages.iter().rev() {
+            current = Some(Box::new(ChainError {
+                message: message.to_string(),
+                source: current,
+            }));
+        }
+        *current.unwrap()
+    }
+
+    #[test]
+    fn detects_incomplete_message_deep_in_chain() {
+        // Mirrors the real reqwest -> hyper chain we saw on a dropped v6 pull.
+        let error = chain(&[
+            "error sending request for url (http://host/central/sync/pull)",
+            "client error (SendRequest)",
+            "connection closed before message completed",
+        ]);
+        assert!(chain_contains_transient_drop(&error));
+    }
+
+    #[test]
+    fn detects_connection_reset() {
+        let error = chain(&["error sending request", "Connection reset by peer (os error 54)"]);
+        assert!(chain_contains_transient_drop(&error));
+    }
+
+    #[test]
+    fn ignores_non_transient_errors() {
+        // A connect refusal is handled by `is_connect`, not here; a status/body error must not match.
+        let connect = chain(&["error sending request", "tcp connect error", "Connection refused (os error 111)"]);
+        assert!(!chain_contains_transient_drop(&connect));
+
+        let bad_request = chain(&["builder error", "invalid header value"]);
+        assert!(!chain_contains_transient_drop(&bad_request));
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11885 

# 👩🏻‍💻 What does this PR do?
Makes OMS sync resilient and performant when initialising sites against a large central server (the companion to the 4D async-initialise change). It covers the OMS-client side of initialisation plus two central-server-side performance/robustness fixes that large multi-site setups hit.

**1. Initialisation wait is now progress/liveness-based, not a fixed timeout.** `/sync/v5/initialise` on 4D now returns immediately and generates the queue in a background worker, so the client polls. `wait_for_initialisation` waits while central is *making progress* (worker alive via `site_status`, and `queue_length` growing) and only fails after a stall window — no fixed wall-clock cap, so a legitimately long initial sync completes instead of timing out. `request_initialisation` gates the re-POST on live worker status (not the persisted `initialisation_status`), so a crashed worker self-heals next cycle. (`remote_data_synchroniser.rs`, `get_site_info.rs` adds `queueLength`.)

**2. Retry idempotent sync requests on a dropped connection.** A mid-flight connection drop (hyper `IncompleteMessage`) was fatal and not retried, so a transient drop during a long multi-site init failed the whole sync. Now retried for endpoints that opt in (v6 pulls/pushes; v5 stays off to avoid self-overlap). (`util/src api_helper.rs`.)

**3. `changelog_deduped` view rewrite (NOT EXISTS anti-join).** On a large central (~millions of changelog rows) the old `GROUP BY MAX(cursor)` form deduped the whole table before the `WHERE cursor >= ?` filter, so every per-batch sync query was a full scan (measured ~172s for a 13-row result on a 12 GB SQLite DB). The equivalent anti-join lets the planner push the cursor predicate to the index — same rows, ~43,000× faster for cursor bounded queries. No Rust changes; applied via the existing view-rebuild on migrate.

**4. Drop the per-batch full count in the central v6 pull.** `count_outgoing_sync_records_from_central` ran on every `/central/sync/pull` batch (a full changelog scan), which made pulls slow and exhausted the DB pool under concurrent multi-site init. Replaced with `is_last_batch = records.len() < batch_size` + a cheap cursor-based progress estimate; `SyncBatchV6` unchanged (backward/forward compatible). (`sync_on_central/mod.rs`.)

**5. `ledger_fix` background loop no longer crashes the server.** It ran `basic_context().unwrap()` on the main loop; a transient connection-pool exhaustion (caused by #4 above) panicked and took the whole central down. Now logs and skips, retrying next interval. (`ledger_fix/ledger_fix_driver.rs`.)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?
- **Highest-risk item to focus on: the `changelog_deduped` view rewrite (# 3).** It's the broadest blast radius (all sync paths use it). It's proven row-for-row equivalent (cursor is unique, so "no newer row" ≡ "is the max"), validated on a real 12 GB DB (same total row count) and by the existing changelog tests.
- **v6 pull change (# 4)** alters only `is_last_batch`/progress semantics, not the `SyncBatchV6` wire struct — old/new clients interoperate. Minor cosmetic effects: progress total is now an estimate, and an exact-multiple-of batch_size run does one extra empty pull at the end.
- The removed `count_outgoing_*` repository methods were dead after # 4 (shared query builders kept).
- Out of scope (separate spec): reducing the *generation* time on the 4D side for very large sites.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] [4D legacy central](https://github.com/msupply-foundation/msupply/pull/18406) + an OMS-central running this PR + ≥1 OMS remote site (web and/or Android), ideally with a large multi-store dataset so initialisation takes time.
- [ ] Initialise the OMS-central from 4D: it completes to the login screen (doesn't time out at the old 30-min cap); logs show the queue-length progressing.
- [ ] Initialise 2 remote sites against the OMS-central concurrently: both reach login; the central does **not** crash (no `ledger_fix_driver` panic / sustained `DB pool exhausted`), and v6 pulls return promptly.
- [ ] Force a transient connection drop during a v6 pull → it retries and continues (no whole-sync failure).
- [ ] An incremental sync of a few hundred records completes quickly (not minutes).
- [ ] Re-run a normal small/normal-DB sync environment — no regression (progress bar still advances; same records synced).
- [ ] Automated: `cargo nextest run -p service sync::` and `-p repository changelog` and `-p util api_helper` all pass (Postgres + SQLite).

# 📃 Documentation
- [x] **No documentation required**: bug fix, no user-facing change in behaviour beyond not erroring out during initialisation

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

