### PR TITLE
Render Eastern numerals for Dari & Pashto

### DIFF
--- a/client/packages/common/src/intl/context/IntlContext.tsx
+++ b/client/packages/common/src/intl/context/IntlContext.tsx
@@ -8,6 +8,7 @@ import { browserLanguageDetector } from './browserLanguageDetector';
 import { createRegisteredContext } from 'react-singleton-context';
 import { Environment } from '@openmsupply-client/config';
 import { GetBackendByNamespace } from './GetBackendByNamespace';
+import { intlNumberFormat } from '../number/IntlNumber';
 const appVersion = require('../../../../../../package.json').version; // eslint-disable-line @typescript-eslint/no-var-requires
 
 // Created by webpack DefinePlugin see webpack.config.js
@@ -89,6 +90,14 @@ export function initialiseI18n({
         escapeValue: false, // not needed for react!!
       },
     });
+
+  // i18next's built-in `number` formatter uses `Intl.NumberFormat(lng)` directly,
+  // which ignores our numbering-system overrides (e.g. Pashto defaults to Latin
+  // digits). Route `{{x, number}}` through `intlNumberFormat` so interpolated
+  // counts render in the locale's numerals (Eastern/extended-Arabic for ar/prs/ps).
+  i18next.services.formatter?.add('number', (value, lng, options) =>
+    intlNumberFormat(lng ?? 'en', options).format(Number(value))
+  );
 }
 
 export const IntlContext = createRegisteredContext<I18nextProviderProps>(

--- a/client/packages/common/src/intl/context/IntlContext.tsx
+++ b/client/packages/common/src/intl/context/IntlContext.tsx
@@ -92,12 +92,18 @@ export function initialiseI18n({
     });
 
   // i18next's built-in `number` formatter uses `Intl.NumberFormat(lng)` directly,
-  // which ignores our numbering-system overrides (e.g. Pashto defaults to Latin
-  // digits). Route `{{x, number}}` through `intlNumberFormat` so interpolated
-  // counts render in the locale's numerals (Eastern/extended-Arabic for ar/prs/ps).
-  i18next.services.formatter?.add('number', (value, lng, options) =>
-    intlNumberFormat(lng ?? 'en', options).format(Number(value))
-  );
+  // which ignores our numbering-system overrides (see localeNumberOverrides —
+  // e.g. Pashto otherwise defaults to Latin digits). Route `{{x, number}}`
+  // through `intlNumberFormat` so interpolated counts render in
+  // locale-appropriate digits (Arabic-Indic ٠-٩ for ar; extended-Arabic ۰-۹ for
+  // prs/ps). Fall back to the active language rather than 'en' if i18next
+  // doesn't supply one, and leave non-numeric values untouched instead of
+  // emitting "NaN".
+  i18next.services.formatter?.add('number', (value, lng, options) => {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return value == null ? '' : String(value);
+    return intlNumberFormat(lng ?? i18next.language, options).format(num);
+  });
 }
 
 export const IntlContext = createRegisteredContext<I18nextProviderProps>(

--- a/client/packages/common/src/intl/number/IntlNumber.test.ts
+++ b/client/packages/common/src/intl/number/IntlNumber.test.ts
@@ -1,0 +1,58 @@
+import { intlNumberFormat } from './IntlNumber';
+
+// NOTE on the test environment: the bug these overrides fix is browser-only.
+// In a browser, `Intl.NumberFormat('ps')` defaults to Latin digits, which is
+// why Pashto needs routing through `fa-AF`. Node's full-ICU happens to render
+// `ps`/`prs` with extended-Arabic digits already, so these assertions document
+// the intended per-locale numbering-system policy (and guard the lookup logic /
+// non-overridden locales) rather than reproducing the raw browser divergence.
+
+const N = 1234567;
+
+const LATIN = /[0-9]/;
+const ARABIC_INDIC = /[٠-٩]/; // ٠-٩
+const EXTENDED_ARABIC = /[۰-۹]/; // ۰-۹ (a.k.a. arabext / Eastern)
+
+describe('intlNumberFormat numbering systems', () => {
+  it('uses Latin digits for non-overridden locales (en)', () => {
+    const out = intlNumberFormat('en').format(N);
+    expect(out).toBe('1,234,567');
+    expect(out).toMatch(LATIN);
+  });
+
+  it('uses Arabic-Indic digits for ar', () => {
+    const out = intlNumberFormat('ar').format(N);
+    expect(out).toMatch(ARABIC_INDIC);
+    expect(out).not.toMatch(LATIN);
+    expect(out).not.toMatch(EXTENDED_ARABIC);
+  });
+
+  it('uses extended-Arabic (Eastern) digits for Dari (prs)', () => {
+    const out = intlNumberFormat('prs').format(N);
+    expect(out).toMatch(EXTENDED_ARABIC);
+    expect(out).not.toMatch(LATIN);
+  });
+
+  it('uses extended-Arabic (Eastern) digits for Pashto (ps)', () => {
+    const out = intlNumberFormat('ps').format(N);
+    expect(out).toMatch(EXTENDED_ARABIC);
+    expect(out).not.toMatch(LATIN);
+  });
+
+  it('applies the override to regional variants via base-language fallback', () => {
+    // i18next/the browser may resolve to a regional tag (e.g. `ps-AF`); the
+    // base-language override must still apply so digits don't revert to Latin.
+    expect(intlNumberFormat('ps-AF').format(N)).toBe(
+      intlNumberFormat('ps').format(N)
+    );
+    expect(intlNumberFormat('prs-AF').format(N)).toBe(
+      intlNumberFormat('prs').format(N)
+    );
+  });
+
+  it('passes Intl.NumberFormat options through', () => {
+    expect(intlNumberFormat('en', { minimumFractionDigits: 2 }).format(5)).toBe(
+      '5.00'
+    );
+  });
+});

--- a/client/packages/common/src/intl/number/IntlNumber.ts
+++ b/client/packages/common/src/intl/number/IntlNumber.ts
@@ -6,11 +6,15 @@ import { MAX_FRACTION_DIGITS, SupportedLocales, useIntlUtils } from '../utils';
 const localeNumberOverrides: { [locale: string]: /* Override */ string } = {
   tet: 'en-US',
   ar: 'ar-u-nu-arab',
-  // Dari & Pashto (Afghanistan) use Eastern/extended-Arabic digits (۰-۹). The
-  // browser's default numbering system for `ps` is Latin (and `ar` is too),
-  // so force `arabext` explicitly — otherwise Pashto renders Western numerals.
-  prs: 'prs-u-nu-arabext',
-  ps: 'ps-u-nu-arabext',
+  // Dari (prs) & Pashto (ps), Afghanistan — both should render Eastern /
+  // extended-Arabic digits (۰-۹). We can't just tag the numbering system: ICU
+  // pins `ps` to Latin digits and *silently ignores* a `-u-nu-arabext`
+  // override on it (it resolves straight back to `latn`), so Pashto kept
+  // rendering Western numerals. Afghan Persian (`fa-AF`) natively uses the same
+  // digits and separators, so we format both languages through it. (`prs`
+  // already defaults to extended-Arabic; routed the same way for consistency.)
+  prs: 'fa-AF',
+  ps: 'fa-AF',
 };
 
 // This method needs to be used instead of Intl.NumberFormat directly

--- a/client/packages/common/src/intl/number/IntlNumber.ts
+++ b/client/packages/common/src/intl/number/IntlNumber.ts
@@ -22,7 +22,14 @@ export const intlNumberFormat = (
   locale: string,
   params?: Intl.NumberFormatOptions
 ) => {
-  return new Intl.NumberFormat(localeNumberOverrides[locale] ?? locale, params);
+  // Fall back to the base language so regional tags (e.g. `ps-AF`, `ar-SA`)
+  // still pick up the override; otherwise their digits revert to the browser
+  // default (Latin for Pashto).
+  const override =
+    localeNumberOverrides[locale] ??
+    localeNumberOverrides[locale.split('-')[0] ?? locale] ??
+    locale;
+  return new Intl.NumberFormat(override, params);
 };
 
 export const useFormatNumber = () => {

--- a/client/packages/common/src/intl/number/IntlNumber.ts
+++ b/client/packages/common/src/intl/number/IntlNumber.ts
@@ -6,6 +6,11 @@ import { MAX_FRACTION_DIGITS, SupportedLocales, useIntlUtils } from '../utils';
 const localeNumberOverrides: { [locale: string]: /* Override */ string } = {
   tet: 'en-US',
   ar: 'ar-u-nu-arab',
+  // Dari & Pashto (Afghanistan) use Eastern/extended-Arabic digits (۰-۹). The
+  // browser's default numbering system for `ps` is Latin (and `ar` is too),
+  // so force `arabext` explicitly — otherwise Pashto renders Western numerals.
+  prs: 'prs-u-nu-arabext',
+  ps: 'ps-u-nu-arabext',
 };
 
 // This method needs to be used instead of Intl.NumberFormat directly


### PR DESCRIPTION
Closes #12118

For Afghan RTL locales (Dari `prs`, Pashto `ps`) numbers were rendering as Western (Latin) digits in several places. Number formatting is **host-owned (`common`)**, so plugins (e.g. the Daily Tally plugin — afghanistan-plugins#40) can't fix this themselves.

## Two causes, both fixed here

1. **`useFormatNumber` / `Intl` default numbering system.** In the browser, `Intl.NumberFormat('ps')` defaults to **Latin** digits (same as `ar`), while `prs` resolves to Persian — which is exactly why "Dari was fixed but Pashto wasn't". Routed `prs`/`ps` through Afghan Persian (`fa-AF`) in `localeNumberOverrides`, which natively renders extended-Arabic digits (۰-۹) plus matching separators. (A `…-u-nu-arabext` tag does *not* work here: ICU pins the `ps` locale to Latin digits and silently ignores the numbering-system override, resolving back to `latn` — so `fa-AF` is used instead.) Fixes every number routed through `useFormatNumber` (and the plugin's `useDoseFormat`, `NumericTextInput`, etc.).

2. **i18next `{{count}}` interpolation.** i18next's built-in `number` formatter calls `Intl.NumberFormat(lng)` directly, bypassing the overrides above. Registered a `number` formatter that delegates to `intlNumberFormat`, so `{{x, number}}` interpolations localise their digits too.

## Notes / scope

- **Backwards-compatible:** only the *numbering system* changes for `ar`/`prs`/`ps`; all other locales are untouched (`localeNumberOverrides[locale] ?? locale`). As a small bonus, existing `{{x, number}}` strings now render Arabic digits under `ar` (consistent with the rest of `ar` formatting).
- **Out of scope (deferred):** date numerals + the MUI datepicker calendar, and the wizard-stepper step numbers — those go through date-fns / MUI rather than `useFormatNumber` and need separate work.

## Verification

- `tsc` clean for `@openmsupply-client/common` (one pre-existing unrelated test-file error on `develop`).
- In Pashto: doses, stock movement, prescription/wastage values, numeric inputs, and `{{count, number}}` strings render `۰-۹`. No regression in Dari; non-RTL locales unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)