### PR TITLE
#12122 Fix "Store ID required" error when opening preferences

### DIFF
--- a/client/packages/system/src/Manage/Preferences/api/useAdminPrefsList.ts
+++ b/client/packages/system/src/Manage/Preferences/api/useAdminPrefsList.ts
@@ -21,5 +21,8 @@ export const useAdminPrefsList = (
 
       return result.preferenceDescriptions;
     },
+    // Store preferences require a store id to load - skip the query until one
+    // is available (e.g. while the store is loading, or for non-store names)
+    enabled: prefType !== PreferenceNodeType.Store || !!storeId,
   });
 };


### PR DESCRIPTION
Fixes #12122

# 👩🏻‍💻 What does this PR do?

Clicking the pen icon in the footer opens the store edit modal, which runs the store preference descriptions query (`useAdminPrefsList`). That query fired immediately on render — before the store name document had resolved, so `storeId` was still `undefined`. With `prefType: Store` and no store id, the server raised `Store ID is required for store preference`, which the global query error handler surfaced as a toast.

This gates the query with `enabled` so it only fires once a store id is available (global preferences never need one), matching the existing `enabled: !!storeId` convention already used by `usePreferences`.

One-line change in `client/packages/system/src/Manage/Preferences/api/useAdminPrefsList.ts`.

## 💌 Any notes for the reviewer?

- **Latent bug, recently exposed**: the query has fired without a store id since the modal was built (`useAdminPrefsList`, unchanged since Aug 2025), always failing server-side but *silently*. PR #11444 (merged 2026-06-15) added the global `QueryErrorHandler` that now surfaces `InternalServerError`s as toasts — so the same failure became user-visible. The issue was filed against the build from that day.
- The server-side guard in `server/service/src/preference/types.rs` is correct and unchanged — the frontend simply shouldn't request store preferences without a store. Fix is frontend-only.
- For names that aren't stores, the Preferences tab is already hidden; the disabled query means it no longer errors in the background for those either.

# 🧪 Testing

- [ ] On a central server, log in and click the pen icon in the footer
- [ ] Confirm no "Store ID is required for store preference" error toast appears
- [ ] Open the Preferences tab in the modal and confirm store preferences load and save correctly
- [ ] Confirm the global preferences page (Admin) still loads

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in intended behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
