### PR TITLE
#12126 Guard useQuery hooks against undefined queryFn results

### DIFF
--- a/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
+++ b/client/packages/programs/src/JsonForms/components/ProgramEvent.tsx
@@ -95,8 +95,8 @@ const Options = z
 type Options = z.infer<typeof Options>;
 
 const extractAt = (
-  encounter?: EncounterFragment,
-  program?: ProgramEnrolmentFragment,
+  encounter?: EncounterFragment | null,
+  program?: ProgramEnrolmentFragment | null,
   options?: Options
 ): Date => {
   const date = new Date();

--- a/client/packages/programs/src/api/hooks/document/useEncounterByDocName.ts
+++ b/client/packages/programs/src/api/hooks/document/useEncounterByDocName.ts
@@ -6,7 +6,9 @@ export const useEncounterByDocName = (documentName: string | undefined) => {
 
   return useQuery({
     queryKey: api.keys.byDocName(documentName ?? ''),
-    queryFn: () => api.byDocName(documentName ?? ''),
+    // Coalesce to null: api.byDocName returns undefined when no encounter
+    // matches, which TanStack Query forbids and would crash the page.
+    queryFn: async () => (await api.byDocName(documentName ?? '')) ?? null,
     enabled: !!documentName
   });
 };

--- a/client/packages/programs/src/api/hooks/document/useFormSchemaByType.ts
+++ b/client/packages/programs/src/api/hooks/document/useFormSchemaByType.ts
@@ -6,7 +6,9 @@ export const useFormSchemaByType = (type: string | undefined) => {
 
   return useQuery({
     queryKey: api.keys.byType(type ?? ''),
-    queryFn: () => api.get.byType(type ?? ''),
+    // Coalesce to null: api.get.byType returns undefined when no schema
+    // matches, which TanStack Query forbids and would crash the page.
+    queryFn: async () => (await api.get.byType(type ?? '')) ?? null,
     refetchOnMount: false,
     gcTime: 0,
     enabled: !!type

--- a/client/packages/programs/src/api/hooks/document/useProgramEnrolmentByDocName.ts
+++ b/client/packages/programs/src/api/hooks/document/useProgramEnrolmentByDocName.ts
@@ -8,7 +8,9 @@ export const useProgramEnrolmentByDocName = (
 
   return useQuery({
     queryKey: api.keys.byDocName(documentName ?? ''),
-    queryFn: () => api.byDocName(documentName ?? ''),
+    // Coalesce to null: api.byDocName returns undefined when no enrolment
+    // matches, which TanStack Query forbids and would crash the page.
+    queryFn: async () => (await api.byDocName(documentName ?? '')) ?? null,
     enabled: !!documentName
   });
 };

--- a/client/packages/programs/src/api/hooks/useImmunisationProgram.ts
+++ b/client/packages/programs/src/api/hooks/useImmunisationProgram.ts
@@ -24,8 +24,11 @@ const useGet = (id: string) => {
     });
 
     if (result.programs.__typename === 'ProgramConnector') {
-      return result.programs.nodes[0];
+      // Coalesce to null: TanStack Query forbids a queryFn resolving to
+      // undefined (empty nodes / non-connector result would crash the page).
+      return result.programs.nodes[0] ?? null;
     }
+    return null;
   };
 
   const query = useQuery({

--- a/client/packages/programs/src/api/hooks/useVaccineCourse.ts
+++ b/client/packages/programs/src/api/hooks/useVaccineCourse.ts
@@ -129,8 +129,11 @@ const useGet = (id: string) => {
     });
 
     if (result.vaccineCourses.__typename === 'VaccineCourseConnector') {
-      return result.vaccineCourses.nodes[0];
+      // Coalesce to null: TanStack Query forbids a queryFn resolving to
+      // undefined (empty nodes / non-connector result would crash the page).
+      return result.vaccineCourses.nodes[0] ?? null;
     }
+    return null;
   };
 
   const query = useQuery({

--- a/client/packages/system/src/Item/api/hooks/useItem.ts
+++ b/client/packages/system/src/Item/api/hooks/useItem.ts
@@ -46,8 +46,11 @@ export const useGetById = (itemId: string) => {
     });
 
     if (result.items.__typename === 'ItemConnector') {
-      return result.items.nodes[0];
+      // Coalesce to null: TanStack Query forbids a queryFn resolving to
+      // undefined (empty nodes / non-connector result would crash the page).
+      return result.items.nodes[0] ?? null;
     }
+    return null;
   };
 
   const query = useQuery({


### PR DESCRIPTION
Fixes #12126

# 👩🏻‍💻 What does this PR do?

Follow-up to #12123 / #12125. While fixing the inbound-shipment "Add item" crash, we found the same landmine in **6 other `useQuery` hooks**: a `queryFn` that can resolve to `undefined`.

Each had the shape `if (result.x.__typename === 'XConnector') return result.x.nodes[0];` — which is `undefined` when zero rows match, and also falls through to an implicit `undefined` return when the typename isn't the connector. TanStack Query v5 forbids a `queryFn` resolving to `undefined` and throws `<queryHash> data is undefined`; the global `throwOnError` (in `Host.tsx`) then escalates it to the global `ErrorBoundary`, crashing the whole page.

Hooks fixed:
- `useItem` (`useGetById`) — **highest impact**: navigating to a deleted/inactive item id crashed the item detail page
- `useVaccineCourse` (`useGet`)
- `useImmunisationProgram` (`useGet`)
- `useEncounterByDocName`, `useProgramEnrolmentByDocName`, `useFormSchemaByType`

For each, the `queryFn` now coalesces its result to `null`:
- Inline queryFns also `return null` on the non-connector fall-through.
- The `byDocName`/`byType` hooks coalesce at the `queryFn` wiring (`async () => (await api.xxx(...)) ?? null`), leaving the api-layer return types untouched.

## 💌 Any notes for the reviewer?

- The data type of these hooks widens from `… | undefined` to `… | null`. The only consumer that didn't already accept null was `extractAt` in `ProgramEvent.tsx`; its `encounter`/`program` params are widened to `… | null` (it already reads them via optional chaining). `yarn re-compile` (tsc over the host project) passes clean.
- The `enabled: !!id` guards on several of these only covered the empty-id case; this PR also closes the **valid-id-but-zero-rows** path (stale URL, deleted/inactivated record), which is the less-tested one.

# 🧪 Testing

- [ ] Navigate to an **item detail** page for an item id that no longer exists / is inactive → page loads gracefully instead of "Oops! Something's gone wrong."
- [ ] Open vaccine course / immunisation program detail views → still load normally
- [ ] Open a program document / encounter (JSON forms `ProgramEvent`) → event dates still resolve correctly
- [ ] General smoke test of item, vaccine course and program areas

# 📃 Documentation

- [x] **No documentation required**: bug fix, no change in intended behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
