### PR TITLE
12092 unable to access requisitions and invoices where the 'other party' store is disabled

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -758,6 +758,7 @@
   "info.automatic-return-no-edit": "You are unable to edit details until the status is confirmed as Delivered.",
   "info.automatic-shipment": "This shipment was created automatically, as the result of an outbound shipment in another store.",
   "info.automatic-shipment-no-edit": "You are unable to edit details until the status is confirmed as Delivered.",
+  "info.cannot-edit-disabled-store": "This record is read-only because the other party's store has been disabled.",
   "info.cannot-edit-program-requisition": "Cannot edit supplier, reorder threshold MOS, target MOS or add items in a program requisition.",
   "info.cost-price-not-editable": "Cost price is controlled by the supplying store or purchase order and cannot be edited here.",
   "info.manual-return": "This return was created manually. The delivery status will not be automatically updated.",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -758,7 +758,7 @@
   "info.automatic-return-no-edit": "You are unable to edit details until the status is confirmed as Delivered.",
   "info.automatic-shipment": "This shipment was created automatically, as the result of an outbound shipment in another store.",
   "info.automatic-shipment-no-edit": "You are unable to edit details until the status is confirmed as Delivered.",
-  "info.cannot-edit-disabled-store": "This record is read-only because the other party's store has been disabled.",
+  "info.cannot-edit-disabled-store": "This record is read-only because the customer/supplier store has been disabled..",
   "info.cannot-edit-program-requisition": "Cannot edit supplier, reorder threshold MOS, target MOS or add items in a program requisition.",
   "info.cost-price-not-editable": "Cost price is controlled by the supplying store or purchase order and cannot be edited here.",
   "info.manual-return": "This return was created manually. The delivery status will not be automatically updated.",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -758,7 +758,7 @@
   "info.automatic-return-no-edit": "You are unable to edit details until the status is confirmed as Delivered.",
   "info.automatic-shipment": "This shipment was created automatically, as the result of an outbound shipment in another store.",
   "info.automatic-shipment-no-edit": "You are unable to edit details until the status is confirmed as Delivered.",
-  "info.cannot-edit-disabled-store": "This record is read-only because the customer/supplier store has been disabled..",
+  "info.cannot-edit-disabled-store": "This record is read-only because the customer/supplier store has been disabled.",
   "info.cannot-edit-program-requisition": "Cannot edit supplier, reorder threshold MOS, target MOS or add items in a program requisition.",
   "info.cost-price-not-editable": "Cost price is controlled by the supplying store or purchase order and cannot be edited here.",
   "info.manual-return": "This return was created manually. The delivery status will not be automatically updated.",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -10022,6 +10022,8 @@ export type StoreNode = {
   code: Scalars['String']['output'];
   createdDate?: Maybe<Scalars['NaiveDate']['output']>;
   id: Scalars['String']['output'];
+  /** Whether the store has been disabled, either by a user or as a result of a store merge. */
+  isDisabled: Scalars['Boolean']['output'];
   /**
    * Returns the associated store logo.
    * The logo is returned as a data URL schema, e.g. "data:image/png;base64,..."

--- a/client/packages/common/src/ui/components/panels/DisabledStoreNotice.tsx
+++ b/client/packages/common/src/ui/components/panels/DisabledStoreNotice.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Alert } from './Alert';
+import { useTranslation } from '@common/intl';
+
+interface DisabledStoreNoticeProps {
+  otherParty?: { store?: { isDisabled: boolean } | null } | null;
+}
+
+export const DisabledStoreNotice = ({
+  otherParty,
+}: DisabledStoreNoticeProps) => {
+  const t = useTranslation();
+
+  if (!otherParty?.store?.isDisabled) return null;
+
+  return (
+    <Alert severity="info" sx={{ width: '100%' }}>
+      {t('info.cannot-edit-disabled-store')}
+    </Alert>
+  );
+};

--- a/client/packages/common/src/ui/components/panels/index.ts
+++ b/client/packages/common/src/ui/components/panels/index.ts
@@ -1,6 +1,7 @@
 export * from './DetailPanelAction';
 export * from './DetailPanelSection';
 export * from './Alert';
+export * from './DisabledStoreNotice';
 export * from './SlidePanel';
 export * from './ImportPanel';
 export * from './StatusChip';

--- a/client/packages/inventory/src/Stocktake/api/operations.generated.ts
+++ b/client/packages/inventory/src/Stocktake/api/operations.generated.ts
@@ -45,12 +45,7 @@ export type StocktakeLineFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: {
-      __typename: 'StoreNode';
-      id: string;
-      code: string;
-      isDisabled: boolean;
-    } | null;
+    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
   } | null;
   location?: {
     __typename: 'LocationNode';
@@ -157,12 +152,7 @@ export type StocktakeFragment = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: {
-          __typename: 'StoreNode';
-          id: string;
-          code: string;
-          isDisabled: boolean;
-        } | null;
+        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
       } | null;
       location?: {
         __typename: 'LocationNode';
@@ -317,7 +307,6 @@ export type StocktakeQuery = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
-                isDisabled: boolean;
               } | null;
             } | null;
             location?: {
@@ -449,7 +438,6 @@ export type StocktakeByNumberQuery = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
-                isDisabled: boolean;
               } | null;
             } | null;
             location?: {
@@ -562,12 +550,7 @@ export type StocktakeLinesQuery = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: {
-          __typename: 'StoreNode';
-          id: string;
-          code: string;
-          isDisabled: boolean;
-        } | null;
+        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
       } | null;
       location?: {
         __typename: 'LocationNode';

--- a/client/packages/inventory/src/Stocktake/api/operations.generated.ts
+++ b/client/packages/inventory/src/Stocktake/api/operations.generated.ts
@@ -45,7 +45,12 @@ export type StocktakeLineFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   } | null;
   location?: {
     __typename: 'LocationNode';
@@ -152,7 +157,12 @@ export type StocktakeFragment = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+        store?: {
+          __typename: 'StoreNode';
+          id: string;
+          code: string;
+          isDisabled: boolean;
+        } | null;
       } | null;
       location?: {
         __typename: 'LocationNode';
@@ -307,6 +317,7 @@ export type StocktakeQuery = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
+                isDisabled: boolean;
               } | null;
             } | null;
             location?: {
@@ -438,6 +449,7 @@ export type StocktakeByNumberQuery = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
+                isDisabled: boolean;
               } | null;
             } | null;
             location?: {
@@ -550,7 +562,12 @@ export type StocktakeLinesQuery = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+        store?: {
+          __typename: 'StoreNode';
+          id: string;
+          code: string;
+          isDisabled: boolean;
+        } | null;
       } | null;
       location?: {
         __typename: 'LocationNode';

--- a/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -11,6 +11,7 @@ import {
   BufferedTextArea,
   Link,
   RouteBuilder,
+  DisabledStoreNotice,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { SupplierSearchInput } from '@openmsupply-client/system';
@@ -134,6 +135,9 @@ export const Toolbar = () => {
         )}
         <Grid>
           <ReceivedDateInput />
+        </Grid>
+        <Grid size={12}>
+          <DisabledStoreNotice otherParty={otherParty} />
         </Grid>
         <Grid size={12}>
           <InboundInfoPanel shipment={shipment} />

--- a/client/packages/invoices/src/InboundShipment/api/hooks/document/useInboundShipment.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/document/useInboundShipment.ts
@@ -55,7 +55,11 @@ export const useInboundShipment = (id?: string) => {
   const hasVerifyPermission = isExternal
     ? userHasPermission(UserPermission.InboundShipmentExternalVerify)
     : userHasPermission(UserPermission.InboundShipmentVerify);
-  const isDisabled = isInboundDisabled(data) || !hasMutatePermission;
+  // The other party's store may have been disabled (e.g. after a store merge);
+  // such records remain viewable but must not be editable.
+  const isOtherPartyDisabled = !!data?.otherParty?.store?.isDisabled;
+  const isDisabled =
+    isInboundDisabled(data) || isOtherPartyDisabled || !hasMutatePermission;
   const isStatusChangeDisabled = isInboundStatusChangeDisabled(data);
   // A shipment that went through line authorisation (any line has an auth
   // status) can only be received once every line is approved or rejected, so

--- a/client/packages/invoices/src/InboundShipment/api/hooks/document/useInboundShipment.ts
+++ b/client/packages/invoices/src/InboundShipment/api/hooks/document/useInboundShipment.ts
@@ -42,7 +42,11 @@ export const useInboundShipment = (id?: string) => {
     ? InvoiceTypeInput.InboundShipmentExternal
     : InvoiceTypeInput.InboundShipment;
 
-  const { data, isLoading: loading, error } = useGetById(invoiceId, invoiceType);
+  const {
+    data,
+    isLoading: loading,
+    error,
+  } = useGetById(invoiceId, invoiceType);
   const { queryClient } = useInboundGraphQL();
   const { userHasPermission } = useAuthContext();
   const isHoldable = isInboundHoldable(data);
@@ -55,8 +59,6 @@ export const useInboundShipment = (id?: string) => {
   const hasVerifyPermission = isExternal
     ? userHasPermission(UserPermission.InboundShipmentExternalVerify)
     : userHasPermission(UserPermission.InboundShipmentVerify);
-  // The other party's store may have been disabled (e.g. after a store merge);
-  // such records remain viewable but must not be editable.
   const isOtherPartyDisabled = !!data?.otherParty?.store?.isDisabled;
   const isDisabled =
     isInboundDisabled(data) || isOtherPartyDisabled || !hasMutatePermission;
@@ -167,7 +169,7 @@ export const useInboundShipment = (id?: string) => {
 
   const invalidateQuery = () => {
     queryClient.invalidateQueries({
-      queryKey: [INBOUND, INBOUND_LINE, invoiceId]
+      queryKey: [INBOUND, INBOUND_LINE, invoiceId],
     });
   };
 
@@ -192,10 +194,7 @@ export const useInboundShipment = (id?: string) => {
   };
 };
 
-const useGetById = (
-  invoiceId: string | undefined,
-  type?: InvoiceTypeInput
-) => {
+const useGetById = (invoiceId: string | undefined, type?: InvoiceTypeInput) => {
   const { inboundApi, storeId } = useInboundGraphQL();
 
   const queryFn = async (): Promise<InboundFragment> => {
@@ -254,7 +253,7 @@ const useUpdate = (isExternal: boolean) => {
     mutationFn,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [INBOUND]
+        queryKey: [INBOUND],
       });
     },
   });
@@ -286,8 +285,9 @@ const useCreate = () => {
 
   return useMutation({
     mutationFn,
-    onSuccess: () => queryClient.invalidateQueries({
-      queryKey: [INBOUND]
-    }),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: [INBOUND],
+      }),
   });
 };

--- a/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
+++ b/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
@@ -38,7 +38,12 @@ export type InboundLineFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   } | null;
   program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
   campaign?: { __typename: 'CampaignNode'; id: string; name: string } | null;
@@ -203,7 +208,12 @@ export type InboundFragment = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+        store?: {
+          __typename: 'StoreNode';
+          id: string;
+          code: string;
+          isDisabled: boolean;
+        } | null;
       } | null;
       program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
       campaign?: {
@@ -299,7 +309,12 @@ export type InboundFragment = {
     isCustomer: boolean;
     isSupplier: boolean;
     isOnHold: boolean;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   };
   pricing: {
     __typename: 'PricingNode';
@@ -561,6 +576,7 @@ export type InvoiceQuery = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
+                isDisabled: boolean;
               } | null;
             } | null;
             program?: {
@@ -661,7 +677,12 @@ export type InvoiceQuery = {
           isCustomer: boolean;
           isSupplier: boolean;
           isOnHold: boolean;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         };
         pricing: {
           __typename: 'PricingNode';
@@ -830,6 +851,7 @@ export type InboundByNumberQuery = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
+                isDisabled: boolean;
               } | null;
             } | null;
             program?: {
@@ -930,7 +952,12 @@ export type InboundByNumberQuery = {
           isCustomer: boolean;
           isSupplier: boolean;
           isOnHold: boolean;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         };
         pricing: {
           __typename: 'PricingNode';
@@ -1969,6 +1996,7 @@ export const InboundFragmentDoc = gql`
       store {
         id
         code
+        isDisabled
       }
     }
     pricing {

--- a/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
+++ b/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
@@ -38,12 +38,7 @@ export type InboundLineFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: {
-      __typename: 'StoreNode';
-      id: string;
-      code: string;
-      isDisabled: boolean;
-    } | null;
+    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
   } | null;
   program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
   campaign?: { __typename: 'CampaignNode'; id: string; name: string } | null;
@@ -208,12 +203,7 @@ export type InboundFragment = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: {
-          __typename: 'StoreNode';
-          id: string;
-          code: string;
-          isDisabled: boolean;
-        } | null;
+        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
       } | null;
       program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
       campaign?: {
@@ -576,7 +566,6 @@ export type InvoiceQuery = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
-                isDisabled: boolean;
               } | null;
             } | null;
             program?: {
@@ -851,7 +840,6 @@ export type InboundByNumberQuery = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
-                isDisabled: boolean;
               } | null;
             } | null;
             program?: {

--- a/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
+++ b/client/packages/invoices/src/InboundShipment/api/operations.generated.ts
@@ -38,7 +38,12 @@ export type InboundLineFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   } | null;
   program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
   campaign?: { __typename: 'CampaignNode'; id: string; name: string } | null;
@@ -203,7 +208,12 @@ export type InboundFragment = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+        store?: {
+          __typename: 'StoreNode';
+          id: string;
+          code: string;
+          isDisabled: boolean;
+        } | null;
       } | null;
       program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
       campaign?: {
@@ -566,6 +576,7 @@ export type InvoiceQuery = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
+                isDisabled: boolean;
               } | null;
             } | null;
             program?: {
@@ -840,6 +851,7 @@ export type InboundByNumberQuery = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
+                isDisabled: boolean;
               } | null;
             } | null;
             program?: {

--- a/client/packages/invoices/src/InboundShipment/api/operations.graphql
+++ b/client/packages/invoices/src/InboundShipment/api/operations.graphql
@@ -198,6 +198,7 @@ fragment Inbound on InvoiceNode {
     store {
       id
       code
+      isDisabled
     }
   }
 

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   useNavigate,
   RouteBuilder,
+  DisabledStoreNotice,
 } from '@openmsupply-client/common';
 import { CustomerSearchInput } from '@openmsupply-client/system';
 import { useOutbound } from '../api';
@@ -83,6 +84,7 @@ export const Toolbar = () => {
           </Tooltip>
         }
       />
+      <DisabledStoreNotice otherParty={otherParty} />
     </AppBarContentPortal>
   );
 };

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/utils/useOutboundIsDisabled.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/utils/useOutboundIsDisabled.ts
@@ -4,5 +4,8 @@ import { isOutboundDisabled } from '../../../../utils';
 export const useOutboundIsDisabled = (): boolean => {
   const { data } = useOutbound();
   if (!data) return true;
+  // The other party's store may have been disabled (e.g. after a store merge);
+  // such records remain viewable but must not be editable.
+  if (data.otherParty?.store?.isDisabled) return true;
   return isOutboundDisabled(data);
 };

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/utils/useOutboundIsDisabled.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/utils/useOutboundIsDisabled.ts
@@ -4,8 +4,6 @@ import { isOutboundDisabled } from '../../../../utils';
 export const useOutboundIsDisabled = (): boolean => {
   const { data } = useOutbound();
   if (!data) return true;
-  // The other party's store may have been disabled (e.g. after a store merge);
-  // such records remain viewable but must not be editable.
   if (data.otherParty?.store?.isDisabled) return true;
   return isOutboundDisabled(data);
 };

--- a/client/packages/invoices/src/OutboundShipment/api/operations.generated.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/operations.generated.ts
@@ -122,7 +122,12 @@ export type OutboundFragment = {
     isCustomer: boolean;
     isSupplier: boolean;
     isOnHold: boolean;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   };
   pricing: {
     __typename: 'PricingNode';
@@ -381,7 +386,12 @@ export type InvoiceQuery = {
           isCustomer: boolean;
           isSupplier: boolean;
           isOnHold: boolean;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         };
         pricing: {
           __typename: 'PricingNode';
@@ -545,7 +555,12 @@ export type OutboundByNumberQuery = {
           isCustomer: boolean;
           isSupplier: boolean;
           isOnHold: boolean;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         };
         pricing: {
           __typename: 'PricingNode';
@@ -1178,6 +1193,7 @@ export const OutboundFragmentDoc = gql`
       store {
         id
         code
+        isDisabled
       }
     }
     pricing {

--- a/client/packages/invoices/src/OutboundShipment/api/operations.graphql
+++ b/client/packages/invoices/src/OutboundShipment/api/operations.graphql
@@ -59,6 +59,7 @@ fragment Outbound on InvoiceNode {
     store {
       id
       code
+      isDisabled
     }
   }
 

--- a/client/packages/invoices/src/Returns/CustomerDetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/Toolbar.tsx
@@ -8,6 +8,7 @@ import {
   useTranslation,
   Alert,
   InvoiceNodeStatus,
+  DisabledStoreNotice,
 } from '@openmsupply-client/common';
 import { CustomerReturnFragment, useReturns } from '../api';
 import { CustomerSearchInput } from '@openmsupply-client/system';
@@ -71,6 +72,7 @@ export const Toolbar: FC = () => {
                 />
               }
             />
+            <DisabledStoreNotice otherParty={otherParty} />
             <InfoAlert customerReturn={draft} />
           </Box>
         </Grid>

--- a/client/packages/invoices/src/Returns/SupplierDetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/Toolbar.tsx
@@ -8,6 +8,7 @@ import {
   useTranslation,
   useNavigate,
   RouteBuilder,
+  DisabledStoreNotice,
 } from '@openmsupply-client/common';
 import { SupplierReturnFragment, useReturns } from '../api';
 import { SupplierSearchInput } from '@openmsupply-client/system';
@@ -85,6 +86,7 @@ export const Toolbar: FC = () => {
                 />
               }
             />
+            <DisabledStoreNotice otherParty={otherParty} />
           </Box>
         </Grid>
       </Grid>

--- a/client/packages/invoices/src/Returns/api/hooks/utils/useCustomerReturnIsDisabled.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/utils/useCustomerReturnIsDisabled.ts
@@ -5,5 +5,6 @@ export const useCustomerReturnIsDisabled = (): boolean => {
   const { data } = useCustomerReturn();
   // When there's no customer return at all, this should mean we're in the process of creating a new return, so it shouldn't be disabled
   if (!data) return false;
+  if (data.otherParty?.store?.isDisabled) return true;
   return isCustomerReturnDisabled(data);
 };

--- a/client/packages/invoices/src/Returns/api/hooks/utils/useSupplierReturnIsDisabled.ts
+++ b/client/packages/invoices/src/Returns/api/hooks/utils/useSupplierReturnIsDisabled.ts
@@ -4,5 +4,6 @@ import { useSupplierReturn } from '../document/useSupplierReturn';
 export const useSupplierReturnIsDisabled = (): boolean => {
   const { data } = useSupplierReturn();
   if (!data) return true;
+  if (data.otherParty?.store?.isDisabled) return true;
   return isOutboundDisabled(data);
 };

--- a/client/packages/invoices/src/Returns/api/operations.generated.ts
+++ b/client/packages/invoices/src/Returns/api/operations.generated.ts
@@ -61,7 +61,12 @@ export type SupplierReturnFragment = {
     isCustomer: boolean;
     isSupplier: boolean;
     isOnHold: boolean;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   };
   user?: {
     __typename: 'UserNode';
@@ -117,7 +122,12 @@ export type CustomerReturnFragment = {
     isCustomer: boolean;
     isSupplier: boolean;
     isOnHold: boolean;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   };
 };
 
@@ -437,7 +447,12 @@ export type SupplierReturnByNumberQuery = {
           isCustomer: boolean;
           isSupplier: boolean;
           isOnHold: boolean;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         };
         user?: {
           __typename: 'UserNode';
@@ -513,7 +528,12 @@ export type SupplierReturnByIdQuery = {
           isCustomer: boolean;
           isSupplier: boolean;
           isOnHold: boolean;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         };
         user?: {
           __typename: 'UserNode';
@@ -604,7 +624,12 @@ export type CustomerReturnByNumberQuery = {
           isCustomer: boolean;
           isSupplier: boolean;
           isOnHold: boolean;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         };
       }
     | { __typename: 'NodeError' };
@@ -682,7 +707,12 @@ export type CustomerReturnByIdQuery = {
           isCustomer: boolean;
           isSupplier: boolean;
           isOnHold: boolean;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         };
       }
     | { __typename: 'NodeError' };
@@ -890,6 +920,7 @@ export const SupplierReturnFragmentDoc = gql`
       store {
         id
         code
+        isDisabled
       }
     }
     user {
@@ -958,6 +989,7 @@ export const CustomerReturnFragmentDoc = gql`
       store {
         id
         code
+        isDisabled
       }
     }
   }

--- a/client/packages/invoices/src/Returns/api/operations.graphql
+++ b/client/packages/invoices/src/Returns/api/operations.graphql
@@ -63,6 +63,7 @@ fragment SupplierReturn on InvoiceNode {
     store {
       id
       code
+      isDisabled
     }
   }
 
@@ -139,6 +140,7 @@ fragment CustomerReturn on InvoiceNode {
     store {
       id
       code
+      isDisabled
     }
   }
 }

--- a/client/packages/purchasing/src/purchase_order/api/operations.generated.ts
+++ b/client/packages/purchasing/src/purchase_order/api/operations.generated.ts
@@ -102,7 +102,12 @@ export type PurchaseOrderFragment = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+        store?: {
+          __typename: 'StoreNode';
+          id: string;
+          code: string;
+          isDisabled: boolean;
+        } | null;
       } | null;
       purchaseOrder?: {
         __typename: 'PurchaseOrderNode';
@@ -190,7 +195,12 @@ export type PurchaseOrderLineFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   } | null;
   purchaseOrder?: {
     __typename: 'PurchaseOrderNode';
@@ -337,6 +347,7 @@ export type PurchaseOrderByIdQuery = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
+                isDisabled: boolean;
               } | null;
             } | null;
             purchaseOrder?: {
@@ -509,7 +520,12 @@ export type PurchaseOrderLinesQuery = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+        store?: {
+          __typename: 'StoreNode';
+          id: string;
+          code: string;
+          isDisabled: boolean;
+        } | null;
       } | null;
       purchaseOrder?: {
         __typename: 'PurchaseOrderNode';
@@ -587,7 +603,12 @@ export type PurchaseOrderLineQuery = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+        store?: {
+          __typename: 'StoreNode';
+          id: string;
+          code: string;
+          isDisabled: boolean;
+        } | null;
       } | null;
       purchaseOrder?: {
         __typename: 'PurchaseOrderNode';

--- a/client/packages/purchasing/src/purchase_order/api/operations.generated.ts
+++ b/client/packages/purchasing/src/purchase_order/api/operations.generated.ts
@@ -102,12 +102,7 @@ export type PurchaseOrderFragment = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: {
-          __typename: 'StoreNode';
-          id: string;
-          code: string;
-          isDisabled: boolean;
-        } | null;
+        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
       } | null;
       purchaseOrder?: {
         __typename: 'PurchaseOrderNode';
@@ -195,12 +190,7 @@ export type PurchaseOrderLineFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: {
-      __typename: 'StoreNode';
-      id: string;
-      code: string;
-      isDisabled: boolean;
-    } | null;
+    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
   } | null;
   purchaseOrder?: {
     __typename: 'PurchaseOrderNode';
@@ -347,7 +337,6 @@ export type PurchaseOrderByIdQuery = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
-                isDisabled: boolean;
               } | null;
             } | null;
             purchaseOrder?: {
@@ -520,12 +509,7 @@ export type PurchaseOrderLinesQuery = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: {
-          __typename: 'StoreNode';
-          id: string;
-          code: string;
-          isDisabled: boolean;
-        } | null;
+        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
       } | null;
       purchaseOrder?: {
         __typename: 'PurchaseOrderNode';
@@ -603,12 +587,7 @@ export type PurchaseOrderLineQuery = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: {
-          __typename: 'StoreNode';
-          id: string;
-          code: string;
-          isDisabled: boolean;
-        } | null;
+        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
       } | null;
       purchaseOrder?: {
         __typename: 'PurchaseOrderNode';

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -17,7 +17,7 @@ import {
 } from '@openmsupply-client/system';
 import { RequestFragment, useRequest } from '../../api';
 import { useDraftRequisitionLine, useNextRequestLine } from './hooks';
-import { isRequestDisabled, shouldDeleteLine } from '../../../utils';
+import { shouldDeleteLine } from '../../../utils';
 import { RequestLineEdit } from './RequestLineEdit';
 
 interface RequestLineEditModalProps {
@@ -39,7 +39,7 @@ export const RequestLineEditModal = ({
 }: RequestLineEditModalProps) => {
   const { error } = useNotification();
   const deleteLine = useRequest.line.deleteLine();
-  const isDisabled = isRequestDisabled(requisition);
+  const isDisabled = useRequest.utils.isDisabled();
   const { orderInPacks, manageVaccinesInDoses } = usePreferences();
 
   const lines = useMemo(

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -14,6 +14,7 @@ import {
   usePreferences,
   NameNodeType,
   SearchBar,
+  DisabledStoreNotice,
 } from '@openmsupply-client/common';
 import {
   CustomerSearchInput,
@@ -125,6 +126,7 @@ export const Toolbar = () => {
               }
             />
           )}
+          <DisabledStoreNotice otherParty={otherParty} />
           {isProgram && (
             <Alert severity="info" sx={{ maxWidth: 1000 }}>
               {t('info.cannot-edit-program-requisition')}

--- a/client/packages/requisitions/src/RequestRequisition/api/hooks/utils/useIsRequestDisabled.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/hooks/utils/useIsRequestDisabled.ts
@@ -4,5 +4,8 @@ import { isRequestDisabled } from './../../../../utils';
 export const useIsRequestDisabled = (): boolean => {
   const { data } = useRequest();
   if (!data) return true;
+  // The other party's store may have been disabled (e.g. after a store merge);
+  // such records remain viewable but must not be editable.
+  if (data.otherParty?.store?.isDisabled) return true;
   return isRequestDisabled(data);
 };

--- a/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
@@ -854,7 +854,12 @@ export type SupplierProgramSettingsFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   }>;
   orderTypes: Array<{
     __typename: 'ProgramRequisitionOrderTypeNode';
@@ -888,7 +893,12 @@ export type SupplierProgramSettingsQuery = {
       isSupplier: boolean;
       isOnHold: boolean;
       name: string;
-      store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+      store?: {
+        __typename: 'StoreNode';
+        id: string;
+        code: string;
+        isDisabled: boolean;
+      } | null;
     }>;
     orderTypes: Array<{
       __typename: 'ProgramRequisitionOrderTypeNode';

--- a/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
@@ -97,7 +97,12 @@ export type RequestByNumberQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           margin?: number | null;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         };
         ancillaryState: {
           __typename: 'AncillaryStateResponse';
@@ -227,7 +232,12 @@ export type RequestByNumberQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         } | null;
         linkedRequisition?: {
           __typename: 'RequisitionNode';
@@ -288,7 +298,12 @@ export type RequestByIdQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           margin?: number | null;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         };
         ancillaryState: {
           __typename: 'AncillaryStateResponse';
@@ -418,7 +433,12 @@ export type RequestByIdQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         } | null;
         linkedRequisition?: {
           __typename: 'RequisitionNode';
@@ -834,7 +854,12 @@ export type SupplierProgramSettingsFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   }>;
   orderTypes: Array<{
     __typename: 'ProgramRequisitionOrderTypeNode';
@@ -868,7 +893,12 @@ export type SupplierProgramSettingsQuery = {
       isSupplier: boolean;
       isOnHold: boolean;
       name: string;
-      store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+      store?: {
+        __typename: 'StoreNode';
+        id: string;
+        code: string;
+        isDisabled: boolean;
+      } | null;
     }>;
     orderTypes: Array<{
       __typename: 'ProgramRequisitionOrderTypeNode';

--- a/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
+++ b/client/packages/requisitions/src/RequestRequisition/api/operations.generated.ts
@@ -854,12 +854,7 @@ export type SupplierProgramSettingsFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: {
-      __typename: 'StoreNode';
-      id: string;
-      code: string;
-      isDisabled: boolean;
-    } | null;
+    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
   }>;
   orderTypes: Array<{
     __typename: 'ProgramRequisitionOrderTypeNode';
@@ -893,12 +888,7 @@ export type SupplierProgramSettingsQuery = {
       isSupplier: boolean;
       isOnHold: boolean;
       name: string;
-      store?: {
-        __typename: 'StoreNode';
-        id: string;
-        code: string;
-        isDisabled: boolean;
-      } | null;
+      store?: { __typename: 'StoreNode'; id: string; code: string } | null;
     }>;
     orderTypes: Array<{
       __typename: 'ProgramRequisitionOrderTypeNode';

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
   BasicTextInput,
   SearchBar,
+  DisabledStoreNotice,
 } from '@openmsupply-client/common';
 import { CustomerSearchInput } from '@openmsupply-client/system';
 import { useResponse } from '../../api';
@@ -103,6 +104,7 @@ export const Toolbar = () => {
                   }
                 />
               )}
+              <DisabledStoreNotice otherParty={otherParty} />
             </Box>
             <Box display="flex" flex={1} flexDirection="column" gap={1}>
               <InputWithLabelRow

--- a/client/packages/requisitions/src/ResponseRequisition/api/hooks/utils/useIsResponseDisabled.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/hooks/utils/useIsResponseDisabled.ts
@@ -14,5 +14,8 @@ export const useIsResponseDisabled = (): boolean => {
         data?.approvalStatus === RequisitionNodeApprovalStatus.Pending))
   )
     return true;
+  // The other party's store may have been disabled (e.g. after a store merge);
+  // such records remain viewable but must not be editable.
+  if (data.otherParty?.store?.isDisabled) return true;
   return isResponseDisabled(data);
 };

--- a/client/packages/requisitions/src/ResponseRequisition/api/operations.generated.ts
+++ b/client/packages/requisitions/src/ResponseRequisition/api/operations.generated.ts
@@ -281,7 +281,12 @@ export type ResponseFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   };
   destinationCustomer?: {
     __typename: 'NameNode';
@@ -291,7 +296,12 @@ export type ResponseFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   } | null;
   program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
   period?: {
@@ -446,7 +456,12 @@ export type ResponseByNumberQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         };
         destinationCustomer?: {
           __typename: 'NameNode';
@@ -456,7 +471,12 @@ export type ResponseByNumberQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         } | null;
         program?: {
           __typename: 'ProgramNode';
@@ -619,7 +639,12 @@ export type ResponseByIdQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         };
         destinationCustomer?: {
           __typename: 'NameNode';
@@ -629,7 +654,12 @@ export type ResponseByIdQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         } | null;
         program?: {
           __typename: 'ProgramNode';
@@ -1291,6 +1321,7 @@ export const ResponseFragmentDoc = gql`
       store {
         id
         code
+        isDisabled
       }
     }
     destinationCustomer(storeId: $storeId) {
@@ -1304,6 +1335,7 @@ export const ResponseFragmentDoc = gql`
       store {
         id
         code
+        isDisabled
       }
     }
     programName

--- a/client/packages/requisitions/src/ResponseRequisition/api/operations.graphql
+++ b/client/packages/requisitions/src/ResponseRequisition/api/operations.graphql
@@ -196,6 +196,7 @@ fragment Response on RequisitionNode {
     store {
       id
       code
+      isDisabled
     }
   }
   destinationCustomer(storeId: $storeId) {
@@ -209,6 +210,7 @@ fragment Response on RequisitionNode {
     store {
       id
       code
+      isDisabled
     }
   }
   programName

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -274,12 +274,7 @@ export type ItemVariantFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: {
-      __typename: 'StoreNode';
-      id: string;
-      code: string;
-      isDisabled: boolean;
-    } | null;
+    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
   } | null;
   locationType?: {
     __typename: 'LocationTypeNode';
@@ -470,12 +465,7 @@ export type ItemFragment = {
       isSupplier: boolean;
       isOnHold: boolean;
       name: string;
-      store?: {
-        __typename: 'StoreNode';
-        id: string;
-        code: string;
-        isDisabled: boolean;
-      } | null;
+      store?: { __typename: 'StoreNode'; id: string; code: string } | null;
     } | null;
     locationType?: {
       __typename: 'LocationTypeNode';
@@ -719,12 +709,7 @@ export type ItemsWithStockLinesQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: {
-            __typename: 'StoreNode';
-            id: string;
-            code: string;
-            isDisabled: boolean;
-          } | null;
+          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
         } | null;
         locationType?: {
           __typename: 'LocationTypeNode';
@@ -1096,12 +1081,7 @@ export type ItemByIdQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: {
-            __typename: 'StoreNode';
-            id: string;
-            code: string;
-            isDisabled: boolean;
-          } | null;
+          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
         } | null;
         locationType?: {
           __typename: 'LocationTypeNode';
@@ -1240,12 +1220,7 @@ export type ItemVariantsQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: {
-            __typename: 'StoreNode';
-            id: string;
-            code: string;
-            isDisabled: boolean;
-          } | null;
+          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
         } | null;
         locationType?: {
           __typename: 'LocationTypeNode';
@@ -1426,7 +1401,6 @@ export type UpsertItemVariantMutation = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
-                isDisabled: boolean;
               } | null;
             } | null;
             locationType?: {

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -274,7 +274,12 @@ export type ItemVariantFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   } | null;
   locationType?: {
     __typename: 'LocationTypeNode';
@@ -465,7 +470,12 @@ export type ItemFragment = {
       isSupplier: boolean;
       isOnHold: boolean;
       name: string;
-      store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+      store?: {
+        __typename: 'StoreNode';
+        id: string;
+        code: string;
+        isDisabled: boolean;
+      } | null;
     } | null;
     locationType?: {
       __typename: 'LocationTypeNode';
@@ -709,7 +719,12 @@ export type ItemsWithStockLinesQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         } | null;
         locationType?: {
           __typename: 'LocationTypeNode';
@@ -1081,7 +1096,12 @@ export type ItemByIdQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         } | null;
         locationType?: {
           __typename: 'LocationTypeNode';
@@ -1220,7 +1240,12 @@ export type ItemVariantsQuery = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         } | null;
         locationType?: {
           __typename: 'LocationTypeNode';
@@ -1401,6 +1426,7 @@ export type UpsertItemVariantMutation = {
                 __typename: 'StoreNode';
                 id: string;
                 code: string;
+                isDisabled: boolean;
               } | null;
             } | null;
             locationType?: {

--- a/client/packages/system/src/Name/api/operations.generated.ts
+++ b/client/packages/system/src/Name/api/operations.generated.ts
@@ -11,7 +11,12 @@ export type NameRowFragment = {
   isSupplier: boolean;
   isOnHold: boolean;
   name: string;
-  store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+  store?: {
+    __typename: 'StoreNode';
+    id: string;
+    code: string;
+    isDisabled: boolean;
+  } | null;
 };
 
 export type FacilityNameRowFragment = {
@@ -24,7 +29,12 @@ export type FacilityNameRowFragment = {
   isOnHold: boolean;
   name: string;
   properties: string;
-  store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+  store?: {
+    __typename: 'StoreNode';
+    id: string;
+    code: string;
+    isDisabled: boolean;
+  } | null;
 };
 
 export type NameFragment = {
@@ -52,7 +62,12 @@ export type NameFragment = {
   hshName?: string | null;
   margin?: number | null;
   freightFactor?: number | null;
-  store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+  store?: {
+    __typename: 'StoreNode';
+    id: string;
+    code: string;
+    isDisabled: boolean;
+  } | null;
   currency?: { __typename: 'CurrencyNode'; id: string; code: string } | null;
 };
 
@@ -87,7 +102,12 @@ export type NamesQuery = {
       isSupplier: boolean;
       isOnHold: boolean;
       name: string;
-      store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+      store?: {
+        __typename: 'StoreNode';
+        id: string;
+        code: string;
+        isDisabled: boolean;
+      } | null;
     }>;
   };
 };
@@ -116,7 +136,12 @@ export type FacilitiesQuery = {
       isOnHold: boolean;
       name: string;
       properties: string;
-      store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+      store?: {
+        __typename: 'StoreNode';
+        id: string;
+        code: string;
+        isDisabled: boolean;
+      } | null;
     }>;
   };
 };
@@ -156,7 +181,12 @@ export type NameByIdQuery = {
       hshName?: string | null;
       margin?: number | null;
       freightFactor?: number | null;
-      store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+      store?: {
+        __typename: 'StoreNode';
+        id: string;
+        code: string;
+        isDisabled: boolean;
+      } | null;
       currency?: {
         __typename: 'CurrencyNode';
         id: string;
@@ -223,7 +253,12 @@ export type UpdateNamePropertiesMutation = {
         hshName?: string | null;
         margin?: number | null;
         freightFactor?: number | null;
-        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+        store?: {
+          __typename: 'StoreNode';
+          id: string;
+          code: string;
+          isDisabled: boolean;
+        } | null;
         currency?: {
           __typename: 'CurrencyNode';
           id: string;
@@ -247,6 +282,7 @@ export const NameRowFragmentDoc = gql`
     store {
       id
       code
+      isDisabled
     }
   }
 `;
@@ -262,6 +298,7 @@ export const FacilityNameRowFragmentDoc = gql`
     store {
       id
       code
+      isDisabled
     }
     properties
   }
@@ -289,6 +326,7 @@ export const NameFragmentDoc = gql`
     store {
       id
       code
+      isDisabled
     }
     properties
     hshCode

--- a/client/packages/system/src/Name/api/operations.generated.ts
+++ b/client/packages/system/src/Name/api/operations.generated.ts
@@ -11,12 +11,7 @@ export type NameRowFragment = {
   isSupplier: boolean;
   isOnHold: boolean;
   name: string;
-  store?: {
-    __typename: 'StoreNode';
-    id: string;
-    code: string;
-    isDisabled: boolean;
-  } | null;
+  store?: { __typename: 'StoreNode'; id: string; code: string } | null;
 };
 
 export type FacilityNameRowFragment = {
@@ -29,12 +24,7 @@ export type FacilityNameRowFragment = {
   isOnHold: boolean;
   name: string;
   properties: string;
-  store?: {
-    __typename: 'StoreNode';
-    id: string;
-    code: string;
-    isDisabled: boolean;
-  } | null;
+  store?: { __typename: 'StoreNode'; id: string; code: string } | null;
 };
 
 export type NameFragment = {
@@ -62,12 +52,7 @@ export type NameFragment = {
   hshName?: string | null;
   margin?: number | null;
   freightFactor?: number | null;
-  store?: {
-    __typename: 'StoreNode';
-    id: string;
-    code: string;
-    isDisabled: boolean;
-  } | null;
+  store?: { __typename: 'StoreNode'; id: string; code: string } | null;
   currency?: { __typename: 'CurrencyNode'; id: string; code: string } | null;
 };
 
@@ -102,12 +87,7 @@ export type NamesQuery = {
       isSupplier: boolean;
       isOnHold: boolean;
       name: string;
-      store?: {
-        __typename: 'StoreNode';
-        id: string;
-        code: string;
-        isDisabled: boolean;
-      } | null;
+      store?: { __typename: 'StoreNode'; id: string; code: string } | null;
     }>;
   };
 };
@@ -136,12 +116,7 @@ export type FacilitiesQuery = {
       isOnHold: boolean;
       name: string;
       properties: string;
-      store?: {
-        __typename: 'StoreNode';
-        id: string;
-        code: string;
-        isDisabled: boolean;
-      } | null;
+      store?: { __typename: 'StoreNode'; id: string; code: string } | null;
     }>;
   };
 };
@@ -181,12 +156,7 @@ export type NameByIdQuery = {
       hshName?: string | null;
       margin?: number | null;
       freightFactor?: number | null;
-      store?: {
-        __typename: 'StoreNode';
-        id: string;
-        code: string;
-        isDisabled: boolean;
-      } | null;
+      store?: { __typename: 'StoreNode'; id: string; code: string } | null;
       currency?: {
         __typename: 'CurrencyNode';
         id: string;
@@ -253,12 +223,7 @@ export type UpdateNamePropertiesMutation = {
         hshName?: string | null;
         margin?: number | null;
         freightFactor?: number | null;
-        store?: {
-          __typename: 'StoreNode';
-          id: string;
-          code: string;
-          isDisabled: boolean;
-        } | null;
+        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
         currency?: {
           __typename: 'CurrencyNode';
           id: string;
@@ -282,7 +247,6 @@ export const NameRowFragmentDoc = gql`
     store {
       id
       code
-      isDisabled
     }
   }
 `;
@@ -298,7 +262,6 @@ export const FacilityNameRowFragmentDoc = gql`
     store {
       id
       code
-      isDisabled
     }
     properties
   }
@@ -326,7 +289,6 @@ export const NameFragmentDoc = gql`
     store {
       id
       code
-      isDisabled
     }
     properties
     hshCode

--- a/client/packages/system/src/Name/api/operations.graphql
+++ b/client/packages/system/src/Name/api/operations.graphql
@@ -8,7 +8,6 @@ fragment NameRow on NameNode {
   store {
     id
     code
-    isDisabled
   }
 }
 
@@ -23,7 +22,6 @@ fragment FacilityNameRow on NameNode {
   store {
     id
     code
-    isDisabled
   }
   properties
 }
@@ -50,7 +48,6 @@ fragment Name on NameNode {
   store {
     id
     code
-    isDisabled
   }
   properties
   hshCode

--- a/client/packages/system/src/Name/api/operations.graphql
+++ b/client/packages/system/src/Name/api/operations.graphql
@@ -8,6 +8,7 @@ fragment NameRow on NameNode {
   store {
     id
     code
+    isDisabled
   }
 }
 
@@ -22,6 +23,7 @@ fragment FacilityNameRow on NameNode {
   store {
     id
     code
+    isDisabled
   }
   properties
 }
@@ -48,6 +50,7 @@ fragment Name on NameNode {
   store {
     id
     code
+    isDisabled
   }
   properties
   hshCode

--- a/client/packages/system/src/RequestRequisitionLine/operations.generated.ts
+++ b/client/packages/system/src/RequestRequisitionLine/operations.generated.ts
@@ -244,7 +244,12 @@ export type RequestFragment = {
     isOnHold: boolean;
     name: string;
     margin?: number | null;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   };
   destinationCustomer?: {
     __typename: 'NameNode';
@@ -254,7 +259,12 @@ export type RequestFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   } | null;
   linkedRequisition?: {
     __typename: 'RequisitionNode';
@@ -446,6 +456,7 @@ export const RequestFragmentDoc = gql`
       store {
         id
         code
+        isDisabled
       }
     }
     destinationCustomer(storeId: $storeId) {
@@ -458,6 +469,7 @@ export const RequestFragmentDoc = gql`
       store {
         id
         code
+        isDisabled
       }
     }
     linkedRequisition {

--- a/client/packages/system/src/RequestRequisitionLine/operations.graphql
+++ b/client/packages/system/src/RequestRequisitionLine/operations.graphql
@@ -159,6 +159,7 @@ fragment Request on RequisitionNode {
     store {
       id
       code
+      isDisabled
     }
   }
 
@@ -172,6 +173,7 @@ fragment Request on RequisitionNode {
     store {
       id
       code
+      isDisabled
     }
   }
 

--- a/client/packages/system/src/Stock/api/operations.generated.ts
+++ b/client/packages/system/src/Stock/api/operations.generated.ts
@@ -96,12 +96,7 @@ export type StockLineRowFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: {
-      __typename: 'StoreNode';
-      id: string;
-      code: string;
-      isDisabled: boolean;
-    } | null;
+    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
   } | null;
   program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
   campaign?: { __typename: 'CampaignNode'; id: string; name: string } | null;
@@ -351,12 +346,7 @@ export type StockLinesQuery = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: {
-          __typename: 'StoreNode';
-          id: string;
-          code: string;
-          isDisabled: boolean;
-        } | null;
+        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
       } | null;
       program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
       campaign?: {
@@ -482,12 +472,7 @@ export type StockLineQuery = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: {
-          __typename: 'StoreNode';
-          id: string;
-          code: string;
-          isDisabled: boolean;
-        } | null;
+        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
       } | null;
       program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
       campaign?: {
@@ -651,12 +636,7 @@ export type UpdateStockLineMutation = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: {
-            __typename: 'StoreNode';
-            id: string;
-            code: string;
-            isDisabled: boolean;
-          } | null;
+          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
         } | null;
         program?: {
           __typename: 'ProgramNode';
@@ -994,12 +974,7 @@ export type InsertStockLineMutation = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: {
-            __typename: 'StoreNode';
-            id: string;
-            code: string;
-            isDisabled: boolean;
-          } | null;
+          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
         } | null;
         program?: {
           __typename: 'ProgramNode';
@@ -1196,7 +1171,6 @@ export type ItemsByStockLineFilterQuery = {
               __typename: 'StoreNode';
               id: string;
               code: string;
-              isDisabled: boolean;
             } | null;
           } | null;
           program?: {

--- a/client/packages/system/src/Stock/api/operations.generated.ts
+++ b/client/packages/system/src/Stock/api/operations.generated.ts
@@ -96,7 +96,12 @@ export type StockLineRowFragment = {
     isSupplier: boolean;
     isOnHold: boolean;
     name: string;
-    store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+    store?: {
+      __typename: 'StoreNode';
+      id: string;
+      code: string;
+      isDisabled: boolean;
+    } | null;
   } | null;
   program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
   campaign?: { __typename: 'CampaignNode'; id: string; name: string } | null;
@@ -346,7 +351,12 @@ export type StockLinesQuery = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+        store?: {
+          __typename: 'StoreNode';
+          id: string;
+          code: string;
+          isDisabled: boolean;
+        } | null;
       } | null;
       program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
       campaign?: {
@@ -472,7 +482,12 @@ export type StockLineQuery = {
         isSupplier: boolean;
         isOnHold: boolean;
         name: string;
-        store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+        store?: {
+          __typename: 'StoreNode';
+          id: string;
+          code: string;
+          isDisabled: boolean;
+        } | null;
       } | null;
       program?: { __typename: 'ProgramNode'; id: string; name: string } | null;
       campaign?: {
@@ -636,7 +651,12 @@ export type UpdateStockLineMutation = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         } | null;
         program?: {
           __typename: 'ProgramNode';
@@ -974,7 +994,12 @@ export type InsertStockLineMutation = {
           isSupplier: boolean;
           isOnHold: boolean;
           name: string;
-          store?: { __typename: 'StoreNode'; id: string; code: string } | null;
+          store?: {
+            __typename: 'StoreNode';
+            id: string;
+            code: string;
+            isDisabled: boolean;
+          } | null;
         } | null;
         program?: {
           __typename: 'ProgramNode';
@@ -1171,6 +1196,7 @@ export type ItemsByStockLineFilterQuery = {
               __typename: 'StoreNode';
               id: string;
               code: string;
+              isDisabled: boolean;
             } | null;
           } | null;
           program?: {

--- a/server/graphql/core/src/loader/name.rs
+++ b/server/graphql/core/src/loader/name.rs
@@ -50,7 +50,11 @@ impl Loader<NameByIdLoaderInput> for NameByIdLoader {
                     &service_context,
                     &store_id,
                     None, // TODO this needs to be ALL without limit
-                    Some(NameFilter::new().id(EqualFilter::equal_any(names))),
+                    // Names referenced by an existing record should still show
+                    Some(
+                        NameFilter::new()
+                            .include_disabled(true),
+                    ),
                     None,
                 )
                 .map_err(|err| StandardGraphqlError::InternalError(format!("{err:?}")))?;

--- a/server/graphql/core/src/loader/name.rs
+++ b/server/graphql/core/src/loader/name.rs
@@ -53,6 +53,7 @@ impl Loader<NameByIdLoaderInput> for NameByIdLoader {
                     // Names referenced by an existing record should still show
                     Some(
                         NameFilter::new()
+                            .id(EqualFilter::equal_any(names))
                             .include_disabled(true),
                     ),
                     None,

--- a/server/graphql/general/src/queries/names.rs
+++ b/server/graphql/general/src/queries/names.rs
@@ -169,6 +169,7 @@ impl NameFilterInput {
             email: email.map(StringFilter::from),
             supplying_store_id: supplying_store_id.map(EqualFilter::from),
             store: None,
+            include_disabled: None,
         }
     }
 }

--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -189,6 +189,7 @@ mod graphql {
                 code_or_name: _,
                 supplying_store_id: _,
                 store: _,
+                include_disabled: _,
             } = filter.unwrap();
 
             assert_eq!(

--- a/server/graphql/invoice/src/mutations/customer_return/delete.rs
+++ b/server/graphql/invoice/src/mutations/customer_return/delete.rs
@@ -70,6 +70,7 @@ fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
         // Standard Graphql Errors
         ServiceError::InvoiceDoesNotExist
         | ServiceError::CannotEditFinalised
+        | ServiceError::OtherPartyStoreDisabled
         | ServiceError::NotACustomerReturn
         | ServiceError::NotThisStoreInvoice => BadUserInput(formatted_error),
 

--- a/server/graphql/invoice/src/mutations/inbound_shipment/delete.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/delete.rs
@@ -91,7 +91,7 @@ fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
         ServiceError::InvoiceDoesNotExist => {
             return Ok(DeleteErrorInterface::RecordNotFound(RecordNotFound {}))
         }
-        ServiceError::CannotEditFinalised => {
+        ServiceError::CannotEditFinalised | ServiceError::OtherPartyStoreDisabled => {
             return Ok(DeleteErrorInterface::CannotEditInvoice(
                 CannotEditInvoice {},
             ))

--- a/server/graphql/invoice/src/mutations/inbound_shipment/update.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/update.rs
@@ -184,7 +184,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
                 CannotReverseInvoiceStatus,
             ))
         }
-        ServiceError::CannotEditFinalised => {
+        ServiceError::CannotEditFinalised | ServiceError::OtherPartyStoreDisabled => {
             return Ok(UpdateErrorInterface::CannotEditInvoice(CannotEditInvoice))
         }
         ServiceError::CannotReceiveWithPendingLines => {

--- a/server/graphql/invoice/src/mutations/outbound_shipment/delete.rs
+++ b/server/graphql/invoice/src/mutations/outbound_shipment/delete.rs
@@ -71,7 +71,7 @@ fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
         ServiceError::InvoiceDoesNotExist => {
             return Ok(DeleteErrorInterface::RecordNotFound(RecordNotFound {}))
         }
-        ServiceError::CannotEditFinalised => {
+        ServiceError::CannotEditFinalised | ServiceError::OtherPartyStoreDisabled => {
             return Ok(DeleteErrorInterface::CannotEditInvoice(
                 CannotEditInvoice {},
             ))

--- a/server/graphql/invoice/src/mutations/supplier_return/delete.rs
+++ b/server/graphql/invoice/src/mutations/supplier_return/delete.rs
@@ -70,6 +70,7 @@ fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
         // Standard Graphql Errors
         ServiceError::InvoiceDoesNotExist
         | ServiceError::CannotEditFinalised
+        | ServiceError::OtherPartyStoreDisabled
         | ServiceError::NotAnSupplierReturn
         | ServiceError::NotThisStoreInvoice => BadUserInput(formatted_error),
 

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/delete.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/delete.rs
@@ -98,6 +98,7 @@ fn map_error(error: ServiceError) -> Result<DeleteErrorInterface> {
             return Ok(DeleteErrorInterface::RecordNotFound(RecordNotFound {}))
         }
         ServiceError::CannotEditFinalised
+        | ServiceError::OtherPartyStoreDisabled
         | ServiceError::CannotDeleteLinesOfAuthorisedReceivedInvoice => {
             return Ok(DeleteErrorInterface::CannotEditInvoice(
                 CannotEditInvoice {},

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
@@ -178,6 +178,7 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         }
 
         ServiceError::CannotEditFinalised
+        | ServiceError::OtherPartyStoreDisabled
         | ServiceError::CannotAddLinesToAuthorisedReceivedInvoice => {
             return Ok(InsertErrorInterface::CannotEditInvoice(
                 CannotEditInvoice {},

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert_from_internal_order.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert_from_internal_order.rs
@@ -65,6 +65,7 @@ fn map_error(error: ServiceError) -> Result<InsertFromInternalOrderResponse> {
         InvoiceDoesNotExist
         | NotThisStoreInvoice
         | CannotEditFinalised
+        | OtherPartyStoreDisabled
         | NotAnInboundShipment
         | RequisitionLineDoesNotExist
         | RequisitionNotLinkedToInvoice

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
@@ -219,7 +219,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
                 ForeignKey::InvoiceId,
             )))
         }
-        ServiceError::CannotEditFinalised => {
+        ServiceError::CannotEditFinalised | ServiceError::OtherPartyStoreDisabled => {
             return Ok(UpdateErrorInterface::CannotEditInvoice(
                 CannotEditInvoice {},
             ))

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/insert.rs
@@ -134,7 +134,7 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
                 ForeignKey::InvoiceId,
             )))
         }
-        CannotEditFinalised => {
+        CannotEditFinalised | OtherPartyStoreDisabled => {
             return Ok(InsertErrorInterface::CannotEditInvoice(
                 simple_generic_errors::CannotEditInvoice {},
             ))

--- a/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/outbound_shipment_line/line/update.rs
@@ -135,7 +135,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
                 ForeignKey::InvoiceId,
             )))
         }
-        CannotEditFinalised => {
+        CannotEditFinalised | OtherPartyStoreDisabled => {
             return Ok(UpdateErrorInterface::CannotEditInvoice(
                 CannotEditInvoice {},
             ))

--- a/server/graphql/invoice_line/src/mutations/prescription_line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/prescription_line/insert.rs
@@ -94,7 +94,7 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
                 ForeignKey::InvoiceId,
             )))
         }
-        CannotEditFinalised => {
+        CannotEditFinalised | OtherPartyStoreDisabled => {
             return Ok(InsertErrorInterface::CannotEditInvoice(
                 simple_generic_errors::CannotEditInvoice {},
             ))

--- a/server/graphql/invoice_line/src/mutations/prescription_line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/prescription_line/update.rs
@@ -122,7 +122,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
                 ForeignKey::InvoiceId,
             )))
         }
-        CannotEditFinalised => {
+        CannotEditFinalised | OtherPartyStoreDisabled => {
             return Ok(UpdateErrorInterface::CannotEditInvoice(
                 CannotEditInvoice {},
             ))

--- a/server/graphql/types/src/types/store.rs
+++ b/server/graphql/types/src/types/store.rs
@@ -47,6 +47,11 @@ impl StoreNode {
     pub async fn site_id(&self) -> i32 {
         self.row().site_id
     }
+
+    /// Whether the store has been disabled, either by a user or as a result of a store merge.
+    pub async fn is_disabled(&self) -> bool {
+        self.row().is_disabled
+    }
     /// Returns the associated store logo.
     /// The logo is returned as a data URL schema, e.g. "data:image/png;base64,..."
     /// Lazy-loaded — the logo is not pulled with the default store row.

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -411,6 +411,14 @@ impl Name {
         self.name_store_join_row.is_some()
     }
 
+    /// Name store's disabled based on merge or user action
+    pub fn is_disabled(&self) -> bool {
+        self.store_row
+            .as_ref()
+            .map(|store_row| store_row.is_disabled)
+            .unwrap_or(false)
+    }
+
     pub fn is_system_name(&self) -> bool {
         SYSTEM_NAME_CODES
             .iter()

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -56,6 +56,9 @@ pub struct NameFilter {
 
     pub code_or_name: Option<StringFilter>,
     pub store: Option<StoreFilter>,
+    /// Store can be disabled due to merge or due to it actually being disabled
+    /// by user.
+    pub include_disabled: Option<bool>,
 }
 
 #[derive(PartialEq, Debug)]
@@ -164,12 +167,19 @@ impl<'a> NameRepository<'a> {
     pub fn create_filtered_query(store_id: String, filter: Option<NameFilter>) -> BoxedNameQuery {
         let mut query = query(store_id)
             .into_boxed()
-            .filter(name::type_.ne(NameRowType::Patient))
-            .filter(
+            .filter(name::type_.ne(NameRowType::Patient));
+
+        let include_disabled = filter
+            .as_ref()
+            .and_then(|f| f.include_disabled)
+            .unwrap_or(false);
+        if !include_disabled {
+            query = query.filter(
                 store::is_disabled
                     .is_null()
                     .or(store::is_disabled.eq(false)),
-            ); // Filter out disabled stores, these are usually due to store merge, and should not be visible
+            );
+        }
 
         if let Some(f) = filter {
             let NameFilter {
@@ -193,6 +203,7 @@ impl<'a> NameRepository<'a> {
                 code_or_name,
                 supplying_store_id,
                 store,
+                include_disabled: _,
             } = f;
 
             // or filter need to be applied before and filters
@@ -364,6 +375,11 @@ impl NameFilter {
 
     pub fn store(mut self, filter: StoreFilter) -> Self {
         self.store = Some(filter);
+        self
+    }
+
+    pub fn include_disabled(mut self, value: bool) -> Self {
+        self.include_disabled = Some(value);
         self
     }
 }

--- a/server/service/src/invoice/customer_return/delete/mod.rs
+++ b/server/service/src/invoice/customer_return/delete/mod.rs
@@ -62,6 +62,7 @@ pub enum DeleteCustomerReturnError {
     DatabaseError(RepositoryError),
     NotThisStoreInvoice,
     CannotEditFinalised,
+    OtherPartyStoreDisabled,
     LineDeleteError {
         line_id: String,
         error: DeleteStockInLineError,

--- a/server/service/src/invoice/customer_return/delete/validate.rs
+++ b/server/service/src/invoice/customer_return/delete/validate.rs
@@ -2,6 +2,7 @@ use super::DeleteCustomerReturnError;
 use crate::invoice::{
     check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store,
 };
+use crate::validate::check_other_party_store_is_disabled;
 use repository::{InvoiceRow, InvoiceType, StorageConnection};
 
 pub fn validate(
@@ -16,6 +17,9 @@ pub fn validate(
         return Err(NotThisStoreInvoice);
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditFinalised);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditFinalised);
     }
     if !check_invoice_type(&invoice, InvoiceType::CustomerReturn) {

--- a/server/service/src/invoice/customer_return/delete/validate.rs
+++ b/server/service/src/invoice/customer_return/delete/validate.rs
@@ -20,7 +20,7 @@ pub fn validate(
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
-        return Err(CannotEditFinalised);
+        return Err(OtherPartyStoreDisabled);
     }
     if !check_invoice_type(&invoice, InvoiceType::CustomerReturn) {
         return Err(NotACustomerReturn);

--- a/server/service/src/invoice/customer_return/update/validate.rs
+++ b/server/service/src/invoice/customer_return/update/validate.rs
@@ -3,7 +3,10 @@ use crate::{
         check_invoice_exists, check_invoice_is_editable, check_invoice_status, check_invoice_type,
         check_status_change, check_store, InvoiceRowStatusError,
     },
-    validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors},
+    validate::{
+        check_other_party, check_other_party_store_is_disabled, CheckOtherPartyType,
+        OtherPartyErrors,
+    },
 };
 use repository::{InvoiceLineRowRepository, InvoiceRow, InvoiceType, Name, StorageConnection};
 
@@ -22,6 +25,9 @@ pub fn validate(
         return Err(NotThisStoreInvoice);
     }
     if !check_invoice_is_editable(&return_row) {
+        return Err(ReturnIsNotEditable);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &return_row.name_id)? {
         return Err(ReturnIsNotEditable);
     }
     if !check_invoice_type(&return_row, InvoiceType::CustomerReturn) {

--- a/server/service/src/invoice/customer_return/update_lines/validate.rs
+++ b/server/service/src/invoice/customer_return/update_lines/validate.rs
@@ -3,6 +3,7 @@ use repository::{InvoiceType, StorageConnection};
 use crate::invoice::{
     check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store,
 };
+use crate::validate::check_other_party_store_is_disabled;
 
 use super::UpdateCustomerReturnLinesError;
 
@@ -19,6 +20,9 @@ pub fn validate(
         return Err(ReturnDoesNotBelongToCurrentStore);
     }
     if !check_invoice_is_editable(&return_row) {
+        return Err(ReturnIsNotEditable);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &return_row.name_id)? {
         return Err(ReturnIsNotEditable);
     }
     if !check_invoice_type(&return_row, InvoiceType::CustomerReturn) {

--- a/server/service/src/invoice/inbound_shipment/delete/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/delete/mod.rs
@@ -74,6 +74,7 @@ pub enum DeleteInboundShipmentError {
     WrongInboundShipmentType,
     NotThisStoreInvoice,
     CannotEditFinalised,
+    OtherPartyStoreDisabled,
     LineDeleteError {
         line_id: String,
         error: DeleteStockInLineError,

--- a/server/service/src/invoice/inbound_shipment/delete/validate.rs
+++ b/server/service/src/invoice/inbound_shipment/delete/validate.rs
@@ -1,6 +1,7 @@
 use crate::invoice::{
     check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store,
 };
+use crate::validate::check_other_party_store_is_disabled;
 use repository::{InvoiceRow, InvoiceType, StorageConnection};
 
 use super::{super::InboundShipmentType, DeleteInboundShipment, DeleteInboundShipmentError};
@@ -25,6 +26,9 @@ pub fn validate(
         return Err(WrongInboundShipmentType);
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditFinalised);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditFinalised);
     }
 

--- a/server/service/src/invoice/inbound_shipment/delete/validate.rs
+++ b/server/service/src/invoice/inbound_shipment/delete/validate.rs
@@ -29,7 +29,7 @@ pub fn validate(
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
-        return Err(CannotEditFinalised);
+        return Err(OtherPartyStoreDisabled);
     }
 
     Ok(invoice)

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -217,6 +217,7 @@ pub enum UpdateInboundShipmentError {
     NotThisStoreInvoice,
     CannotReverseInvoiceStatus,
     CannotEditFinalised,
+    OtherPartyStoreDisabled,
     CannotChangeStatusOfInvoiceOnHold,
     CannotIssueForeignCurrencyForInternalSuppliers,
     CannotUpdateStatusAndDonorAtTheSameTime,

--- a/server/service/src/invoice/inbound_shipment/update/validate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/validate.rs
@@ -32,7 +32,7 @@ pub fn validate(
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
-        return Err(CannotEditFinalised);
+        return Err(OtherPartyStoreDisabled);
     }
     if !check_invoice_type(&invoice, InvoiceType::InboundShipment) {
         return Err(NotAnInboundShipment);

--- a/server/service/src/invoice/inbound_shipment/update/validate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/validate.rs
@@ -4,7 +4,9 @@ use crate::invoice::{
     inbound_shipment::UpdateInboundShipmentStatus, InvoiceRowStatusError,
 };
 use crate::preference::{preferences::Backdating, Preference};
-use crate::validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors};
+use crate::validate::{
+    check_other_party, check_other_party_store_is_disabled, CheckOtherPartyType, OtherPartyErrors,
+};
 use chrono::{Duration, Utc};
 use repository::{
     InvoiceLineRowRepository, InvoiceLineStatus, InvoiceRow, InvoiceStatus, InvoiceType, Name,
@@ -27,6 +29,9 @@ pub fn validate(
     }
 
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditFinalised);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditFinalised);
     }
     if !check_invoice_type(&invoice, InvoiceType::InboundShipment) {

--- a/server/service/src/invoice/outbound_shipment/add_from_master_list.rs
+++ b/server/service/src/invoice/outbound_shipment/add_from_master_list.rs
@@ -1,6 +1,7 @@
 use crate::invoice::common::check_master_list_for_name_id;
 use crate::invoice::common::get_lines_for_invoice;
 use crate::invoice::common::AddToShipmentFromMasterListInput as ServiceInput;
+use crate::validate::check_other_party_store_is_disabled;
 use crate::{invoice::check_invoice_exists, service_provider::ServiceContext};
 use repository::EqualFilter;
 use repository::ItemType;
@@ -74,6 +75,9 @@ fn validate(
         || invoice_row.status == InvoiceStatus::Received
         || invoice_row.status == InvoiceStatus::Verified
     {
+        return Err(OutError::CannotEditShipment);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice_row.name_id)? {
         return Err(OutError::CannotEditShipment);
     }
 

--- a/server/service/src/invoice/outbound_shipment/delete/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/delete/mod.rs
@@ -68,6 +68,7 @@ pub enum DeleteOutboundShipmentError {
     DatabaseError(RepositoryError),
     NotThisStoreInvoice,
     CannotEditFinalised,
+    OtherPartyStoreDisabled,
     LineDeleteError {
         line_id: String,
         error: DeleteStockOutLineError,

--- a/server/service/src/invoice/outbound_shipment/delete/validate.rs
+++ b/server/service/src/invoice/outbound_shipment/delete/validate.rs
@@ -2,6 +2,7 @@ use super::DeleteOutboundShipmentError;
 use crate::invoice::{
     check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store,
 };
+use crate::validate::check_other_party_store_is_disabled;
 use repository::{InvoiceRow, InvoiceType, StorageConnection};
 
 pub fn validate(
@@ -16,6 +17,9 @@ pub fn validate(
         return Err(NotThisStoreInvoice);
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditFinalised);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditFinalised);
     }
     if !check_invoice_type(&invoice, InvoiceType::OutboundShipment) {

--- a/server/service/src/invoice/outbound_shipment/delete/validate.rs
+++ b/server/service/src/invoice/outbound_shipment/delete/validate.rs
@@ -20,7 +20,7 @@ pub fn validate(
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
-        return Err(CannotEditFinalised);
+        return Err(OtherPartyStoreDisabled);
     }
     if !check_invoice_type(&invoice, InvoiceType::OutboundShipment) {
         return Err(NotAnOutboundShipment);

--- a/server/service/src/invoice/outbound_shipment/update/validate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/validate.rs
@@ -6,7 +6,7 @@ use crate::invoice::{
     check_status_change, check_store, InvoiceRowStatusError,
 };
 use crate::preference::{preferences::Backdating, Preference};
-use crate::validate::get_other_party;
+use crate::validate::{check_other_party_store_is_disabled, get_other_party};
 use crate::NullableUpdate;
 use chrono::{Duration, Utc};
 use repository::{
@@ -22,8 +22,6 @@ pub fn validate(
     use UpdateOutboundShipmentError::*;
 
     let invoice = check_invoice_exists(&patch.id, connection)?.ok_or(InvoiceDoesNotExist)?;
-    let other_party =
-        get_other_party(connection, store_id, &invoice.name_id)?.ok_or(OtherPartyDoesNotExist)?;
 
     if !check_store(&invoice, store_id) {
         return Err(NotThisStoreInvoice);
@@ -31,6 +29,13 @@ pub fn validate(
     if !check_invoice_is_editable(&invoice) {
         return Err(InvoiceIsNotEditable);
     }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
+        return Err(InvoiceIsNotEditable);
+    }
+
+    let other_party =
+        get_other_party(connection, store_id, &invoice.name_id)?.ok_or(OtherPartyDoesNotExist)?;
+
     if !check_invoice_type(&invoice, InvoiceType::OutboundShipment) {
         return Err(NotAnOutboundShipment);
     }

--- a/server/service/src/invoice/supplier_return/delete/mod.rs
+++ b/server/service/src/invoice/supplier_return/delete/mod.rs
@@ -66,6 +66,7 @@ pub enum DeleteSupplierReturnError {
     DatabaseError(RepositoryError),
     NotThisStoreInvoice,
     CannotEditFinalised,
+    OtherPartyStoreDisabled,
     LineDeleteError {
         line_id: String,
         error: DeleteStockOutLineError,

--- a/server/service/src/invoice/supplier_return/delete/validate.rs
+++ b/server/service/src/invoice/supplier_return/delete/validate.rs
@@ -20,7 +20,7 @@ pub fn validate(
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
-        return Err(CannotEditFinalised);
+        return Err(OtherPartyStoreDisabled);
     }
     if !check_invoice_type(&invoice, InvoiceType::SupplierReturn) {
         return Err(NotAnSupplierReturn);

--- a/server/service/src/invoice/supplier_return/delete/validate.rs
+++ b/server/service/src/invoice/supplier_return/delete/validate.rs
@@ -2,6 +2,7 @@ use super::DeleteSupplierReturnError;
 use crate::invoice::{
     check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store,
 };
+use crate::validate::check_other_party_store_is_disabled;
 use repository::{InvoiceRow, InvoiceType, StorageConnection};
 
 pub fn validate(
@@ -16,6 +17,9 @@ pub fn validate(
         return Err(NotThisStoreInvoice);
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditFinalised);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditFinalised);
     }
     if !check_invoice_type(&invoice, InvoiceType::SupplierReturn) {

--- a/server/service/src/invoice/supplier_return/update/validate.rs
+++ b/server/service/src/invoice/supplier_return/update/validate.rs
@@ -4,6 +4,7 @@ use crate::invoice::{
     check_invoice_exists, check_invoice_is_editable, check_invoice_status, check_invoice_type,
     check_status_change, check_store, InvoiceRowStatusError,
 };
+use crate::validate::check_other_party_store_is_disabled;
 
 use super::{UpdateSupplierReturn, UpdateSupplierReturnError};
 
@@ -21,6 +22,9 @@ pub fn validate(
         return Err(ReturnDoesNotBelongToCurrentStore);
     }
     if !check_invoice_is_editable(&return_row) {
+        return Err(ReturnIsNotEditable);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &return_row.name_id)? {
         return Err(ReturnIsNotEditable);
     }
     if !check_invoice_type(&return_row, InvoiceType::SupplierReturn) {

--- a/server/service/src/invoice/supplier_return/update_lines/validate.rs
+++ b/server/service/src/invoice/supplier_return/update_lines/validate.rs
@@ -3,6 +3,7 @@ use repository::{InvoiceType, StorageConnection};
 use crate::invoice::{
     check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store,
 };
+use crate::validate::check_other_party_store_is_disabled;
 
 use super::UpdateSupplierReturnLinesError;
 
@@ -19,6 +20,9 @@ pub fn validate(
         return Err(ReturnDoesNotBelongToCurrentStore);
     }
     if !check_invoice_is_editable(&return_row) {
+        return Err(ReturnIsNotEditable);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &return_row.name_id)? {
         return Err(ReturnIsNotEditable);
     }
     if !check_invoice_type(&return_row, InvoiceType::SupplierReturn) {

--- a/server/service/src/invoice/supplier_return/update_other_party/validate.rs
+++ b/server/service/src/invoice/supplier_return/update_other_party/validate.rs
@@ -1,7 +1,9 @@
 use crate::invoice::{
     check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store,
 };
-use crate::validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors};
+use crate::validate::{
+    check_other_party, check_other_party_store_is_disabled, CheckOtherPartyType, OtherPartyErrors,
+};
 use repository::{InvoiceRow, InvoiceType, Name, StorageConnection};
 
 use super::{UpdateSupplierReturnOtherParty, UpdateSupplierReturnOtherPartyError};
@@ -21,6 +23,9 @@ pub fn validate(
         return Err(NotAnSupplierReturn);
     }
     if !check_invoice_is_editable(&return_row) {
+        return Err(InvoiceIsNotEditable);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &return_row.name_id)? {
         return Err(InvoiceIsNotEditable);
     }
 

--- a/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/mod.rs
+++ b/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/mod.rs
@@ -23,6 +23,7 @@ pub enum InsertFromInternalOrderLineError {
     InvoiceDoesNotExist,
     NotThisStoreInvoice,
     CannotEditFinalised,
+    OtherPartyStoreDisabled,
     NotAnInboundShipment,
     RequisitionLineDoesNotExist,
     ItemDoesNotExist,

--- a/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/validate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/validate.rs
@@ -37,7 +37,7 @@ pub fn validate(
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
-        return Err(CannotEditFinalised);
+        return Err(OtherPartyStoreDisabled);
     }
 
     let requisition_line = check_requisition_line_exists(connection, &input.requisition_line_id)?

--- a/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/validate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/validate.rs
@@ -4,6 +4,7 @@ use crate::{
     invoice::{check_invoice_exists, check_invoice_is_editable, check_store},
     invoice_line::validate::check_item_exists,
     requisition_line::common::check_requisition_line_exists,
+    validate::check_other_party_store_is_disabled,
 };
 
 use super::{InsertFromInternalOrderLine, InsertFromInternalOrderLineError};
@@ -33,6 +34,9 @@ pub fn validate(
     }
 
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditFinalised);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditFinalised);
     }
 

--- a/server/service/src/invoice_line/inbound_shipment_service_line/delete/validate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/delete/validate.rs
@@ -7,6 +7,7 @@ use crate::{
         stock_in_line::DeleteStockInLine,
         validate::{check_line_belongs_to_invoice, check_line_row_exists},
     },
+    validate::check_other_party_store_is_disabled,
 };
 use repository::{InvoiceLineRow, InvoiceType, StorageConnection};
 
@@ -35,6 +36,9 @@ pub fn validate(
         }
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditInvoice);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditInvoice);
     }
     if !check_line_belongs_to_invoice(&line, &invoice) {

--- a/server/service/src/invoice_line/inbound_shipment_service_line/insert/validate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/insert/validate.rs
@@ -10,6 +10,7 @@ use crate::{
         inbound_shipment::InboundShipmentType,
     },
     invoice_line::validate::{check_item_exists, check_line_exists},
+    validate::check_other_party_store_is_disabled,
 };
 
 use super::{InsertInboundShipmentServiceLine, InsertInboundShipmentServiceLineError};
@@ -53,6 +54,9 @@ pub fn validate(
         }
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(OutError::CannotEditInvoice);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(OutError::CannotEditInvoice);
     }
 

--- a/server/service/src/invoice_line/inbound_shipment_service_line/update/validate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/update/validate.rs
@@ -6,6 +6,7 @@ use crate::{
         inbound_shipment::InboundShipmentType,
     },
     invoice_line::validate::{check_item_exists, check_line_belongs_to_invoice, check_line_exists},
+    validate::check_other_party_store_is_disabled,
 };
 
 use super::{UpdateInboundShipmentServiceLine, UpdateInboundShipmentServiceLineError};
@@ -43,6 +44,9 @@ pub fn validate(
         }
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditInvoice);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditInvoice);
     }
     if !check_line_belongs_to_invoice(&line.invoice_line_row, &invoice) {

--- a/server/service/src/invoice_line/outbound_shipment_service_line/delete/validate.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/delete/validate.rs
@@ -4,6 +4,7 @@ use crate::{
         stock_out_line::delete::DeleteStockOutLine,
         validate::{check_line_belongs_to_invoice, check_line_row_exists},
     },
+    validate::check_other_party_store_is_disabled,
 };
 use repository::{InvoiceLineRow, InvoiceType, StorageConnection};
 
@@ -26,6 +27,9 @@ pub fn validate(
         return Err(NotAnOutboundShipment);
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditInvoice);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditInvoice);
     }
     if !check_line_belongs_to_invoice(&line, &invoice) {

--- a/server/service/src/invoice_line/outbound_shipment_service_line/insert/validate.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/insert/validate.rs
@@ -7,6 +7,7 @@ use util::constants::DEFAULT_SERVICE_ITEM_CODE;
 use crate::{
     invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
     invoice_line::validate::{check_item_exists, check_line_exists},
+    validate::check_other_party_store_is_disabled,
 };
 
 use super::{InsertOutboundShipmentServiceLine, InsertOutboundShipmentServiceLineError};
@@ -44,6 +45,9 @@ pub fn validate(
         return Err(OutError::NotAnOutboundShipment);
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(OutError::CannotEditInvoice);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(OutError::CannotEditInvoice);
     }
 

--- a/server/service/src/invoice_line/outbound_shipment_service_line/update/validate.rs
+++ b/server/service/src/invoice_line/outbound_shipment_service_line/update/validate.rs
@@ -3,6 +3,7 @@ use repository::{InvoiceLine, InvoiceRow, InvoiceType, ItemRow, ItemType, Storag
 use crate::{
     invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
     invoice_line::validate::{check_item_exists, check_line_belongs_to_invoice, check_line_exists},
+    validate::check_other_party_store_is_disabled,
 };
 
 use super::{UpdateOutboundShipmentServiceLine, UpdateOutboundShipmentServiceLineError};
@@ -34,6 +35,9 @@ pub fn validate(
         return Err(NotAnOutboundShipment);
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditInvoice);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditInvoice);
     }
     if !check_line_belongs_to_invoice(&line.invoice_line_row, &invoice) {

--- a/server/service/src/invoice_line/save_stock_out_item_lines/validate.rs
+++ b/server/service/src/invoice_line/save_stock_out_item_lines/validate.rs
@@ -3,6 +3,7 @@ use repository::{InvoiceRow, InvoiceType, StorageConnection};
 use crate::{
     invoice::{check_invoice_exists, check_invoice_is_editable, check_store},
     invoice_line::save_stock_out_item_lines::SaveStockOutItemLinesError,
+    validate::check_other_party_store_is_disabled,
 };
 
 fn is_stock_out_invoice(invoice: &InvoiceRow) -> bool {
@@ -25,6 +26,9 @@ pub fn validate(
         return Err(InvoiceDoesNotBelongToCurrentStore);
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(InvoiceNotEditable);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(InvoiceNotEditable);
     }
     if !is_stock_out_invoice(&invoice) {

--- a/server/service/src/invoice_line/stock_in_line/delete/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/delete/mod.rs
@@ -67,6 +67,7 @@ pub enum DeleteStockInLineError {
     NotAStockIn,
     NotThisStoreInvoice,
     CannotEditFinalised,
+    OtherPartyStoreDisabled,
     CannotDeleteLinesOfAuthorisedReceivedInvoice,
     BatchIsReserved,
     NotThisInvoiceLine(String),

--- a/server/service/src/invoice_line/stock_in_line/delete/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/delete/validate.rs
@@ -8,6 +8,7 @@ use crate::{
             check_line_row_exists,
         },
     },
+    validate::check_other_party_store_is_disabled,
 };
 use repository::{InvoiceLineRow, InvoiceRow, StorageConnection};
 
@@ -36,6 +37,9 @@ pub fn validate(
         }
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditFinalised);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditFinalised);
     }
     if check_lines_locked_by_authorisation(connection, &invoice) {

--- a/server/service/src/invoice_line/stock_in_line/delete/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/delete/validate.rs
@@ -40,7 +40,7 @@ pub fn validate(
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
-        return Err(CannotEditFinalised);
+        return Err(OtherPartyStoreDisabled);
     }
     if check_lines_locked_by_authorisation(connection, &invoice) {
         return Err(CannotDeleteLinesOfAuthorisedReceivedInvoice);

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -109,6 +109,7 @@ pub enum InsertStockInLineError {
     DonorNotVisible,
     SelectedDonorPartyIsNotADonor,
     CannotEditFinalised,
+    OtherPartyStoreDisabled,
     CannotAddLinesToAuthorisedReceivedInvoice,
     LocationDoesNotExist,
     ItemVariantDoesNotExist,

--- a/server/service/src/invoice_line/stock_in_line/insert/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/validate.rs
@@ -82,7 +82,7 @@ pub fn validate(
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
-        return Err(CannotEditFinalised);
+        return Err(OtherPartyStoreDisabled);
     }
     if check_lines_locked_by_authorisation(connection, &invoice) {
         return Err(CannotAddLinesToAuthorisedReceivedInvoice);

--- a/server/service/src/invoice_line/stock_in_line/insert/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/validate.rs
@@ -8,7 +8,10 @@ use crate::{
         stock_in_line::{check_lines_locked_by_authorisation, check_pack_size},
         validate::{check_item_exists, check_line_exists, check_number_of_packs},
     },
-    validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors},
+    validate::{
+        check_other_party, check_other_party_store_is_disabled, CheckOtherPartyType,
+        OtherPartyErrors,
+    },
     NullableUpdate,
 };
 use repository::{InvoiceRow, ItemRow, PurchaseOrderLineRowRepository, StorageConnection};
@@ -76,6 +79,9 @@ pub fn validate(
         }
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditFinalised);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditFinalised);
     }
     if check_lines_locked_by_authorisation(connection, &invoice) {

--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -116,6 +116,7 @@ pub enum UpdateStockInLineError {
     NotAStockIn,
     NotThisStoreInvoice,
     CannotEditFinalised,
+    OtherPartyStoreDisabled,
     CannotChangeLineStatusOfReceivedInvoice,
     LocationDoesNotExist,
     ItemVariantDoesNotExist,

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -12,7 +12,10 @@ use crate::{
             check_number_of_packs,
         },
     },
-    validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors},
+    validate::{
+        check_other_party, check_other_party_store_is_disabled, CheckOtherPartyType,
+        OtherPartyErrors,
+    },
     NullableUpdate,
 };
 use repository::{
@@ -56,6 +59,9 @@ pub fn validate(
         }
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditFinalised);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditFinalised);
     }
     if !check_store(&invoice, store_id) {

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -62,7 +62,7 @@ pub fn validate(
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
-        return Err(CannotEditFinalised);
+        return Err(OtherPartyStoreDisabled);
     }
     if !check_store(&invoice, store_id) {
         return Err(NotThisStoreInvoice);

--- a/server/service/src/invoice_line/stock_out_line/delete/validate.rs
+++ b/server/service/src/invoice_line/stock_out_line/delete/validate.rs
@@ -1,6 +1,7 @@
 use crate::{
     invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
     invoice_line::validate::{check_line_belongs_to_invoice, check_line_row_exists},
+    validate::check_other_party_store_is_disabled,
 };
 use repository::{InvoiceLineRow, StorageConnection};
 
@@ -27,6 +28,9 @@ pub fn validate(
         return Err(NoInvoiceType);
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditInvoice);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditInvoice);
     }
     if !check_line_belongs_to_invoice(&line, &invoice) {

--- a/server/service/src/invoice_line/stock_out_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/mod.rs
@@ -52,6 +52,7 @@ pub enum InsertStockOutLineError {
     InvoiceTypeDoesNotMatch,
     NotThisStoreInvoice,
     CannotEditFinalised,
+    OtherPartyStoreDisabled,
     StockLineNotFound,
     NumberOfPacksBelowZero,
     LocationIsOnHold,

--- a/server/service/src/invoice_line/stock_out_line/insert/validate.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/validate.rs
@@ -10,6 +10,7 @@ use crate::{
         LocationIsOnHoldError,
     },
     stock_line::historical_stock::get_historical_stock_line_available_quantity,
+    validate::check_other_party_store_is_disabled,
 };
 use repository::{
     InvoiceRow, InvoiceStatus, ItemRow, LocationRowRepository, StockLine, StorageConnection,
@@ -57,6 +58,9 @@ pub fn validate(
         return Err(InvoiceTypeDoesNotMatch);
     }
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditFinalised);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditFinalised);
     }
     if !check_batch_on_hold(&batch, &input.r#type) {

--- a/server/service/src/invoice_line/stock_out_line/insert/validate.rs
+++ b/server/service/src/invoice_line/stock_out_line/insert/validate.rs
@@ -61,7 +61,7 @@ pub fn validate(
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
-        return Err(CannotEditFinalised);
+        return Err(OtherPartyStoreDisabled);
     }
     if !check_batch_on_hold(&batch, &input.r#type) {
         return Err(BatchIsOnHold);

--- a/server/service/src/invoice_line/stock_out_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_out_line/update/mod.rs
@@ -43,6 +43,7 @@ pub enum UpdateStockOutLineError {
     NotThisStoreInvoice,
     NotThisInvoiceLine(String),
     CannotEditFinalised,
+    OtherPartyStoreDisabled,
     ItemNotFound,
     StockLineNotFound,
     NumberOfPacksBelowZero,

--- a/server/service/src/invoice_line/stock_out_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_out_line/update/validate.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     service_provider::ServiceContext,
     stock_line::historical_stock::get_historical_stock_line_available_quantity,
+    validate::check_other_party_store_is_disabled,
 };
 use repository::{
     InvoiceLineRow, InvoiceRow, InvoiceStatus, ItemRow, ReasonOptionRowRepository,
@@ -62,6 +63,9 @@ pub fn validate(
     };
 
     if !check_invoice_is_editable(&invoice) {
+        return Err(CannotEditFinalised);
+    }
+    if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
         return Err(CannotEditFinalised);
     }
     if !check_line_belongs_to_invoice(line_row, &invoice) {

--- a/server/service/src/invoice_line/stock_out_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_out_line/update/validate.rs
@@ -66,7 +66,7 @@ pub fn validate(
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
-        return Err(CannotEditFinalised);
+        return Err(OtherPartyStoreDisabled);
     }
     if !check_line_belongs_to_invoice(line_row, &invoice) {
         return Err(NotThisInvoiceLine(line.invoice_line_row.invoice_id));

--- a/server/service/src/requisition/request_requisition/add_from_master_list.rs
+++ b/server/service/src/requisition/request_requisition/add_from_master_list.rs
@@ -7,6 +7,7 @@ use crate::{
         check_master_list_for_store, check_requisition_row_exists, get_lines_for_requisition,
     },
     service_provider::ServiceContext,
+    validate::check_other_party_store_is_disabled,
     PluginOrRepositoryError,
 };
 use repository::{
@@ -96,6 +97,10 @@ fn validate(
     }
 
     if requisition_row.status != RequisitionStatus::Draft {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
 

--- a/server/service/src/requisition/request_requisition/delete.rs
+++ b/server/service/src/requisition/request_requisition/delete.rs
@@ -6,6 +6,7 @@ use crate::{
         DeleteRequestRequisitionLineError,
     },
     service_provider::ServiceContext,
+    validate::check_other_party_store_is_disabled,
 };
 use repository::{
     requisition_row::{RequisitionStatus, RequisitionType},
@@ -102,6 +103,10 @@ fn validate(
     }
 
     if requisition_row.status != RequisitionStatus::Draft {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
     // Note that lines are not deleted when an invoice is deleted, due to issues with batch deletes.

--- a/server/service/src/requisition/request_requisition/update/validate.rs
+++ b/server/service/src/requisition/request_requisition/update/validate.rs
@@ -5,7 +5,10 @@ use crate::{
         OrderTypeNotFoundError,
     },
     store_preference::get_store_preferences,
-    validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors},
+    validate::{
+        check_other_party, check_other_party_store_is_disabled, CheckOtherPartyType,
+        OtherPartyErrors,
+    },
     NullableUpdate,
 };
 use repository::{
@@ -45,6 +48,10 @@ pub fn validate(
     }
 
     if requisition_row.status != RequisitionStatus::Draft {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
 

--- a/server/service/src/requisition/request_requisition/use_suggested_quantity.rs
+++ b/server/service/src/requisition/request_requisition/use_suggested_quantity.rs
@@ -1,6 +1,7 @@
 use crate::{
     requisition::common::{check_requisition_row_exists, get_lines_for_requisition},
     service_provider::ServiceContext,
+    validate::check_other_party_store_is_disabled,
 };
 use repository::EqualFilter;
 use repository::{
@@ -72,6 +73,10 @@ fn validate(
     }
 
     if requisition_row.status != RequisitionStatus::Draft {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
     Ok(())

--- a/server/service/src/requisition/response_requisition/add_from_master_list.rs
+++ b/server/service/src/requisition/response_requisition/add_from_master_list.rs
@@ -5,6 +5,7 @@ use crate::{
         get_lines_for_requisition,
     },
     service_provider::ServiceContext,
+    validate::check_other_party_store_is_disabled,
 };
 use chrono::Utc;
 use repository::{
@@ -80,6 +81,10 @@ fn validate(
     }
 
     if requisition_row.status != RequisitionStatus::New {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
 

--- a/server/service/src/requisition/response_requisition/create_requisition_shipment/validate.rs
+++ b/server/service/src/requisition/response_requisition/create_requisition_shipment/validate.rs
@@ -7,6 +7,7 @@ use crate::requisition::requisition_supply_status::RequisitionLineSupplyStatus;
 use crate::requisition::{
     common::check_requisition_exists, requisition_supply_status::get_requisitions_supply_statuses,
 };
+use crate::validate::check_other_party_store_is_disabled;
 
 use super::{CreateRequisitionShipment, OutError};
 
@@ -27,6 +28,10 @@ pub fn validate(
     }
 
     if requisition_row.status != RequisitionStatus::New {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
 

--- a/server/service/src/requisition/response_requisition/supply_requested_quantity.rs
+++ b/server/service/src/requisition/response_requisition/supply_requested_quantity.rs
@@ -4,6 +4,7 @@ use crate::{
         get_lines_for_requisition,
     },
     service_provider::ServiceContext,
+    validate::check_other_party_store_is_disabled,
 };
 
 use repository::{
@@ -85,6 +86,10 @@ fn validate(
     }
 
     if requisition_row.status != RequisitionStatus::New {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
 

--- a/server/service/src/requisition/response_requisition/update.rs
+++ b/server/service/src/requisition/response_requisition/update.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     service_provider::ServiceContext,
     store_preference::get_store_preferences,
+    validate::check_other_party_store_is_disabled,
 };
 use chrono::Utc;
 use repository::{
@@ -112,6 +113,10 @@ pub fn validate(
     }
 
     if requisition_row.status != RequisitionStatus::New {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
 

--- a/server/service/src/requisition_line/request_requisition_line/delete.rs
+++ b/server/service/src/requisition_line/request_requisition_line/delete.rs
@@ -1,6 +1,7 @@
 use crate::{
     requisition::common::check_requisition_row_exists,
     requisition_line::common::check_requisition_line_exists, service_provider::ServiceContext,
+    validate::check_other_party_store_is_disabled,
 };
 use repository::{
     requisition_row::{RequisitionStatus, RequisitionType},
@@ -63,6 +64,10 @@ fn validate(
     }
 
     if requisition_row.status != RequisitionStatus::Draft {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
 

--- a/server/service/src/requisition_line/request_requisition_line/insert/validate.rs
+++ b/server/service/src/requisition_line/request_requisition_line/insert/validate.rs
@@ -5,6 +5,7 @@ use crate::{
         common::{check_item_exists_in_requisition, check_requisition_line_exists},
         request_requisition_line::{insert::OutError, InsertRequestRequisitionLine},
     },
+    validate::check_other_party_store_is_disabled,
 };
 use repository::{RequisitionRow, RequisitionStatus, RequisitionType, StorageConnection};
 
@@ -33,6 +34,10 @@ pub fn validate(
     }
 
     if requisition_row.status != RequisitionStatus::Draft {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
 

--- a/server/service/src/requisition_line/request_requisition_line/update.rs
+++ b/server/service/src/requisition_line/request_requisition_line/update.rs
@@ -4,6 +4,7 @@ use crate::{
     requisition_line::{common::check_requisition_line_exists, query::get_requisition_line},
     service_provider::ServiceContext,
     store_preference::get_store_preferences,
+    validate::check_other_party_store_is_disabled,
 };
 
 use repository::{
@@ -79,6 +80,10 @@ fn validate(
     }
 
     if requisition_row.status != RequisitionStatus::Draft {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
 

--- a/server/service/src/requisition_line/response_requisition_line/delete.rs
+++ b/server/service/src/requisition_line/response_requisition_line/delete.rs
@@ -6,6 +6,7 @@ use repository::{
 use crate::{
     requisition::common::check_requisition_row_exists,
     requisition_line::common::check_requisition_line_exists, service_provider::ServiceContext,
+    validate::check_other_party_store_is_disabled,
 };
 
 #[derive(Debug, PartialEq, Clone, Default)]
@@ -67,6 +68,10 @@ fn validate(
     }
 
     if requisition_row.status == RequisitionStatus::Finalised {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
 

--- a/server/service/src/requisition_line/response_requisition_line/insert/validate.rs
+++ b/server/service/src/requisition_line/response_requisition_line/insert/validate.rs
@@ -4,6 +4,7 @@ use crate::{
     item::get_item,
     requisition::common::check_requisition_row_exists,
     requisition_line::common::{check_item_exists_in_requisition, check_requisition_line_exists},
+    validate::check_other_party_store_is_disabled,
 };
 
 use super::{InsertResponseRequisitionLine, OutError};
@@ -29,6 +30,10 @@ pub fn validate(
     }
 
     if requisition_row.status == RequisitionStatus::Finalised {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
 

--- a/server/service/src/requisition_line/response_requisition_line/update.rs
+++ b/server/service/src/requisition_line/response_requisition_line/update.rs
@@ -5,6 +5,7 @@ use crate::{
     requisition_line::{common::check_requisition_line_exists, query::get_requisition_line},
     service_provider::ServiceContext,
     store_preference::get_store_preferences,
+    validate::check_other_party_store_is_disabled,
 };
 
 use repository::{
@@ -101,6 +102,10 @@ fn validate(
     }
 
     if requisition_row.status != RequisitionStatus::New {
+        return Err(OutError::CannotEditRequisition);
+    }
+
+    if check_other_party_store_is_disabled(connection, store_id, &requisition_row.name_id)? {
         return Err(OutError::CannotEditRequisition);
     }
 

--- a/server/service/src/validate.rs
+++ b/server/service/src/validate.rs
@@ -124,6 +124,27 @@ pub fn check_other_party(
     Ok(other_party)
 }
 
+pub fn check_other_party_store_is_disabled(
+    connection: &StorageConnection,
+    store_id: &str,
+    other_party_id: &str,
+) -> Result<bool, RepositoryError> {
+    let mut results = NameRepository::new(connection).query_by_filter(
+        store_id,
+        NameFilter::new()
+            .id(EqualFilter::equal_to(other_party_id.to_string()))
+            .include_disabled(true),
+    )?;
+
+    let name = results
+        .iter()
+        .find(|name| name.name_store_join_row.is_some())
+        .cloned()
+        .or_else(|| results.pop());
+
+    Ok(name.map(|name| name.is_disabled()).unwrap_or(false))
+}
+
 pub fn check_property_key_does_not_exist(
     connection: &StorageConnection,
     key: &str,


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12092

# 👩🏻‍💻 What does this PR do?
Allow users to access transactions from disabled stores, but keep the transaction disabled! Also add a message to make it clear to the user why the transaction is disabled

<img width="1722" height="721" alt="Screenshot 2026-06-16 at 13 57 08" src="https://github.com/user-attachments/assets/3520573f-c71f-48ef-af40-c60eba99f5a2" />


## 💌 Any notes for the reviewer?
>.> We should really implement store merging and also why is OG using isDisabled for store merge AND disabled names?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Have some transactions for a name either supplier or customer 
- [ ] Go to OG disable store
- [ ] Sync
- [ ] Back in OMS, click on a transaction (Outbound, Inbound, Internal Order, etc) 
- [ ] Should be able to access the transaction
- [ ] Shouldn't be able to edit the transaction

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

