### PR TITLE
fix(sync-v7): allow all central sites to reset token

### DIFF
--- a/server/graphql/site/src/mutations/clear_token.rs
+++ b/server/graphql/site/src/mutations/clear_token.rs
@@ -25,7 +25,7 @@ pub fn clear_site_token(ctx: &Context<'_>, site_id: i32) -> Result<ClearSiteToke
         &ResourceAccessRequest {
             resource: Resource::MutateSites,
             store_id: None,
-            require_central_standalone: true,
+            require_central_standalone: false,
         },
     )?;
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12093

# 👩🏻‍💻 What does this PR do?

rest token graphql endpoint used to check if standalone central. This is wrong and now changed not to check for standalone

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Try to reset token on a central site which isn't standalone

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

