### PR TITLE
Optimise sync v7 changelog query (#12144)

### DIFF
--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -2,11 +2,12 @@ use crate::{
     db_diesel::{changelog::changelog_cursor_tracker::ChangelogCursorTracker, store_row::store},
     diesel_macros::diesel_string_enum,
     dynamic_query_filter::create_condition,
+    name_link,
     name_store_join::name_store_join,
     vaccination_row::vaccination,
     KeyType, KeyValueStoreRepository, RepositoryError, StorageConnection, TransactionNotification,
 };
-use diesel::{dsl::LeftJoinQuerySource, prelude::*};
+use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use thiserror::Error;
@@ -14,7 +15,6 @@ use ts_rs::TS;
 
 use super::sync_style::{ChangeLogSyncStyle, SyncVersions};
 
-// Underlying table — INSERTs target this. Carries raw `*_link_id` columns.
 table! {
     #[sql_name = "changelog"]
     changelog_with_links (cursor) {
@@ -29,81 +29,18 @@ table! {
         patient_link_id -> Nullable<Text>,
     }
 }
-
-// View — SELECTs target this. Exposes resolved `patient_id`
-// (via LEFT JOIN name_link on the patient_link_id column).
-table! {
-    #[sql_name = "changelog_view"]
-    changelog (cursor) {
-        cursor -> BigInt,
-        table_name -> Text,
-        record_id -> Text,
-        row_action -> Text,
-        store_id -> Nullable<Text>,
-        is_sync_update -> Bool,
-        source_site_id -> Nullable<Integer>,
-        transfer_store_id -> Nullable<Text>,
-        patient_id -> Nullable<Text>,
-    }
-}
-
-allow_tables_to_appear_in_same_query!(changelog, vaccination);
-allow_tables_to_appear_in_same_query!(changelog, store);
-allow_tables_to_appear_in_same_query!(changelog, name_store_join);
+allow_tables_to_appear_in_same_query!(changelog_with_links, vaccination);
+allow_tables_to_appear_in_same_query!(changelog_with_links, store);
+allow_tables_to_appear_in_same_query!(changelog_with_links, name_store_join);
+allow_tables_to_appear_in_same_query!(changelog_with_links, name_link);
 
 diesel::alias!(
     store as transfer_stores: TransferStores,
     store as patient_stores: PatientStore,
+    // Used inside the patient_site_id subquery so it doesn't collide with the outer query's
+    // name_link join (Diesel rejects a table appearing more than once across the statement).
+    name_link as patient_name_links: PatientNameLink,
 );
-
-#[diesel::dsl::auto_type]
-fn query() -> _ {
-    changelog::table
-        .left_join(store::table.on(store::id.nullable().eq(changelog::store_id)))
-        .left_join(
-            transfer_stores.on(transfer_stores
-                .field(store::id)
-                .nullable()
-                .eq(changelog::transfer_store_id)),
-        )
-        .left_join(
-            name_store_join::table.on(name_store_join::name_id
-                .nullable()
-                .eq(changelog::patient_id)),
-        )
-        .left_join(
-            patient_stores.on(patient_stores
-                .field(store::id)
-                .nullable()
-                .eq(name_store_join::store_id.nullable())),
-        )
-}
-
-// Expand macro recurseively for auto_type, hen replace "diesel::dsl::LeftJoin" with "LeftJoinQuerySource"
-// And then remove diesel::dsl::On< keeping what's inside here >
-type Source = LeftJoinQuerySource<
-    LeftJoinQuerySource<
-        LeftJoinQuerySource<
-            LeftJoinQuerySource<
-                changelog::table,
-                store::table,
-                diesel::dsl::Eq<diesel::dsl::Nullable<store::id>, changelog::store_id>,
-            >,
-            transfer_stores,
-            diesel::dsl::Eq<
-                diesel::dsl::Nullable<diesel::dsl::Field<transfer_stores, store::id>>,
-                changelog::transfer_store_id,
-            >,
-        >,
-        name_store_join::table,
-        diesel::dsl::Eq<diesel::dsl::Nullable<name_store_join::name_id>, changelog::patient_id>,
-    >,
-    patient_stores,
-    diesel::dsl::Eq<
-        diesel::dsl::Nullable<diesel::dsl::Field<patient_stores, store::id>>,
-        diesel::dsl::Nullable<name_store_join::store_id>,
-    >,
->;
 
 diesel_string_enum! {
     #[derive(Clone, Eq, Serialize, Deserialize, TS)]
@@ -265,7 +202,6 @@ pub struct ChangeLogInsertRow {
 }
 
 #[derive(Clone, Queryable, Debug, PartialEq, Serialize, Deserialize, TS, Default)]
-#[diesel(table_name = changelog)]
 pub struct ChangelogRow {
     pub cursor: i64,
     pub table_name: ChangelogTableName,
@@ -313,28 +249,8 @@ impl<'a> ChangelogRepository<'a> {
             let window_end = current_cursor.saturating_add(CURSOR_WINDOW).min(max_cursor);
             let remaining = limit - results.len() as i64;
 
-            let sub_filter = ChangelogCondition::And(vec![
-                filter.clone(),
-                ChangelogCondition::cursor::greater_than(current_cursor),
-                // `lower_than(window_end + 1)` expresses `cursor <= window_end`;
-                // the macro does not generate a `lower_than_or_equal` helper.
-                ChangelogCondition::cursor::lower_than(window_end + 1),
-            ]);
-
-            let sub_query = query()
-                .filter(sub_filter.to_boxed())
-                .order(changelog::cursor.asc())
-                .limit(remaining)
-                .select(changelog::all_columns);
-
-            // Debug diesel query
-            // println!(
-            //     "{}",
-            //     diesel::debug_query::<crate::DBType, _>(&sub_query).to_string()
-            // );
-
-            let sub_results: Vec<ChangelogRow> =
-                sub_query.load(self.connection.lock().connection())?;
+            let sub_results =
+                self.query_cursor_window(filter.clone(), current_cursor, window_end, remaining)?;
 
             results.extend(sub_results);
             current_cursor = window_end;
@@ -350,6 +266,55 @@ impl<'a> ChangelogRepository<'a> {
             max_cursor: max_cursor as u64,
             last_cursor_in_batch,
         })
+    }
+
+    /// Loads one cursor window: changelog rows matching `filter` with
+    /// `current_cursor < cursor <= window_end`, ordered by cursor, capped at `limit`.
+    ///
+    /// The filter is applied directly to the `changelog_with_links LEFT JOIN name_link` query and
+    /// `name_link.name_id` is selected to resolve `patient_id` in one pass (no separate
+    /// `cursor IN (...)` subselect). The patient/store/transfer site filters use their own
+    /// (aliased) subqueries, so they don't collide with this outer name_link join.
+    fn query_cursor_window(
+        &self,
+        filter: ChangelogCondition::Inner,
+        current_cursor: i64,
+        window_end: i64,
+        limit: i64,
+    ) -> Result<Vec<ChangelogRow>, RepositoryError> {
+        let filter = ChangelogCondition::And(vec![
+            filter,
+            ChangelogCondition::cursor::greater_than(current_cursor),
+            // `lower_than(window_end + 1)` expresses `cursor <= window_end`;
+            // the macro does not generate a `lower_than_or_equal` helper.
+            ChangelogCondition::cursor::lower_than(window_end + 1),
+        ]);
+
+        let query = changelog_with_links::table
+            .left_join(
+                name_link::table
+                    .on(changelog_with_links::patient_link_id.eq(name_link::id.nullable())),
+            )
+            .filter(filter.to_boxed())
+            .order(changelog_with_links::cursor.asc())
+            .limit(limit)
+            .select((
+                changelog_with_links::cursor,
+                changelog_with_links::table_name,
+                changelog_with_links::record_id,
+                changelog_with_links::row_action,
+                changelog_with_links::store_id,
+                changelog_with_links::is_sync_update,
+                changelog_with_links::source_site_id,
+                changelog_with_links::transfer_store_id,
+                name_link::name_id.nullable(),
+            ));
+
+        // Uncomment to print the generated SQL (e.g. from the ignored
+        // `print_all_data_for_site_query_for_site_300` test):
+        // println!("{}", diesel::debug_query::<crate::DBType, _>(&query));
+
+        Ok(query.load(self.connection.lock().connection())?)
     }
 
     /// Returns latest/max change log cursor.
@@ -393,21 +358,61 @@ impl<'a> ChangelogRepository<'a> {
     }
 }
 
-// Dynamic query filter for changelog
-// Source type is the changelog table (for queries directly against the table)
+// Dynamic query filter for changelog.
+// The Source is `changelog_with_links LEFT JOIN name_link` (the shape the query runs against):
+// the filter only references changelog_with_links columns, but typing the boxed condition against
+// the joined source lets it be applied directly to the joined query in `query_cursor_window`.
+type ChangelogConditionSource = diesel::dsl::LeftJoinQuerySource<
+    changelog_with_links::table,
+    name_link::table,
+    diesel::dsl::Eq<changelog_with_links::patient_link_id, diesel::dsl::Nullable<name_link::id>>,
+>;
+
 create_condition!(
     ChangelogCondition,
-    Source,
-    (cursor, i64, changelog::cursor),
-    (site_id, i32, store::site_id),
-    (action, RowActionType, changelog::row_action),
-    (table_name, ChangelogTableName, changelog::table_name),
-    (store_id, string, changelog::store_id),
-    (source_site_id, i32, changelog::source_site_id),
-    (transfer_store_id, string, changelog::transfer_store_id),
-    (patient_id, string, changelog::patient_id),
-    (transfer_site_id, i32, transfer_stores.field(store::site_id)),
-    (patient_site_id, i32, patient_stores.field(store::site_id)),
+    ChangelogConditionSource,
+    (cursor, i64, changelog_with_links::cursor),
+    (action, RowActionType, changelog_with_links::row_action),
+    (table_name, ChangelogTableName, changelog_with_links::table_name),
+    (source_site_id, i32, changelog_with_links::source_site_id),
+    (store_id, string, changelog_with_links::store_id),
+    (transfer_store_id, string, changelog_with_links::transfer_store_id),
+    (patient_link_id, string, changelog_with_links::patient_link_id),
+    // Each site filter is gated by `<column> IS NOT NULL AND <column> IN (...)` so the IN subquery
+    // is only evaluated for rows that actually carry that column (most rows have a null transfer /
+    // patient link), letting the planner short-circuit.
+    (transfer_site_id, subquery: i32, |for_site| changelog_with_links::transfer_store_id.is_not_null().and(
+        changelog_with_links::transfer_store_id.eq_any(
+            store::table
+                .filter(store::site_id.eq(for_site))
+                .select(store::id.nullable())
+        )
+    )),
+     (store_site_id, subquery: i32, |for_site| changelog_with_links::store_id.is_not_null().and(
+        changelog_with_links::store_id.eq_any(
+            store::table
+                .filter(store::site_id.eq(for_site))
+                .select(store::id.nullable())
+        )
+    )),
+    (patient_site_id, subquery: i32, |for_site| changelog_with_links::patient_link_id.is_not_null().and(
+        changelog_with_links::patient_link_id.eq_any(
+            name_store_join::table
+                .inner_join(patient_name_links.on(name_store_join::name_id.eq(patient_name_links.field(name_link::id))))
+                .inner_join(patient_stores.on(patient_stores.field(store::id).eq(name_store_join::store_id)))
+                .filter(patient_stores.field(store::site_id).eq(for_site))
+                .select(patient_name_links.field(name_link::id).nullable())
+        )
+    )),
+    // Resolve a patient by their (resolved) name_id: match changelog rows whose patient_link_id
+    // points at any name_link row resolving to that name_id.
+    //   changelog.patient_link_id IN (SELECT name_link.id FROM name_link WHERE name_link.name_id = $patient_id)
+    // `patient_name_links` (a name_link alias) avoids colliding with the outer query's name_link join.
+    (patient_id, subquery: String, |for_patient| changelog_with_links::patient_link_id.eq_any(
+        patient_name_links
+            .filter(patient_name_links.field(name_link::name_id).eq(for_patient))
+            .select(patient_name_links.field(name_link::id).nullable())
+    )),
 );
 
 use crate::dynamic_query_filter::*;
@@ -450,22 +455,22 @@ impl ChangelogFilter {
                     // We have central and remote records with same table_name, so need to make sure to include only central ones (where store_id is null)
                     C::store_id::is_null(),
                     // We have patients that are also central data, therefore patient_id should be null
-                    C::patient_id::is_null(),
+                    C::patient_link_id::is_null(),
                 ]),
                 ToLegacyCentralOnly | RemoteToCentral => {
                     // Don't sync
                     continue;
                 }
-                Remote => C::site_id::equal(site_id),
+                Remote => C::store_site_id::matching(site_id),
                 RemoteOwned => {
                     // Central never has edits to push back — relay only during initialisation.
                     if !is_initialising {
                         continue;
                     }
-                    C::site_id::equal(site_id)
+                    C::store_site_id::matching(site_id)
                 }
-                Transfer => C::transfer_site_id::equal(site_id),
-                Patient => C::patient_site_id::equal(site_id),
+                Transfer => C::transfer_site_id::matching(site_id),
+                Patient => C::patient_site_id::matching(site_id),
             };
 
             inner_or_conditions.push(C::And(vec![pre_condition, condition]));
@@ -494,7 +499,7 @@ impl ChangelogFilter {
 
         C::And(vec![
             C::table_name::any(table_names),
-            C::patient_site_id::equal(site_id),
+            C::patient_site_id::matching(site_id),
         ])
     }
 
@@ -577,22 +582,25 @@ impl ChangelogFilter {
 #[cfg(test)]
 mod print_query_tests {
     use super::*;
-    use crate::DBType;
-    use diesel::debug_query;
 
-    // Remove ignore when you need to print the query
+    // To see the SQL: remove `#[ignore]`, uncomment the `debug_query` line inside
+    // `ChangelogRepository::query_cursor_window`, and run this test with --nocapture.
     #[ignore]
-    #[test]
-    fn print_all_data_for_site_query_for_site_300() {
+    #[actix_rt::test]
+    async fn print_all_data_for_site_query_for_site_300() {
+        let (_, connection, _, _) = crate::test_db::setup_all(
+            "print_all_data_for_site_query_for_site_300",
+            crate::mock::MockDataInserts::none(),
+        )
+        .await;
+
+        // Mirrors a single cursor window of `ChangelogRepository::query`.
+        // Values are illustrative (cursor window 0..=250_000, limit 100).
         let filter = ChangelogFilter::all_data_for_site(300, false, None);
 
-        let q = query()
-            .filter(filter.to_boxed())
-            .order(changelog::cursor.asc())
-            .limit(100)
-            .select(changelog::all_columns);
-
-        println!("{}", debug_query::<DBType, _>(&q));
+        ChangelogRepository::new(&connection)
+            .query_cursor_window(filter, 0, 250_000, 100)
+            .unwrap();
     }
 
     /// Locks the Rust↔DB contract for `row_action`: the column was the PG enum

--- a/server/repository/src/db_diesel/changelog/compatibility_changelog.rs
+++ b/server/repository/src/db_diesel/changelog/compatibility_changelog.rs
@@ -34,7 +34,7 @@ impl<'a> ChangelogRepository<'a> {
         filter: Option<CompatibilityChangelogFilter>,
     ) -> Result<Vec<ChangelogRow>, RepositoryError> {
         let query = create_filtered_query(earliest, filter)
-            .order(changelog::dsl::cursor.asc())
+            .order(changelog_with_links::dsl::cursor.asc())
             .limit(limit.into());
 
         // // Debug diesel query
@@ -48,11 +48,11 @@ impl<'a> ChangelogRepository<'a> {
     }
 }
 
-type BoxedChangelogQuery = IntoBoxed<'static, changelog::table, DBType>;
+type BoxedChangelogQuery = IntoBoxed<'static, changelog_with_links::table, DBType>;
 
 fn create_base_query(earliest: u64) -> BoxedChangelogQuery {
-    changelog::table
-        .filter(changelog::cursor.ge(earliest.try_into().unwrap_or(0)))
+    changelog_with_links::table
+        .filter(changelog_with_links::cursor.ge(earliest.try_into().unwrap_or(0)))
         .into_boxed()
 }
 
@@ -72,12 +72,12 @@ fn create_filtered_query(
             source_site_id,
         } = f;
 
-        apply_equal_filter!(query, table_name, changelog::table_name);
-        apply_equal_filter!(query, store_id, changelog::store_id);
-        apply_equal_filter!(query, record_id, changelog::record_id);
-        apply_equal_filter!(query, action, changelog::row_action);
-        apply_equal_filter!(query, is_sync_update, changelog::is_sync_update);
-        apply_equal_filter!(query, source_site_id, changelog::source_site_id);
+        apply_equal_filter!(query, table_name, changelog_with_links::table_name);
+        apply_equal_filter!(query, store_id, changelog_with_links::store_id);
+        apply_equal_filter!(query, record_id, changelog_with_links::record_id);
+        apply_equal_filter!(query, action, changelog_with_links::row_action);
+        apply_equal_filter!(query, is_sync_update, changelog_with_links::is_sync_update);
+        apply_equal_filter!(query, source_site_id, changelog_with_links::source_site_id);
     }
 
     query

--- a/server/repository/src/db_diesel/changelog/test.rs
+++ b/server/repository/src/db_diesel/changelog/test.rs
@@ -903,7 +903,7 @@ async fn test_changelog_outgoing_patient_sync_records() {
         .query(
             ChangelogCondition::And(vec![
                 ChangelogFilter::patient_data_for_site(site1_id, None),
-                ChangelogCondition::patient_id::equal("patient2".to_string()),
+                ChangelogCondition::patient_id::matching("patient2".to_string()),
             ]),
             CursorAndLimit {
                 cursor: cursor_before,
@@ -921,7 +921,7 @@ async fn test_changelog_outgoing_patient_sync_records() {
         .query(
             ChangelogCondition::And(vec![
                 ChangelogFilter::patient_data_for_site(5, None),
-                ChangelogCondition::patient_id::equal("patient2".to_string()),
+                ChangelogCondition::patient_id::matching("patient2".to_string()),
             ]),
             CursorAndLimit {
                 cursor: cursor + 500,

--- a/server/repository/src/db_diesel/name_store_join.rs
+++ b/server/repository/src/db_diesel/name_store_join.rs
@@ -1,4 +1,4 @@
-use super::{name_row::name, store_row::store, StorageConnection};
+use super::{name_link_row::name_link, name_row::name, store_row::store, StorageConnection};
 use crate::db_diesel::changelog::changelog::RowOrId;
 use crate::diesel_macros::define_linked_tables;
 use crate::{
@@ -45,6 +45,9 @@ pub struct NameStoreJoin {
 
 joinable!(name_store_join -> store (store_id));
 joinable!(name_store_join -> name (name_id));
+allow_tables_to_appear_in_same_query!(name_store_join, name_link);
+// store + name_link both appear (as aliases) in the changelog patient_site_id subquery.
+allow_tables_to_appear_in_same_query!(store, name_link);
 
 type NameStoreJoins = (NameStoreJoinRow, NameRow);
 

--- a/server/repository/src/dynamic_query_filter.rs
+++ b/server/repository/src/dynamic_query_filter.rs
@@ -80,9 +80,108 @@ pub trait FilterBuilder<T: Clone + serde::Serialize + serde::de::DeserializeOwne
 }
 
 // Generates a filter module for a given query Source.
-// create_condition!(ModuleName, Source, (field_name, kind, dsl_expression), ...);
+//
+// Two field shapes can be freely mixed in one list:
+//   Scalar:    (field_name, kind, dsl_expression)
+//              kind is `number`, `string`, or a custom `T: Clone + Serialize + DeserializeOwned`.
+//              Exposes GeneralFilter operators: equal/not_equal/greater_than/lower_than/any/is_null.
+//   Subquery:  (field_name, subquery: ValueType, |value| <select expression>)
+//              The variant carries a plain `ValueType` (so it serializes trivially). The closure
+//              maps that value to a Diesel subquery expression — typically
+//              `outer_col.eq_any(other_table::table.filter(...).select(other_col))` — replacing a
+//              JOIN with an `IN (...)`. Built at the call site with `FieldName::matching(value)`.
+//              NB: the closure parameter must not be named after another field in this condition
+//              (each field generates a unit struct of that name, which would shadow the binding).
+//
+// create_condition!(ModuleName, Source, <field>, <field>, ...);
+//
+// Because a `macro_rules!` call can't expand in enum-variant position, the field list is consumed
+// by an internal accumulator (@build): it munches one field at a time, classifying scalar vs
+// subquery, and appends generated tokens to three accumulators (enum variants, field structs/impls,
+// match arms). The terminal @build arm emits the whole module at once.
 macro_rules! create_condition {
-    ($mod_name:ident, $source:ty, $(($variant:ident, $filter_kind:ident, $dsl_expr:expr)),+ $(,)?) => {
+    ($mod_name:ident, $source:ty, $($field:tt),+ $(,)?) => {
+        create_condition!(@build
+            mod_name: $mod_name,
+            source: $source,
+            fields: [ $($field),+ ],
+            variants: [],
+            items: [],
+            arms: [],
+        );
+    };
+
+    // ===== Accumulator: classify and consume the next field =====
+
+    // Subquery field. Variant carries the value type; the closure builds the subquery expression.
+    (@build
+        mod_name: $mod_name:ident, source: $source:ty,
+        fields: [ ($variant:ident, subquery: $value_ty:ty, |$v:ident| $body:expr) $(, $rest:tt)* ],
+        variants: [ $($variants:tt)* ],
+        items: [ $($items:tt)* ],
+        arms: [ $($arms:tt)* ],
+    ) => {
+        create_condition!(@build
+            mod_name: $mod_name, source: $source,
+            fields: [ $($rest),* ],
+            variants: [ $($variants)* $variant($value_ty), ],
+            items: [
+                $($items)*
+                #[allow(non_snake_case)]
+                pub struct $variant;
+                impl $variant {
+                    pub fn matching(value: $value_ty) -> Inner {
+                        Inner::$variant(value)
+                    }
+                }
+            ],
+            arms: [
+                $($arms)*
+                // Bind to a fixed internal name (not `$v`) so the pattern can't collide with a
+                // same-named unit struct generated for another field; then expose it as `$v`.
+                Inner::$variant(__subquery_value) => {
+                    let $v: $value_ty = __subquery_value;
+                    Some(Box::new(($body).nullable()))
+                },
+            ],
+        );
+    };
+
+    // Scalar field. Variant carries a GeneralFilter; operators come from the FilterBuilder trait.
+    (@build
+        mod_name: $mod_name:ident, source: $source:ty,
+        fields: [ ($variant:ident, $filter_kind:ident, $dsl_expr:expr) $(, $rest:tt)* ],
+        variants: [ $($variants:tt)* ],
+        items: [ $($items:tt)* ],
+        arms: [ $($arms:tt)* ],
+    ) => {
+        create_condition!(@build
+            mod_name: $mod_name, source: $source,
+            fields: [ $($rest),* ],
+            variants: [ $($variants)* $variant(create_condition!(@filter_type $filter_kind)), ],
+            items: [
+                $($items)*
+                #[allow(non_snake_case)]
+                pub struct $variant;
+                create_condition!(@impl_trait $variant, $filter_kind);
+            ],
+            arms: [
+                $($arms)*
+                Inner::$variant(f) => {
+                    Some(create_condition!(@filter_macro $filter_kind, f, $dsl_expr))
+                },
+            ],
+        );
+    };
+
+    // ===== Terminal: all fields consumed, emit the module =====
+    (@build
+        mod_name: $mod_name:ident, source: $source:ty,
+        fields: [],
+        variants: [ $($variants:tt)* ],
+        items: [ $($items:tt)* ],
+        arms: [ $($arms:tt)* ],
+    ) => {
         #[allow(non_snake_case, non_camel_case_types)]
         pub mod $mod_name {
             use super::*;
@@ -90,9 +189,7 @@ macro_rules! create_condition {
             #[derive(Clone, serde::Serialize, serde::Deserialize)]
             #[allow(non_snake_case)]
             pub enum Inner {
-                $(
-                    $variant(create_condition!(@filter_type $filter_kind)),
-                )+
+                $($variants)*
                 And(Vec<Inner>),
                 Or(Vec<Inner>),
                 True,
@@ -109,12 +206,7 @@ macro_rules! create_condition {
             pub const TRUE: Inner = Inner::True;
             pub const FALSE: Inner = Inner::False;
 
-            $(
-                #[allow(non_snake_case)]
-                pub struct $variant;
-
-                create_condition!(@impl_trait $variant, $filter_kind);
-            )+
+            $($items)*
 
             pub fn And(conditions: Vec<Inner>) -> Inner {
                 Inner::And(conditions)
@@ -138,11 +230,7 @@ macro_rules! create_condition {
             impl Inner {
                  fn to_boxed_condition(self) -> Option<BoxedCondition> {
                    match self {
-                        $(
-                            Inner::$variant(f) => {
-                                Some(create_condition!(@filter_macro $filter_kind, f, $dsl_expr))
-                            },
-                        )+
+                        $($arms)*
                         Inner::And(conditions) => create_filter(conditions, crate::dynamic_query_filter::AndOr::And),
                         Inner::Or(conditions) => create_filter(conditions, crate::dynamic_query_filter::AndOr::Or),
                         Inner::True => Some(Box::new(true.into_sql::<diesel::sql_types::Bool>().nullable())),

--- a/server/service/src/sync/sync_on_central/mod.rs
+++ b/server/service/src/sync/sync_on_central/mod.rs
@@ -238,7 +238,7 @@ pub async fn patient_pull(
                 is_v5: false,
             }),
         ),
-        ChangelogCondition::patient_id::equal(fetch_patient_id),
+        ChangelogCondition::patient_id::matching(fetch_patient_id),
     ]);
     let QueryWithData {
         rows,

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -6,9 +6,9 @@ use std::{
 use repository::{
     migrations::Version,
     syncv7::{SiteLockError, SyncError},
-    ChangelogCondition, ChangelogFilter, EqualFilter, FilterBuilder, KeyType,
-    KeyValueStoreRepository, Pagination, RepositoryError, SiteFilter, SiteRepository, SiteRow,
-    SiteRowRepository, SourceSiteId, StorageConnection, SyncBufferRepository, SyncVersion,
+    ChangelogCondition, ChangelogFilter, EqualFilter, KeyType, KeyValueStoreRepository, Pagination,
+    RepositoryError, SiteFilter, SiteRepository, SiteRow, SiteRowRepository, SourceSiteId,
+    StorageConnection, SyncBufferRepository, SyncVersion,
 };
 use thiserror::Error;
 use util::format_error;
@@ -381,7 +381,7 @@ pub async fn patient_data_for_site(
 
         let filter = ChangelogCondition::And(vec![
             ChangelogFilter::patient_data_for_site(site.id, None),
-            ChangelogCondition::patient_id::equal(patient_id),
+            ChangelogCondition::patient_id::matching(patient_id),
         ]);
 
         let batch = SyncBatchV7::generate(&ctx.connection, filter, 0, None)?;


### PR DESCRIPTION
Fixes #12144

## What

Optimises the sync v7 changelog query. The previous query LEFT JOINed `store` three times (main + `transfer_stores` + `patient_stores` aliases) and `name_store_join` onto `changelog_view`, then filtered on the joined columns. The site filters are now expressed as gated `IN`-subqueries against the raw `changelog` table, and `patient_id` is resolved through a single `name_link` left join.

## Why / impact

On the **TL data file** (search `12144` in mega — available as a SQL dump or as a Postgres 17 data folder), measured on **HPE server (sync v7 test server 1)**:

| | Time |
|---|---|
| Before | ~1 s |
| After | ~250 ms |

## How

- New `subquery` field kind in `create_condition!` so site filters compile to `<col> IS NOT NULL AND <col> IN (SELECT ... WHERE site_id = $site)`. The `IS NOT NULL` gate lets the planner skip the subquery for the common null case (most rows have no transfer/patient link).
- The patient site filter joins `name_store_join -> name_link (aliased patient_name_links) -> store (aliased patient_stores)` inside the subquery, so it doesn't collide with the outer `name_link` join used to resolve `patient_id` in the SELECT.
- `patient_id` filter switches from `::equal` to `::matching` (the new subquery constructor).

## Before query

<details>
<summary>Full runnable query (~1 s)</summary>

```sql
SELECT "changelog_view"."cursor",
    "changelog_view"."table_name",
    "changelog_view"."record_id",
    "changelog_view"."row_action",
    "changelog_view"."store_id",
    "changelog_view"."is_sync_update",
    "changelog_view"."source_site_id",
    "changelog_view"."transfer_store_id",
    "changelog_view"."patient_id"
FROM (
        (
            (
                (
                    "changelog_view"
                    LEFT OUTER JOIN "store_view" ON ("store_view"."id" = "changelog_view"."store_id")
                )
                LEFT OUTER JOIN "store_view" AS "transfer_stores" ON (
                    "transfer_stores"."id" = "changelog_view"."transfer_store_id"
                )
            )
            LEFT OUTER JOIN "name_store_join_view" ON (
                "name_store_join_view"."name_id" = "changelog_view"."patient_id"
            )
        )
        LEFT OUTER JOIN "store_view" AS "patient_stores" ON (
            "patient_stores"."id" = "name_store_join_view"."store_id"
        )
    )
WHERE (
        (
            (
                (
                    (
                        (
                            (
                                "changelog_view"."table_name" = ANY(
                                    ARRAY ['abbreviation','ancillary_item','asset_catalogue_item','asset_catalogue_type','asset_category','asset_class','asset_log_reason','asset_property','backend_plugin','barcode','bundled_item','campaign','category','clinician','contact','context','currency','demographic','demographic_indicator','diagnosis','document_registry','form_schema','frontend_plugin','indicator_column','indicator_line','insurance_provider','item','item_category_join','item_direction','item_variant','item_warning_join','location_type','master_list','master_list_line','master_list_name_join','name','name_oms_fields','name_property','name_tag','name_tag_join','packaging_variant','period','period_schedule','plugin_data','preference','printer','program','program_indicator','program_requisition_order_type','program_requisition_settings','property','reason_option','report','shipping_method','store','store_preference','sync_message','unit','user_account','user_permission','user_store_join','vvm_status','vaccine_course','vaccine_course_dose','vaccine_course_item','vaccine_course_store_config']::text []
                                )
                            )
                            AND (
                                ("changelog_view"."store_id" IS NULL)
                                AND ("changelog_view"."patient_id" IS NULL)
                            )
                        )
                        OR (
                            (
                                "changelog_view"."table_name" = ANY(
                                    ARRAY ['asset','asset_internal_location','clinician_store_join','contact_trace','encounter','item_store_join','name_store_join','plugin_data','preference','sync_message','vaccination']::text []
                                )
                            )
                            AND ("store_view"."site_id" = 300)
                        )
                    )
                    OR (
                        (
                            "changelog_view"."table_name" = ANY(ARRAY ['sync_file_reference']::text [])
                        )
                        AND (
                            ("changelog_view"."store_id" IS NULL)
                            AND ("changelog_view"."patient_id" IS NULL)
                        )
                    )
                )
                OR (
                    (
                        "changelog_view"."table_name" = ANY(
                            ARRAY ['invoice','invoice_line','requisition','requisition_line']::text []
                        )
                    )
                    AND ("transfer_stores"."site_id" = 300)
                )
            )
            OR (
                (
                    "changelog_view"."table_name" = ANY(
                        ARRAY ['contact_trace','document','encounter','invoice','invoice_line','name','name_insurance_join','program_enrolment','program_event','vaccination']::text []
                    )
                )
                AND ("patient_stores"."site_id" = 300)
            )
        )
        AND ("changelog_view"."source_site_id" != 300)
              AND ("changelog_view"."cursor" < 500000)
    )
ORDER BY "changelog_view"."cursor" ASC
LIMIT 500;
```

</details>

## After query

<details>
<summary>Full runnable query (~250 ms)</summary>

```sql
SELECT "changelog"."cursor",
    "changelog"."table_name",
    "changelog"."record_id",
    "changelog"."row_action",
    "changelog"."store_id",
    "changelog"."is_sync_update",
    "changelog"."source_site_id",
    "changelog"."transfer_store_id",
    "name_link"."name_id"
FROM (
        "changelog"
        LEFT OUTER JOIN "name_link" ON ("changelog"."patient_link_id" = "name_link"."id")
    )
WHERE (
        (
            (
                (
                    (
                        (
                            (
                                (
                                    (
                                        "changelog"."table_name" = ANY(
                                            ARRAY ['abbreviation','ancillary_item','asset_catalogue_item','asset_catalogue_type','asset_category','asset_class','asset_log_reason','asset_property','backend_plugin','barcode','bundled_item','campaign','category','clinician','contact','context','currency','demographic','demographic_indicator','diagnosis','document_registry','form_schema','frontend_plugin','indicator_column','indicator_line','insurance_provider','item','item_category_join','item_direction','item_variant','item_warning_join','location_type','master_list','master_list_line','master_list_name_join','name','name_oms_fields','name_property','name_tag','name_tag_join','packaging_variant','period','period_schedule','plugin_data','preference','printer','program','program_indicator','program_requisition_order_type','program_requisition_settings','property','reason_option','report','shipping_method','store','store_preference','sync_message','unit','user_account','user_permission','user_store_join','vvm_status','vaccine_course','vaccine_course_dose','vaccine_course_item','vaccine_course_store_config']::text []
                                        )
                                    )
                                    AND (
                                        ("changelog"."store_id" IS NULL)
                                        AND ("changelog"."patient_link_id" IS NULL)
                                    )
                                )
                                OR (
                                    (
                                        "changelog"."table_name" = ANY(
                                            ARRAY ['asset','asset_internal_location','clinician_store_join','contact_trace','encounter','item_store_join','name_store_join','plugin_data','preference','sync_message','vaccination']::text []
                                        )
                                    )
                                    AND (
                                        ("changelog"."store_id" IS NOT NULL)
                                        AND (
                                            "changelog"."store_id" = ANY(
                                                SELECT "store_view"."id"
                                                FROM "store_view"
                                                WHERE ("store_view"."site_id" = 300)
                                            )
                                        )
                                    )
                                )
                            )
                            OR (
                                (
                                    "changelog"."table_name" = ANY(ARRAY ['sync_file_reference']::text [])
                                )
                                AND (
                                    ("changelog"."store_id" IS NULL)
                                    AND ("changelog"."patient_link_id" IS NULL)
                                )
                            )
                        )
                        OR (
                            (
                                "changelog"."table_name" = ANY(
                                    ARRAY ['invoice','invoice_line','requisition','requisition_line']::text []
                                )
                            )
                            AND (
                                ("changelog"."transfer_store_id" IS NOT NULL)
                                AND (
                                    "changelog"."transfer_store_id" = ANY(
                                        SELECT "store_view"."id"
                                        FROM "store_view"
                                        WHERE ("store_view"."site_id" = 300)
                                    )
                                )
                            )
                        )
                    )
                    OR (
                        (
                            "changelog"."table_name" = ANY(
                                ARRAY ['contact_trace','document','encounter','invoice','invoice_line','name','name_insurance_join','program_enrolment','program_event','vaccination']::text []
                            )
                        )
                        AND (
                            ("changelog"."patient_link_id" IS NOT NULL)
                            AND (
                                "changelog"."patient_link_id" = ANY(
                                    SELECT "patient_name_links"."id"
                                    FROM (
                                            (
                                                "name_store_join_view"
                                                INNER JOIN "name_link" AS "patient_name_links" ON (
                                                    "name_store_join_view"."name_id" = "patient_name_links"."id"
                                                )
                                            )
                                            INNER JOIN "store_view" AS "patient_stores" ON (
                                                "patient_stores"."id" = "name_store_join_view"."store_id"
                                            )
                                        )
                                    WHERE ("patient_stores"."site_id" = 300)
                                )
                            )
                        )
                    )
                )
                AND ("changelog"."source_site_id" != 300)
            )
            AND ("changelog"."cursor" > 0)
        )
        AND ("changelog"."cursor" < 500000)
    )
ORDER BY "changelog"."cursor" ASC
LIMIT 500;
```

</details>

## Testing

`cargo check -p repository --tests` and `cargo check -p service` pass. The before/after queries were captured with `diesel::debug_query` (see the `print_all_data_for_site_query_for_site_300` ignored test). Benchmark run manually against the TL data file on the HPE test server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
