### PR TITLE
12085 Grid lines on stock take printout

### DIFF
--- a/standard_forms/generated/standard_forms.json
+++ b/standard_forms/generated/standard_forms.json
@@ -951,7 +951,7 @@
       "excel_template_buffer": null
     },
     {
-      "id": "stock-take-detail-view_2_13_2_false",
+      "id": "stock-take-detail-view_2_13_3_false",
       "name": "Stocktake",
       "description": null,
       "template": {
@@ -982,7 +982,7 @@
           },
           "style.css": {
             "type": "Resource",
-            "data": "@media print {\n  @page {\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\nheader_image_section,\n.header_supplied_section {\n  margin-inline-start: 8px;\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\n.body_column_label th {\n  border-bottom: 0.5px solid black;\n  text-align: start;\n}\n\n.body_column_label th,\n.body_value td {\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.batch {\n  word-break: break-word;\n}\n"
+            "data": "@media print {\n  @page {\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\nheader_image_section,\n.header_supplied_section {\n  margin-inline-start: 8px;\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\n.body_section {\n  border-collapse: collapse;\n  width: 100%;\n}\n\n.body_column_label th,\n.body_value td {\n  border: 1px solid black;\n  padding: 3px 4px;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.body_column_label th {\n  text-align: start;\n}\n\n.batch {\n  word-break: break-word;\n}\n"
           },
           "template.html": {
             "type": "TeraTemplate",
@@ -998,7 +998,7 @@
       "argument_schema_id": null,
       "comment": null,
       "is_custom": false,
-      "version": "2.13.2",
+      "version": "2.13.3",
       "code": "stock-take-detail-view",
       "form_schema": null,
       "excel_template_buffer": null
@@ -1110,7 +1110,7 @@
       "excel_template_buffer": null
     },
     {
-      "id": "stock-take-variance_2_8_3_false",
+      "id": "stock-take-variance_2_8_4_false",
       "name": "Stocktake Variance",
       "description": null,
       "template": {
@@ -1141,13 +1141,13 @@
           },
           "style.css": {
             "type": "Resource",
-            "data": "@media print {\n  @page {\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\n\n.header_image_section,\n.header_supplied_section {\n  margin-inline-start: 8px;\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\nbody {\n  margin: 10px 5% 10px 5%;\n  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;\n}\n\ntable.center {\n  margin-left: auto;\n  margin-right: auto;\n  width: 98%;\n  border-collapse: collapse;\n  font-size: 12px;\n}\n\ntd.borderline {\n  border-bottom: 1px solid black;\n}\n\ntd {\n  vertical-align: top;\n  padding: 2px;\n}\n\nth {\n  padding: 2px;\n}\n\ntr.borderline {\n  border-bottom: 1px solid black;\n}\n\ntd.borderlineTopBottom {\n  border-bottom: 1px solid black;\n  border-top: 1px solid black;\n}\n\n.Report_title {\n  text-align: center;\n  padding-top: 8px;\n  font-weight: bold;\n  font-size: 12pt;\n}\n\n.name_centre {\n  text-align: center;\n  font-weight: bold;\n  font-size: 14pt;\n}\n.name_address {\n  text-align: center;\n  font-weight: normal;\n  font-size: 10pt;\n}\n\n.name_right {\n  text-align: end;\n  font-weight: normal;\n  font-size: 10pt;\n}\n\n.col-item-code {\n  width: 6%;\n  text-align: start;\n}\n\n.col-item-name {\n  text-align: start;\n}\n\n.col-batch {\n  width: 5%;\n  text-align: start;\n}\n\n.col-expiry-date {\n  width: 7.5%;\n  text-align: end;\n}\n\n.col-packsize {\n  width: 5%;\n  text-align: right;\n}\n\n.col-cost-price {\n  width: 8%;\n  text-align: right;\n}\n\n.col-snapshot-packs {\n  width: 6%;\n  text-align: right;\n}\n\n.col-counted-packs {\n  width: 6%;\n  text-align: right;\n}\n\n.col-variance-packs {\n  width: 6%;\n  text-align: right;\n}\n\n.col-variance-values {\n  width: 6%;\n  text-align: right;\n}\n\n.col-reason {\n  width: 10%;\n  text-align: end;\n}\n\n.col-comment {\n  width: 12%;\n  text-align: end;\n}\n\n.batch-wrap {\n  word-break: break-word;\n}\n\n@media print {\n  @page {\n    size: landscape;\n  }\n}\n"
+            "data": "@media print {\n  @page {\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\n\n.header_image_section,\n.header_supplied_section {\n  margin-inline-start: 8px;\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\nbody {\n  margin: 10px 5% 10px 5%;\n  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;\n}\n\ntable.center {\n  margin-left: auto;\n  margin-right: auto;\n  width: 98%;\n  border-collapse: collapse;\n  font-size: 12px;\n}\n\ntd.borderline {\n  border-bottom: 1px solid black;\n}\n\ntd {\n  vertical-align: top;\n  padding: 2px;\n}\n\nth {\n  padding: 2px;\n}\n\ntable.center td,\ntable.center th {\n  border: 1px solid black;\n}\n\ntable.center td.no-border {\n  border: none;\n}\n\ntr.borderline {\n  border-bottom: 1px solid black;\n}\n\ntd.borderlineTopBottom {\n  border-bottom: 1px solid black;\n  border-top: 1px solid black;\n}\n\n.Report_title {\n  text-align: center;\n  padding-top: 8px;\n  font-weight: bold;\n  font-size: 12pt;\n}\n\n.name_centre {\n  text-align: center;\n  font-weight: bold;\n  font-size: 14pt;\n}\n.name_address {\n  text-align: center;\n  font-weight: normal;\n  font-size: 10pt;\n}\n\n.name_right {\n  text-align: end;\n  font-weight: normal;\n  font-size: 10pt;\n}\n\n.col-item-code {\n  width: 6%;\n  text-align: start;\n}\n\n.col-item-name {\n  text-align: start;\n}\n\n.col-batch {\n  width: 5%;\n  text-align: start;\n}\n\n.col-expiry-date {\n  width: 7.5%;\n  text-align: end;\n}\n\n.col-packsize {\n  width: 5%;\n  text-align: right;\n}\n\n.col-cost-price {\n  width: 8%;\n  text-align: right;\n}\n\n.col-snapshot-packs {\n  width: 6%;\n  text-align: right;\n}\n\n.col-counted-packs {\n  width: 6%;\n  text-align: right;\n}\n\n.col-variance-packs {\n  width: 6%;\n  text-align: right;\n}\n\n.col-variance-values {\n  width: 6%;\n  text-align: right;\n}\n\n.col-reason {\n  width: 10%;\n  text-align: end;\n}\n\n.col-comment {\n  width: 12%;\n  text-align: end;\n}\n\n.batch-wrap {\n  word-break: break-word;\n}\n\n@media print {\n  @page {\n    size: landscape;\n  }\n}\n"
           },
           "template.html": {
             "type": "TeraTemplate",
             "data": {
               "output": "Html",
-              "template": "\n<style>\n  {% include \"style.css\" %}\n</style>\n\n<body>\n  {% set_global VvalueIncrease=0 %}\n  {% set_global VvalueDecrease=0 %}\n  {% set_global VnetVarience=0 %}\n  {% set_global Vnumofpackscounted=0 %} \n\n<table class=\"center\">\n  <thead>\n    <tr>\n      <td width=\"60\" class=\"borderline\"> <span class=\"table_header\">{{t(k=\"report.item-code\",f=\"Item code\")}}</span></td>\n      <td class=\"borderline\"><span class=\"table_header\">{{t(k=\"report.item-name\",f=\"Item name\")}}</span></td>\n      <td class=\"borderline\"><span class=\"table_header\">{{t(k=\"label.batch\",f=\"Batch\")}}</span></td>\n      <td width=\"60\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"label.expiry\",f=\"Expiry\")}}</span></td>\n      <td width=\"50\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"report.pack-size\",f=\"Pack size\")}}</span></td>\n      <td width=\"60\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"report.cost-price-per-pack\",f=\"Cost price (per pack)\")}}</span></td>\n      <td width=\"60\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"report.snapshot-packs\",f=\"Snapshot Packs\")}}</span></td>\n      <td width=\"60\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"label.counted-num-of-packs\",f=\"Counted Packs\")}}</span></td>\n      <td width=\"60\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"report.variance-packs\",f=\"Variance (packs)\")}}</span></td>\n      <td width=\"60\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"report.variance-value\",f=\"Variance (Value)\")}}</span></td>\n      <td width=\"100\"class=\"borderline\"><span class=\"table_header\">{{t(k=\"label.reason\",f=\"Reason\")}}</span></td>\n      <td width=\"100\"class=\"borderline\"><span class=\"table_header\">{{t(k=\"label.comment\",f=\"Comment\")}}</span></td>\n    </tr>\n  </thead>\n\n  {% for line in data.stocktakeLines.nodes -%}\n  {%set costPricePerPack=line.costPricePerPack | default(value=0) %}\n    <td class=\"table_text\">{{line.item.code}}</td>\n    <td class=\"table_text\">{{line.item.name}}</td>\n    <td class=\"table_text batch-wrap\">{{line.batch}}</td>\n    <td class=\"table_number\">{{line.expiryDate}}</td>\n    <td class=\"table_number\">{{line.packSize}}</td>\n    <td class=\"table_number\">{{costPricePerPack}}</td>\n    <td class=\"table_number\">{{line.snapshotNumberOfPacks | round( precision=2)}}</td>\n\n\n    <!-- Counted packs and potential variance should only show if stock line has been counted -->\n    {% if line.countedNumberOfPacks is number %}\n\n      {% set_global Vnumofpackscounted=line.countedNumberOfPacks %}\n      {% set Vvariance=Vnumofpackscounted - line.snapshotNumberOfPacks %}\n      {% set VvarianceValue=Vvariance * costPricePerPack %}\n\n      <!-- Handle -0 -->\n      {% if VvarianceValue == -0 %}  {% set VvarianceValue=0 %}  {% endif %}\n\n      <td class=\"table_number\">{{line.countedNumberOfPacks}}</td>\n      <td class=\"table_number\">{{Vvariance | round(precision=2)}}</td>\n      <td class=\"table_number\">{{VvarianceValue | round(precision=2)}}</td>\n    {% else %}\n      {% set VvarianceValue=0 %}\n\n      <td class=\"table_number\">-</td>\n      <td class=\"table_number\">-</td>\n      <td class=\"table_number\">-</td>\n    {% endif %}\n\n    {% if line.reasonOption.id %}\n    <td  class=\"table_text\">{{line.reasonOption.reason}}</td>\n    {% else %}\n    <td  class=\"table_text\">N/A</td>\n    {% endif %}\n    <td  class=\"table_text\">{{line.comment}}</td>\n\n    {% if VvarianceValue > 0 %}\n    {% set_global VvalueIncrease=VvalueIncrease + VvarianceValue  %}\n    {% else %}\n    {% set_global VvalueDecrease=VvalueDecrease + VvarianceValue  %}\n    {% endif %}\n\n  </tr>\n  {%- endfor %}\n  {% set_global VnetVarience=VvalueIncrease + VvalueDecrease %}\n\n  <tr>\n    <td colspan=\"12\"  class=\"borderline\" />\n  </tr>\n\n\n\n\n  <tr>\n    <td colspan=\"10\" />\n    <td  class=\"borderline\"><span class=\"table_text\">{{t(k=\"report.net-increase\",f=\"Net Increase\")}}</span></td>\n    <td class=\"borderline\"><span class=\"table_text\">{{VvalueIncrease | round( precision=2)}}</span></td>\n  </tr>\n\n\n\n  <tr>\n    <td colspan=\"10\" />\n    <td class=\"borderline\"><span class=\"table_text\">{{t(k=\"report.net-decrease\",f=\"Net Decrease\")}}</span></td>\n    <td class=\"borderline\"><span class=\"table_text\">{{VvalueDecrease | round( precision=2)}}</span></td>\n  </tr>\n\n  <tr>\n    <td colspan=\"10\"  />\n    <td  class=\"borderline\"><span class=\"table_text\">{{t(k=\"report.net-variance\",f=\"Net Variance\")}}</span></td>\n    <td  class=\"borderline\"><span class=\"table_text\">{{VnetVarience | round( precision=2)}}</span></td>\n  </tr>\n</table>\n\n</body>\n"
+              "template": "\n<style>\n  {% include \"style.css\" %}\n</style>\n\n<body>\n  {% set_global VvalueIncrease=0 %}\n  {% set_global VvalueDecrease=0 %}\n  {% set_global VnetVarience=0 %}\n  {% set_global Vnumofpackscounted=0 %} \n\n<table class=\"center\">\n  <thead>\n    <tr>\n      <td width=\"60\" class=\"borderline\"> <span class=\"table_header\">{{t(k=\"report.item-code\",f=\"Item code\")}}</span></td>\n      <td class=\"borderline\"><span class=\"table_header\">{{t(k=\"report.item-name\",f=\"Item name\")}}</span></td>\n      <td class=\"borderline\"><span class=\"table_header\">{{t(k=\"label.batch\",f=\"Batch\")}}</span></td>\n      <td width=\"60\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"label.expiry\",f=\"Expiry\")}}</span></td>\n      <td width=\"50\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"report.pack-size\",f=\"Pack size\")}}</span></td>\n      <td width=\"60\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"report.cost-price-per-pack\",f=\"Cost price (per pack)\")}}</span></td>\n      <td width=\"60\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"report.snapshot-packs\",f=\"Snapshot Packs\")}}</span></td>\n      <td width=\"60\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"label.counted-num-of-packs\",f=\"Counted Packs\")}}</span></td>\n      <td width=\"60\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"report.variance-packs\",f=\"Variance (packs)\")}}</span></td>\n      <td width=\"60\" class=\"borderline\"><span class=\"table_header\">{{t(k=\"report.variance-value\",f=\"Variance (Value)\")}}</span></td>\n      <td width=\"100\"class=\"borderline\"><span class=\"table_header\">{{t(k=\"label.reason\",f=\"Reason\")}}</span></td>\n      <td width=\"100\"class=\"borderline\"><span class=\"table_header\">{{t(k=\"label.comment\",f=\"Comment\")}}</span></td>\n    </tr>\n  </thead>\n\n  {% for line in data.stocktakeLines.nodes -%}\n  {%set costPricePerPack=line.costPricePerPack | default(value=0) %}\n  <tr>\n    <td class=\"table_text\">{{line.item.code}}</td>\n    <td class=\"table_text\">{{line.item.name}}</td>\n    <td class=\"table_text batch-wrap\">{{line.batch}}</td>\n    <td class=\"table_number\">{{line.expiryDate}}</td>\n    <td class=\"table_number\">{{line.packSize}}</td>\n    <td class=\"table_number\">{{costPricePerPack}}</td>\n    <td class=\"table_number\">{{line.snapshotNumberOfPacks | round( precision=2)}}</td>\n\n\n    <!-- Counted packs and potential variance should only show if stock line has been counted -->\n    {% if line.countedNumberOfPacks is number %}\n\n      {% set_global Vnumofpackscounted=line.countedNumberOfPacks %}\n      {% set Vvariance=Vnumofpackscounted - line.snapshotNumberOfPacks %}\n      {% set VvarianceValue=Vvariance * costPricePerPack %}\n\n      <!-- Handle -0 -->\n      {% if VvarianceValue == -0 %}  {% set VvarianceValue=0 %}  {% endif %}\n\n      <td class=\"table_number\">{{line.countedNumberOfPacks}}</td>\n      <td class=\"table_number\">{{Vvariance | round(precision=2)}}</td>\n      <td class=\"table_number\">{{VvarianceValue | round(precision=2)}}</td>\n    {% else %}\n      {% set VvarianceValue=0 %}\n\n      <td class=\"table_number\">-</td>\n      <td class=\"table_number\">-</td>\n      <td class=\"table_number\">-</td>\n    {% endif %}\n\n    {% if line.reasonOption.id %}\n    <td  class=\"table_text\">{{line.reasonOption.reason}}</td>\n    {% else %}\n    <td  class=\"table_text\">N/A</td>\n    {% endif %}\n    <td  class=\"table_text\">{{line.comment}}</td>\n\n    {% if VvarianceValue > 0 %}\n    {% set_global VvalueIncrease=VvalueIncrease + VvarianceValue  %}\n    {% else %}\n    {% set_global VvalueDecrease=VvalueDecrease + VvarianceValue  %}\n    {% endif %}\n\n  </tr>\n  {%- endfor %}\n  {% set_global VnetVarience=VvalueIncrease + VvalueDecrease %}\n\n  <tr>\n    <td colspan=\"12\"  class=\"borderline\" />\n  </tr>\n\n\n\n\n  <tr>\n    <td colspan=\"10\" class=\"no-border\" />\n    <td  class=\"borderline\"><span class=\"table_text\">{{t(k=\"report.net-increase\",f=\"Net Increase\")}}</span></td>\n    <td class=\"borderline\"><span class=\"table_text\">{{VvalueIncrease | round( precision=2)}}</span></td>\n  </tr>\n\n\n\n  <tr>\n    <td colspan=\"10\" class=\"no-border\" />\n    <td class=\"borderline\"><span class=\"table_text\">{{t(k=\"report.net-decrease\",f=\"Net Decrease\")}}</span></td>\n    <td class=\"borderline\"><span class=\"table_text\">{{VvalueDecrease | round( precision=2)}}</span></td>\n  </tr>\n\n  <tr>\n    <td colspan=\"10\"  class=\"no-border\" />\n    <td  class=\"borderline\"><span class=\"table_text\">{{t(k=\"report.net-variance\",f=\"Net Variance\")}}</span></td>\n    <td  class=\"borderline\"><span class=\"table_text\">{{VnetVarience | round( precision=2)}}</span></td>\n  </tr>\n</table>\n\n</body>\n"
             }
           }
         }
@@ -1157,7 +1157,7 @@
       "argument_schema_id": null,
       "comment": null,
       "is_custom": false,
-      "version": "2.8.3",
+      "version": "2.8.4",
       "code": "stock-take-variance",
       "form_schema": null,
       "excel_template_buffer": null
@@ -1220,7 +1220,7 @@
       "excel_template_buffer": null
     },
     {
-      "id": "stock-take-with-quantity_2_6_4_false",
+      "id": "stock-take-with-quantity_2_6_5_false",
       "name": "Stocktake with snapshot quantity",
       "description": null,
       "template": {
@@ -1248,7 +1248,7 @@
           },
           "style.css": {
             "type": "Resource",
-            "data": "@media print {\n  @page {\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\n\n.header_image_section,\n.header_supplied_section {\n  margin-inline-start: 8px;\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\n.body_column_label th {\n  border-bottom: 0.5px solid black;\n  text-align: start;\n}\n\n.body_column_label th,\n.body_value td {\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.batch {\n  word-break: break-word;\n}\n"
+            "data": "@media print {\n  @page {\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\n\n.header_image_section,\n.header_supplied_section {\n  margin-inline-start: 8px;\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\n.body_section {\n  border-collapse: collapse;\n  width: 100%;\n}\n\n.body_column_label th,\n.body_value td {\n  border: 1px solid black;\n  padding: 3px 4px;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.body_column_label th {\n  text-align: start;\n}\n\n.batch {\n  word-break: break-word;\n}\n"
           },
           "template.html": {
             "type": "TeraTemplate",
@@ -1264,7 +1264,7 @@
       "argument_schema_id": null,
       "comment": null,
       "is_custom": false,
-      "version": "2.6.4",
+      "version": "2.6.5",
       "code": "stock-take-with-quantity",
       "form_schema": null,
       "excel_template_buffer": null
@@ -1327,7 +1327,7 @@
       "excel_template_buffer": null
     },
     {
-      "id": "stock-take-without-quantity_2_6_4_false",
+      "id": "stock-take-without-quantity_2_6_5_false",
       "name": "Stocktake without snapshot quantity",
       "description": null,
       "template": {
@@ -1355,7 +1355,7 @@
           },
           "style.css": {
             "type": "Resource",
-            "data": "@media print {\n  @page {\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\n\n.header_image_section,\n.header_supplied_section {\n  margin-inline-start: 8px;\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\n.body_column_label th {\n  border-bottom: 0.5px solid black;\n  text-align: start;\n}\n\n.body_column_label th,\n.body_value td {\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.batch {\n  word-break: break-word;\n}\n"
+            "data": "@media print {\n  @page {\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\n\n.header_image_section,\n.header_supplied_section {\n  margin-inline-start: 8px;\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\n.body_section {\n  border-collapse: collapse;\n  width: 100%;\n}\n\n.body_column_label th,\n.body_value td {\n  border: 1px solid black;\n  padding: 3px 4px;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.body_column_label th {\n  text-align: start;\n}\n\n.batch {\n  word-break: break-word;\n}\n"
           },
           "template.html": {
             "type": "TeraTemplate",
@@ -1371,7 +1371,7 @@
       "argument_schema_id": null,
       "comment": null,
       "is_custom": false,
-      "version": "2.6.4",
+      "version": "2.6.5",
       "code": "stock-take-without-quantity",
       "form_schema": null,
       "excel_template_buffer": null

--- a/standard_forms/stock-take-detail-view/latest/report-manifest.json
+++ b/standard_forms/stock-take-detail-view/latest/report-manifest.json
@@ -1,6 +1,6 @@
 {
   "is_custom": false,
-  "version": "2.13.2",
+  "version": "2.13.3",
   "code": "stock-take-detail-view",
   "context": "STOCKTAKE",
   "name": "Stocktake",

--- a/standard_forms/stock-take-detail-view/latest/src/style.css
+++ b/standard_forms/stock-take-detail-view/latest/src/style.css
@@ -24,15 +24,21 @@ header_image_section,
   height: 96px;
 }
 
-.body_column_label th {
-  border-bottom: 0.5px solid black;
-  text-align: start;
+.body_section {
+  border-collapse: collapse;
+  width: 100%;
 }
 
 .body_column_label th,
 .body_value td {
+  border: 1px solid black;
+  padding: 3px 4px;
   font-family: Tahoma;
   font-size: 8pt;
+}
+
+.body_column_label th {
+  text-align: start;
 }
 
 .batch {

--- a/standard_forms/stock-take-variance/latest/report-manifest.json
+++ b/standard_forms/stock-take-variance/latest/report-manifest.json
@@ -1,6 +1,6 @@
 {
   "is_custom": false,
-  "version": "2.8.3",
+  "version": "2.8.4",
   "code": "stock-take-variance",
   "context": "STOCKTAKE",
   "sub_context": "",

--- a/standard_forms/stock-take-variance/latest/src/style.css
+++ b/standard_forms/stock-take-variance/latest/src/style.css
@@ -51,6 +51,15 @@ th {
   padding: 2px;
 }
 
+table.center td,
+table.center th {
+  border: 1px solid black;
+}
+
+table.center td.no-border {
+  border: none;
+}
+
 tr.borderline {
   border-bottom: 1px solid black;
 }

--- a/standard_forms/stock-take-variance/latest/src/template.html
+++ b/standard_forms/stock-take-variance/latest/src/template.html
@@ -29,6 +29,7 @@
 
   {% for line in data.stocktakeLines.nodes -%}
   {%set costPricePerPack=line.costPricePerPack | default(value=0) %}
+  <tr>
     <td class="table_text">{{line.item.code}}</td>
     <td class="table_text">{{line.item.name}}</td>
     <td class="table_text batch-wrap">{{line.batch}}</td>
@@ -84,7 +85,7 @@
 
 
   <tr>
-    <td colspan="10" />
+    <td colspan="10" class="no-border" />
     <td  class="borderline"><span class="table_text">{{t(k="report.net-increase",f="Net Increase")}}</span></td>
     <td class="borderline"><span class="table_text">{{VvalueIncrease | round( precision=2)}}</span></td>
   </tr>
@@ -92,13 +93,13 @@
 
 
   <tr>
-    <td colspan="10" />
+    <td colspan="10" class="no-border" />
     <td class="borderline"><span class="table_text">{{t(k="report.net-decrease",f="Net Decrease")}}</span></td>
     <td class="borderline"><span class="table_text">{{VvalueDecrease | round( precision=2)}}</span></td>
   </tr>
 
   <tr>
-    <td colspan="10"  />
+    <td colspan="10"  class="no-border" />
     <td  class="borderline"><span class="table_text">{{t(k="report.net-variance",f="Net Variance")}}</span></td>
     <td  class="borderline"><span class="table_text">{{VnetVarience | round( precision=2)}}</span></td>
   </tr>

--- a/standard_forms/stock-take-with-quantity/latest/report-manifest.json
+++ b/standard_forms/stock-take-with-quantity/latest/report-manifest.json
@@ -1,6 +1,6 @@
 {
   "is_custom": false,
-  "version": "2.6.4",
+  "version": "2.6.5",
   "code": "stock-take-with-quantity",
   "context": "STOCKTAKE",
   "sub_context": "picklist",

--- a/standard_forms/stock-take-with-quantity/latest/src/style.css
+++ b/standard_forms/stock-take-with-quantity/latest/src/style.css
@@ -25,15 +25,21 @@
   height: 96px;
 }
 
-.body_column_label th {
-  border-bottom: 0.5px solid black;
-  text-align: start;
+.body_section {
+  border-collapse: collapse;
+  width: 100%;
 }
 
 .body_column_label th,
 .body_value td {
+  border: 1px solid black;
+  padding: 3px 4px;
   font-family: Tahoma;
   font-size: 8pt;
+}
+
+.body_column_label th {
+  text-align: start;
 }
 
 .batch {

--- a/standard_forms/stock-take-without-quantity/latest/report-manifest.json
+++ b/standard_forms/stock-take-without-quantity/latest/report-manifest.json
@@ -1,6 +1,6 @@
 {
   "is_custom": false,
-  "version": "2.6.4",
+  "version": "2.6.5",
   "code": "stock-take-without-quantity",
   "context": "STOCKTAKE",
   "name": "Stocktake without snapshot quantity",

--- a/standard_forms/stock-take-without-quantity/latest/src/style.css
+++ b/standard_forms/stock-take-without-quantity/latest/src/style.css
@@ -25,15 +25,21 @@
   height: 96px;
 }
 
-.body_column_label th {
-  border-bottom: 0.5px solid black;
-  text-align: start;
+.body_section {
+  border-collapse: collapse;
+  width: 100%;
 }
 
 .body_column_label th,
 .body_value td {
+  border: 1px solid black;
+  padding: 3px 4px;
   font-family: Tahoma;
   font-size: 8pt;
+}
+
+.body_column_label th {
+  text-align: start;
 }
 
 .batch {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12085

# 👩🏻‍💻 What does this PR do?
Put borders around all stocktake reports, example below

<img width="637" height="600" alt="Screenshot 2026-06-12 at 09 25 41" src="https://github.com/user-attachments/assets/7b61e07a-80c1-4cb0-aa25-400e2e5f3f28" />


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Go to a stocktake
- [ ] Try all reports
- [ ] Should all be gridded

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

