### PR TITLE
11956 fix pending count including records never integrated

### DIFF
--- a/client/packages/host/src/components/Sync/SyncModal.tsx
+++ b/client/packages/host/src/components/Sync/SyncModal.tsx
@@ -227,15 +227,6 @@ export const SyncModal = ({ onCancel, open, width = 800 }: SyncModalProps) => {
           </Box>
         )}
 
-        {!!numberOfRecordsInPushQueue && numberOfRecordsInPushQueue >= 100 && (
-          <Alert
-            severity="warning"
-            sx={{ fontSize: '14px', marginTop: error ? '5' : '20' }}
-          >
-            {t('warning.high-number-records-to-sync')}
-          </Alert>
-        )}
-
         {!error && latestSuccessfulSyncDate && (
           <Alert
             sx={{

--- a/server/cli/src/reintegrate_buffer.rs
+++ b/server/cli/src/reintegrate_buffer.rs
@@ -59,8 +59,6 @@ pub fn reintegrate_buffer(
     }
 
     let connection = connection_manager.connection()?;
-    // Unfiltered count — includes rows for tables with no translator, which the
-    // integrator itself excludes from its progress total.
     let total_pending = SyncBufferRepository::new(&connection).count_pending(
         source_site_id,
         SyncVersion::V5V6,

--- a/server/cli/src/reintegrate_buffer.rs
+++ b/server/cli/src/reintegrate_buffer.rs
@@ -59,12 +59,15 @@ pub fn reintegrate_buffer(
     }
 
     let connection = connection_manager.connection()?;
+    // Unfiltered count — includes rows for tables with no translator, which the
+    // integrator itself excludes from its progress total.
     let total_pending = SyncBufferRepository::new(&connection).count_pending(
         source_site_id,
         SyncVersion::V5V6,
         None,
+        None,
     )?;
-    info!("Starting reintegration for source_site_id={source_site_id} ({total_pending} pending)");
+    info!("Starting reintegration for source_site_id: {source_site_id} pending: {total_pending}");
 
     // The integrator logs per-batch progress at `info` level as it goes.
     let start = std::time::Instant::now();

--- a/server/repository/src/db_diesel/sync_buffer.rs
+++ b/server/repository/src/db_diesel/sync_buffer.rs
@@ -283,11 +283,17 @@ impl<'a> SyncBufferRepository<'a> {
 
     /// Total pending rows across all tables and actions, for the given
     /// source/version/reference_id. Used for progress reporting.
+    ///
+    /// `table_names`, when given, restricts the count to those tables. Integration only
+    /// visits tables it has translators for, so the buffer can hold rows (e.g. legacy
+    /// tables with no translator) that will never integrate — pass the set of tables
+    /// integration will actually visit so those rows don't report as forever-pending.
     pub fn count_pending(
         &self,
         source_site_id: i32,
         sync_version: SyncVersion,
         reference_id: Option<&str>,
+        table_names: Option<&[&str]>,
     ) -> Result<i64, RepositoryError> {
         let mut q = sync_buffer::table
             .filter(sync_buffer::is_integrated.eq(false))
@@ -299,6 +305,11 @@ impl<'a> SyncBufferRepository<'a> {
             q = q.filter(sync_buffer::reference_id.eq(reference_id.to_string()));
         } else {
             q = q.filter(sync_buffer::reference_id.is_null());
+        }
+
+        if let Some(table_names) = table_names {
+            let table_names: Vec<String> = table_names.iter().map(|s| s.to_string()).collect();
+            q = q.filter(sync_buffer::table_name.eq_any(table_names));
         }
 
         let count: i64 = q.count().get_result(self.connection.lock().connection())?;
@@ -462,6 +473,44 @@ mod test {
             .unwrap();
         let ids: Vec<_> = rows.iter().map(|r| r.record_id.as_str()).collect();
         assert_eq!(ids, vec!["b1"]);
+    }
+
+    #[actix_rt::test]
+    async fn test_sync_buffer_count_pending() {
+        let (_, connection, _, _) =
+            test_db::setup_all("test_sync_buffer_count_pending", MockDataInserts::none()).await;
+
+        let repo = SyncBufferRepository::new(&connection);
+
+        repo.insert_many(&[
+            SyncBufferRowInsert {
+                source_site_id: 1,
+                ..insert("s1", "store")
+            },
+            SyncBufferRowInsert {
+                source_site_id: 1,
+                ..insert("n1", "name")
+            },
+            // Legacy table with no translator — never visited by integration
+            SyncBufferRowInsert {
+                source_site_id: 1,
+                ..insert("p1", "pref")
+            },
+        ])
+        .unwrap();
+
+        // Unfiltered count includes the unsupported table
+        assert_eq!(
+            repo.count_pending(1, SyncVersion::V5V6, None, None).unwrap(),
+            3
+        );
+
+        // Filtered to the tables integration will visit, the unsupported row is excluded
+        assert_eq!(
+            repo.count_pending(1, SyncVersion::V5V6, None, Some(&["store", "name"]))
+                .unwrap(),
+            2
+        );
     }
 
     #[actix_rt::test]

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -479,9 +479,6 @@ pub fn integrate_and_translate_sync_buffer(
 
         // Seed integration progress total with the global pending count so the logger
         // reports a real total across all (action, table) batches, not just the first 10k slice.
-        // Restricted to tables in the integration order — the buffer can hold records for
-        // tables with no translator (e.g. legacy pref/report), which would otherwise be
-        // counted but never integrated, leaving reported progress permanently short of total.
         let total_pending = SyncBufferRepository::new(connection).count_pending(
             source_site_id,
             SyncVersion::V5V6,

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -479,10 +479,14 @@ pub fn integrate_and_translate_sync_buffer(
 
         // Seed integration progress total with the global pending count so the logger
         // reports a real total across all (action, table) batches, not just the first 10k slice.
+        // Restricted to tables in the integration order — the buffer can hold records for
+        // tables with no translator (e.g. legacy pref/report), which would otherwise be
+        // counted but never integrated, leaving reported progress permanently short of total.
         let total_pending = SyncBufferRepository::new(connection).count_pending(
             source_site_id,
             SyncVersion::V5V6,
             None,
+            Some(&table_order),
         )? as u64;
         if let Some(logger) = logger.as_mut() {
             logger

--- a/server/service/src/sync_v7/validate_translate_integrate.rs
+++ b/server/service/src/sync_v7/validate_translate_integrate.rs
@@ -305,8 +305,6 @@ fn validate_translate_integrate_inner<'a>(
 
     let repo = SyncBufferRepository::new(connection);
 
-    // Only count tables the integration loop below will visit — rows for tables outside
-    // INTEGRATION_ORDER (e.g. from a newer central) would otherwise report as forever-pending.
     let integration_tables: Vec<&str> = INTEGRATION_ORDER.iter().map(|t| t.as_ref()).collect();
     let mut total = repo.count_pending(
         source_site_id,

--- a/server/service/src/sync_v7/validate_translate_integrate.rs
+++ b/server/service/src/sync_v7/validate_translate_integrate.rs
@@ -305,7 +305,15 @@ fn validate_translate_integrate_inner<'a>(
 
     let repo = SyncBufferRepository::new(connection);
 
-    let mut total = repo.count_pending(source_site_id, SyncVersion::V7, reference_id)?;
+    // Only count tables the integration loop below will visit — rows for tables outside
+    // INTEGRATION_ORDER (e.g. from a newer central) would otherwise report as forever-pending.
+    let integration_tables: Vec<&str> = INTEGRATION_ORDER.iter().map(|t| t.as_ref()).collect();
+    let mut total = repo.count_pending(
+        source_site_id,
+        SyncVersion::V7,
+        reference_id,
+        Some(&integration_tables),
+    )?;
     let mut last_progress = total / PROGRESS_INTERVAL;
 
     if let Some(logger) = logger.as_mut() {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11956 

# 👩🏻‍💻 What does this PR do?

Tables that OMS ignores from OG sync v5 are ignored from the total to be integrated.

Note a completely fresh ROMS initialised from COMS on v7 shouldn't receive any tables that it doesn't support, but a ROMS that has migrated from <OMS3.0 may have old records in the sync buffer. Perhaps if they're _never_ going to be integrated, we should delete them from the sync buffer.

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Sync COMS. The modal has no amount remaining to integrate.
- [ ] Sync ROMS, same as above.
