### PR TITLE
feat(cli): implement cli command to reset site auth

### DIFF
--- a/docs/content/server/cli/reset_site_auth/_index.md
+++ b/docs/content/server/cli/reset_site_auth/_index.md
@@ -29,8 +29,8 @@ For the full cli argument list and up to date description please run the command
 
 ### Usage
 
-Target sites by name with `--site-names` (comma-separated; names are matched **exactly**,
-case-sensitive, and may contain spaces). Choose what to clear with `--token` and/or
+Target sites by name with `--site-names` (comma-separated; names are matched
+**case-insensitively** and may contain spaces). Choose what to clear with `--token` and/or
 `--hardware-id` — at least one is required; pass both to clear both.
 
 ```
@@ -56,7 +56,7 @@ aborts with an error.
 
 | Flag | Description |
 | --- | --- |
-| `-n`, `--site-names` | Comma-separated list of site names to reset (matched exactly, case-sensitive). Names may contain spaces, e.g. `--site-names "Site A,Site B"`. |
+| `-n`, `--site-names` | Comma-separated list of site names to reset (matched case-insensitively). Names may contain spaces, e.g. `--site-names "Site A,Site B"`. |
 | `-t`, `--token` | Reset the sync token. Pass together with `--hardware-id` to reset both. |
 | `-i`, `--hardware-id` | Reset the hardware id. Pass together with `--token` to reset both. |
 

--- a/docs/content/server/cli/reset_site_auth/_index.md
+++ b/docs/content/server/cli/reset_site_auth/_index.md
@@ -1,0 +1,69 @@
++++
+title = "Reset Site Auth"
+weight = 30
+sort_by = "weight"
+template = "docs/section.html"
+
+[extra]
+source = "code"
++++
+
+# Reset Site Auth
+
+The `reset-site-auth` cli command clears the sync **token** and/or **hardware id** for one or
+more sites. It mirrors the "reset token" / "reset hardware id" actions available in the central
+server's site admin UI, for cases where the UI isn't convenient (e.g. automated testing, resetting many sites at
+once, or from a terminal during support).
+
+- **Clearing the token** invalidates a site's stored auth, forcing it to re-authenticate on its
+  next sync.
+- **Clearing the hardware id** lets a site sync from a different machine (the hardware id is
+  re-recorded on its next sync).
+
+`NOTE` This command **only runs on a central server**, where the `site` table holds the
+downstream sites' tokens and hardware ids. It aborts unless `server.override_is_central_server`
+is set in the configuration `.yaml`.
+
+For the full cli argument list and up to date description please run the command with just
+`--help`.
+
+### Usage
+
+Target sites by name with `--site-names` (comma-separated; names are matched **exactly**,
+case-sensitive, and may contain spaces). Choose what to clear with `--token` and/or
+`--hardware-id` — at least one is required; pass both to clear both.
+
+```
+# In development
+cargo run --bin remote_server_cli --features postgres -- \
+  reset-site-auth --site-names "Site A,Site B" --token --hardware-id
+
+# In production
+omSupply-cli reset-site-auth --site-names "Site A,Site B" --token --hardware-id
+
+# Reset just the token for a single site (short flags: -n, -t)
+omSupply-cli reset-site-auth -n "Clinic North" -t
+
+# Reset just the hardware id (-i)
+omSupply-cli reset-site-auth -n "Clinic North" -i
+```
+
+All names are resolved **before** anything is mutated, so a typo or unknown name aborts the whole
+command without clearing any site. Resetting the **current** site's own auth is not allowed and
+aborts with an error.
+
+### Options
+
+| Flag | Description |
+| --- | --- |
+| `-n`, `--site-names` | Comma-separated list of site names to reset (matched exactly, case-sensitive). Names may contain spaces, e.g. `--site-names "Site A,Site B"`. |
+| `-t`, `--token` | Reset the sync token. Pass together with `--hardware-id` to reset both. |
+| `-i`, `--hardware-id` | Reset the hardware id. Pass together with `--token` to reset both. |
+
+`NOTE` If neither `--token` nor `--hardware-id` is given the command errors — it never defaults to
+clearing both.
+
+### Extra
+
+- Each reset is logged at `info` level, naming the site and what was cleared.
+- Sites not listed in `--site-names` are left untouched.

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -284,7 +284,7 @@ enum Action {
     /// allows the site to sync from a different machine. Pass `--token` and/or
     /// `--hardware-id` to choose what to reset; at least one is required.
     ResetSiteAuth {
-        /// Comma-separated list of site names to reset (matched exactly, case-sensitive).
+        /// Comma-separated list of site names to reset (matched case-insensitively).
         /// Names may contain spaces, e.g. `--site-names "Site A,Site B"`.
         #[clap(short = 'n', long, value_delimiter = ',')]
         site_names: Vec<String>,

--- a/server/cli/src/cli.rs
+++ b/server/cli/src/cli.rs
@@ -48,6 +48,9 @@ use backup::*;
 mod reintegrate_buffer;
 use reintegrate_buffer::reintegrate_buffer;
 
+mod reset_site_auth;
+use reset_site_auth::reset_site_auth;
+
 #[cfg(feature = "integration_test")]
 use cli::LoadTest;
 use cli::{
@@ -276,6 +279,22 @@ enum Action {
         #[clap(long)]
         skip_buffer_reset: bool,
     },
+    /// Reset the sync token and/or hardware id for sites (central server only).
+    /// Clearing the token forces a site to re-authenticate; clearing the hardware id
+    /// allows the site to sync from a different machine. Pass `--token` and/or
+    /// `--hardware-id` to choose what to reset; at least one is required.
+    ResetSiteAuth {
+        /// Comma-separated list of site names to reset (matched exactly, case-sensitive).
+        /// Names may contain spaces, e.g. `--site-names "Site A,Site B"`.
+        #[clap(short = 'n', long, value_delimiter = ',')]
+        site_names: Vec<String>,
+        /// Reset the sync token. Pass together with `--hardware-id` to reset both.
+        #[clap(short, long, action = ArgAction::SetTrue)]
+        token: bool,
+        /// Reset the hardware id. Pass together with `--token` to reset both.
+        #[clap(short = 'i', long, action = ArgAction::SetTrue)]
+        hardware_id: bool,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -411,6 +430,13 @@ async fn main() -> anyhow::Result<()> {
                 should_migrate,
                 skip_buffer_reset,
             )?;
+        }
+        Action::ResetSiteAuth {
+            site_names,
+            token,
+            hardware_id,
+        } => {
+            reset_site_auth(&settings, site_names, token, hardware_id)?;
         }
         Action::InitialiseFromCentral { users } => {
             initialise_from_central(settings, &users).await?;

--- a/server/cli/src/reset_site_auth.rs
+++ b/server/cli/src/reset_site_auth.rs
@@ -1,0 +1,263 @@
+use anyhow::anyhow;
+use log::info;
+use repository::{
+    get_storage_connection_manager, KeyType, KeyValueStoreRepository, SiteRowRepository,
+};
+use service::{
+    service_provider::{ServiceContext, ServiceProvider},
+    settings::Settings,
+};
+
+/// Resets the sync token and/or hardware id for the named sites.
+///
+/// Intended to be run on a central server, where the `site` table holds the downstream
+/// sites' tokens and hardware ids. Clearing a site's token forces it to re-authenticate;
+/// clearing its hardware id lets it sync from a different machine. Site names are matched
+/// exactly (case-sensitive). All names are resolved up front, so an unknown name or a
+/// reference to the current site aborts before anything is mutated — resetting the current
+/// site's own auth is not allowed. Each reset is logged at `info` level.
+///
+/// Only runs on a central server: aborts unless `server.override_is_central_server` is set in
+/// the configuration. (The runtime [`service::sync::CentralServerConfig`] check can't be used
+/// here — that static is only populated during server startup, not in the cli process.)
+pub fn reset_site_auth(
+    settings: &Settings,
+    site_names: Vec<String>,
+    reset_token: bool,
+    reset_hardware_id: bool,
+) -> anyhow::Result<()> {
+    if !settings.server.override_is_central_server {
+        return Err(anyhow!(
+            "reset-site-auth can only be run on a central server"
+        ));
+    }
+
+    let connection_manager = get_storage_connection_manager(&settings.database);
+    let service_provider = ServiceProvider::new(connection_manager);
+    let ctx = service_provider.basic_context()?;
+
+    reset_site_auth_inner(
+        &service_provider,
+        &ctx,
+        site_names,
+        reset_token,
+        reset_hardware_id,
+    )
+}
+
+/// Core logic for [`reset_site_auth`], taking a `ServiceProvider`/`ServiceContext` directly
+/// so it can be exercised against a test database. See [`reset_site_auth`] for behaviour.
+fn reset_site_auth_inner(
+    service_provider: &ServiceProvider,
+    ctx: &ServiceContext,
+    site_names: Vec<String>,
+    reset_token: bool,
+    reset_hardware_id: bool,
+) -> anyhow::Result<()> {
+    if site_names.is_empty() {
+        return Err(anyhow!(
+            "--site-names is required (comma-separated list of site names)"
+        ));
+    }
+
+    // At least one of `--token` / `--hardware-id` must be given; pass both to reset both.
+    if !reset_token && !reset_hardware_id {
+        return Err(anyhow!(
+            "Specify what to reset: pass --token and/or --hardware-id"
+        ));
+    }
+
+    let current_site_id =
+        KeyValueStoreRepository::new(&ctx.connection).get_i32(KeyType::SettingsSyncSiteId)?;
+    let site_row_repo = SiteRowRepository::new(&ctx.connection);
+
+    // Resolve all names to sites up front, so we fail before mutating anything if
+    // a name is unknown or refers to the current site.
+    let mut sites = Vec::with_capacity(site_names.len());
+    for name in &site_names {
+        let name = name.trim();
+        let site = site_row_repo
+            .find_one_by_name(name)?
+            .ok_or(anyhow!("No site found with name '{}'", name))?;
+
+        if current_site_id == Some(site.id) {
+            return Err(anyhow!(
+                "Cannot reset auth for the current site '{}' (id {})",
+                site.name,
+                site.id
+            ));
+        }
+        sites.push(site);
+    }
+
+    for site in sites {
+        if reset_token {
+            service_provider
+                .site_service
+                .clear_site_token(ctx, site.id)
+                .map_err(|e| anyhow!("Failed to reset token for site '{}': {:?}", site.name, e))?;
+        }
+        if reset_hardware_id {
+            service_provider
+                .site_service
+                .clear_site_hardware_id(ctx, site.id)
+                .map_err(|e| {
+                    anyhow!(
+                        "Failed to reset hardware id for site '{}': {:?}",
+                        site.name,
+                        e
+                    )
+                })?;
+        }
+
+        let what = match (reset_token, reset_hardware_id) {
+            (true, true) => "token and hardware id",
+            (true, false) => "token",
+            (false, true) => "hardware id",
+            (false, false) => unreachable!(),
+        };
+        info!("Reset {} for site '{}' (id {})", what, site.name, site.id);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::{
+        mock::MockDataInserts, test_db::setup_all, SiteRow, StorageConnection, SyncVersion,
+    };
+    use service::service_provider::ServiceProvider;
+
+    fn site(connection: &StorageConnection, id: i32, name: &str) -> SiteRow {
+        let row = SiteRow {
+            id,
+            og_id: None,
+            code: format!("code{id}"),
+            name: name.to_string(),
+            hashed_password: "hash".to_string(),
+            hardware_id: Some("hw".to_string()),
+            token: Some("token".to_string()),
+            sync_version: SyncVersion::V5V6,
+        };
+        SiteRowRepository::new(connection).upsert(&row).unwrap();
+        row
+    }
+
+    fn stored(connection: &StorageConnection, id: i32) -> SiteRow {
+        SiteRowRepository::new(connection)
+            .find_one_by_id(id)
+            .unwrap()
+            .unwrap()
+    }
+
+    #[actix_rt::test]
+    async fn reset_site_auth_error_cases() {
+        let (_, connection, connection_manager, _) =
+            setup_all("reset_site_auth_errors", MockDataInserts::none()).await;
+        let service_provider = ServiceProvider::new(connection_manager);
+        let ctx = service_provider.basic_context().unwrap();
+
+        let current = site(&connection, 1, "Current Site");
+        KeyValueStoreRepository::new(&connection)
+            .set_i32(KeyType::SettingsSyncSiteId, Some(current.id))
+            .unwrap();
+
+        let reset = |names: Vec<String>, token, hw| {
+            reset_site_auth_inner(&service_provider, &ctx, names, token, hw)
+        };
+
+        // No flags: must specify what to reset.
+        assert!(reset(vec!["Current Site".to_string()], false, false)
+            .unwrap_err()
+            .to_string()
+            .contains("--token"));
+
+        // Unknown site name (also covers wrong-case, since matching is exact).
+        assert!(reset(vec!["nonexistent".to_string()], true, true)
+            .unwrap_err()
+            .to_string()
+            .contains("No site found"));
+
+        // Current site can't reset its own auth.
+        assert!(reset(vec!["Current Site".to_string()], true, true)
+            .unwrap_err()
+            .to_string()
+            .contains("current site"));
+
+        // None of the error cases mutated the site.
+        assert_eq!(
+            stored(&connection, current.id).token.as_deref(),
+            Some("token")
+        );
+    }
+
+    #[actix_rt::test]
+    async fn reset_site_auth_selective_flags() {
+        let (_, connection, connection_manager, _) =
+            setup_all("reset_site_auth_selective", MockDataInserts::none()).await;
+        let service_provider = ServiceProvider::new(connection_manager);
+        let ctx = service_provider.basic_context().unwrap();
+
+        let token_site = site(&connection, 1, "Token Site");
+        let hw_site = site(&connection, 2, "Hardware Site");
+
+        // --token only clears the token, leaving the hardware id.
+        reset_site_auth_inner(
+            &service_provider,
+            &ctx,
+            vec!["Token Site".to_string()],
+            true,
+            false,
+        )
+        .unwrap();
+        let token_stored = stored(&connection, token_site.id);
+        assert_eq!(token_stored.token, None);
+        assert_eq!(token_stored.hardware_id.as_deref(), Some("hw"));
+
+        // --hardware-id only clears the hardware id, leaving the token.
+        reset_site_auth_inner(
+            &service_provider,
+            &ctx,
+            vec!["Hardware Site".to_string()],
+            false,
+            true,
+        )
+        .unwrap();
+        let hw_stored = stored(&connection, hw_site.id);
+        assert_eq!(hw_stored.token.as_deref(), Some("token"));
+        assert_eq!(hw_stored.hardware_id, None);
+    }
+
+    #[actix_rt::test]
+    async fn reset_site_auth_both_multiple_sites_exact_case() {
+        let (_, connection, connection_manager, _) =
+            setup_all("reset_site_auth_multiple", MockDataInserts::none()).await;
+        let service_provider = ServiceProvider::new(connection_manager);
+        let ctx = service_provider.basic_context().unwrap();
+
+        let a = site(&connection, 1, "Site A");
+        let b = site(&connection, 2, "Site B");
+        let c = site(&connection, 3, "Site C");
+
+        // Exact-case names (whitespace trimmed) reset both fields; "Site C" is untouched.
+        reset_site_auth_inner(
+            &service_provider,
+            &ctx,
+            vec!["Site A".to_string(), " Site B ".to_string()],
+            true,
+            true,
+        )
+        .unwrap();
+
+        for id in [a.id, b.id] {
+            let stored = stored(&connection, id);
+            assert_eq!(stored.token, None);
+            assert_eq!(stored.hardware_id, None);
+        }
+        let untouched = stored(&connection, c.id);
+        assert_eq!(untouched.token.as_deref(), Some("token"));
+        assert_eq!(untouched.hardware_id.as_deref(), Some("hw"));
+    }
+}

--- a/server/cli/src/reset_site_auth.rs
+++ b/server/cli/src/reset_site_auth.rs
@@ -13,7 +13,7 @@ use service::{
 /// Intended to be run on a central server, where the `site` table holds the downstream
 /// sites' tokens and hardware ids. Clearing a site's token forces it to re-authenticate;
 /// clearing its hardware id lets it sync from a different machine. Site names are matched
-/// exactly (case-sensitive). All names are resolved up front, so an unknown name or a
+/// case-insensitively. All names are resolved up front, so an unknown name or a
 /// reference to the current site aborts before anything is mutated — resetting the current
 /// site's own auth is not allowed. Each reset is logged at `info` level.
 ///
@@ -77,7 +77,7 @@ fn reset_site_auth_inner(
     for name in &site_names {
         let name = name.trim();
         let site = site_row_repo
-            .find_one_by_name(name)?
+            .find_one_by_name_case_insensitive(name)?
             .ok_or(anyhow!("No site found with name '{}'", name))?;
 
         if current_site_id == Some(site.id) {
@@ -174,7 +174,7 @@ mod tests {
             .to_string()
             .contains("--token"));
 
-        // Unknown site name (also covers wrong-case, since matching is exact).
+        // Unknown site name.
         assert!(reset(vec!["nonexistent".to_string()], true, true)
             .unwrap_err()
             .to_string()
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[actix_rt::test]
-    async fn reset_site_auth_both_multiple_sites_exact_case() {
+    async fn reset_site_auth_both_multiple_sites_case_insensitive() {
         let (_, connection, connection_manager, _) =
             setup_all("reset_site_auth_multiple", MockDataInserts::none()).await;
         let service_provider = ServiceProvider::new(connection_manager);
@@ -241,11 +241,12 @@ mod tests {
         let b = site(&connection, 2, "Site B");
         let c = site(&connection, 3, "Site C");
 
-        // Exact-case names (whitespace trimmed) reset both fields; "Site C" is untouched.
+        // Names are matched case-insensitively and whitespace-trimmed; both fields are
+        // reset for the matched sites, while "Site C" is left untouched.
         reset_site_auth_inner(
             &service_provider,
             &ctx,
-            vec!["Site A".to_string(), " Site B ".to_string()],
+            vec!["site a".to_string(), " SITE B ".to_string()],
             true,
             true,
         )

--- a/server/repository/src/db_diesel/site_row.rs
+++ b/server/repository/src/db_diesel/site_row.rs
@@ -92,6 +92,14 @@ impl<'a> SiteRowRepository<'a> {
         Ok(result)
     }
 
+    pub fn find_one_by_name(&self, name: &str) -> Result<Option<SiteRow>, RepositoryError> {
+        let result = site::table
+            .filter(site::name.eq(name))
+            .first(self.connection.lock().connection())
+            .optional()?;
+        Ok(result)
+    }
+
     pub fn find_many_by_id(&self, ids: &[i32]) -> Result<Vec<SiteRow>, RepositoryError> {
         Ok(site::table
             .filter(site::id.eq_any(ids))

--- a/server/repository/src/db_diesel/site_row.rs
+++ b/server/repository/src/db_diesel/site_row.rs
@@ -92,14 +92,6 @@ impl<'a> SiteRowRepository<'a> {
         Ok(result)
     }
 
-    pub fn find_one_by_name(&self, name: &str) -> Result<Option<SiteRow>, RepositoryError> {
-        let result = site::table
-            .filter(site::name.eq(name))
-            .first(self.connection.lock().connection())
-            .optional()?;
-        Ok(result)
-    }
-
     pub fn find_many_by_id(&self, ids: &[i32]) -> Result<Vec<SiteRow>, RepositoryError> {
         Ok(site::table
             .filter(site::id.eq_any(ids))


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12050

# 👩🏻‍💻 What does this PR do?

Allows reseting token and hardware id for a site via cli.
The usage is document in developer docs.

Quick guide:
```bash
# View help
omSupply-cli reset-site-auth -h

# Reset both token and hardware-id for multiple sites
omSupply-cli reset-site-auth --site-names "Site A,Site B" --token --hardware-id

# Reset just the token for a single site (short flags: -n, -t)
omSupply-cli reset-site-auth -n "Clinic North" -t

# Reset just the hardware id (-i)
omSupply-cli reset-site-auth -n "Clinic North" -i
```
<!-- Explain the changes you made -->
This is to help with Automation testing to be able to reset site auth for reinitialisation, moving to a new device etc. 
<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

Checks the override_is_central_server flag in yaml settings. The command aborts if not true.
If trying to clear its own hardware_id/ token it fails
site name is case sensitive

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] set up coms with this branch (latest v3.00.0 for testers)
- [ ] run the cli command as shown
- [ ] be able to clear a remote site's token id / hardware id
- [ ] Be able to clear both token id and hardware id for one or more sites
- [ ] if trying to clear central's own id, then fails with a useful message

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

