### PR TITLE
11885 Fix sync initialisation failing on multiple-site central servers v2.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.16.05",
+  "version": "2.16.06-rc1",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -49,11 +49,6 @@ allow_tables_to_appear_in_same_query!(changelog_deduped, vaccination);
 joinable!(changelog -> name_link (name_link_id));
 allow_tables_to_appear_in_same_query!(changelog, name_link);
 
-// Aliased changelog used to build the head-dedupe subquery in `create_filtered_head_count_query`.
-// Diesel rejects a subquery on the same table as the outer query's FROM clause; the alias makes
-// the inner `changelog` distinct from the outer one.
-diesel::alias!(changelog as changelog_head: ChangelogHead);
-
 #[cfg(not(feature = "postgres"))]
 define_sql_function!(
     fn last_insert_rowid() -> BigInt
@@ -328,17 +323,9 @@ impl<'a> ChangelogRepository<'a> {
 
     /// Counts deduped changelog records with cursor >= `earliest` that match `filter`.
     ///
-    /// This is equivalent to counting rows of the `changelog_deduped` view (see
-    /// [`create_filtered_query`]), but only dedupes the "head" of the changelog
-    /// (rows with cursor >= `earliest`) instead of grouping the entire history and
-    /// trimming afterwards.
-    ///
-    /// It is exact, not approximate: the deduped view keeps the global-max-cursor row
-    /// per (record_id, store_id) group, and a group's global max is >= `earliest` iff
-    /// the group has any row >= `earliest` — in which case that max row is itself in the
-    /// head. So grouping only over the head yields the same latest row per group, and the
-    /// filter is applied to that same row (important for fields like `is_sync_update` /
-    /// `source_site_id` that can vary within a group).
+    /// Counts rows of the `changelog_deduped` view (see [`create_filtered_query`]). The view's
+    /// `NOT EXISTS` anti-join lets the planner push the `cursor >= earliest` predicate down to the
+    /// cursor index, so this stays a tail scan on a large changelog rather than a full dedupe.
     pub fn count(
         &self,
         earliest: u64,
@@ -347,8 +334,10 @@ impl<'a> ChangelogRepository<'a> {
         // Clamp identically to the row reader so callers that drive a push/processor loop off
         // `count` (e.g. the `_ => continue` termination check) stay consistent with `changelogs()`
         // while a tx is in flight — otherwise count could report rows the clamped reader won't
-        // return, spinning the loop. The clamp is applied inside the head-count query.
-        let result = create_filtered_head_count_query(self.connection, earliest, filter)
+        // return, spinning the loop.
+        let mut query = create_filtered_query(earliest, filter);
+        query = clamp_to_safe_cursor(self.connection, query);
+        let result = query
             .count()
             .get_result::<i64>(self.connection.lock().connection())?;
         Ok(result as u64)
@@ -529,70 +518,6 @@ fn create_filtered_query(earliest: u64, filter: Option<ChangelogFilter>) -> Boxe
         apply_equal_filter!(query, action, changelog_deduped::row_action);
         apply_equal_filter!(query, is_sync_update, changelog_deduped::is_sync_update);
         apply_equal_filter!(query, source_site_id, changelog_deduped::source_site_id);
-    }
-
-    query
-}
-
-type BoxedRawChangelogQuery =
-    IntoBoxed<'static, LeftJoin<changelog::table, name_link::table>, DBType>;
-
-/// Builds the filtered count query for [`ChangelogRepository::count`], deduping only the
-/// head of the changelog (cursor >= `earliest`) rather than the whole history.
-///
-/// `head_max_cursors` is the latest cursor per (record_id, store_id) group restricted to the
-/// head — one cursor per group, and (since cursor is unique) exactly the global-latest row of
-/// each group present in the head. Filtering `cursor IN (head_max_cursors)` therefore selects
-/// the same rows the `changelog_deduped` view would keep, and the `ChangelogFilter` is applied
-/// to those latest rows — matching the view's filter-on-latest semantics.
-fn create_filtered_head_count_query(
-    connection: &StorageConnection,
-    earliest: u64,
-    filter: Option<ChangelogFilter>,
-) -> BoxedRawChangelogQuery {
-    let head_max_cursors = changelog_head
-        .filter(
-            changelog_head
-                .field(changelog::cursor)
-                .ge(earliest.try_into().unwrap_or(0)),
-        )
-        .group_by((
-            changelog_head.field(changelog::record_id),
-            changelog_head.field(changelog::store_id),
-        ))
-        .select(diesel::dsl::max(changelog_head.field(changelog::cursor)));
-
-    let mut query = changelog::table
-        .left_join(name_link::table)
-        .into_boxed()
-        .filter(changelog::cursor.nullable().eq_any(head_max_cursors));
-
-    // Apply the same safe-cursor ceiling as [`clamp_to_safe_cursor`] (see its docs for why).
-    // The clamp goes on the OUTER query only: the inner subquery still takes the unbounded global
-    // max per group, so a group whose latest change sits above the safe cursor is excluded
-    // entirely — exactly matching `clamp_to_safe_cursor(create_filtered_query(..))`.
-    if let Some(safe) = ChangelogCursorTracker::max_safe_cursor(connection) {
-        query = query.filter(changelog::cursor.le(safe as i64));
-    }
-
-    if let Some(f) = filter {
-        let ChangelogFilter {
-            table_name,
-            name_id,
-            store_id,
-            record_id,
-            is_sync_update,
-            action,
-            source_site_id,
-        } = f;
-
-        apply_equal_filter!(query, table_name, changelog::table_name);
-        apply_equal_filter!(query, name_id, name_link::name_id);
-        apply_equal_filter!(query, store_id, changelog::store_id);
-        apply_equal_filter!(query, record_id, changelog::record_id);
-        apply_equal_filter!(query, action, changelog::row_action);
-        apply_equal_filter!(query, is_sync_update, changelog::is_sync_update);
-        apply_equal_filter!(query, source_site_id, changelog::source_site_id);
     }
 
     query

--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -401,41 +401,6 @@ impl<'a> ChangelogRepository<'a> {
         Ok(result.into_iter().map(ChangelogRow::from_join).collect())
     }
 
-    /// This returns the number of changelog records that should be evaluated to send to the remote site when doing a v6_pull
-    /// This looks up associated records to decide if change log should be sent to the site or not
-    /// Update this method when adding new record types to the system
-    pub fn count_outgoing_sync_records_from_central(
-        &self,
-        earliest: u64,
-        sync_site_id: i32,
-        is_initialized: bool,
-    ) -> Result<u64, RepositoryError> {
-        let query = clamp_to_safe_cursor(
-            self.connection,
-            create_filtered_outgoing_sync_query(earliest, sync_site_id, is_initialized),
-        );
-        let result = query
-            .count()
-            .get_result::<i64>(self.connection.lock().connection())?;
-        Ok(result as u64)
-    }
-
-    pub fn count_outgoing_patient_sync_records_from_central(
-        &self,
-        earliest: u64,
-        sync_site_id: i32,
-        fetch_patient_id: String,
-    ) -> Result<u64, RepositoryError> {
-        let query = clamp_to_safe_cursor(
-            self.connection,
-            create_filtered_outgoing_patient_sync_query(earliest, sync_site_id, fetch_patient_id),
-        );
-        let result = query
-            .count()
-            .get_result::<i64>(self.connection.lock().connection())?;
-        Ok(result as u64)
-    }
-
     /// Returns latest change log
     /// After initial sync we use this method to get the latest cursor to make sure we don't try to push any records that were synced to this site on initialisation
     pub fn absolute_latest_cursor(&self) -> Result<u64, RepositoryError> {
@@ -586,7 +551,11 @@ fn create_filtered_head_count_query(
     filter: Option<ChangelogFilter>,
 ) -> BoxedRawChangelogQuery {
     let head_max_cursors = changelog_head
-        .filter(changelog_head.field(changelog::cursor).ge(earliest.try_into().unwrap_or(0)))
+        .filter(
+            changelog_head
+                .field(changelog::cursor)
+                .ge(earliest.try_into().unwrap_or(0)),
+        )
         .group_by((
             changelog_head.field(changelog::record_id),
             changelog_head.field(changelog::store_id),
@@ -908,7 +877,9 @@ mod test {
             })
             .unwrap();
 
-        let cursor_before = ChangelogRepository::new(&observer).absolute_latest_cursor().unwrap();
+        let cursor_before = ChangelogRepository::new(&observer)
+            .absolute_latest_cursor()
+            .unwrap();
 
         // Channels to drive connection A: signal it has registered an in-flight cursor, then
         // signal it to commit.
@@ -953,14 +924,16 @@ mod test {
 
         // The clamp is active: safe cursor is pegged below the (now higher) raw max.
         assert!(ChangelogCursorTracker::max_safe_cursor(&observer).is_some());
-        let safe_during = ChangelogRepository::new(&observer)
-            .latest_cursor()
+        let safe_during = ChangelogRepository::new(&observer).latest_cursor().unwrap();
+        let raw_during = ChangelogRepository::new(&observer)
+            .absolute_latest_cursor()
             .unwrap();
-        let raw_during = ChangelogRepository::new(&observer).absolute_latest_cursor().unwrap();
         assert!(
             safe_during <= cursor_before && safe_during < raw_during,
             "expected safe cursor clamped (<= {}, < raw {}), got {}",
-            cursor_before, raw_during, safe_during
+            cursor_before,
+            raw_during,
+            safe_during
         );
 
         // The reader must not return the committed-after row past the clamp.
@@ -1000,13 +973,12 @@ mod test {
         slow_tx.await.unwrap();
 
         assert_eq!(ChangelogCursorTracker::max_safe_cursor(&observer), None);
-        let safe_after = ChangelogRepository::new(&observer)
-            .latest_cursor()
-            .unwrap();
+        let safe_after = ChangelogRepository::new(&observer).latest_cursor().unwrap();
         assert!(
             safe_after > cursor_before,
             "expected cursor to advance past {} after commit, got {}",
-            cursor_before, safe_after
+            cursor_before,
+            safe_after
         );
 
         let rows_after = ChangelogRepository::new(&observer)

--- a/server/repository/src/db_diesel/changelog/test.rs
+++ b/server/repository/src/db_diesel/changelog/test.rs
@@ -313,14 +313,17 @@ async fn test_changelog_filter() {
     );
 }
 
-/// `count` dedupes only the head of the changelog (cursor >= earliest) instead of the whole
-/// view, but must stay exactly equal to the deduped result. We pin that against `changelogs`
-/// (which reads the `changelog_deduped` view) for the same earliest/filter — this is the same
-/// consistency the sync push loop relies on (count vs the batch fetch).
+/// `count` must stay exactly equal to the deduped result returned by `changelogs` (which reads the
+/// `changelog_deduped` view) for the same earliest/filter — this is the consistency the sync push
+/// loop relies on (count vs the batch fetch). In particular the filter must apply to the latest row
+/// per (record_id, store_id), not any earlier row in the group.
 #[actix_rt::test]
-async fn test_changelog_count_head_dedupe() {
-    let (_, connection, _, _) =
-        setup_all("test_changelog_count_head_dedupe", MockDataInserts::none().names()).await;
+async fn test_changelog_count_dedupes_to_latest_row() {
+    let (_, connection, _, _) = setup_all(
+        "test_changelog_count_dedupes_to_latest_row",
+        MockDataInserts::none().names(),
+    )
+    .await;
 
     let repo = ChangelogRepository::new(&connection);
     repo.delete(0).unwrap();

--- a/server/repository/src/migrations/views/changelog_deduped.rs
+++ b/server/repository/src/migrations/views/changelog_deduped.rs
@@ -19,18 +19,12 @@ impl ViewMigrationFragment for ViewMigration {
         sql!(
             connection,
             r#"
-                -- View of the changelog that only contains the most recent changes to a row, i.e. previous row
-    -- edits are removed.
-    -- Note, an insert + delete will show up as an orphaned delete.
-    -- For records that can be transferred between stores (like assets), we dedupe by both
-    -- record_id and store_id so changes are not lost when an asset is moved.
-    --
-    -- This is expressed as "keep the row that has no newer row for the same (record_id, store_id)"
-    -- (a NOT EXISTS anti-join) rather than the equivalent GROUP BY ... MAX(cursor) self-join.
-    -- Both produce the same rows (cursor is unique), but the anti-join form lets the query planner
-    -- push a caller's `WHERE cursor >= ?` predicate down to the base table's cursor index instead of
-    -- deduping the entire changelog first. On a large changelog (e.g. a central server) this turns
-    -- the per-batch sync push/pull queries from a full-table dedup into a tail scan.
+                -- Most recent change per row only (an insert + delete shows as an orphaned delete).
+    -- Dedupe by (record_id, store_id) so store transfers (e.g. assets) aren't lost.
+    -- "Keep the row with no newer row for the same key" (NOT EXISTS anti-join) is equivalent to the
+    -- old GROUP BY MAX(cursor) self-join (cursor is unique), but lets the planner push a
+    -- `WHERE cursor >= ?` down to the cursor index instead of deduping the whole changelog first -
+    -- turning per-batch sync queries on a large changelog from a full scan into a tail scan.
   CREATE VIEW changelog_deduped AS
     SELECT c.cursor,
         c.table_name,

--- a/server/repository/src/migrations/views/changelog_deduped.rs
+++ b/server/repository/src/migrations/views/changelog_deduped.rs
@@ -31,12 +31,10 @@ impl ViewMigrationFragment for ViewMigration {
         c.record_id,
         c.row_action,
         c.name_link_id,
-        name_link.name_id,
         c.store_id,
         c.is_sync_update,
         c.source_site_id
     FROM changelog c
-    LEFT JOIN name_link ON c.name_link_id = name_link.id
     WHERE NOT EXISTS (
         SELECT 1
         FROM changelog newer

--- a/server/repository/src/migrations/views/changelog_deduped.rs
+++ b/server/repository/src/migrations/views/changelog_deduped.rs
@@ -22,26 +22,34 @@ impl ViewMigrationFragment for ViewMigration {
                 -- View of the changelog that only contains the most recent changes to a row, i.e. previous row
     -- edits are removed.
     -- Note, an insert + delete will show up as an orphaned delete.
-    -- For records that can be transferred between stores (like assets), we need to group by both
-    -- record_id and store_id to ensure changes are not lost when an asset is moved.
+    -- For records that can be transferred between stores (like assets), we dedupe by both
+    -- record_id and store_id so changes are not lost when an asset is moved.
+    --
+    -- This is expressed as "keep the row that has no newer row for the same (record_id, store_id)"
+    -- (a NOT EXISTS anti-join) rather than the equivalent GROUP BY ... MAX(cursor) self-join.
+    -- Both produce the same rows (cursor is unique), but the anti-join form lets the query planner
+    -- push a caller's `WHERE cursor >= ?` predicate down to the base table's cursor index instead of
+    -- deduping the entire changelog first. On a large changelog (e.g. a central server) this turns
+    -- the per-batch sync push/pull queries from a full-table dedup into a tail scan.
   CREATE VIEW changelog_deduped AS
     SELECT c.cursor,
         c.table_name,
         c.record_id,
         c.row_action,
         c.name_link_id,
+        name_link.name_id,
         c.store_id,
         c.is_sync_update,
         c.source_site_id
-    FROM (
-        SELECT record_id, store_id, MAX(cursor) AS max_cursor
-        FROM changelog
-        GROUP BY record_id, store_id
-    ) grouped
-    INNER JOIN changelog c
-        ON c.record_id = grouped.record_id 
-        AND (c.store_id = grouped.store_id OR (c.store_id IS NULL AND grouped.store_id IS NULL))
-        AND c.cursor = grouped.max_cursor
+    FROM changelog c
+    LEFT JOIN name_link ON c.name_link_id = name_link.id
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM changelog newer
+        WHERE newer.record_id = c.record_id
+            AND (newer.store_id = c.store_id OR (newer.store_id IS NULL AND c.store_id IS NULL))
+            AND newer.cursor > c.cursor
+    )
     ORDER BY c.cursor;            "#
         )?;
 

--- a/server/service/src/ledger_fix/ledger_fix_driver.rs
+++ b/server/service/src/ledger_fix/ledger_fix_driver.rs
@@ -61,10 +61,8 @@ impl LedgerFixDriver {
 }
 
 async fn ledger_fix(service_provider: Arc<ServiceProvider>) {
-    // This runs on the main `select!` loop, so a panic here would take down the whole server.
-    // Acquiring a DB context can fail under transient connection-pool exhaustion (e.g. a large
-    // central serving many concurrent sync pulls) - log and skip this run rather than crash; the
-    // loop will re-trigger on the next interval.
+    // Runs on the main loop, so never panic: a transient pool-exhaustion failure here would crash
+    // the server. Log and skip; the loop retries next interval.
     let ctx = match service_provider.basic_context() {
         Ok(ctx) => ctx,
         Err(error) => {

--- a/server/service/src/ledger_fix/ledger_fix_driver.rs
+++ b/server/service/src/ledger_fix/ledger_fix_driver.rs
@@ -61,18 +61,31 @@ impl LedgerFixDriver {
 }
 
 async fn ledger_fix(service_provider: Arc<ServiceProvider>) {
-    let ctx = service_provider.basic_context().unwrap();
+    // This runs on the main `select!` loop, so a panic here would take down the whole server.
+    // Acquiring a DB context can fail under transient connection-pool exhaustion (e.g. a large
+    // central serving many concurrent sync pulls) - log and skip this run rather than crash; the
+    // loop will re-trigger on the next interval.
+    let ctx = match service_provider.basic_context() {
+        Ok(ctx) => ctx,
+        Err(error) => {
+            log::error!(
+                "Ledger fix: skipping run, could not acquire DB context (DB unavailable?): {error:?}"
+            );
+            return;
+        }
+    };
 
     let stock_line_ids = match find_stock_line_ledger_discrepancies(&ctx.connection, None) {
         Ok(stock_line_ids) => stock_line_ids,
         Err(e) => {
-            system_error_log(
+            if let Err(log_error) = system_error_log(
                 &ctx.connection,
                 SystemLogType::LedgerFixError,
                 &e,
                 "Error while finding stock line ledger discrepancies",
-            )
-            .unwrap();
+            ) {
+                log::error!("Ledger fix: failed to write system log: {log_error:?}");
+            }
             return;
         }
     };
@@ -83,7 +96,9 @@ async fn ledger_fix(service_provider: Arc<ServiceProvider>) {
         stock_line_ids
     );
 
-    system_log(&ctx.connection, SystemLogType::LedgerFixError, &error_msg).unwrap()
+    if let Err(log_error) = system_log(&ctx.connection, SystemLogType::LedgerFixError, &error_msg) {
+        log::error!("Ledger fix: failed to write system log: {log_error:?}");
+    }
 }
 
 impl LedgerFixTrigger {
@@ -105,8 +120,16 @@ impl LedgerFixTrigger {
 async fn delay(service_provider: Arc<ServiceProvider>, duration: Duration) -> bool {
     tokio::time::sleep(duration).await;
 
-    let last_ledger_fix_run = get_last_ledger_fix_run(&service_provider)
-        .expect("Repository error while getting last ledger fix run");
+    let last_ledger_fix_run = match get_last_ledger_fix_run(&service_provider) {
+        Ok(value) => value,
+        Err(error) => {
+            // Don't panic the main loop on a transient DB error - skip and retry next interval.
+            log::error!(
+                "Ledger fix: skipping run, could not read last run (DB unavailable?): {error:?}"
+            );
+            return false;
+        }
+    };
 
     // Do ledger fix if date is not set yet
     let Some(last_ledger_fix_run) = last_ledger_fix_run else {
@@ -122,7 +145,7 @@ async fn delay(service_provider: Arc<ServiceProvider>, duration: Duration) -> bo
 fn get_last_ledger_fix_run(
     service_provider: &ServiceProvider,
 ) -> Result<Option<NaiveDateTime>, RepositoryError> {
-    let ctx = service_provider.basic_context().unwrap();
+    let ctx = service_provider.basic_context()?;
     let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
 
     // Get and parse last ledger fix run, if not set or filed to parse return epoch
@@ -145,14 +168,20 @@ fn get_last_ledger_fix_run(
 }
 
 fn set_last_ledger_fix_run(service_provider: &ServiceProvider) {
-    let ctx = service_provider.basic_context().unwrap();
+    let ctx = match service_provider.basic_context() {
+        Ok(ctx) => ctx,
+        Err(error) => {
+            log::error!("Ledger fix: could not record last run, DB context unavailable: {error:?}");
+            return;
+        }
+    };
     let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
 
     let now = Utc::now().naive_utc();
     let now_string =
         serde_json::to_string(&now).expect("Failed to serialize last ledger fix run datetime");
 
-    key_value_store
-        .set_string(KeyType::LastLedgerFixRun, Some(now_string))
-        .expect("Database error while setting last ledger fix run");
+    if let Err(error) = key_value_store.set_string(KeyType::LastLedgerFixRun, Some(now_string)) {
+        log::error!("Ledger fix: failed to persist last run datetime: {error:?}");
+    }
 }

--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -37,6 +37,10 @@ pub struct SyncApiSettings {
 pub struct SyncApiV5 {
     pub url: Url,
     pub settings: SyncApiSettings,
+    /// Poll period for [`SyncApiV5::wait_until_central_idle`] when central is busy with another
+    /// session for this site. Defaults to `CENTRAL_BUSY_POLL_PERIOD_SECONDS` in production; tests
+    /// set it to 0 to drive the busy-retry loops without real sleeps.
+    pub(crate) busy_poll_period_seconds: u64,
 }
 
 fn tuple_vec_to_header(tuple_vec: Vec<(&str, &str)>) -> HeaderMap {
@@ -91,6 +95,7 @@ impl SyncApiV5 {
                 SyncApiV5CreatingError::CannotParseSyncUrl(settings.server_url.clone(), error)
             })?,
             settings,
+            busy_poll_period_seconds: CENTRAL_BUSY_POLL_PERIOD_SECONDS,
         })
     }
 
@@ -110,6 +115,7 @@ impl SyncApiV5 {
                 app_version: Version::from_package_json().to_string(),
                 app_name: APP_NAME.to_string(),
             },
+            busy_poll_period_seconds: CENTRAL_BUSY_POLL_PERIOD_SECONDS,
         }
     }
 
@@ -203,11 +209,8 @@ impl SyncApiV5 {
     /// "central busy" response (another sync session for this site is in progress;
     /// legacy central gates sync per-site) before retrying. Errors on timeout.
     pub(crate) async fn wait_until_central_idle(&self) -> Result<(), SyncApiError> {
-        self.wait_until_central_idle_for(
-            CENTRAL_BUSY_POLL_PERIOD_SECONDS,
-            CENTRAL_BUSY_TIMEOUT_SECONDS,
-        )
-        .await
+        self.wait_until_central_idle_for(self.busy_poll_period_seconds, CENTRAL_BUSY_TIMEOUT_SECONDS)
+            .await
     }
 
     /// As [`Self::wait_until_central_idle`], with the poll period and timeout injected so tests can

--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -11,7 +11,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
 use thiserror::Error;
 use url::ParseError;
-use util::{format_error, with_retries, RetrySeconds};
+use util::{format_error, with_retries_opts, RetrySeconds};
 
 use super::*;
 
@@ -132,7 +132,10 @@ impl SyncApiV5 {
             .join(route)
             .map_err(|error| self.api_error(route, error.into()))?;
 
-        let result = with_retries(RetrySeconds::default(), |client| {
+        // Don't retry idle-timeouts: legacy sync v5 requests can run for minutes server-side
+        // and continue after the client gives up; retrying would overlap the same site's
+        // in-flight request and trip `sync_is_running`. Connect errors are still retried.
+        let result = with_retries_opts(RetrySeconds::default(), false, |client| {
             client
                 .get(url.clone())
                 .headers(tuple_vec_to_header(vec![
@@ -170,7 +173,8 @@ impl SyncApiV5 {
             .join(route)
             .map_err(|error| self.api_error(route, error.into()))?;
 
-        let result = with_retries(RetrySeconds::default(), |client| {
+        // See `do_get`: don't retry idle-timeouts for sync v5 (avoids same-site self-overlap).
+        let result = with_retries_opts(RetrySeconds::default(), false, |client| {
             client
                 .post(url.clone())
                 .headers(tuple_vec_to_header(vec![
@@ -194,7 +198,40 @@ impl SyncApiV5 {
     pub(crate) async fn do_empty_post(&self, route: &str) -> Result<Response, SyncApiError> {
         self.do_post(route, &json!({})).await
     }
+
+    /// Poll `/sync/v5/site_status` until central reports `Idle`. Used to wait out a
+    /// "central busy" response (another sync session for this site is in progress;
+    /// legacy central gates sync per-site) before retrying. Errors on timeout.
+    pub(crate) async fn wait_until_central_idle(&self) -> Result<(), SyncApiError> {
+        let route = "/sync/v5/site_status";
+        let start = std::time::SystemTime::now();
+        let poll_period = std::time::Duration::from_secs(CENTRAL_BUSY_POLL_PERIOD_SECONDS);
+        let timeout = std::time::Duration::from_secs(CENTRAL_BUSY_TIMEOUT_SECONDS);
+        log::info!("Central server busy with another sync session for this site; waiting for it to become idle...");
+        loop {
+            tokio::time::sleep(poll_period).await;
+
+            if self.get_site_status().await?.code == SiteStatusCodeV5::Idle {
+                log::info!("Central server is idle; retrying request");
+                return Ok(());
+            }
+
+            if start.elapsed().unwrap_or(timeout) >= timeout {
+                return Err(self.api_error(
+                    route,
+                    SyncApiErrorVariantV5::Other(anyhow::anyhow!(
+                        "Timed out waiting for central server to become idle"
+                    )),
+                ));
+            }
+        }
+    }
 }
+
+// When central is busy with another sync session for this site, poll site status
+// this often, up to this long, before giving up.
+const CENTRAL_BUSY_POLL_PERIOD_SECONDS: u64 = 15;
+const CENTRAL_BUSY_TIMEOUT_SECONDS: u64 = 30 * 60;
 
 #[derive(Error, Debug)]
 pub enum ParsingResponseError {

--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -203,10 +203,24 @@ impl SyncApiV5 {
     /// "central busy" response (another sync session for this site is in progress;
     /// legacy central gates sync per-site) before retrying. Errors on timeout.
     pub(crate) async fn wait_until_central_idle(&self) -> Result<(), SyncApiError> {
+        self.wait_until_central_idle_for(
+            CENTRAL_BUSY_POLL_PERIOD_SECONDS,
+            CENTRAL_BUSY_TIMEOUT_SECONDS,
+        )
+        .await
+    }
+
+    /// As [`Self::wait_until_central_idle`], with the poll period and timeout injected so tests can
+    /// pass `0` to avoid real sleeping / waiting. Behaviour is identical otherwise.
+    async fn wait_until_central_idle_for(
+        &self,
+        poll_period_seconds: u64,
+        timeout_seconds: u64,
+    ) -> Result<(), SyncApiError> {
         let route = "/sync/v5/site_status";
         let start = std::time::SystemTime::now();
-        let poll_period = std::time::Duration::from_secs(CENTRAL_BUSY_POLL_PERIOD_SECONDS);
-        let timeout = std::time::Duration::from_secs(CENTRAL_BUSY_TIMEOUT_SECONDS);
+        let poll_period = std::time::Duration::from_secs(poll_period_seconds);
+        let timeout = std::time::Duration::from_secs(timeout_seconds);
         log::info!("Central server busy with another sync session for this site; waiting for it to become idle...");
         loop {
             tokio::time::sleep(poll_period).await;
@@ -321,7 +335,10 @@ pub async fn validate_site_auth(
 
 #[cfg(test)]
 mod tests {
-    use httpmock::{Method::POST, MockServer};
+    use httpmock::{
+        Method::{GET, POST},
+        MockServer,
+    };
     use reqwest::header::AUTHORIZATION;
 
     use super::*;
@@ -379,5 +396,106 @@ mod tests {
             .await;
 
         assert!(result_with_auth.is_err());
+    }
+
+    fn site_status_body(code: &str) -> String {
+        format!(r#"{{ "code": "{}", "message": "", "data": null }}"#, code)
+    }
+
+    /// Central reports idle on the first poll -> return Ok promptly (the caller can retry).
+    #[actix_rt::test]
+    async fn test_wait_until_central_idle_returns_when_idle() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site_status");
+            then.status(200).body(site_status_body("idle"));
+        });
+
+        // Poll fast (0s) so the test doesn't sleep; generous timeout it never reaches.
+        let result = create_api(&server.base_url(), "", "")
+            .wait_until_central_idle_for(0, 600)
+            .await;
+
+        mock.assert();
+        assert!(result.is_ok());
+    }
+
+    /// Central stays busy past the timeout -> error (so a wedged central can't block forever).
+    #[actix_rt::test]
+    async fn test_wait_until_central_idle_times_out_while_busy() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site_status");
+            then.status(200).body(site_status_body("sync_is_running"));
+        });
+
+        // timeout = 0 -> trips on the first non-idle observation.
+        let result = create_api(&server.base_url(), "", "")
+            .wait_until_central_idle_for(0, 0)
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    /// A hard error from `/site_status` (e.g. auth) propagates rather than being treated as "busy".
+    #[actix_rt::test]
+    async fn test_wait_until_central_idle_propagates_status_error() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site_status");
+            then.status(401).body(
+                r#"{ "error": { "code": "site_incorrect_password", "message": "x", "data": null } }"#,
+            );
+        });
+
+        let result = create_api(&server.base_url(), "", "")
+            .wait_until_central_idle_for(0, 600)
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    /// v5 endpoints pass `retry_on_idle_timeout = false`: an idle timeout (modelled here as a 408,
+    /// which `with_retries_opts` classifies as one) must NOT be retried. Retrying would overlap the
+    /// same site's still-running server-side request and trip `sync_is_running` - the bug this fix
+    /// addresses. One attempt, one upstream hit.
+    #[actix_rt::test]
+    async fn test_idle_timeout_not_retried_for_v5() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/timeout");
+            then.status(408);
+        });
+        let url = format!("{}/timeout", server.base_url());
+
+        let _ = with_retries_opts(RetrySeconds::default(), false, |client| {
+            client.get(url.as_str())
+        })
+        .await;
+
+        mock.assert_hits(1);
+    }
+
+    /// The default (v6) policy opts in to retrying idle timeouts (idempotent reads/upserts), so the
+    /// same 408 is retried for each `RetrySeconds` entry. Contrasts with the v5 case above.
+    #[actix_rt::test]
+    async fn test_idle_timeout_retried_for_v6() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/timeout");
+            then.status(408);
+        });
+        let url = format!("{}/timeout", server.base_url());
+
+        let _ = with_retries_opts(RetrySeconds::default(), true, |client| {
+            client.get(url.as_str())
+        })
+        .await;
+
+        assert!(
+            mock.hits() > 1,
+            "expected an idle timeout to be retried, got {} attempt(s)",
+            mock.hits()
+        );
     }
 }

--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, convert::TryInto};
 use crate::{
     apis::api_on_central::CentralApiError,
     service_provider::{ServiceContext, ServiceProvider},
-    sync::settings::SyncSettings,
+    sync::settings::{SyncSettings, SYNC_V5_MINOR},
 };
 use repository::{migrations::Version, KeyType, KeyValueStoreRepository};
 use reqwest::{header::HeaderMap, Response, Url};
@@ -141,6 +141,7 @@ impl SyncApiV5 {
         // Don't retry idle-timeouts: legacy sync v5 requests can run for minutes server-side
         // and continue after the client gives up; retrying would overlap the same site's
         // in-flight request and trip `sync_is_running`. Connect errors are still retried.
+        let sync_v5_minor = SYNC_V5_MINOR.to_string();
         let result = with_retries_opts(RetrySeconds::default(), false, |client| {
             client
                 .get(url.clone())
@@ -149,6 +150,7 @@ impl SyncApiV5 {
                     ("app-version", app_version),
                     ("app-name", app_name),
                     ("version", sync_version),
+                    ("version-minor", &sync_v5_minor),
                 ]))
                 .basic_auth(username, Some(password_sha256))
                 .query(query)
@@ -180,6 +182,7 @@ impl SyncApiV5 {
             .map_err(|error| self.api_error(route, error.into()))?;
 
         // See `do_get`: don't retry idle-timeouts for sync v5 (avoids same-site self-overlap).
+        let sync_v5_minor = SYNC_V5_MINOR.to_string();
         let result = with_retries_opts(RetrySeconds::default(), false, |client| {
             client
                 .post(url.clone())
@@ -188,6 +191,7 @@ impl SyncApiV5 {
                     ("app-version", app_version),
                     ("app-name", app_name),
                     ("version", sync_version),
+                    ("version-minor", &sync_v5_minor),
                 ]))
                 .basic_auth(username, Some(password_sha256))
                 // Re unwrap, from to_string documentation:
@@ -356,6 +360,7 @@ mod tests {
                 .header("msupply-site-uuid", "site_id")
                 .header("app-version", Version::from_package_json().to_string())
                 .header("app-name", "Open mSupply Desktop")
+                .header("version-minor", SYNC_V5_MINOR.to_string())  // advertise sync v5 minor (e.g. 14.1) for compatibility gating
                 .path("/sync/v5/acknowledged_records");
             then.status(204);
         });

--- a/server/service/src/sync/api/error.rs
+++ b/server/service/src/sync/api/error.rs
@@ -134,9 +134,8 @@ impl SyncApiError {
         matches!(self.source, SyncApiErrorVariantV5::Other(_))
     }
 
-    /// Central is busy with another sync session for this site (legacy central gates
-    /// sync per-site via the site_status state machine: sync / integration /
-    /// initialisation in progress). Caller should wait for central to be idle and retry.
+    /// Central is busy with another session for this site (sync / integration / initialisation in
+    /// progress). Caller should wait for central to be idle and retry.
     pub(crate) fn is_central_busy(&self) -> bool {
         matches!(
             &self.source,

--- a/server/service/src/sync/api/error.rs
+++ b/server/service/src/sync/api/error.rs
@@ -133,6 +133,23 @@ impl SyncApiError {
     pub(crate) fn is_unknown(&self) -> bool {
         matches!(self.source, SyncApiErrorVariantV5::Other(_))
     }
+
+    /// Central is busy with another sync session for this site (legacy central gates
+    /// sync per-site via the site_status state machine: sync / integration /
+    /// initialisation in progress). Caller should wait for central to be idle and retry.
+    pub(crate) fn is_central_busy(&self) -> bool {
+        matches!(
+            &self.source,
+            SyncApiErrorVariantV5::ParsedError { source, .. }
+                if matches!(
+                    &source.code,
+                    SyncErrorCodeV5::Other(code)
+                        if code == "sync_is_running"
+                            || code == "integration_in_progress"
+                            || code == "initialisation_in_progress"
+                )
+        )
+    }
 }
 
 #[cfg(test)]
@@ -326,5 +343,67 @@ mod test {
                 ..
             }
         );
+    }
+
+    /// The three transient "central busy" codes must classify as busy (so callers poll and
+    /// retry instead of failing). Connection / unrelated errors must not.
+    #[actix_rt::test]
+    async fn test_central_busy_classification() {
+        // Helper: stand up a mock that returns `code` with 503 on /initialise, and return
+        // the resulting parsed error.
+        async fn busy_error(code: &str) -> SyncApiError {
+            let mock_server = MockServer::start();
+            let url = mock_server.base_url();
+            let body = format!(
+                r#"{{ "error": {{ "code": "{}", "message": "busy", "data": null }} }}"#,
+                code
+            );
+            mock_server.mock(|when, then| {
+                when.method(POST).path("/sync/v5/initialise");
+                then.status(503).body(body);
+            });
+            create_api(&url, "", "")
+                .post_initialise()
+                .await
+                .expect_err("Should result in error")
+        }
+
+        // All three transient codes must classify as central-busy.
+        for code in [
+            "initialisation_in_progress",
+            "sync_is_running",
+            "integration_in_progress",
+        ] {
+            let result = busy_error(code).await;
+            assert!(result.is_central_busy(), "{} should be central-busy", code);
+        }
+
+        // `initialisation_in_progress` parses as an `Other` 503 code.
+        let result = busy_error("initialisation_in_progress").await;
+        assert_matches!(
+            &result,
+            SyncApiError {
+                source: SyncApiErrorVariantV5::ParsedError {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    source: ParsedError {
+                        code: SyncErrorCodeV5::Other(_),
+                        ..
+                    }
+                },
+                ..
+            }
+        );
+
+        // An unrelated 503 code must NOT be treated as busy.
+        let result = busy_error("some_other_error").await;
+        assert!(!result.is_central_busy());
+
+        // A connection error must NOT be treated as busy.
+        let result = create_api("http://localhost:9999", "", "")
+            .post_initialise()
+            .await
+            .expect_err("Should result in error");
+        assert!(!result.is_central_busy());
+        assert!(result.is_connection());
     }
 }

--- a/server/service/src/sync/api/get_site_info.rs
+++ b/server/service/src/sync/api/get_site_info.rs
@@ -8,9 +8,8 @@ pub struct SiteInfoV5 {
     pub(crate) id: String,
     pub(crate) site_id: i32,
     pub(crate) initialisation_status: InitialisationStatus,
-    /// Live count of `sync_out` records queued for this site on central. Grows server-side as
-    /// the initialisation worker generates records, so it's a network-independent progress
-    /// signal. Optional: older central versions / some responses may omit it.
+    /// Live count of `sync_out` records queued for this site on central (an init progress signal).
+    /// Optional: older central versions may omit it.
     #[serde(default)]
     pub(crate) queue_length: Option<i64>,
     #[serde(rename = "omSupplyCentralServerUrl")]

--- a/server/service/src/sync/api/get_site_info.rs
+++ b/server/service/src/sync/api/get_site_info.rs
@@ -8,6 +8,11 @@ pub struct SiteInfoV5 {
     pub(crate) id: String,
     pub(crate) site_id: i32,
     pub(crate) initialisation_status: InitialisationStatus,
+    /// Live count of `sync_out` records queued for this site on central. Grows server-side as
+    /// the initialisation worker generates records, so it's a network-independent progress
+    /// signal. Optional: older central versions / some responses may omit it.
+    #[serde(default)]
+    pub(crate) queue_length: Option<i64>,
     #[serde(rename = "omSupplyCentralServerUrl")]
     pub(crate) central_server_url: String,
     #[serde(rename = "isOmSupplyCentralServer")]
@@ -73,6 +78,7 @@ mod test {
                 id: "abc123".to_string(),
                 site_id: 123,
                 initialisation_status: InitialisationStatus::New,
+                queue_length: None,
                 is_central_server: false,
                 central_server_url: "http://localhost:2000".to_string(),
                 msupply_central_site_id: 1,

--- a/server/service/src/sync/api/get_site_info.rs
+++ b/server/service/src/sync/api/get_site_info.rs
@@ -52,7 +52,10 @@ mod test {
         let url = mock_server.base_url();
 
         let mock = mock_server.mock(|when, then| {
-            when.method(GET).path("/sync/v5/site");
+            // GET requests also advertise the sync v5 minor version (compatibility gating)
+            when.method(GET)
+                .header("version-minor", "1")
+                .path("/sync/v5/site");
             then.status(200).body(
                 r#"{
                     "id": "abc123",

--- a/server/service/src/sync/api/post_initialise.rs
+++ b/server/service/src/sync/api/post_initialise.rs
@@ -1,15 +1,13 @@
 use super::*;
 
 impl SyncApiV5 {
-    // Initialize remote sync queue.
-    // Should only be called on initial sync or when re-initialising an existing data file.
-    pub(crate) async fn post_initialise(&self) -> Result<RemoteSyncBatchV5, SyncApiError> {
+    // Request remote sync queue (re)initialisation (initial sync, or re-initialising a data file).
+    // Central generates the queue asynchronously and responds 202 (older central: 200). We ignore the
+    // body and just confirm the POST was accepted; the caller polls /sync/v5/site for progress.
+    pub(crate) async fn post_initialise(&self) -> Result<(), SyncApiError> {
         let route = "/sync/v5/initialise";
-        let response = self.do_empty_post(route).await?;
-
-        to_json(response)
-            .await
-            .map_err(|error| self.api_error(route, error.into()))
+        self.do_empty_post(route).await?;
+        Ok(())
     }
 }
 
@@ -18,8 +16,30 @@ mod test {
     use super::*;
     use httpmock::{Method::POST, MockServer};
 
+    // New central: 202 Accepted with an initialisationStatus body (body ignored, status is what matters).
     #[actix_rt::test]
-    async fn test_initialise_remote_records() {
+    async fn test_initialise_accepts_202() {
+        let mock_server = MockServer::start();
+        let url = mock_server.base_url();
+
+        let mock = mock_server.mock(|when, then| {
+            when.method(POST).path("/sync/v5/initialise");
+            then.status(202).body(
+                r#"{
+                    "initialisationStatus": "started"
+                }"#,
+            );
+        });
+
+        let result = create_api(&url, "", "").post_initialise().await;
+
+        mock.assert();
+
+        assert!(result.is_ok());
+    }
+
+    #[actix_rt::test]
+    async fn test_initialise_accepts_legacy_200() {
         let mock_server = MockServer::start();
         let url = mock_server.base_url();
 

--- a/server/service/src/sync/central_data_synchroniser.rs
+++ b/server/service/src/sync/central_data_synchroniser.rs
@@ -49,10 +49,22 @@ impl CentralDataSynchroniser {
         loop {
             let start_cursor = cursor_controller.get(connection)?;
 
-            let CentralSyncBatchV5 { max_cursor, data } = self
-                .sync_api_v5
-                .get_central_records(start_cursor, batch_size)
-                .await?;
+            // Retry while central is busy with another sync session for this site
+            // (legacy central gates sync per-site); wait for idle then re-request the
+            // same cursor.
+            let CentralSyncBatchV5 { max_cursor, data } = loop {
+                match self
+                    .sync_api_v5
+                    .get_central_records(start_cursor, batch_size)
+                    .await
+                {
+                    Ok(batch) => break batch,
+                    Err(error) if error.is_central_busy() => {
+                        self.sync_api_v5.wait_until_central_idle().await?;
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            };
             let batch_length = data.len();
 
             logger.progress(SyncStepProgress::PullCentral, max_cursor - start_cursor)?;

--- a/server/service/src/sync/central_data_synchroniser.rs
+++ b/server/service/src/sync/central_data_synchroniser.rs
@@ -101,3 +101,89 @@ impl CentralDataSynchroniser {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use actix_web::{web, App, HttpResponse, HttpServer};
+    use repository::{mock::MockDataInserts, test_db};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    /// The central pull loop must treat a "central busy" error (central is mid-session for another
+    /// sync of this site; legacy central gates sync per-site) as retryable: wait for central to go
+    /// idle, then re-request the same cursor - rather than failing the whole pull. Here a mock
+    /// central is busy on the first `central_records` call and serves an empty (terminal) batch
+    /// thereafter; the loop should poll `site_status`, see idle, retry, and finish Ok.
+    #[actix_rt::test]
+    async fn test_central_pull_retries_when_central_busy() {
+        let (_, connection, _, _) = test_db::setup_all(
+            "test_central_pull_retries_when_central_busy",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        // Count `central_records` calls to prove the loop retried after the busy response.
+        let central_records_hits = Arc::new(AtomicUsize::new(0));
+
+        async fn central_records(hits: web::Data<Arc<AtomicUsize>>) -> HttpResponse {
+            // First call: central busy with another session for this site.
+            if hits.fetch_add(1, Ordering::SeqCst) == 0 {
+                return HttpResponse::ServiceUnavailable().json(serde_json::json!({
+                    "error": { "code": "sync_is_running", "message": "busy", "data": null }
+                }));
+            }
+            // Subsequent calls: empty terminal batch (maxCursor 0 ends the pull loop).
+            HttpResponse::Ok().json(serde_json::json!({ "maxCursor": 0, "data": [] }))
+        }
+
+        // Central is idle, so `wait_until_central_idle` returns on its first poll.
+        async fn site_status() -> HttpResponse {
+            HttpResponse::Ok()
+                .json(serde_json::json!({ "code": "idle", "message": "", "data": null }))
+        }
+
+        let hits_for_server = central_records_hits.clone();
+        let server = HttpServer::new(move || {
+            App::new()
+                .app_data(web::Data::new(hits_for_server.clone()))
+                .route("/sync/v5/central_records", web::to(central_records))
+                .route("/sync/v5/site_status", web::to(site_status))
+        })
+        .workers(1)
+        .bind(("127.0.0.1", 0))
+        .unwrap();
+
+        let url = format!("http://{}", server.addrs()[0]);
+
+        let mut sync_api_v5 = SyncApiV5::new_test(&url, "", "", "site");
+        // Poll for idle immediately - no real 15s sleep between the busy response and the retry.
+        sync_api_v5.busy_poll_period_seconds = 0;
+        let synchroniser = CentralDataSynchroniser { sync_api_v5 };
+
+        let mut logger = SyncLogger::start(&connection).unwrap();
+
+        let server_future = server.run();
+        let server_handle = server_future.handle();
+
+        let result = tokio::select! {
+            _ = server_future => unreachable!("server should not finish before the pull"),
+            result = synchroniser.pull(&connection, 10, &mut logger) => result,
+        };
+
+        server_handle.stop(false).await;
+
+        assert!(
+            result.is_ok(),
+            "pull should succeed after retrying: {:?}",
+            result
+        );
+        assert!(
+            central_records_hits.load(Ordering::SeqCst) >= 2,
+            "expected a retry after the busy response, got {} call(s)",
+            central_records_hits.load(Ordering::SeqCst)
+        );
+    }
+}

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -523,6 +523,36 @@ mod test {
         assert_matches!(result, Err(WaitForInitialisationError::TimeoutReached));
     }
 
+    /// A transient poll failure (connection/unknown) must NOT abort the wait - it's tolerated and
+    /// retried. With no server listening every poll fails this way; with no forward progress the
+    /// wait ends in the recoverable `TimeoutReached`, never surfacing the connection error.
+    #[actix_rt::test]
+    async fn test_wait_for_initialisation_tolerates_transient_poll_failure() {
+        // Port 1 has nothing listening -> every `get_site_info` is a connection error.
+        let result = synchroniser("http://localhost:1")
+            .wait_for_initialisation(0, 0)
+            .await;
+        assert_matches!(result, Err(WaitForInitialisationError::TimeoutReached));
+    }
+
+    /// A hard (non-transient) error from `/site` propagates as `SyncApiError`, distinct from the
+    /// recoverable `TimeoutReached` - the outcome is not recoverable by re-POSTing.
+    #[actix_rt::test]
+    async fn test_wait_for_initialisation_hard_error_propagates() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site");
+            then.status(401).body(
+                r#"{ "error": { "code": "site_incorrect_password", "message": "x", "data": null } }"#,
+            );
+        });
+
+        let result = synchroniser(&server.base_url())
+            .wait_for_initialisation(0, 600)
+            .await;
+        assert_matches!(result, Err(WaitForInitialisationError::SyncApiError(_)));
+    }
+
     /// No live worker (idle) -> `request_initialisation` re-POSTs `/sync/v5/initialise`.
     /// (POST is made to return a non-tolerated error so the call returns immediately.)
     #[actix_rt::test]

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -26,11 +26,8 @@ use repository::{
 use thiserror::Error;
 
 const INITIALISATION_POLL_PERIOD_SECONDS: u64 = 15;
-// Fail only after this long with NO forward progress: i.e. central reports no live worker AND
-// the sync queue is not growing. This is a *stall* timeout, NOT a run-length cap - a legitimate
-// large initial sync can run for hours and never trip it, as long as the queue keeps growing.
-// Mirrors the `util::api_helper::READ_IDLE_TIMEOUT` philosophy (succeed while making progress,
-// fail fast when genuinely stalled).
+// Stall timeout, not a run-length cap: fail only after this long with no forward progress (no live
+// worker and the queue not growing). A large initial sync can run for hours as long as it progresses.
 const INITIALISATION_STALL_TIMEOUT_SECONDS: u64 = 20 * 60;
 
 #[derive(Error, Debug)]
@@ -94,17 +91,12 @@ pub struct RemoteDataSynchroniser {
 }
 
 impl RemoteDataSynchroniser {
-    /// Request initialisation.
+    /// Request initialisation, then poll until central finishes generating the queue.
     ///
-    /// `post_initialise` returns immediately: central generates the initial sync queue in a
-    /// dedicated worker process (see `syncInitialiseSiteProcess` in legacy central) rather than
-    /// inline in the request. We then poll until central reports the queue is `completed`.
-    ///
-    /// We decide whether to POST on the *live* worker status (`site_status`), not the persisted
-    /// `initialisation_status`. A worker that crashed (or whose spawn failed) leaves the persisted
-    /// status stuck at `started` with no process running; gating on that would suppress the
-    /// re-POST forever. Gating on liveness instead makes a crashed initialisation self-heal on the
-    /// next sync cycle, while still avoiding a duplicate POST when a worker is genuinely running.
+    /// `post_initialise` returns immediately (central generates the queue in a worker process). We
+    /// gate the POST on live worker status (`site_status`), not the persisted `initialisation_status`:
+    /// a crashed worker leaves status stuck at `started`, and gating on liveness lets it self-heal on
+    /// the next cycle while still avoiding a duplicate POST when a worker is genuinely running.
     pub(crate) async fn request_initialisation(
         &self,
         _site_info: &SiteInfoV5,
@@ -117,16 +109,12 @@ impl RemoteDataSynchroniser {
 
         if !worker_running {
             if let Err(error) = self.sync_api_v5.post_initialise().await {
-                // Tolerate transient conditions and just poll: connection/unknown errors, and any
-                // "central busy" code (another sync session for this site is in progress, or central
-                // is already building the queue - e.g. a worker started between our status check and
-                // the POST). Anything else is a real failure.
+                // Tolerate transient errors (connection/unknown) and "central busy" codes, then poll.
                 if !(error.is_connection() || error.is_unknown() || error.is_central_busy()) {
                     return Err(error.into());
                 }
             }
         }
-        // Wait for the central worker to finish generating the initial sync queue
         self.wait_for_initialisation(
             INITIALISATION_POLL_PERIOD_SECONDS,
             INITIALISATION_STALL_TIMEOUT_SECONDS,
@@ -138,19 +126,11 @@ impl RemoteDataSynchroniser {
 
     /// Wait for central to finish generating the initial sync queue.
     ///
-    /// Central does this work in a worker process; on a large dataset it can legitimately run for
-    /// hours. Rather than a fixed wall-clock cap, we wait as long as central is making *progress*
-    /// and only give up after `stall_timeout_seconds` of none:
-    /// - `site_info.initialisation_status` gives the authoritative outcome (`completed`/`error`),
-    ///   set before the worker exits so it's race-safe.
-    /// - `site_status` tells us whether a worker is alive, and `queue_length` tells us whether the
-    ///   queue is actually growing (a server-side count, independent of our network speed).
-    ///
-    /// We refresh the progress clock while the worker is alive and either still in its pre-generation
-    /// phase (`queue_length == 0`) or the queue is growing. A `TimeoutReached` therefore only fires
-    /// when central is genuinely stalled: the worker died without finishing (`idle` + not
-    /// `completed`/`error`), or it's alive but the queue has stopped growing (a wedge). Both are
-    /// recoverable - the next sync cycle re-POSTs via `request_initialisation`.
+    /// No fixed wall-clock cap: we wait while central makes progress and only give up after
+    /// `stall_timeout_seconds` of none. `site_info.initialisation_status` is the authoritative outcome
+    /// (`completed`/`error`, set before the worker exits); `site_status` (worker alive) and a growing
+    /// `queue_length` are the progress signals. `TimeoutReached` only fires when genuinely stalled
+    /// (worker died, or alive but queue not growing) - recoverable via a re-POST next cycle.
     pub(crate) async fn wait_for_initialisation(
         &self,
         poll_period_seconds: u64,
@@ -164,11 +144,10 @@ impl RemoteDataSynchroniser {
         loop {
             tokio::time::sleep(poll_period).await;
 
-            // Outcome first - this is authoritative and set before the worker exits.
+            // Outcome first - authoritative, set before the worker exits.
             let site_info = match self.sync_api_v5.get_site_info().await {
                 Ok(info) => info,
-                // A transient poll failure doesn't affect the server-side worker; log and retry
-                // rather than aborting the whole sync. A prolonged outage trips the stall timeout.
+                // Transient poll failures don't affect the worker; retry until the stall timeout.
                 Err(error) if error.is_connection() || error.is_unknown() => {
                     log::warn!(
                         "Polling central site info failed (will retry): {:#?}",
@@ -403,11 +382,9 @@ impl From<PushSyncRecord> for RemoteSyncRecordV5 {
     }
 }
 
-/// Whether an initialisation poll observation represents forward progress, and so should refresh
-/// the stall clock in [`RemoteDataSynchroniser::wait_for_initialisation`]. Progress means a live
-/// worker that is either still in its pre-generation phase (no records queued yet) or actively
-/// growing the queue. A live worker whose non-empty queue has stopped growing (a wedge), or a dead
-/// worker (`worker_alive == false`), is NOT progress and will eventually trip the stall timeout.
+/// Forward progress (refreshes the stall clock): a live worker that's either still pre-generation
+/// (`queue_length == 0`) or growing the queue. A dead worker, or a live worker whose non-empty queue
+/// has stopped growing (a wedge), is not progress and eventually trips the stall timeout.
 fn is_initialisation_progressing(
     worker_alive: bool,
     queue_length: i64,
@@ -597,7 +574,7 @@ mod test {
         .await;
 
         assert!(result.is_err(), "should still be waiting, not returned");
-        post.assert_calls(0); // no duplicate POST while a worker is running
+        post.assert_hits(0); // no duplicate POST while a worker is running
     }
 
     fn dummy_site_info() -> SiteInfoV5 {

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use crate::{
     cursor_controller::CursorController,
@@ -26,15 +26,19 @@ use repository::{
 use thiserror::Error;
 
 const INITIALISATION_POLL_PERIOD_SECONDS: u64 = 15;
-// 30 minutes
-const INITIALISATION_TIMEOUT_SECONDS: u64 = 30 * 60;
+// Fail only after this long with NO forward progress: i.e. central reports no live worker AND
+// the sync queue is not growing. This is a *stall* timeout, NOT a run-length cap - a legitimate
+// large initial sync can run for hours and never trip it, as long as the queue keeps growing.
+// Mirrors the `util::api_helper::READ_IDLE_TIMEOUT` philosophy (succeed while making progress,
+// fail fast when genuinely stalled).
+const INITIALISATION_STALL_TIMEOUT_SECONDS: u64 = 20 * 60;
 
 #[derive(Error, Debug)]
 pub(crate) enum PostInitialisationError {
     #[error(transparent)]
     SyncApiError(#[from] SyncApiError),
     #[error("Error while waiting for initialisation")]
-    WaitForInitialisationError(#[from] WaitForSyncOperationError),
+    WaitForInitialisationError(#[from] WaitForInitialisationError),
 }
 
 #[derive(Error, Debug)]
@@ -75,42 +79,147 @@ pub(crate) enum WaitForSyncOperationError {
     TimeoutReached,
 }
 
+#[derive(Error, Debug)]
+pub(crate) enum WaitForInitialisationError {
+    #[error(transparent)]
+    SyncApiError(#[from] SyncApiError),
+    #[error("Timeout was reached while waiting for central server initialisation")]
+    TimeoutReached,
+    #[error("Central server reported an error while generating the initial sync queue")]
+    InitialisationFailed,
+}
+
 pub struct RemoteDataSynchroniser {
     pub(crate) sync_api_v5: SyncApiV5,
 }
 
 impl RemoteDataSynchroniser {
-    /// Request initialisation
-    /// This api call is blocking, and will wait while central server adds relevant records to sync queue.
-    /// If there is a connection problem while initialisation is happening, we don't want to restart initialisation on next sync
-    /// thus polling and a check for initialisation status was introduced. When initialisation is in progress,
-    /// api will return `initialisation_in_progress` and `get_site_info` will return `initialisationStatus` = `started`
+    /// Request initialisation.
+    ///
+    /// `post_initialise` returns immediately: central generates the initial sync queue in a
+    /// dedicated worker process (see `syncInitialiseSiteProcess` in legacy central) rather than
+    /// inline in the request. We then poll until central reports the queue is `completed`.
+    ///
+    /// We decide whether to POST on the *live* worker status (`site_status`), not the persisted
+    /// `initialisation_status`. A worker that crashed (or whose spawn failed) leaves the persisted
+    /// status stuck at `started` with no process running; gating on that would suppress the
+    /// re-POST forever. Gating on liveness instead makes a crashed initialisation self-heal on the
+    /// next sync cycle, while still avoiding a duplicate POST when a worker is genuinely running.
     pub(crate) async fn request_initialisation(
         &self,
-        site_info: &SiteInfoV5,
+        _site_info: &SiteInfoV5,
     ) -> Result<(), PostInitialisationError> {
-        // First check if already initialising
-        let should_post_initialise =
-            site_info.initialisation_status != InitialisationStatus::Started;
+        // Only POST if there isn't already a live worker generating the queue.
+        let worker_running = matches!(
+            self.sync_api_v5.get_site_status().await?.code,
+            SiteStatusCodeV5::InitialisationInProgress
+        );
 
-        if should_post_initialise {
-            let Err(error) = self.sync_api_v5.post_initialise().await else {
-                return Ok(());
-            };
-            // Ignore connection or unknown error. There is high chance of connection error
-            // on post_initialise end point (since it's blocking and can take awhile).
-            if !(error.is_connection() || error.is_unknown()) {
-                return Err(error.into());
+        if !worker_running {
+            if let Err(error) = self.sync_api_v5.post_initialise().await {
+                // Tolerate transient conditions and just poll: connection/unknown errors, and any
+                // "central busy" code (another sync session for this site is in progress, or central
+                // is already building the queue - e.g. a worker started between our status check and
+                // the POST). Anything else is a real failure.
+                if !(error.is_connection() || error.is_unknown() || error.is_central_busy()) {
+                    return Err(error.into());
+                }
             }
         }
-        // Wait for initialisation to finish
-        self.wait_for_sync_operation(
+        // Wait for the central worker to finish generating the initial sync queue
+        self.wait_for_initialisation(
             INITIALISATION_POLL_PERIOD_SECONDS,
-            INITIALISATION_TIMEOUT_SECONDS,
+            INITIALISATION_STALL_TIMEOUT_SECONDS,
         )
         .await?;
 
         Ok(())
+    }
+
+    /// Wait for central to finish generating the initial sync queue.
+    ///
+    /// Central does this work in a worker process; on a large dataset it can legitimately run for
+    /// hours. Rather than a fixed wall-clock cap, we wait as long as central is making *progress*
+    /// and only give up after `stall_timeout_seconds` of none:
+    /// - `site_info.initialisation_status` gives the authoritative outcome (`completed`/`error`),
+    ///   set before the worker exits so it's race-safe.
+    /// - `site_status` tells us whether a worker is alive, and `queue_length` tells us whether the
+    ///   queue is actually growing (a server-side count, independent of our network speed).
+    ///
+    /// We refresh the progress clock while the worker is alive and either still in its pre-generation
+    /// phase (`queue_length == 0`) or the queue is growing. A `TimeoutReached` therefore only fires
+    /// when central is genuinely stalled: the worker died without finishing (`idle` + not
+    /// `completed`/`error`), or it's alive but the queue has stopped growing (a wedge). Both are
+    /// recoverable - the next sync cycle re-POSTs via `request_initialisation`.
+    pub(crate) async fn wait_for_initialisation(
+        &self,
+        poll_period_seconds: u64,
+        stall_timeout_seconds: u64,
+    ) -> Result<(), WaitForInitialisationError> {
+        let poll_period = Duration::from_secs(poll_period_seconds);
+        let stall_timeout = Duration::from_secs(stall_timeout_seconds);
+        let mut last_progress = Instant::now();
+        let mut previous_queue_length: Option<i64> = None;
+        info!("Awaiting central server initialisation...");
+        loop {
+            tokio::time::sleep(poll_period).await;
+
+            // Outcome first - this is authoritative and set before the worker exits.
+            let site_info = match self.sync_api_v5.get_site_info().await {
+                Ok(info) => info,
+                // A transient poll failure doesn't affect the server-side worker; log and retry
+                // rather than aborting the whole sync. A prolonged outage trips the stall timeout.
+                Err(error) if error.is_connection() || error.is_unknown() => {
+                    log::warn!(
+                        "Polling central site info failed (will retry): {:#?}",
+                        error
+                    );
+                    if last_progress.elapsed() >= stall_timeout {
+                        return Err(WaitForInitialisationError::TimeoutReached);
+                    }
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
+
+            match site_info.initialisation_status {
+                InitialisationStatus::Completed => {
+                    info!("Central server initialisation finished");
+                    return Ok(());
+                }
+                InitialisationStatus::Error => {
+                    return Err(WaitForInitialisationError::InitialisationFailed);
+                }
+                // `New` / `Started`: still in progress - assess liveness and progress below.
+                InitialisationStatus::New | InitialisationStatus::Started => {}
+            }
+
+            let worker_alive = matches!(
+                self.sync_api_v5.get_site_status().await?.code,
+                SiteStatusCodeV5::InitialisationInProgress
+                    | SiteStatusCodeV5::SyncIsRunning
+                    | SiteStatusCodeV5::IntegrationInProgress
+            );
+
+            let queue_length = site_info.queue_length.unwrap_or(0);
+            let progressing =
+                is_initialisation_progressing(worker_alive, queue_length, previous_queue_length);
+            previous_queue_length = Some(queue_length);
+
+            if progressing {
+                last_progress = Instant::now();
+            }
+
+            log::info!(
+                "Central still initialising: queue_length = {}, worker_alive = {}",
+                queue_length,
+                worker_alive,
+            );
+
+            if last_progress.elapsed() >= stall_timeout {
+                return Err(WaitForInitialisationError::TimeoutReached);
+            }
+        }
     }
 
     /// Update push cursor after initial sync, i.e. set it to the end of the just received data
@@ -144,7 +253,17 @@ impl RemoteDataSynchroniser {
         );
 
         loop {
-            let sync_batch = self.sync_api_v5.get_queued_records(batch_size).await?;
+            // Retry while central is busy with another sync session for this site
+            // (legacy central gates sync per-site); wait for idle then re-request.
+            let sync_batch = loop {
+                match self.sync_api_v5.get_queued_records(batch_size).await {
+                    Ok(batch) => break batch,
+                    Err(error) if error.is_central_busy() => {
+                        self.sync_api_v5.wait_until_central_idle().await?;
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            };
 
             // queued_length is number of remote pull records awaiting acknowledgement
             // at this point it's number of records waiting to be pulled including records in this pull batch
@@ -213,10 +332,21 @@ impl RemoteDataSynchroniser {
             .map(RemoteSyncRecordV5::from)
             .collect();
 
-            let response = self
+            let response = match self
                 .sync_api_v5
                 .post_queued_records(change_logs_total, records)
-                .await?;
+                .await
+            {
+                Ok(response) => response,
+                // Retry while central is busy with another sync session for this site
+                // (legacy central gates sync per-site). Cursor hasn't advanced, so wait
+                // for idle then rebuild this batch.
+                Err(error) if error.is_central_busy() => {
+                    self.sync_api_v5.wait_until_central_idle().await?;
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
 
             // Update cursor only if record for that cursor has been pushed/processed
             if let Some(last_pushed_cursor_id) = last_pushed_cursor {
@@ -269,6 +399,216 @@ impl From<PushSyncRecord> for RemoteSyncRecordV5 {
         RemoteSyncRecordV5 {
             sync_id: cursor.to_string(),
             record,
+        }
+    }
+}
+
+/// Whether an initialisation poll observation represents forward progress, and so should refresh
+/// the stall clock in [`RemoteDataSynchroniser::wait_for_initialisation`]. Progress means a live
+/// worker that is either still in its pre-generation phase (no records queued yet) or actively
+/// growing the queue. A live worker whose non-empty queue has stopped growing (a wedge), or a dead
+/// worker (`worker_alive == false`), is NOT progress and will eventually trip the stall timeout.
+fn is_initialisation_progressing(
+    worker_alive: bool,
+    queue_length: i64,
+    previous_queue_length: Option<i64>,
+) -> bool {
+    let queue_grew = previous_queue_length.map_or(false, |prev| queue_length > prev);
+    worker_alive && (queue_length == 0 || queue_grew)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::sync::api::SyncApiV5;
+    use httpmock::{
+        Method::{GET, POST},
+        MockServer,
+    };
+    use std::time::Duration;
+    use util::assert_matches;
+
+    fn synchroniser(url: &str) -> RemoteDataSynchroniser {
+        RemoteDataSynchroniser {
+            sync_api_v5: SyncApiV5::new_test(url, "", "", "site"),
+        }
+    }
+
+    /// Body for `GET /sync/v5/site`. `queue_length` of `None` omits the field (older central).
+    fn site_info_body(status: &str, queue_length: Option<i64>) -> String {
+        let queue = queue_length
+            .map(|q| format!(r#""queueLength": {},"#, q))
+            .unwrap_or_default();
+        format!(
+            r#"{{
+                "id": "abc",
+                "siteId": 1,
+                "initialisationStatus": "{}",
+                {}
+                "isOmSupplyCentralServer": false,
+                "omSupplyCentralServerUrl": "http://localhost",
+                "mSupplyCentralSiteId": 1
+            }}"#,
+            status, queue
+        )
+    }
+
+    fn site_status_body(code: &str) -> String {
+        format!(r#"{{ "code": "{}", "message": "", "data": null }}"#, code)
+    }
+
+    /// The pure progress predicate that decides whether the stall clock is refreshed.
+    #[test]
+    fn test_is_initialisation_progressing() {
+        // Live worker, no records yet (prep/delete phase) -> progressing.
+        assert!(is_initialisation_progressing(true, 0, None));
+        assert!(is_initialisation_progressing(true, 0, Some(0)));
+        // Live worker, queue grew -> progressing.
+        assert!(is_initialisation_progressing(true, 10, Some(5)));
+        // Live worker, non-empty queue not growing (wedge) -> NOT progressing.
+        assert!(!is_initialisation_progressing(true, 5, Some(5)));
+        assert!(!is_initialisation_progressing(true, 5, None));
+        // Dead worker is never progress, regardless of queue.
+        assert!(!is_initialisation_progressing(false, 0, None));
+        assert!(!is_initialisation_progressing(false, 10, Some(5)));
+    }
+
+    /// `completed` returns Ok before the stall clock is ever consulted.
+    #[actix_rt::test]
+    async fn test_wait_for_initialisation_completed() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site");
+            then.status(200).body(site_info_body("completed", Some(42)));
+        });
+
+        let result = synchroniser(&server.base_url())
+            .wait_for_initialisation(0, 600)
+            .await;
+        assert_matches!(result, Ok(()));
+    }
+
+    /// `error` fails fast with `InitialisationFailed`.
+    #[actix_rt::test]
+    async fn test_wait_for_initialisation_error() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site");
+            then.status(200).body(site_info_body("error", None));
+        });
+
+        let result = synchroniser(&server.base_url())
+            .wait_for_initialisation(0, 600)
+            .await;
+        assert_matches!(
+            result,
+            Err(WaitForInitialisationError::InitialisationFailed)
+        );
+    }
+
+    /// Worker gone (idle) but not completed -> no progress -> stall timeout (recoverable).
+    #[actix_rt::test]
+    async fn test_wait_for_initialisation_crashed_worker_times_out() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site");
+            then.status(200).body(site_info_body("started", None));
+        });
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site_status");
+            then.status(200).body(site_status_body("idle"));
+        });
+
+        // stall = 0 -> trips on the first observation with no progress.
+        let result = synchroniser(&server.base_url())
+            .wait_for_initialisation(0, 0)
+            .await;
+        assert_matches!(result, Err(WaitForInitialisationError::TimeoutReached));
+    }
+
+    /// Worker alive but its non-empty queue is not growing (wedge) -> stall timeout.
+    #[actix_rt::test]
+    async fn test_wait_for_initialisation_wedged_worker_times_out() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site");
+            then.status(200).body(site_info_body("started", Some(5)));
+        });
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site_status");
+            then.status(200)
+                .body(site_status_body("initialisation_in_progress"));
+        });
+
+        let result = synchroniser(&server.base_url())
+            .wait_for_initialisation(0, 0)
+            .await;
+        assert_matches!(result, Err(WaitForInitialisationError::TimeoutReached));
+    }
+
+    /// No live worker (idle) -> `request_initialisation` re-POSTs `/sync/v5/initialise`.
+    /// (POST is made to return a non-tolerated error so the call returns immediately.)
+    #[actix_rt::test]
+    async fn test_request_initialisation_reposts_when_no_worker() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site_status");
+            then.status(200).body(site_status_body("idle"));
+        });
+        let post = server.mock(|when, then| {
+            when.method(POST).path("/sync/v5/initialise");
+            then.status(401).body(
+                r#"{ "error": { "code": "site_incorrect_hardware_id", "message": "x", "data": null } }"#,
+            );
+        });
+
+        let result = synchroniser(&server.base_url())
+            .request_initialisation(&dummy_site_info())
+            .await;
+
+        post.assert(); // the re-POST happened (crash recovery)
+        assert_matches!(result, Err(_));
+    }
+
+    /// A live worker (initialisation_in_progress) must NOT trigger a duplicate POST; we just wait.
+    #[actix_rt::test]
+    async fn test_request_initialisation_skips_post_when_worker_running() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site_status");
+            then.status(200)
+                .body(site_status_body("initialisation_in_progress"));
+        });
+        server.mock(|when, then| {
+            when.method(GET).path("/sync/v5/site");
+            then.status(200).body(site_info_body("started", Some(1)));
+        });
+        let post = server.mock(|when, then| {
+            when.method(POST).path("/sync/v5/initialise");
+            then.status(200).body(r#"{ "queueLength": 0 }"#);
+        });
+
+        // request_initialisation uses the real 15s poll period before its first site check, so
+        // it's still sleeping after a short wait - long enough to prove no POST was made.
+        let result = tokio::time::timeout(
+            Duration::from_millis(300),
+            synchroniser(&server.base_url()).request_initialisation(&dummy_site_info()),
+        )
+        .await;
+
+        assert!(result.is_err(), "should still be waiting, not returned");
+        post.assert_calls(0); // no duplicate POST while a worker is running
+    }
+
+    fn dummy_site_info() -> SiteInfoV5 {
+        SiteInfoV5 {
+            id: "abc".to_string(),
+            site_id: 1,
+            initialisation_status: InitialisationStatus::Started,
+            queue_length: None,
+            central_server_url: "http://localhost".to_string(),
+            is_central_server: false,
+            msupply_central_site_id: 1,
         }
     }
 }

--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -2,6 +2,11 @@ use serde::{Deserialize, Serialize};
 
 // See README.md for description of when this API version needs to be updated
 pub(crate) static SYNC_V5_VERSION: u32 = 14; // bumped for v2.13.0 OG version 8.06
+// Minor ("patch") version for incremental, backward-compatible sync v5 changes within a major version.
+// Sent as the `version-minor` header alongside `version`; central servers that don't understand it
+// ignore it and treat the client as minor 0 (legacy behaviour). 14.1 = this client understands the
+// async (202 + initialisationStatus) initialise response.
+pub(crate) static SYNC_V5_MINOR: u32 = 1;
 pub(crate) static SYNC_V6_VERSION: u32 = 5; // bumped for 2.9.02 (adding new types to system log)
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -86,14 +86,10 @@ pub async fn pull(
     // A short batch means the changelog tail is exhausted (= last batch). Avoids a full count, which
     // scans the changelog on every pull and exhausts the DB pool under concurrent multi-site init.
     let num_changelogs = changelogs.len();
+    let last_cursor = changelogs.last().map(|log| log.cursor as u64);
     // Clamp the empty-batch fallback so we don't advance past an in-flight (uncommitted, lower)
     // changelog cursor. The non-empty path is already safe because the query is clamped.
     let max_cursor = changelog_repo.latest_cursor()?;
-
-    let end_cursor = changelogs
-        .last()
-        .map(|log| log.cursor as u64)
-        .unwrap_or(max_cursor);
 
     let records: Vec<SyncRecordV6> = translate_changelogs_to_sync_records(
         &ctx.connection,
@@ -112,9 +108,11 @@ pub async fn pull(
     );
     log::debug!("Sending records as central server: {:#?}", records);
 
-    let is_last_batch = num_changelogs < batch_size as usize;
-    // Cheap progress-bar estimate (over-estimates, but monotonic and snaps to done on the last batch).
-    let total_records = max_cursor.saturating_sub(cursor);
+    let BatchPaging {
+        end_cursor,
+        is_last_batch,
+        total_records,
+    } = derive_batch_paging(last_cursor, num_changelogs, batch_size, max_cursor, cursor);
 
     Ok(SyncBatchV6 {
         total_records,
@@ -240,14 +238,10 @@ pub async fn patient_pull(
     )?;
     // See `pull`: short batch = last batch; avoids a full count and uses a cheap progress estimate.
     let num_changelogs = changelogs.len();
+    let last_cursor = changelogs.last().map(|log| log.cursor as u64);
     // Clamp the empty-batch fallback so we don't advance past an in-flight (uncommitted, lower)
     // changelog cursor. The non-empty path is already safe because the query is clamped.
     let max_cursor = changelog_repo.latest_cursor()?;
-
-    let end_cursor = changelogs
-        .last()
-        .map(|log| log.cursor as u64)
-        .unwrap_or(max_cursor);
 
     let records: Vec<SyncRecordV6> = translate_changelogs_to_sync_records(
         &ctx.connection,
@@ -269,8 +263,11 @@ pub async fn patient_pull(
         records
     );
 
-    let is_last_batch = num_changelogs < batch_size as usize;
-    let total_records = max_cursor.saturating_sub(cursor);
+    let BatchPaging {
+        end_cursor,
+        is_last_batch,
+        total_records,
+    } = derive_batch_paging(last_cursor, num_changelogs, batch_size, max_cursor, cursor);
 
     Ok(SyncBatchV6 {
         total_records,
@@ -475,4 +472,80 @@ fn set_integrating(site_id: i32, is_integrating: bool) {
 
 fn is_sync_version_compatible(sync_v6_version: u32) -> bool {
     MIN_VERSION <= sync_v6_version && sync_v6_version <= MAX_VERSION
+}
+
+/// The paging fields a v6 pull batch reports back to the requesting site, derived from the batch
+/// alone - without a full changelog count (which scans the whole changelog on every pull and, under
+/// concurrent multi-site init, exhausts the DB pool).
+struct BatchPaging {
+    /// Cursor the site resumes from on its next pull.
+    end_cursor: u64,
+    /// Whether the changelog tail is exhausted (the pull loop terminates on this).
+    is_last_batch: bool,
+    /// Progress-bar estimate only (see [`derive_batch_paging`]).
+    total_records: u64,
+}
+
+/// Derive a batch's paging fields for [`pull`] / [`patient_pull`].
+///
+/// - `is_last_batch`: a short batch (fewer rows than `batch_size`) means the tail is exhausted, so
+///   this is the final batch. An exactly-full batch is treated as not-last; the next pull confirms
+///   it by returning a short/empty batch. (An empty batch is `0 < batch_size`, i.e. also last.)
+/// - `end_cursor`: the last row's cursor, or `max_cursor` for an empty batch so the site still
+///   advances past the clamped head instead of re-requesting the same empty tail forever.
+/// - `total_records`: a cheap cursor-span estimate for the progress bar - it over-counts (the span
+///   includes filtered/deduped rows) but is monotonic; `is_last_batch` is what actually terminates
+///   the loop, not this.
+fn derive_batch_paging(
+    last_cursor: Option<u64>,
+    num_changelogs: usize,
+    batch_size: u32,
+    max_cursor: u64,
+    cursor: u64,
+) -> BatchPaging {
+    BatchPaging {
+        end_cursor: last_cursor.unwrap_or(max_cursor),
+        is_last_batch: num_changelogs < batch_size as usize,
+        total_records: max_cursor.saturating_sub(cursor),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// A short batch (fewer rows than asked for) is the last batch; an exactly-full one is not.
+    #[test]
+    fn test_is_last_batch() {
+        // Short batch -> tail exhausted -> last.
+        assert!(derive_batch_paging(Some(40), 3, 10, 100, 0).is_last_batch);
+        // Empty batch (0 rows) is short -> also last.
+        assert!(derive_batch_paging(None, 0, 10, 100, 0).is_last_batch);
+        // Exactly-full batch -> assume more to come (next pull confirms).
+        assert!(!derive_batch_paging(Some(40), 10, 10, 100, 0).is_last_batch);
+        // batch_size of 1: a single-row batch is full, so not last.
+        assert!(!derive_batch_paging(Some(5), 1, 1, 100, 0).is_last_batch);
+        // batch_size of 1: an empty batch is last.
+        assert!(derive_batch_paging(None, 0, 1, 100, 0).is_last_batch);
+    }
+
+    /// `end_cursor` is the last row's cursor, or `max_cursor` when the batch is empty (so the site
+    /// still advances past the clamped head rather than re-requesting the same empty tail).
+    #[test]
+    fn test_end_cursor() {
+        assert_eq!(derive_batch_paging(Some(42), 5, 10, 100, 0).end_cursor, 42);
+        // Empty batch falls back to max_cursor.
+        assert_eq!(derive_batch_paging(None, 0, 10, 100, 0).end_cursor, 100);
+    }
+
+    /// `total_records` is the cursor span from the request cursor to the latest, saturating at 0
+    /// (never underflows if `cursor` somehow exceeds `max_cursor`).
+    #[test]
+    fn test_total_records_estimate() {
+        assert_eq!(derive_batch_paging(Some(40), 3, 10, 100, 30).total_records, 70);
+        // cursor already at the head -> 0 remaining.
+        assert_eq!(derive_batch_paging(None, 0, 10, 100, 100).total_records, 0);
+        // cursor past max_cursor (e.g. clamp moved it) -> saturates at 0, no underflow panic.
+        assert_eq!(derive_batch_paging(None, 0, 10, 100, 150).total_records, 0);
+    }
 }

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -83,11 +83,11 @@ pub async fn pull(
         response.site_id,
         is_initialised,
     )?;
-    let total_records = changelog_repo.count_outgoing_sync_records_from_central(
-        cursor,
-        response.site_id,
-        is_initialised,
-    )?;
+    // A batch shorter than `batch_size` means the changelog tail is exhausted, so this is the last
+    // batch. We deliberately avoid a full `count_outgoing_sync_records_from_central` here: on a large
+    // central it scans the changelog on every pull and, under concurrent multi-site init, holds DB
+    // connections long enough to exhaust the pool. See `total_records` below for the progress value.
+    let num_changelogs = changelogs.len();
     // Clamp the empty-batch fallback so we don't advance past an in-flight (uncommitted, lower)
     // changelog cursor. The non-empty path is already safe because the query is clamped.
     let max_cursor = changelog_repo.latest_cursor()?;
@@ -114,7 +114,12 @@ pub async fn pull(
     );
     log::debug!("Sending records as central server: {:#?}", records);
 
-    let is_last_batch = total_records <= batch_size as u64;
+    let is_last_batch = num_changelogs < batch_size as usize;
+    // Progress estimate for the client's progress bar (the only consumer of `total_records`):
+    // remaining changelog cursors from the requested cursor. Cheap (max_cursor is already loaded),
+    // monotonically decreasing across batches, and the client snaps progress to done on the last
+    // batch. It over-estimates (counts pre-dedup/pre-filter rows) but is purely cosmetic.
+    let total_records = max_cursor.saturating_sub(cursor);
 
     Ok(SyncBatchV6 {
         total_records,
@@ -238,11 +243,9 @@ pub async fn patient_pull(
         response.site_id,
         fetch_patient_id.clone(),
     )?;
-    let total_records = changelog_repo.count_outgoing_patient_sync_records_from_central(
-        cursor,
-        response.site_id,
-        fetch_patient_id,
-    )?;
+    // See `pull` above: a short batch means the tail is exhausted; we avoid the expensive full
+    // `count_outgoing_patient_sync_records_from_central` and use a cheap cursor-based progress value.
+    let num_changelogs = changelogs.len();
     // Clamp the empty-batch fallback so we don't advance past an in-flight (uncommitted, lower)
     // changelog cursor. The non-empty path is already safe because the query is clamped.
     let max_cursor = changelog_repo.latest_cursor()?;
@@ -272,7 +275,8 @@ pub async fn patient_pull(
         records
     );
 
-    let is_last_batch = total_records <= batch_size as u64;
+    let is_last_batch = num_changelogs < batch_size as usize;
+    let total_records = max_cursor.saturating_sub(cursor);
 
     Ok(SyncBatchV6 {
         total_records,

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -83,10 +83,8 @@ pub async fn pull(
         response.site_id,
         is_initialised,
     )?;
-    // A batch shorter than `batch_size` means the changelog tail is exhausted, so this is the last
-    // batch. We deliberately avoid a full `count_outgoing_sync_records_from_central` here: on a large
-    // central it scans the changelog on every pull and, under concurrent multi-site init, holds DB
-    // connections long enough to exhaust the pool. See `total_records` below for the progress value.
+    // A short batch means the changelog tail is exhausted (= last batch). Avoids a full count, which
+    // scans the changelog on every pull and exhausts the DB pool under concurrent multi-site init.
     let num_changelogs = changelogs.len();
     // Clamp the empty-batch fallback so we don't advance past an in-flight (uncommitted, lower)
     // changelog cursor. The non-empty path is already safe because the query is clamped.
@@ -115,10 +113,7 @@ pub async fn pull(
     log::debug!("Sending records as central server: {:#?}", records);
 
     let is_last_batch = num_changelogs < batch_size as usize;
-    // Progress estimate for the client's progress bar (the only consumer of `total_records`):
-    // remaining changelog cursors from the requested cursor. Cheap (max_cursor is already loaded),
-    // monotonically decreasing across batches, and the client snaps progress to done on the last
-    // batch. It over-estimates (counts pre-dedup/pre-filter rows) but is purely cosmetic.
+    // Cheap progress-bar estimate (over-estimates, but monotonic and snaps to done on the last batch).
     let total_records = max_cursor.saturating_sub(cursor);
 
     Ok(SyncBatchV6 {
@@ -243,8 +238,7 @@ pub async fn patient_pull(
         response.site_id,
         fetch_patient_id.clone(),
     )?;
-    // See `pull` above: a short batch means the tail is exhausted; we avoid the expensive full
-    // `count_outgoing_patient_sync_records_from_central` and use a cheap cursor-based progress value.
+    // See `pull`: short batch = last batch; avoids a full count and uses a cheap progress estimate.
     let num_changelogs = changelogs.len();
     // Clamp the empty-batch fallback so we don't advance past an in-flight (uncommitted, lower)
     // changelog cursor. The non-empty path is already safe because the query is clamped.

--- a/server/service/src/sync/sync_status/logger.rs
+++ b/server/service/src/sync/sync_status/logger.rs
@@ -14,7 +14,8 @@ use crate::sync::{
         CentralPullErrorV6, RemotePushErrorV6, WaitForSyncOperationErrorV6,
     },
     remote_data_synchroniser::{
-        PostInitialisationError, RemotePullError, RemotePushError, WaitForSyncOperationError,
+        PostInitialisationError, RemotePullError, RemotePushError, WaitForInitialisationError,
+        WaitForSyncOperationError,
     },
     synchroniser::SyncError,
 };
@@ -395,7 +396,7 @@ impl SyncLogError {
             | SyncError::WaitForIntegrationError(WaitForSyncOperationError::SyncApiError(error))
             | SyncError::PostInitialisationError(
                 PostInitialisationError::WaitForInitialisationError(
-                    WaitForSyncOperationError::SyncApiError(error),
+                    WaitForInitialisationError::SyncApiError(error),
                 ),
             ) => {
                 return Self::from_sync_api_error(

--- a/server/service/src/sync/sync_status/test.rs
+++ b/server/service/src/sync/sync_status/test.rs
@@ -209,10 +209,8 @@ fn get_initialisation_sync_status_tester(
                  ..
              }| {
                 let mut new_status = previous_status.clone();
-                // `summary.duration_in_seconds` is wall-clock and advances during the
-                // initialisation poll wait (the last `/site` poll captured a stale value); it isn't
-                // what this assertion checks (pull_central progress is), so reconcile it like the
-                // `initialise` handler does.
+                // summary.duration_in_seconds advances during the init poll wait; reconcile it (like
+                // the `initialise` handler) - this assertion checks pull_central progress, not summary.
                 new_status.summary.clone_from(&current_status.summary);
                 if iteration == 0 {
                     new_status
@@ -363,8 +361,7 @@ fn get_initialisation_sync_status_tester(
             let site_info = SiteInfoV5 {
                 id: "abc123".to_string(),
                 site_id: 123,
-                // Central reports initialisation completed: `wait_for_initialisation` polls
-                // `/site` and finishes when `initialisationStatus == completed`.
+                // `wait_for_initialisation` finishes when `/site` reports completed.
                 initialisation_status: crate::sync::api::InitialisationStatus::Completed,
                 queue_length: None,
                 central_server_url: format!("http://127.0.0.1:{}", ctx.open_msupply_central_port),
@@ -516,8 +513,7 @@ fn get_push_and_error_sync_status_tester(
             let site_info = SiteInfoV5 {
                 id: "abc123".to_string(),
                 site_id: 123,
-                // Central reports initialisation completed: `wait_for_initialisation` polls
-                // `/site` and finishes when `initialisationStatus == completed`.
+                // `wait_for_initialisation` finishes when `/site` reports completed.
                 initialisation_status: crate::sync::api::InitialisationStatus::Completed,
                 queue_length: None,
                 central_server_url: format!("http://127.0.0.1:{}", ctx.open_msupply_central_port),

--- a/server/service/src/sync/sync_status/test.rs
+++ b/server/service/src/sync/sync_status/test.rs
@@ -209,6 +209,11 @@ fn get_initialisation_sync_status_tester(
                  ..
              }| {
                 let mut new_status = previous_status.clone();
+                // `summary.duration_in_seconds` is wall-clock and advances during the
+                // initialisation poll wait (the last `/site` poll captured a stale value); it isn't
+                // what this assertion checks (pull_central progress is), so reconcile it like the
+                // `initialise` handler does.
+                new_status.summary.clone_from(&current_status.summary);
                 if iteration == 0 {
                     new_status
                         .prepare_initial
@@ -358,7 +363,10 @@ fn get_initialisation_sync_status_tester(
             let site_info = SiteInfoV5 {
                 id: "abc123".to_string(),
                 site_id: 123,
-                initialisation_status: crate::sync::api::InitialisationStatus::New,
+                // Central reports initialisation completed: `wait_for_initialisation` polls
+                // `/site` and finishes when `initialisationStatus == completed`.
+                initialisation_status: crate::sync::api::InitialisationStatus::Completed,
+                queue_length: None,
                 central_server_url: format!("http://127.0.0.1:{}", ctx.open_msupply_central_port),
                 is_central_server: false,
                 msupply_central_site_id: 1,
@@ -508,7 +516,10 @@ fn get_push_and_error_sync_status_tester(
             let site_info = SiteInfoV5 {
                 id: "abc123".to_string(),
                 site_id: 123,
-                initialisation_status: crate::sync::api::InitialisationStatus::New,
+                // Central reports initialisation completed: `wait_for_initialisation` polls
+                // `/site` and finishes when `initialisationStatus == completed`.
+                initialisation_status: crate::sync::api::InitialisationStatus::Completed,
+                queue_length: None,
                 central_server_url: format!("http://127.0.0.1:{}", ctx.open_msupply_central_port),
                 is_central_server: false,
                 msupply_central_site_id: 1,

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -114,11 +114,9 @@ where
         };
 
         let idle_timeout = is_timeout_error || status == Some(StatusCode::REQUEST_TIMEOUT);
-        // A mid-flight connection drop (server closed before completing the response, e.g. hyper
-        // `IncompleteMessage`) is retried for endpoints that opt in via `retry_on_idle_timeout` —
-        // i.e. idempotent reads / upserts like sync v6. Gated the same way as idle timeout so legacy
-        // sync v5 keeps it OFF: there a retry would overlap an in-flight server-side request for the
-        // same site. Connect errors are always retried (no server-side work began).
+        // A mid-flight connection drop (e.g. hyper `IncompleteMessage`) is retried only for endpoints
+        // opting in via `retry_on_idle_timeout` (idempotent reads/upserts like v6); v5 keeps it off to
+        // avoid overlapping an in-flight server-side request. Connect errors are always retried.
         let will_retry = (is_connect_error
             || (retry_on_idle_timeout && (idle_timeout || is_dropped_connection)))
             && (index + 1) < connection_timeouts.0.len();
@@ -171,11 +169,9 @@ where
     }
 }
 
-/// True if `error` is the server closing the connection before the response completed (hyper
-/// `IncompleteMessage` — "connection closed before message completed") or another transient
-/// transport-level drop (reset / broken pipe). Distinct from `is_connect` (never connected) and
-/// `is_timeout` (slow/idle socket): the request was sent on an established connection that was then
-/// dropped, so it's safe to retry for idempotent requests.
+/// True if the server dropped an established connection mid-response (hyper `IncompleteMessage`,
+/// reset, broken pipe) - distinct from `is_connect`/`is_timeout`, and safe to retry for idempotent
+/// requests.
 fn is_connection_dropped(error: &reqwest::Error) -> bool {
     // Only request-phase transport errors; never status / decode / body errors.
     error.is_request() && chain_contains_transient_drop(error)

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -32,6 +32,22 @@ pub async fn with_retries<F>(connection_timeouts: RetrySeconds, f: F) -> Result<
 where
     F: Fn(Client) -> RequestBuilder,
 {
+    with_retries_opts(connection_timeouts, true, f).await
+}
+
+/// As [`with_retries`], but `retry_on_idle_timeout` controls whether an idle read timeout
+/// (or 408) triggers a retry. Pass `false` for long-running endpoints whose server-side
+/// work continues after the client gives up (e.g. legacy sync v5): retrying there spawns
+/// an overlapping server-side request for the same site, which the central then rejects as
+/// "sync already running". Connect errors are always retried (no server-side work began).
+pub async fn with_retries_opts<F>(
+    connection_timeouts: RetrySeconds,
+    retry_on_idle_timeout: bool,
+    f: F,
+) -> Result<Response>
+where
+    F: Fn(Client) -> RequestBuilder,
+{
     let mut index = 0;
     loop {
         let client = Client::builder()
@@ -58,20 +74,23 @@ where
         };
         let elapsed = started.elapsed();
 
-        let (status, is_connect_error, is_timeout_error, url) = match result.as_ref() {
-            Ok(r) => (
-                Some(r.status()),
-                false,
-                false,
-                Some(redact_url_for_log(r.url())),
-            ),
-            Err(e) => (
-                e.status(),
-                e.is_connect(),
-                e.is_timeout(),
-                e.url().map(redact_url_for_log),
-            ),
-        };
+        let (status, is_connect_error, is_timeout_error, is_dropped_connection, url) =
+            match result.as_ref() {
+                Ok(r) => (
+                    Some(r.status()),
+                    false,
+                    false,
+                    false,
+                    Some(redact_url_for_log(r.url())),
+                ),
+                Err(e) => (
+                    e.status(),
+                    e.is_connect(),
+                    e.is_timeout(),
+                    is_connection_dropped(e),
+                    e.url().map(redact_url_for_log),
+                ),
+            };
 
         // Surface the status code (or transport error) for any failed attempt so
         // proxy/upstream errors like 502/503/504 — which we do not currently retry —
@@ -85,6 +104,8 @@ where
                     "connection error"
                 } else if is_timeout_error {
                     "idle timeout"
+                } else if is_dropped_connection {
+                    "connection dropped"
                 } else {
                     "request error"
                 };
@@ -92,9 +113,15 @@ where
             }
         };
 
-        let will_retry =
-            (is_connect_error || is_timeout_error || status == Some(StatusCode::REQUEST_TIMEOUT))
-                && (index + 1) < connection_timeouts.0.len();
+        let idle_timeout = is_timeout_error || status == Some(StatusCode::REQUEST_TIMEOUT);
+        // A mid-flight connection drop (server closed before completing the response, e.g. hyper
+        // `IncompleteMessage`) is retried for endpoints that opt in via `retry_on_idle_timeout` —
+        // i.e. idempotent reads / upserts like sync v6. Gated the same way as idle timeout so legacy
+        // sync v5 keeps it OFF: there a retry would overlap an in-flight server-side request for the
+        // same site. Connect errors are always retried (no server-side work began).
+        let will_retry = (is_connect_error
+            || (retry_on_idle_timeout && (idle_timeout || is_dropped_connection)))
+            && (index + 1) < connection_timeouts.0.len();
 
         if let Ok(response) = result.as_ref() {
             let content_length_display = response
@@ -141,5 +168,113 @@ where
         }
 
         break result;
+    }
+}
+
+/// True if `error` is the server closing the connection before the response completed (hyper
+/// `IncompleteMessage` — "connection closed before message completed") or another transient
+/// transport-level drop (reset / broken pipe). Distinct from `is_connect` (never connected) and
+/// `is_timeout` (slow/idle socket): the request was sent on an established connection that was then
+/// dropped, so it's safe to retry for idempotent requests.
+fn is_connection_dropped(error: &reqwest::Error) -> bool {
+    // Only request-phase transport errors; never status / decode / body errors.
+    error.is_request() && chain_contains_transient_drop(error)
+}
+
+/// Walk the error's source chain looking for a transient transport-drop signature.
+fn chain_contains_transient_drop(error: &(dyn std::error::Error + 'static)) -> bool {
+    // hyper renders `IncompleteMessage` as "connection closed before message completed".
+    const SIGNATURES: [&str; 5] = [
+        "connection closed before message completed",
+        "incompletemessage",
+        "connection reset",
+        "broken pipe",
+        "unexpected end of file",
+    ];
+
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(error);
+    while let Some(err) = current {
+        let message = err.to_string().to_lowercase();
+        if SIGNATURES
+            .iter()
+            .any(|signature| message.contains(signature))
+        {
+            return true;
+        }
+        current = err.source();
+    }
+    false
+}
+
+#[cfg(test)]
+mod test {
+    use super::chain_contains_transient_drop;
+    use std::error::Error;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct ChainError {
+        message: String,
+        source: Option<Box<ChainError>>,
+    }
+
+    impl fmt::Display for ChainError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.message)
+        }
+    }
+
+    impl Error for ChainError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            self.source
+                .as_ref()
+                .map(|boxed| boxed.as_ref() as &(dyn Error + 'static))
+        }
+    }
+
+    fn chain(messages: &[&str]) -> ChainError {
+        // Build innermost-first so the outer error's source points inward.
+        let mut current: Option<Box<ChainError>> = None;
+        for message in messages.iter().rev() {
+            current = Some(Box::new(ChainError {
+                message: message.to_string(),
+                source: current,
+            }));
+        }
+        *current.unwrap()
+    }
+
+    #[test]
+    fn detects_incomplete_message_deep_in_chain() {
+        // Mirrors the real reqwest -> hyper chain we saw on a dropped v6 pull.
+        let error = chain(&[
+            "error sending request for url (http://host/central/sync/pull)",
+            "client error (SendRequest)",
+            "connection closed before message completed",
+        ]);
+        assert!(chain_contains_transient_drop(&error));
+    }
+
+    #[test]
+    fn detects_connection_reset() {
+        let error = chain(&[
+            "error sending request",
+            "Connection reset by peer (os error 54)",
+        ]);
+        assert!(chain_contains_transient_drop(&error));
+    }
+
+    #[test]
+    fn ignores_non_transient_errors() {
+        // A connect refusal is handled by `is_connect`, not here; a status/body error must not match.
+        let connect = chain(&[
+            "error sending request",
+            "tcp connect error",
+            "Connection refused (os error 111)",
+        ]);
+        assert!(!chain_contains_transient_drop(&connect));
+
+        let bad_request = chain(&["builder error", "invalid header value"]);
+        assert!(!chain_contains_transient_drop(&bad_request));
     }
 }


### PR DESCRIPTION
> [!NOTE]
> This is a copy of #12068 targeting `v2.16.06-RC` *before* it had the changes from #12068 (hence base is `2.16.06-before-ravi-changes` instead of `v2.16.06-RC`). I made this PR so I could review #12068 in the context of v2.16 as this is what will be deployed, we can bring changes back up to develop later.

Fixes #11885 

# 👩🏻💻 What does this PR do?
Makes OMS sync resilient and performant when initialising sites against a large central server (the companion to the 4D async-initialise change). It covers the OMS-client side of initialisation plus two central-server-side performance/robustness fixes that large multi-site setups hit.

**1. Initialisation wait is now progress/liveness-based, not a fixed timeout.** `/sync/v5/initialise` on 4D now returns immediately and generates the queue in a background worker, so the client polls. `wait_for_initialisation` waits while central is *making progress* (worker alive via `site_status`, and `queue_length` growing) and only fails after a stall window — no fixed wall-clock cap, so a legitimately long initial sync completes instead of timing out. `request_initialisation` gates the re-POST on live worker status (not the persisted `initialisation_status`), so a crashed worker self-heals next cycle. (`remote_data_synchroniser.rs`, `get_site_info.rs` adds `queueLength`.)

**2. Retry idempotent sync requests on a dropped connection.** A mid-flight connection drop (hyper `IncompleteMessage`) was fatal and not retried, so a transient drop during a long multi-site init failed the whole sync. Now retried for endpoints that opt in (v6 pulls/pushes; v5 stays off to avoid self-overlap). (`util/src api_helper.rs`.)

**3. `changelog_deduped` view rewrite (NOT EXISTS anti-join).** On a large central (~millions of changelog rows) the old `GROUP BY MAX(cursor)` form deduped the whole table before the `WHERE cursor >= ?` filter, so every per-batch sync query was a full scan (measured ~172s for a 13-row result on a 12 GB SQLite DB). The equivalent anti-join lets the planner push the cursor predicate to the index — same rows, ~43,000× faster for cursor bounded queries. No Rust changes; applied via the existing view-rebuild on migrate.

**4. Drop the per-batch full count in the central v6 pull.** `count_outgoing_sync_records_from_central` ran on every `/central/sync/pull` batch (a full changelog scan), which made pulls slow and exhausted the DB pool under concurrent multi-site init. Replaced with `is_last_batch = records.len() < batch_size` + a cheap cursor-based progress estimate; `SyncBatchV6` unchanged (backward/forward compatible). (`sync_on_central/mod.rs`.)

**5. `ledger_fix` background loop no longer crashes the server.** It ran `basic_context().unwrap()` on the main loop; a transient connection-pool exhaustion (caused by #4 above) panicked and took the whole central down. Now logs and skips, retrying next interval. (`ledger_fix/ledger_fix_driver.rs`.)

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?
- **Highest-risk item to focus on: the `changelog_deduped` view rewrite (# 3).** It's the broadest blast radius (all sync paths use it). It's proven row-for-row equivalent (cursor is unique, so "no newer row" ≡ "is the max"), validated on a real 12 GB DB (same total row count) and by the existing changelog tests.
- **v6 pull change (# 4)** alters only `is_last_batch`/progress semantics, not the `SyncBatchV6` wire struct — old/new clients interoperate. Minor cosmetic effects: progress total is now an estimate, and an exact-multiple-of batch_size run does one extra empty pull at the end.
- The removed `count_outgoing_*` repository methods were dead after # 4 (shared query builders kept).
- Out of scope (separate spec): reducing the *generation* time on the 4D side for very large sites.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] [4D legacy central](https://github.com/msupply-foundation/msupply/pull/18406) + an OMS-central running this PR + ≥1 OMS remote site (web and/or Android), ideally with a large multi-store dataset so initialisation takes time.
- [ ] Initialise the OMS-central from 4D: it completes to the login screen (doesn't time out at the old 30-min cap); logs show the queue-length progressing.
- [ ] Initialise 2 remote sites against the OMS-central concurrently: both reach login; the central does **not** crash (no `ledger_fix_driver` panic / sustained `DB pool exhausted`), and v6 pulls return promptly.
- [ ] Force a transient connection drop during a v6 pull → it retries and continues (no whole-sync failure).
- [ ] An incremental sync of a few hundred records completes quickly (not minutes).
- [ ] Re-run a normal small/normal-DB sync environment — no regression (progress bar still advances; same records synced).
- [ ] Automated: `cargo nextest run -p service sync::` and `-p repository changelog` and `-p util api_helper` all pass (Postgres + SQLite).

# 📃 Documentation
- [x] **No documentation required**: bug fix, no user-facing change in behaviour beyond not erroring out during initialisation

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend