### PR TITLE
Fix/12093/show hardware id token reset buttons

### DIFF
--- a/client/packages/system/src/Manage/Sites/ListView/SiteEditModal.tsx
+++ b/client/packages/system/src/Manage/Sites/ListView/SiteEditModal.tsx
@@ -161,7 +161,9 @@ export const SiteEditModal = ({
                     value={hardwareId ?? ''}
                     disabled
                   />
-                  {isEditable && showClearButtons && !!hardwareId && (
+                  {/* Standalone COMS or non-standalone, 
+                  COMS is now responsible for managing ROMS hardware ids */}
+                  {showClearButtons && !!hardwareId && (
                     <LoadingButton
                       color="secondary"
                       variant="contained"
@@ -176,7 +178,8 @@ export const SiteEditModal = ({
               }
             />
           )}
-          {isEditable && isExisting && showClearButtons && (
+          {/* Token is solely managed by COMS, so show regardless of standalone */}
+          {isExisting && showClearButtons && (
             <InputWithLabelRow
               key="sync-token"
               label={t('label.clear-sync-token')}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12093 

# 👩🏻‍💻 What does this PR do?

Fixes hardware_id and token not being shown on non-standalone coms 

## 💌 Any notes for the reviewer?

Whether or not coms is standalone, these need to be shown depending on:
- creating a new site in standalone mode, don't show both
- is existing remote site, show both
- is central, don't show
- hardware id is already cleared, don't show hardware id reset  
 
<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up COMS with OG with at least one ROMS site
- [ ] Go to Manage-> Sites -> click on the remote site
- [ ] If hardware_id is not empty, see reset hardware_id button
- [ ] Always see reset token button


# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

