### PR TITLE
Add Save button to plugin config modal

### DIFF
--- a/client/packages/system/src/Manage/Plugins/ListView/PluginConfigModal.tsx
+++ b/client/packages/system/src/Manage/Plugins/ListView/PluginConfigModal.tsx
@@ -50,15 +50,11 @@ export const PluginConfigModal = ({
     setValue(configuration?.data ?? slot?.defaultConfig);
   }, [isLoading, configuration, slot, value]);
 
-  const persist = async () => {
-    await save(value);
-    success(t('messages.plugin-config-saved'))();
-  };
-
   // Save without closing — lets the user persist progress and keep editing.
   const onSave = async () => {
     try {
-      await persist();
+      await save(value);
+      success(t('messages.plugin-config-saved'))();
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       error(`${t('error.unable-to-save-plugin-config')}: ${message}`)();
@@ -67,7 +63,8 @@ export const PluginConfigModal = ({
 
   const onOk = async () => {
     try {
-      await persist();
+      await save(value);
+      success(t('messages.plugin-config-saved'))();
       onClose();
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);

--- a/client/packages/system/src/Manage/Plugins/ListView/PluginConfigModal.tsx
+++ b/client/packages/system/src/Manage/Plugins/ListView/PluginConfigModal.tsx
@@ -40,17 +40,34 @@ export const PluginConfigModal = ({
   const { Modal } = useDialog({ isOpen, onClose, disableBackdrop: true });
 
   // Seed the local form value once the loaded row resolves; from then on the
-  // form owns its state until save.
+  // form owns its state. Seeding only while `value` is undefined matters for
+  // Save (below): saving refetches the row, and re-seeding here would clobber
+  // any edits made after the save. The modal unmounts on close, so a reopen
+  // remounts fresh and re-seeds.
   const [value, setValue] = useState<unknown>(undefined);
   useEffect(() => {
-    if (isLoading) return;
+    if (isLoading || value !== undefined) return;
     setValue(configuration?.data ?? slot?.defaultConfig);
-  }, [isLoading, configuration, slot]);
+  }, [isLoading, configuration, slot, value]);
+
+  const persist = async () => {
+    await save(value);
+    success(t('messages.plugin-config-saved'))();
+  };
+
+  // Save without closing — lets the user persist progress and keep editing.
+  const onSave = async () => {
+    try {
+      await persist();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      error(`${t('error.unable-to-save-plugin-config')}: ${message}`)();
+    }
+  };
 
   const onOk = async () => {
     try {
-      await save(value);
-      success(t('messages.plugin-config-saved'))();
+      await persist();
       onClose();
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
@@ -88,6 +105,13 @@ export const PluginConfigModal = ({
       height={modalHeight}
       contentProps={{ sx: { overflowY: 'hidden' } }}
       cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
+      saveButton={
+        <DialogButton
+          variant="save"
+          onClick={onSave}
+          disabled={isSaving || isLoading || value === undefined}
+        />
+      }
       okButton={
         <DialogButton
           variant="ok"


### PR DESCRIPTION
As per [this comment](https://github.com/msupply-foundation/afghanistan-plugins/pull/25#pullrequestreview-4480966706)

The Daily Tally plugin is sufficiently complex that users will almostly want to save their progress as the go. Before this change the only way to save was to also close the modal with the "OK" button.

Note, this change will apply to *all* plugin config pages
<img width="1164" height="743" alt="Screenshot 2026-06-15 at 12 53 21 PM" src="https://github.com/user-attachments/assets/5e296541-c450-477e-a5ee-5b727dd2344e" />
