### PR TITLE
#12038 RTL: make table column alignment direction-aware

### DIFF
--- a/client/packages/common/src/ui/layout/tables/useMaterialTableColumns.tsx
+++ b/client/packages/common/src/ui/layout/tables/useMaterialTableColumns.tsx
@@ -17,6 +17,7 @@ import {
   multipleKeys,
   Tooltip,
   useGetColumnTypeDefaults,
+  useIntlUtils,
   useTranslation,
 } from '@openmsupply-client/common';
 
@@ -26,6 +27,7 @@ export const useMaterialTableColumns = <T extends MRT_RowData>(
   omsColumns: ColumnDef<T>[]
 ) => {
   const t = useTranslation();
+  const { isRtl } = useIntlUtils();
   const getColumnTypeDefaults = useGetColumnTypeDefaults();
 
   const tableDefinition = useMemo(() => {
@@ -38,13 +40,38 @@ export const useMaterialTableColumns = <T extends MRT_RowData>(
         // so all the mapping is in one place, easily discoverable?
 
         // Add alignment styling
-        const alignment = col.align ?? columnDefaults.align;
+        const physicalAlignment = col.align ?? columnDefaults.align;
+
+        // Logical text alignment, for wide/block cell content that fills the
+        // column (e.g. item names). Logical start/end track the cell's
+        // direction natively in both LTR and RTL, and aren't flipped by
+        // stylis-plugin-rtl. start = text columns, end = numeric/date columns.
+        const textAlign =
+          physicalAlignment === 'right'
+            ? 'end'
+            : physicalAlignment === 'center'
+              ? 'center'
+              : 'start';
+
+        // Flexbox alignment, for narrow content positioned via justifyContent
+        // (numbers, icons). This must be flipped left<->right for RTL: MRT sets
+        // every cell to align="right" in RTL, applying flex-direction:
+        // row-reverse, which cancels the cell's direction: rtl and leaves the
+        // flex main axis physically LTR — so justifyContent renders unflipped.
+        const alignment = !isRtl
+          ? physicalAlignment
+          : physicalAlignment === 'right'
+            ? 'left' // numeric/date: end edge (left in RTL)
+            : physicalAlignment === 'center'
+              ? 'center'
+              : 'right'; // text: start edge (right in RTL), incl. implicit default
         if (alignment) {
           col.muiTableBodyCellProps = params => {
             return mergeCellProps(
               {
-                sx:
-                  alignment === 'right'
+                sx: {
+                  textAlign,
+                  ...(alignment === 'right'
                     ? {
                         justifyContent: 'flex-end',
                       }
@@ -58,7 +85,8 @@ export const useMaterialTableColumns = <T extends MRT_RowData>(
                             params.table.getState().density === 'compact'
                               ? '0.7em'
                               : '1.2em',
-                        },
+                        }),
+                },
               },
               params
             );
@@ -120,7 +148,7 @@ export const useMaterialTableColumns = <T extends MRT_RowData>(
       });
 
     return { columns };
-  }, [omsColumns]);
+  }, [omsColumns, isRtl]);
 
   return tableDefinition;
 };


### PR DESCRIPTION
Fixes #12038

# 👩🏻‍💻 What does this PR do?

In right-to-left locales (Arabic `ar`, Dari `prs`, Pashto `ps`) the shared table's column alignment didn't flip: text columns stayed on the left and numeric/date columns on the right, instead of reading from the start edge.

The fix makes the body-cell alignment in `useMaterialTableColumns` direction-aware, using two complementary levers:

- **`justifyContent`** is flipped `left`↔`right` for RTL — this positions *narrow* content (numbers, icons).
- **logical `text-align: start/end`** is added — this aligns *wide* content that fills the column (e.g. item names), tracks `direction` natively, and isn't touched by `stylis-plugin-rtl`.

Result in RTL: text columns align to the start edge (right), numeric/date columns to the end edge (left). LTR is unchanged.

| | Before (RTL) | After (RTL) |
|---|---|---|
| Text columns (status, code, item name, unit) | left ✗ | right (start) ✓ |
| Numeric / date / currency columns | right ✗ | left (end) ✓ |

## 💌 Any notes for the reviewer?

**Divergence from the issue's suggested fix.** The issue proposed editing the per-type defaults in `useGetColumnDefDefaults.tsx`. I implemented it one layer down in `useMaterialTableColumns.tsx` instead, because that's the single point where our `align` value is actually turned into CSS — the defaults file is just an abstraction the consumer reads. This also covers text columns that have *no* explicit `align`.

**The real root cause turned out to be different from the issue's description.** The issue attributed it to MRT rendering a literal physical `text-align`. Inspecting the live DOM showed the actual mechanism: in RTL, MaterialReactTable sets `align="right"` on **every** cell (`theme.direction === 'rtl' ? 'right' : 'left'`), which applies MUI's `MuiTableCell-alignRight` → `flex-direction: row-reverse`. Combined with the cell's own `direction: rtl`, the flex main axis is reversed *twice* and ends up physically LTR — so our `justifyContent` rendered unflipped. Hence the explicit flip rather than relying on logical flex values alone.

**Verified in-browser** (Chrome DevTools, Arabic locale) on a purchase order with mixed column types — measured glyph positions confirm text→start and numeric→end, and confirmed LTR is unaffected. Headers were already start-aligned in both directions, so RTL now mirrors LTR exactly.

**Deferred (not in this PR):**
- **Column resizing in RTL** is still off (drag direction feels backwards). It's a separate `stylis-plugin-rtl` ↔ MRT double-flip problem — see upstream [MRT #1282](https://github.com/KevinVandy/material-react-table/issues/1282). Needs its own pass.
- **Static directional icons** (back/forward arrows) not auto-flipping, as noted in the issue.

# 🧪 Testing

- [ ] Switch the app language to Arabic, Dari, or Pashto (any RTL locale)
- [ ] Open any list/table view (e.g. a purchase order with lines, or any list page)
- [ ] Text columns (status, code, item/name) read from the **right** (start) edge
- [ ] Numeric / date / currency columns align to the **left** (end) edge
- [ ] Switch back to English (LTR) and confirm alignment is unchanged (text left, numbers right)

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in behaviour for LTR users

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
