### PR TITLE
12156 Fix yarn install --cwd ambiguous error in CLI with Yarn 4 (Berry)

### DIFF
--- a/server/cli/src/plugins.rs
+++ b/server/cli/src/plugins.rs
@@ -231,17 +231,16 @@ fn process_manifest(bundle: &mut PluginBundle, path: &PathBuf) -> Result<(), Err
     // Yarn install
     run_command_with_error(
         Command::new(YARN_COMMAND)
-            .args(["install", "--cwd"])
-            .arg(plugin_root),
+            .arg("install")
+            .current_dir(plugin_root),
     )
     .map_err(|e| Error::FailedToYarnInstall(plugin_root.to_path_buf(), e))?;
 
     // Yarn build plugin
     run_command_with_error(
         Command::new(YARN_COMMAND)
-            .arg("--cwd")
-            .arg(plugin_root)
-            .arg("build-plugin"),
+            .arg("build-plugin")
+            .current_dir(plugin_root),
     )
     .map_err(|e| Error::FailedToBuildPlugin(plugin_root.to_path_buf(), e))?;
 
@@ -436,10 +435,7 @@ pub async fn uninstall_plugin(
         )
         .await?;
 
-    info!(
-        "Result:{}",
-        serde_json::to_string_pretty(&result).unwrap()
-    );
+    info!("Result:{}", serde_json::to_string_pretty(&result).unwrap());
 
     Ok(())
 }

--- a/server/cli/src/report_utils.rs
+++ b/server/cli/src/report_utils.rs
@@ -203,8 +203,8 @@ fn generate_convert_data(path: &PathBuf, manifest: &Manifest) -> Result<Option<S
     // Yarn install, use lock file bit it should be git ignored
     run_command_with_error(
         Command::new(YARN_COMMAND)
-            .args(["install", "--cwd"])
-            .arg(&convert_dir),
+            .arg("install")
+            .current_dir(&convert_dir),
     )
     .map_err(|e| Error::FailedToYarnInstall(convert_dir.clone(), e))?;
 


### PR DESCRIPTION
Fixes #12156

# 👩🏻‍💻 What does this PR do?
Fixes the `yarn install` failure in the CLI when building/installing plugins and report convert-data.

The CLI was invoking Yarn as `yarn install --cwd <dir>`. The project uses **Yarn 4.13.0 (Berry)**, where `--cwd` is a *global* option that must appear **before** the command path (e.g. `yarn --cwd <dir> install`). Passing it after the command — the old Yarn Classic style — is now rejected with:

Usage Error: The --cwd option is ambiguous when used anywhere else than the very first parameter provided in the command line, before even the command path

The fix drops the `--cwd` argument and sets the working directory via `Command::current_dir(<dir>)` instead. For consistency, all Yarn invocations across both files were converted to the `.current_dir()` pattern (the build commands already used it / had `--cwd` before the command).

Changed call sites:
- `server/cli/src/report_utils.rs` — convert_data `yarn install`
- `server/cli/src/plugins.rs` — plugin `yarn install` and `yarn build-plugin`

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->
- [ ] Build/install a plugin via the CLI (e.g. generate & install a plugin bundle)
- [ ] Build a report with `convert_data` via the CLI
- [ ] Confirm `yarn install` runs in the correct directory and no longer throws the `--cwd is ambiguous` error
- [ ] Confirm the plugin/report bundle is produced as expected

# 📃 Documentation
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

