### PR TITLE
#12100 Omit default port from server URL on Android

### DIFF
--- a/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java
@@ -646,7 +646,15 @@ public class NativeApi extends Plugin implements NsdManager.DiscoveryListener {
          */
         public String getUrl() {
             String host = data.getBool("isLocal") ? "localhost" : data.getString("ip");
-            return data.getString("protocol") + "://" + host + ":" + data.getString("port");
+            Integer port = data.getInteger("port");
+            // A port of 0 (or unspecified) means "use the protocol's default port"
+            // (e.g. 443 for https, 80 for http), so it's omitted from the URL.
+            // This mirrors the frontEndHostUrl helper in the TS client. Appending
+            // ":0" produces an invalid URL (INVALID_PORT) and the connection fails.
+            if (port == null || port == 0) {
+                return data.getString("protocol") + "://" + host;
+            }
+            return data.getString("protocol") + "://" + host + ":" + port;
         }
 
         /**


### PR DESCRIPTION
Fixes #12100

# 👩🏻‍💻 What does this PR do?

Fixes a connection failure on Android when connecting to a remote server in client mode over https on the standard port (443).

The codebase uses a convention where `port === 0` means "use the protocol's default port" (443 for https, 80 for http) and omits it from the URL — this is already honoured by the `frontEndHostUrl` helper on the TS client. When a user enters a URL with no explicit port (or even an explicit `:443`, which JavaScript's `URL` API strips), `Number(url.port)` in `ManualServerConfig.tsx` evaluates to `0`, and that value is stored as the server config and as `previousServer`.

The native `getUrl()` in `NativeApi.java` was the one place that did **not** honour this convention — it blindly appended `:0`, producing `https://host:0/login`, which Android's URL parser rejects with `INVALID_PORT`:

```
{"success":false,"error":"Invalid URL: INVALID_PORT for https://*.msupply.org:0/login"}
```

This broke both the manual connect path and the "Connecting to previous server" auto-reconnect path (both route through native `connectToServer` → `getConnectionUrl` → `getUrl`).

This PR makes `getUrl()` omit the port when it is `0` (or unspecified), mirroring the existing `frontEndHostUrl` TS helper, so the OS uses the protocol's default port.

## 💌 Any notes for the reviewer?

- Fix is a single change to `FrontEndHost.getUrl()` in `client/packages/android/app/src/main/java/org/openmsupply/client/NativeApi.java`. All Android URL construction flows through this method (webview load, connection check, and the prefix-match in `CertWebViewClient`), so this one change covers every path.
- Chose to make the native code honour the existing `port === 0` convention rather than change how the port is parsed/stored on the TS side. This keeps the lone outlier consistent with the rest of the codebase and, importantly, also fixes already-stored `previousServer` entries that have port `0` — no migration needed.
- Discovered (local-network) servers store the real `serviceInfo.getPort()` and local-server URLs use the hardcoded port 8000, so neither is affected.
- This is a native Java change — it needs an Android build/device to verify end-to-end; I was unable to exercise the WebView connection path locally.

# 🧪 Testing

- [ ] Build and run the Android client on a tablet/device.
- [ ] In client mode, connect to a remotely-hosted server with SSL enabled using the standard https port — e.g. enter `https://your-server.msupply.org` (no port) or `https://your-server.msupply.org:443`.
- [ ] Confirm the connection succeeds (previously failed with `Invalid URL: INVALID_PORT ... :0/login`).
- [ ] Restart the app and confirm auto-reconnect to the previous server also succeeds.
- [ ] Regression: connect to a server on a non-default port (e.g. `:8000`) and confirm the explicit port is still used.

# 📃 Documentation

- [x] **No documentation required**: bug fix which restores expected behaviour (no change in intended behaviour).
