### PR TITLE
Export function for downloading JSON content

### DIFF
--- a/client/packages/common/src/utils/files/FileUtils.ts
+++ b/client/packages/common/src/utils/files/FileUtils.ts
@@ -86,6 +86,17 @@ export const useExportCSV = () => {
   return exportCsv;
 };
 
+export const useExportJSON = () => {
+  const exportFile = useExportFile();
+
+  const exportJson = async (data: string, title: string) => {
+    const filename = getFilename('application/json', title);
+    exportFile(data, 'application/json', filename);
+  };
+
+  return exportJson;
+};
+
 export const useExportLog = () => {
   const exportFile = useExportFile();
 
@@ -174,6 +185,9 @@ const getFilename = (type?: string, title?: string) => {
   switch (type) {
     case 'text/csv':
       extension = 'csv';
+      break;
+    case 'application/json':
+      extension = 'json';
       break;
   }
 


### PR DESCRIPTION
Adds to FileUtils export to provide a method for specifically downloading JSON files from in-memory source (as opposed to a file on a URL). Complements `useExportCSV` and `useExportLog`.

Required for Daily Tally plugin