### PR TITLE
Fix/11963/processor cursor fixes

### DIFF
--- a/server/service/src/processors/general_processor.rs
+++ b/server/service/src/processors/general_processor.rs
@@ -187,7 +187,7 @@ pub(crate) async fn process_records(
                 }
 
                 cursor_controller
-                    .update(&ctx.connection, (log.cursor + 1) as u64)
+                    .update(&ctx.connection, log.cursor as u64)
                     .map_err(Error::DatabaseError)?;
             }
         }

--- a/server/service/src/processors/transfer/invoice/mod.rs
+++ b/server/service/src/processors/transfer/invoice/mod.rs
@@ -188,7 +188,7 @@ pub(crate) fn process_invoice_transfers(
             }
 
             cursor_controller
-                .update(&ctx.connection, (log.cursor + 1) as u64)
+                .update(&ctx.connection, log.cursor as u64)
                 .map_err(Error::DatabaseError)?;
         }
     }

--- a/server/service/src/processors/transfer/invoice/test.rs
+++ b/server/service/src/processors/transfer/invoice/test.rs
@@ -30,8 +30,6 @@ use crate::{
 /// This test is for requesting and responding store on the same site
 /// See same site transfer diagram in requisition README.md for example of how
 /// changelog is upserted and processed by the same instance of triggered processor
-// TODO fix test v7
-#[ignore]
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn invoice_transfers() {
     let site_id = 25;
@@ -302,8 +300,6 @@ async fn invoice_transfers() {
 }
 
 /// Checking behavior when a request requisition name_id is that of a merged name. Response requisition for the merged name store should be generated regardless.
-// TODO fix test v7
-#[ignore]
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn invoice_transfers_with_merged_name() {
     let site_id = 25;

--- a/server/service/src/processors/transfer/invoice/test.rs
+++ b/server/service/src/processors/transfer/invoice/test.rs
@@ -30,6 +30,8 @@ use crate::{
 /// This test is for requesting and responding store on the same site
 /// See same site transfer diagram in requisition README.md for example of how
 /// changelog is upserted and processed by the same instance of triggered processor
+// TODO fix test v7
+#[ignore]
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn invoice_transfers() {
     let site_id = 25;
@@ -300,6 +302,8 @@ async fn invoice_transfers() {
 }
 
 /// Checking behavior when a request requisition name_id is that of a merged name. Response requisition for the merged name store should be generated regardless.
+// TODO fix test v7
+#[ignore]
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn invoice_transfers_with_merged_name() {
     let site_id = 25;

--- a/server/service/src/processors/transfer/requisition/mod.rs
+++ b/server/service/src/processors/transfer/requisition/mod.rs
@@ -147,7 +147,7 @@ pub(crate) fn process_requisition_transfers(
 
             // Always update cursor and move on to the next log, even if there's an error
             cursor_controller
-                .update(&ctx.connection, (log.cursor + 1) as u64)
+                .update(&ctx.connection, log.cursor as u64)
                 .map_err(Error::DatabaseError)?;
         }
     }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11963

# 👩🏻‍💻 What does this PR do?

Fixes the changelog cursors updates in processors. (remove + 1)

This also fixes Supplier return <-> Customer return syncing correctly (Picked and Shipped)
<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Tested the whole flow from Internal order -> response requisition -> outbound shipment -> inbound shipment -> supplier return -> customer return

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Setup v7 sync between COMS and ROMS
- [ ] Have supplier store A and an another store B on ROMS
- [ ] Create a return from B to supplier A
- [ ] Sync, and then see the customer return in B show up as picked
- [ ] In A, change the status to shipped for the return. Sync, then see the status change to shipped in B

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

