### PR TITLE
Expose populationPercentage on DemographicNode

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -2431,6 +2431,11 @@ export type DemographicNode = {
   __typename: 'DemographicNode';
   id: Scalars['String']['output'];
   name: Scalars['String']['output'];
+  /**
+   * Percentage of the store's served population this demographic represents
+   * (e.g. 3.5 for under-1s). Used by population-based vaccine forecasting.
+   */
+  populationPercentage: Scalars['Float']['output'];
 };
 
 export type DemographicProjectionConnector = {

--- a/server/graphql/types/src/types/demographic.rs
+++ b/server/graphql/types/src/types/demographic.rs
@@ -15,6 +15,11 @@ impl DemographicNode {
     pub async fn name(&self) -> &str {
         &self.row().name
     }
+    /// Percentage of the store's served population this demographic represents
+    /// (e.g. 3.5 for under-1s). Used by population-based vaccine forecasting.
+    pub async fn population_percentage(&self) -> f64 {
+        self.row().population_percentage
+    }
 }
 
 impl DemographicNode {


### PR DESCRIPTION
_No linked issue — small enabling change for the Afghanistan EPI custom reports._

# 👩🏻‍💻 What does this PR do?

Exposes `populationPercentage` on the GraphQL `DemographicNode`. The value already exists on
`DemographicRow` (and syncs to remote sites) — only the GraphQL getter was missing.

This unblocks **population-based vaccine forecasting on remote sites**: the Afghanistan EPI "HF6"
supply-request report derives a target population from
`vaccineCourses { demographic { populationPercentage } }`. The richer `demographic_indicator`
(which already exposes a percentage) is **central-only** and absent on remote sites, so the synced
`demographic` table is the correct source.

One resolver added in `server/graphql/types/src/types/demographic.rs`; `server/schema.graphql` and
`client/packages/common/src/types/schema.ts` regenerated via `yarn generate` (the one new field).

## 💌 Any notes for the reviewer?

- Purely additive — no behaviour change, no new query, no migration. The resolver just returns
  `self.row().population_percentage`.
- No linked issue (small enabler split out of the custom-reports work in the open-msupply-reports
  repo); happy to attach one if you'd prefer.

# 🧪 Testing

- [ ] Run the server and execute a GraphQL query selecting the new field, e.g.
      `query { demographics(storeId: "<store>") { ... on DemographicConnector { nodes { id name populationPercentage } } } }`
      (or `vaccineCourses { ... on VaccineCourseConnector { nodes { demographic { populationPercentage } } } }`)
      and confirm the configured percentage is returned.

# 📃 Documentation

- [x] **No documentation required**: additive GraphQL field, no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
