### PR TITLE
#12123 Fix crash when adding item to inbound shipment

### DIFF
--- a/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariants.ts
+++ b/client/packages/system/src/Item/api/hooks/useItemVariant/useItemVariants.ts
@@ -13,7 +13,12 @@ export function useItemVariants(itemId: string) {
         storeId,
       });
 
-      return result.items.nodes?.[0];
+      // TanStack Query forbids a queryFn resolving to `undefined`, so coalesce
+      // to null when no item matches (e.g. empty/inactive item id).
+      return result.items.nodes?.[0] ?? null;
     },
+    // Skip the query when there's no item selected (e.g. the InboundLineEdit
+    // "Add item" create flow before an item is chosen).
+    enabled: !!itemId,
   });
 }


### PR DESCRIPTION
Fixes #12123

# 👩🏻‍💻 What does this PR do?

Clicking **Add item** on an inbound shipment opens the `InboundLineEdit` modal in create mode with no item selected. In that state `useItemVariants` ran with an empty `itemId`, and its `queryFn` returned `result.items.nodes?.[0]` — which is `undefined` when nothing matches.

TanStack Query v5 forbids a `queryFn` resolving to `undefined`; it throws `<queryHash> data is undefined` (here `["ITEM_VARIANTS",""] data is undefined`). The app's global `throwOnError` (in `Host.tsx`) escalates any non-typed error to the global `ErrorBoundary`, so the whole page crashed with "Oops! Something's gone wrong."

The fix is scoped to the `useItemVariants` hook:
- Coalesce the `queryFn` result to `null` so it never resolves to `undefined`.
- Add `enabled: !!itemId` so the query is skipped entirely when no item is selected.

This crash path became reachable after add/delete lines was enabled on received inbound shipments (commit `1fd1495f48`, 2026-06-11), which is why it surfaced there.

## 💌 Any notes for the reviewer?

- **Deliberately scoped to `useItemVariants` only.** While investigating, 6 other `useQuery` hooks were found with the same "queryFn can return undefined" anti-pattern (most notably `useItem`/`useGetById`, where navigating to a deleted/inactive item id would crash the detail page). These are captured in follow-up issue #12126 rather than expanded into this hotfix.
- The hook's data type widens from `… | undefined` to `… | null`. All 8 call sites already use optional chaining / `if (!data)`, and `yarn re-compile` (tsc over the host project) passes clean.

# 🧪 Testing

- [ ] Open a **received** inbound shipment (one where add/delete lines is permitted)
- [ ] Click **Add item** → the line-edit modal opens normally (no "Oops! Something's gone wrong." page)
- [ ] Select an item that has variants → the variant panel still appears and works
- [ ] Confirm **Add item** also still works on a **New** inbound shipment

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in intended behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
