### PR TITLE
12159 backend duplicate inbound shipment

### DIFF
--- a/client/packages/system/src/Manage/IndicatorsDemographics/api/operations.generated.ts
+++ b/client/packages/system/src/Manage/IndicatorsDemographics/api/operations.generated.ts
@@ -21,6 +21,7 @@ export type DemographicFragment = {
   __typename: 'DemographicNode';
   id: string;
   name: string;
+  populationPercentage: number;
 };
 
 export type DemographicProjectionFragment = {
@@ -48,7 +49,12 @@ export type DemographicsQuery = {
   demographics: {
     __typename: 'DemographicConnector';
     totalCount: number;
-    nodes: Array<{ __typename: 'DemographicNode'; id: string; name: string }>;
+    nodes: Array<{
+      __typename: 'DemographicNode';
+      id: string;
+      name: string;
+      populationPercentage: number;
+    }>;
   };
 };
 
@@ -276,6 +282,7 @@ export const DemographicFragmentDoc = gql`
   fragment Demographic on DemographicNode {
     id
     name
+    populationPercentage
   }
 `;
 export const DemographicProjectionFragmentDoc = gql`

--- a/client/packages/system/src/Manage/IndicatorsDemographics/api/operations.graphql
+++ b/client/packages/system/src/Manage/IndicatorsDemographics/api/operations.graphql
@@ -14,6 +14,7 @@ fragment DemographicIndicator on DemographicIndicatorNode {
 fragment Demographic on DemographicNode {
   id
   name
+  populationPercentage
 }
 
 fragment DemographicProjection on DemographicProjectionNode {

--- a/server/graphql/invoice/src/lib.rs
+++ b/server/graphql/invoice/src/lib.rs
@@ -165,6 +165,15 @@ impl InvoiceMutations {
         )
     }
 
+    async fn duplicate_inbound_shipment(
+        &self,
+        ctx: &Context<'_>,
+        store_id: String,
+        #[graphql(desc = "id of the inbound shipment to duplicate")] id: String,
+    ) -> Result<graphql_types::types::InvoiceNode> {
+        inbound_shipment::duplicate::duplicate(ctx, &store_id, id)
+    }
+
     async fn delete_inbound_shipment_external(
         &self,
         ctx: &Context<'_>,

--- a/server/graphql/invoice/src/lib.rs
+++ b/server/graphql/invoice/src/lib.rs
@@ -170,7 +170,7 @@ impl InvoiceMutations {
         ctx: &Context<'_>,
         store_id: String,
         #[graphql(desc = "id of the inbound shipment to duplicate")] id: String,
-    ) -> Result<inbound_shipment::duplicate::DuplicateInboundShipmentNode> {
+    ) -> Result<inbound_shipment::duplicate::DuplicateResponse> {
         inbound_shipment::duplicate::duplicate(ctx, &store_id, id)
     }
 

--- a/server/graphql/invoice/src/lib.rs
+++ b/server/graphql/invoice/src/lib.rs
@@ -170,7 +170,7 @@ impl InvoiceMutations {
         ctx: &Context<'_>,
         store_id: String,
         #[graphql(desc = "id of the inbound shipment to duplicate")] id: String,
-    ) -> Result<graphql_types::types::InvoiceNode> {
+    ) -> Result<inbound_shipment::duplicate::DuplicateInboundShipmentNode> {
         inbound_shipment::duplicate::duplicate(ctx, &store_id, id)
     }
 

--- a/server/graphql/invoice/src/mutations/inbound_shipment/duplicate.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/duplicate.rs
@@ -1,13 +1,23 @@
 use async_graphql::*;
-
 use graphql_core::standard_graphql_error::{validate_auth, StandardGraphqlError};
 use graphql_core::ContextExt;
 use graphql_types::types::InvoiceNode;
-use repository::Invoice;
 use service::auth::{Resource, ResourceAccessRequest};
-use service::invoice::inbound_shipment::DuplicateInboundShipmentError as ServiceError;
+use service::invoice::inbound_shipment::{
+    DuplicateInboundShipment as ServiceResult, DuplicateInboundShipmentError as ServiceError,
+};
 
-pub fn duplicate(ctx: &Context<'_>, store_id: &str, id: String) -> Result<InvoiceNode> {
+#[derive(SimpleObject)]
+pub struct DuplicateInboundShipmentNode {
+    pub invoice: InvoiceNode,
+    pub skipped_item_count: u32,
+}
+
+pub fn duplicate(
+    ctx: &Context<'_>,
+    store_id: &str,
+    id: String,
+) -> Result<DuplicateInboundShipmentNode> {
     let user = validate_auth(
         ctx,
         &ResourceAccessRequest {
@@ -26,9 +36,14 @@ pub fn duplicate(ctx: &Context<'_>, store_id: &str, id: String) -> Result<Invoic
     )
 }
 
-pub fn map_response(from: Result<Invoice, ServiceError>) -> Result<InvoiceNode> {
+pub fn map_response(
+    from: Result<ServiceResult, ServiceError>,
+) -> Result<DuplicateInboundShipmentNode> {
     match from {
-        Ok(invoice) => Ok(InvoiceNode::from_domain(invoice)),
+        Ok(result) => Ok(DuplicateInboundShipmentNode {
+            invoice: InvoiceNode::from_domain(result.invoice),
+            skipped_item_count: result.skipped_item_count as u32,
+        }),
         Err(error) => Err(map_error(error)),
     }
 }
@@ -62,14 +77,18 @@ mod test {
     use serde_json::json;
     use service::{
         invoice::{
-            inbound_shipment::DuplicateInboundShipmentError as ServiceError, InvoiceServiceTrait,
+            inbound_shipment::{
+                DuplicateInboundShipment, DuplicateInboundShipmentError as ServiceError,
+            },
+            InvoiceServiceTrait,
         },
         service_provider::{ServiceContext, ServiceProvider},
     };
 
     use crate::InvoiceMutations;
 
-    type DuplicateMethod = dyn Fn(String) -> Result<Invoice, ServiceError> + Sync + Send;
+    type DuplicateMethod =
+        dyn Fn(String) -> Result<DuplicateInboundShipment, ServiceError> + Sync + Send;
 
     pub struct TestService(pub Box<DuplicateMethod>);
 
@@ -78,7 +97,7 @@ mod test {
             &self,
             _: &ServiceContext,
             source_id: String,
-        ) -> Result<Invoice, ServiceError> {
+        ) -> Result<DuplicateInboundShipment, ServiceError> {
             self.0(source_id)
         }
     }
@@ -112,7 +131,9 @@ mod test {
         let mutation = r#"
         mutation ($id: String!, $storeId: String!) {
             duplicateInboundShipment(storeId: $storeId, id: $id) {
-                id
+                invoice {
+                    id
+                }
             }
           }
         "#;
@@ -181,7 +202,10 @@ mod test {
         let mutation = r#"
         mutation ($storeId: String!, $id: String!) {
             duplicateInboundShipment(storeId: $storeId, id: $id) {
-                id
+                invoice {
+                    id
+                }
+                skippedItemCount
             }
           }
         "#;
@@ -189,11 +213,14 @@ mod test {
         // Success
         let test_service = TestService(Box::new(|source_id| {
             assert_eq!(source_id, "source id".to_string());
-            Ok(Invoice {
-                invoice_row: mock_inbound_shipment_c(),
-                name_row: mock_name_a(),
-                store_row: mock_store_a(),
-                clinician_row: None,
+            Ok(DuplicateInboundShipment {
+                invoice: Invoice {
+                    invoice_row: mock_inbound_shipment_c(),
+                    name_row: mock_name_a(),
+                    store_row: mock_store_a(),
+                    clinician_row: None,
+                },
+                skipped_item_count: 2,
             })
         }));
 
@@ -204,7 +231,10 @@ mod test {
 
         let expected = json!({
             "duplicateInboundShipment": {
-                "id": mock_inbound_shipment_c().id
+                "invoice": {
+                    "id": mock_inbound_shipment_c().id
+                },
+                "skippedItemCount": 2
             }
           }
         );

--- a/server/graphql/invoice/src/mutations/inbound_shipment/duplicate.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/duplicate.rs
@@ -1,0 +1,220 @@
+use async_graphql::*;
+
+use graphql_core::standard_graphql_error::{validate_auth, StandardGraphqlError};
+use graphql_core::ContextExt;
+use graphql_types::types::InvoiceNode;
+use repository::Invoice;
+use service::auth::{Resource, ResourceAccessRequest};
+use service::invoice::inbound_shipment::DuplicateInboundShipmentError as ServiceError;
+
+pub fn duplicate(ctx: &Context<'_>, store_id: &str, id: String) -> Result<InvoiceNode> {
+    let user = validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::MutateInboundShipment,
+            store_id: Some(store_id.to_string()),
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.context(store_id.to_string(), user.user_id)?;
+
+    map_response(
+        service_provider
+            .invoice_service
+            .duplicate_inbound_shipment(&service_context, id),
+    )
+}
+
+pub fn map_response(from: Result<Invoice, ServiceError>) -> Result<InvoiceNode> {
+    match from {
+        Ok(invoice) => Ok(InvoiceNode::from_domain(invoice)),
+        Err(error) => Err(map_error(error)),
+    }
+}
+
+fn map_error(error: ServiceError) -> async_graphql::Error {
+    use StandardGraphqlError::*;
+    let formatted_error = format!("{error:#?}");
+
+    let graphql_error = match error {
+        ServiceError::InvoiceDoesNotExist
+        | ServiceError::NotAnInboundShipment
+        | ServiceError::NotThisStoreInvoice => BadUserInput(formatted_error),
+        ServiceError::DatabaseError(_) | ServiceError::NewlyCreatedInvoiceDoesNotExist => {
+            InternalError(formatted_error)
+        }
+    };
+
+    graphql_error.extend()
+}
+
+#[cfg(test)]
+mod test {
+    use async_graphql::EmptyMutation;
+    use graphql_core::{
+        assert_graphql_query, assert_standard_graphql_error, test_helpers::setup_graphql_test,
+    };
+    use repository::{
+        mock::{mock_inbound_shipment_c, mock_name_a, mock_store_a, MockDataInserts},
+        Invoice, RepositoryError, StorageConnectionManager,
+    };
+    use serde_json::json;
+    use service::{
+        invoice::{
+            inbound_shipment::DuplicateInboundShipmentError as ServiceError, InvoiceServiceTrait,
+        },
+        service_provider::{ServiceContext, ServiceProvider},
+    };
+
+    use crate::InvoiceMutations;
+
+    type DuplicateMethod = dyn Fn(String) -> Result<Invoice, ServiceError> + Sync + Send;
+
+    pub struct TestService(pub Box<DuplicateMethod>);
+
+    impl InvoiceServiceTrait for TestService {
+        fn duplicate_inbound_shipment(
+            &self,
+            _: &ServiceContext,
+            source_id: String,
+        ) -> Result<Invoice, ServiceError> {
+            self.0(source_id)
+        }
+    }
+
+    fn service_provider(
+        test_service: TestService,
+        connection_manager: &StorageConnectionManager,
+    ) -> ServiceProvider {
+        let mut service_provider = ServiceProvider::new(connection_manager.clone());
+        service_provider.invoice_service = Box::new(test_service);
+        service_provider
+    }
+
+    fn empty_variables() -> serde_json::Value {
+        json!({
+          "id": "n/a",
+          "storeId": "n/a"
+        })
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_duplicate_inbound_shipment_errors() {
+        let (_, _, connection_manager, settings) = setup_graphql_test(
+            EmptyMutation,
+            InvoiceMutations,
+            "test_graphql_duplicate_inbound_shipment_errors",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($id: String!, $storeId: String!) {
+            duplicateInboundShipment(storeId: $storeId, id: $id) {
+                id
+            }
+          }
+        "#;
+
+        // InvoiceDoesNotExist
+        let test_service = TestService(Box::new(|_| Err(ServiceError::InvoiceDoesNotExist)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotAnInboundShipment
+        let test_service = TestService(Box::new(|_| Err(ServiceError::NotAnInboundShipment)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // NotThisStoreInvoice
+        let test_service = TestService(Box::new(|_| Err(ServiceError::NotThisStoreInvoice)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // DatabaseError
+        let test_service = TestService(Box::new(|_| {
+            Err(ServiceError::DatabaseError(RepositoryError::NotFound))
+        }));
+        let expected_message = "Internal error";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+
+    #[actix_rt::test]
+    async fn test_graphql_duplicate_inbound_shipment_success() {
+        let (_, _, connection_manager, settings) = setup_graphql_test(
+            EmptyMutation,
+            InvoiceMutations,
+            "test_graphql_duplicate_inbound_shipment_success",
+            MockDataInserts::all(),
+        )
+        .await;
+
+        let mutation = r#"
+        mutation ($storeId: String!, $id: String!) {
+            duplicateInboundShipment(storeId: $storeId, id: $id) {
+                id
+            }
+          }
+        "#;
+
+        // Success
+        let test_service = TestService(Box::new(|source_id| {
+            assert_eq!(source_id, "source id".to_string());
+            Ok(Invoice {
+                invoice_row: mock_inbound_shipment_c(),
+                name_row: mock_name_a(),
+                store_row: mock_store_a(),
+                clinician_row: None,
+            })
+        }));
+
+        let variables = json!({
+            "id": "source id",
+            "storeId": "store_a"
+        });
+
+        let expected = json!({
+            "duplicateInboundShipment": {
+                "id": mock_inbound_shipment_c().id
+            }
+          }
+        );
+
+        assert_graphql_query!(
+            &settings,
+            mutation,
+            &Some(variables),
+            &expected,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
+}

--- a/server/graphql/invoice/src/mutations/inbound_shipment/duplicate.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/duplicate.rs
@@ -13,11 +13,35 @@ pub struct DuplicateInboundShipmentNode {
     pub skipped_item_count: u32,
 }
 
-pub fn duplicate(
-    ctx: &Context<'_>,
-    store_id: &str,
-    id: String,
-) -> Result<DuplicateInboundShipmentNode> {
+pub struct SupplierIsInactive;
+#[Object]
+impl SupplierIsInactive {
+    pub async fn description(&self) -> &str {
+        "Cannot duplicate this shipment because its supplier is no longer active"
+    }
+}
+
+#[derive(Interface)]
+#[graphql(name = "DuplicateInboundShipmentErrorInterface")]
+#[graphql(field(name = "description", ty = "&str"))]
+pub enum DuplicateErrorInterface {
+    SupplierIsInactive(SupplierIsInactive),
+}
+
+#[derive(SimpleObject)]
+#[graphql(name = "DuplicateInboundShipmentError")]
+pub struct DuplicateError {
+    pub error: DuplicateErrorInterface,
+}
+
+#[derive(Union)]
+#[graphql(name = "DuplicateInboundShipmentResponse")]
+pub enum DuplicateResponse {
+    Error(DuplicateError),
+    Response(DuplicateInboundShipmentNode),
+}
+
+pub fn duplicate(ctx: &Context<'_>, store_id: &str, id: String) -> Result<DuplicateResponse> {
     let user = validate_auth(
         ctx,
         &ResourceAccessRequest {
@@ -36,23 +60,32 @@ pub fn duplicate(
     )
 }
 
-pub fn map_response(
-    from: Result<ServiceResult, ServiceError>,
-) -> Result<DuplicateInboundShipmentNode> {
-    match from {
-        Ok(result) => Ok(DuplicateInboundShipmentNode {
+pub fn map_response(from: Result<ServiceResult, ServiceError>) -> Result<DuplicateResponse> {
+    let result = match from {
+        Ok(result) => DuplicateResponse::Response(DuplicateInboundShipmentNode {
             invoice: InvoiceNode::from_domain(result.invoice),
             skipped_item_count: result.skipped_item_count as u32,
         }),
-        Err(error) => Err(map_error(error)),
-    }
+        Err(error) => DuplicateResponse::Error(DuplicateError {
+            error: map_error(error)?,
+        }),
+    };
+
+    Ok(result)
 }
 
-fn map_error(error: ServiceError) -> async_graphql::Error {
+fn map_error(error: ServiceError) -> Result<DuplicateErrorInterface> {
     use StandardGraphqlError::*;
     let formatted_error = format!("{error:#?}");
 
     let graphql_error = match error {
+        // Structured Errors
+        ServiceError::SupplierIsInactive => {
+            return Ok(DuplicateErrorInterface::SupplierIsInactive(
+                SupplierIsInactive,
+            ))
+        }
+        // Standard Graphql Errors
         ServiceError::InvoiceDoesNotExist
         | ServiceError::NotAnInboundShipment
         | ServiceError::NotThisStoreInvoice => BadUserInput(formatted_error),
@@ -61,7 +94,7 @@ fn map_error(error: ServiceError) -> async_graphql::Error {
         }
     };
 
-    graphql_error.extend()
+    Err(graphql_error.extend())
 }
 
 #[cfg(test)]
@@ -131,8 +164,10 @@ mod test {
         let mutation = r#"
         mutation ($id: String!, $storeId: String!) {
             duplicateInboundShipment(storeId: $storeId, id: $id) {
-                invoice {
-                    id
+                ... on DuplicateInboundShipmentNode {
+                    invoice {
+                        id
+                    }
                 }
             }
           }
@@ -147,6 +182,34 @@ mod test {
             &Some(empty_variables()),
             &expected_message,
             None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        // SupplierIsInactive (structured error)
+        let supplier_inactive_mutation = r#"
+        mutation ($id: String!, $storeId: String!) {
+            duplicateInboundShipment(storeId: $storeId, id: $id) {
+                ... on DuplicateInboundShipmentError {
+                    error {
+                        __typename
+                    }
+                }
+            }
+          }
+        "#;
+        let test_service = TestService(Box::new(|_| Err(ServiceError::SupplierIsInactive)));
+        let expected = json!({
+            "duplicateInboundShipment": {
+                "error": {
+                    "__typename": "SupplierIsInactive"
+                }
+            }
+        });
+        assert_graphql_query!(
+            &settings,
+            supplier_inactive_mutation,
+            &Some(empty_variables()),
+            &expected,
             Some(service_provider(test_service, &connection_manager))
         );
 
@@ -202,10 +265,12 @@ mod test {
         let mutation = r#"
         mutation ($storeId: String!, $id: String!) {
             duplicateInboundShipment(storeId: $storeId, id: $id) {
-                invoice {
-                    id
+                ... on DuplicateInboundShipmentNode {
+                    invoice {
+                        id
+                    }
+                    skippedItemCount
                 }
-                skippedItemCount
             }
           }
         "#;

--- a/server/graphql/invoice/src/mutations/inbound_shipment/mod.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/mod.rs
@@ -4,6 +4,7 @@ use graphql_core::standard_graphql_error::validate_auth;
 use service::auth::{Resource, ResourceAccessRequest};
 
 pub mod delete;
+pub mod duplicate;
 pub mod insert;
 pub mod update;
 

--- a/server/service/src/invoice/common.rs
+++ b/server/service/src/invoice/common.rs
@@ -2,8 +2,8 @@ use chrono::Utc;
 use repository::{
     vvm_status::vvm_status_log_row::VVMStatusLogRow, CurrencyFilter, CurrencyRepository,
     EqualFilter, InvoiceLine, InvoiceLineFilter, InvoiceLineRepository, InvoiceLineType,
-    InvoiceRow, MasterList, MasterListFilter, MasterListRepository, RepositoryError,
-    StockLineRow, StorageConnection,
+    InvoiceRow, MasterList, MasterListFilter, MasterListRepository, RepositoryError, StockLineRow,
+    StorageConnection,
 };
 use util::uuid::uuid;
 
@@ -30,6 +30,13 @@ pub(crate) fn get_lines_for_invoice(
     )?;
 
     Ok(result)
+}
+
+pub fn generate_duplicate_comment(source_number: i64, source_comment: &Option<String>) -> String {
+    match source_comment {
+        Some(comment) => format!("Copied from shipment #{source_number} ({comment})"),
+        None => format!("Copied from shipment #{source_number}"),
+    }
 }
 
 pub fn calculate_total_after_tax(total_before_tax: f64, tax: Option<f64>) -> f64 {

--- a/server/service/src/invoice/inbound_shipment/duplicate/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/generate.rs
@@ -26,17 +26,51 @@ pub fn generate(
     let comment =
         generate_duplicate_comment(source_invoice.invoice_number, &source_invoice.comment);
 
+    // Field-level rules follow the duplication spec for inbound shipments.
     let new_invoice = InvoiceRow {
+        // --- New shipment identity ---
         id: new_invoice_id.clone(),
         invoice_number: next_number(connection, &NumberRowType::InboundShipment, store_id)?,
         created_datetime: Utc::now().naive_utc(),
         user_id: Some(user_id.to_string()),
         status: InvoiceStatus::New,
+        r#type: source_invoice.r#type.clone(),
+        store_id: source_invoice.store_id.clone(),
+
+        // --- Header fields (copied from source) ---
+        name_id: source_invoice.name_id.clone(),
+        name_store_id: source_invoice.name_store_id.clone(),
+        their_reference: source_invoice.their_reference.clone(),
+        colour: source_invoice.colour.clone(),
         comment: Some(comment),
+        default_donor_id: source_invoice.default_donor_id.clone(),
+        // Hold unchecked, linked requisition & purchase order not copied
         on_hold: false,
-        expected_delivery_date: None,
         requisition_id: None,
         purchase_order_id: None,
+
+        // --- Transport details ---
+        transport_reference: source_invoice.transport_reference.clone(),
+        expected_delivery_date: None,
+        shipping_method_id: source_invoice.shipping_method_id.clone(),
+
+        // --- Charges, tax & currency (copied from source) ---
+        charges_local_currency: source_invoice.charges_local_currency,
+        charges_foreign_currency: source_invoice.charges_foreign_currency,
+        tax_percentage: source_invoice.tax_percentage,
+        currency_id: source_invoice.currency_id.clone(),
+        currency_rate: source_invoice.currency_rate,
+
+        // --- Prescription/dispensing fields: never set on an inbound shipment
+        //     (the inbound insert leaves these None too) ---
+        clinician_link_id: None,
+        diagnosis_id: None,
+        program_id: None,
+        name_insurance_join_id: None,
+        insurance_discount_amount: None,
+        insurance_discount_percentage: None,
+
+        // --- Reset: a fresh New shipment has no workflow history or links ---
         allocated_datetime: None,
         picked_datetime: None,
         shipped_datetime: None,
@@ -48,9 +82,6 @@ pub fn generate(
         linked_invoice_id: None,
         original_shipment_id: None,
         is_cancellation: false,
-        charges_local_currency: 0.0,
-        charges_foreign_currency: 0.0,
-        ..source_invoice.clone()
     };
 
     let source_lines =
@@ -62,14 +93,51 @@ pub fn generate(
     let mut skipped_item_count = 0;
 
     for line in source_lines {
+        // Skip stock lines whose item is no longer in the catalogue; service lines are kept.
         if line.r#type == InvoiceLineType::StockIn && !active_item_ids.contains(&line.item_id) {
             skipped_item_count += 1;
             continue;
         }
 
+        // Inbound rule: copy every line field (item, batch, expiry, pack size, packs, cost/sell
+        // price, location, donor, campaign/program, comment, manufacturer) and only reset the
+        // identity and the fields that tie a line to stock, receipt or another shipment.
+        // Listed explicitly (rather than `..line`) so any new field — particularly a new link —
+        // forces a deliberate copy-vs-reset decision here.
         new_lines.push(InvoiceLineRow {
+            // --- New line identity ---
             id: uuid(),
             invoice_id: new_invoice_id.clone(),
+
+            // --- Copied from source ---
+            r#type: line.r#type,
+            item_id: line.item_id,
+            item_name: line.item_name,
+            item_code: line.item_code,
+            item_variant_id: line.item_variant_id,
+            batch: line.batch,
+            expiry_date: line.expiry_date,
+            manufacture_date: line.manufacture_date,
+            pack_size: line.pack_size,
+            number_of_packs: line.number_of_packs,
+            prescribed_quantity: line.prescribed_quantity,
+            cost_price_per_pack: line.cost_price_per_pack,
+            sell_price_per_pack: line.sell_price_per_pack,
+            total_before_tax: line.total_before_tax,
+            total_after_tax: line.total_after_tax,
+            tax_percentage: line.tax_percentage,
+            foreign_currency_price_before_tax: line.foreign_currency_price_before_tax,
+            location_id: line.location_id,
+            donor_id: line.donor_id,
+            manufacturer_id: line.manufacturer_id,
+            campaign_id: line.campaign_id,
+            program_id: line.program_id,
+            reason_option_id: line.reason_option_id,
+            note: line.note,
+            volume_per_pack: line.volume_per_pack,
+            shipped_pack_size: line.shipped_pack_size,
+
+            // --- Reset: a new New line is not tied to stock, receipt or another shipment ---
             stock_line_id: None,
             received_number_of_packs: None,
             status: None,
@@ -78,7 +146,6 @@ pub fn generate(
             linked_invoice_line_id: None,
             vvm_status_id: None,
             shipped_number_of_packs: None,
-            ..line
         });
     }
 

--- a/server/service/src/invoice/inbound_shipment/duplicate/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/generate.rs
@@ -65,6 +65,9 @@ pub fn generate(
             linked_invoice_line_id: None,
             vvm_status_id: None,
             shipped_number_of_packs: None,
+            location_id: None,
+            batch: None,
+            expiry_date: None,
             ..line
         })
         .collect();

--- a/server/service/src/invoice/inbound_shipment/duplicate/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/generate.rs
@@ -44,6 +44,8 @@ pub fn generate(
         linked_invoice_id: None,
         original_shipment_id: None,
         is_cancellation: false,
+        charges_local_currency: 0.0,
+        charges_foreign_currency: 0.0,
         ..source_invoice.clone()
     };
 
@@ -61,6 +63,8 @@ pub fn generate(
             purchase_order_line_id: None,
             linked_invoice_id: None,
             linked_invoice_line_id: None,
+            vvm_status_id: None,
+            shipped_number_of_packs: None,
             ..line
         })
         .collect();

--- a/server/service/src/invoice/inbound_shipment/duplicate/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/generate.rs
@@ -1,0 +1,72 @@
+use crate::invoice::common::generate_duplicate_comment;
+use crate::number::next_number;
+use chrono::Utc;
+use repository::{
+    InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow, InvoiceStatus, NumberRowType,
+    RepositoryError, StorageConnection,
+};
+use util::uuid::uuid;
+
+pub struct GenerateResult {
+    pub new_invoice: InvoiceRow,
+    pub new_lines: Vec<InvoiceLineRow>,
+}
+
+pub fn generate(
+    connection: &StorageConnection,
+    store_id: &str,
+    user_id: &str,
+    source_invoice: InvoiceRow,
+) -> Result<GenerateResult, RepositoryError> {
+    let new_invoice_id = uuid();
+    let comment =
+        generate_duplicate_comment(source_invoice.invoice_number, &source_invoice.comment);
+
+    let new_invoice = InvoiceRow {
+        id: new_invoice_id.clone(),
+        invoice_number: next_number(connection, &NumberRowType::InboundShipment, store_id)?,
+        created_datetime: Utc::now().naive_utc(),
+        user_id: Some(user_id.to_string()),
+        status: InvoiceStatus::New,
+        comment: Some(comment),
+        on_hold: false,
+        expected_delivery_date: None,
+        requisition_id: None,
+        purchase_order_id: None,
+        allocated_datetime: None,
+        picked_datetime: None,
+        shipped_datetime: None,
+        delivered_datetime: None,
+        received_datetime: None,
+        verified_datetime: None,
+        cancelled_datetime: None,
+        backdated_datetime: None,
+        linked_invoice_id: None,
+        original_shipment_id: None,
+        is_cancellation: false,
+        ..source_invoice.clone()
+    };
+
+    let source_lines =
+        InvoiceLineRowRepository::new(connection).find_many_by_invoice_id(&source_invoice.id)?;
+
+    let new_lines = source_lines
+        .into_iter()
+        .map(|line| InvoiceLineRow {
+            id: uuid(),
+            invoice_id: new_invoice_id.clone(),
+            stock_line_id: None,
+            received_number_of_packs: None,
+            status: None,
+            purchase_order_line_id: None,
+            linked_invoice_id: None,
+            linked_invoice_line_id: None,
+            ..line
+        })
+        .collect();
+
+    Ok(GenerateResult {
+        new_invoice,
+        new_lines,
+    })
+}

--- a/server/service/src/invoice/inbound_shipment/duplicate/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/generate.rs
@@ -1,15 +1,19 @@
+use std::collections::HashSet;
+
 use crate::invoice::common::generate_duplicate_comment;
 use crate::number::next_number;
 use chrono::Utc;
 use repository::{
-    InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow, InvoiceStatus, NumberRowType,
-    RepositoryError, StorageConnection,
+    EqualFilter, InvoiceLineRow, InvoiceLineRowRepository, InvoiceLineType, InvoiceRow,
+    InvoiceStatus, ItemFilter, ItemRepository, NumberRowType, RepositoryError, StorageConnection,
 };
 use util::uuid::uuid;
 
 pub struct GenerateResult {
     pub new_invoice: InvoiceRow,
     pub new_lines: Vec<InvoiceLineRow>,
+    /// Number of source stock lines skipped because their item is no longer in the active/visible.
+    pub skipped_item_count: usize,
 }
 
 pub fn generate(
@@ -52,9 +56,18 @@ pub fn generate(
     let source_lines =
         InvoiceLineRowRepository::new(connection).find_many_by_invoice_id(&source_invoice.id)?;
 
-    let new_lines = source_lines
-        .into_iter()
-        .map(|line| InvoiceLineRow {
+    let active_item_ids = active_item_ids(connection, store_id, &source_lines)?;
+
+    let mut new_lines = Vec::new();
+    let mut skipped_item_count = 0;
+
+    for line in source_lines {
+        if line.r#type == InvoiceLineType::StockIn && !active_item_ids.contains(&line.item_id) {
+            skipped_item_count += 1;
+            continue;
+        }
+
+        new_lines.push(InvoiceLineRow {
             id: uuid(),
             invoice_id: new_invoice_id.clone(),
             stock_line_id: None,
@@ -66,11 +79,37 @@ pub fn generate(
             vvm_status_id: None,
             shipped_number_of_packs: None,
             ..line
-        })
-        .collect();
+        });
+    }
 
     Ok(GenerateResult {
         new_invoice,
         new_lines,
+        skipped_item_count,
     })
+}
+
+fn active_item_ids(
+    connection: &StorageConnection,
+    store_id: &str,
+    source_lines: &[InvoiceLineRow],
+) -> Result<HashSet<String>, RepositoryError> {
+    let stock_item_ids: Vec<String> = source_lines
+        .iter()
+        .map(|line| line.item_id.clone())
+        .collect();
+
+    if stock_item_ids.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let items = ItemRepository::new(connection).query_by_filter(
+        ItemFilter::new()
+            .id(EqualFilter::equal_any(stock_item_ids))
+            .is_visible(true)
+            .is_active(true),
+        Some(store_id.to_string()),
+    )?;
+
+    Ok(items.into_iter().map(|item| item.item_row.id).collect())
 }

--- a/server/service/src/invoice/inbound_shipment/duplicate/generate.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/generate.rs
@@ -65,9 +65,6 @@ pub fn generate(
             linked_invoice_line_id: None,
             vvm_status_id: None,
             shipped_number_of_packs: None,
-            location_id: None,
-            batch: None,
-            expiry_date: None,
             ..line
         })
         .collect();

--- a/server/service/src/invoice/inbound_shipment/duplicate/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/mod.rs
@@ -16,6 +16,7 @@ pub enum DuplicateInboundShipmentError {
     InvoiceDoesNotExist,
     NotThisStoreInvoice,
     NotAnInboundShipment,
+    SupplierIsInactive,
     NewlyCreatedInvoiceDoesNotExist,
     DatabaseError(RepositoryError),
 }
@@ -78,15 +79,16 @@ impl From<RepositoryError> for DuplicateInboundShipmentError {
 
 #[cfg(test)]
 mod test {
+    use chrono::NaiveDate;
     use repository::{
         mock::{
             common::FullMockMasterList, mock_inbound_shipment_a,
             mock_inbound_shipment_a_invoice_lines, mock_outbound_shipment_e, mock_store_a,
             mock_store_b, mock_user_account_a, MockData, MockDataInserts,
         },
-        test_db::{setup_all, setup_all_with_data},
-        InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow, InvoiceStatus, MasterListLineRow,
-        MasterListNameJoinRow, MasterListRow,
+        test_db::setup_all_with_data,
+        InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow, InvoiceStatus, InvoiceType,
+        MasterListLineRow, MasterListNameJoinRow, MasterListRow, NameLinkRow, NameRow,
     };
 
     use crate::service_provider::ServiceProvider;
@@ -124,8 +126,51 @@ mod test {
 
     #[actix_rt::test]
     async fn duplicate_inbound_shipment_errors() {
-        let (_, _, connection_manager, _) =
-            setup_all("duplicate_inbound_shipment_errors", MockDataInserts::all()).await;
+        fn inactive_supplier() -> NameRow {
+            NameRow {
+                id: "duplicate_is_inactive_supplier".to_string(),
+                name: "Inactive supplier".to_string(),
+                code: "inactive_supplier".to_string(),
+                // A deleted name is treated as inactive
+                deleted_datetime: Some(
+                    NaiveDate::from_ymd_opt(2020, 1, 1)
+                        .unwrap()
+                        .and_hms_opt(0, 0, 0)
+                        .unwrap(),
+                ),
+                ..Default::default()
+            }
+        }
+        fn shipment_with_inactive_supplier() -> InvoiceRow {
+            InvoiceRow {
+                id: "duplicate_is_inactive_supplier_shipment".to_string(),
+                name_id: inactive_supplier().id,
+                store_id: mock_store_a().id,
+                invoice_number: 999,
+                r#type: InvoiceType::InboundShipment,
+                status: InvoiceStatus::Received,
+                created_datetime: NaiveDate::from_ymd_opt(2020, 1, 1)
+                    .unwrap()
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap(),
+                ..Default::default()
+            }
+        }
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "duplicate_inbound_shipment_errors",
+            MockDataInserts::all(),
+            MockData {
+                names: vec![inactive_supplier()],
+                name_links: vec![NameLinkRow {
+                    id: inactive_supplier().id,
+                    name_id: inactive_supplier().id,
+                }],
+                invoices: vec![shipment_with_inactive_supplier()],
+                ..Default::default()
+            },
+        )
+        .await;
 
         let service_provider = ServiceProvider::new(connection_manager);
         let mut context = service_provider
@@ -143,6 +188,12 @@ mod test {
         assert_eq!(
             service.duplicate_inbound_shipment(&context, mock_outbound_shipment_e().id),
             Err(ServiceError::NotAnInboundShipment)
+        );
+
+        // SupplierIsInactive
+        assert_eq!(
+            service.duplicate_inbound_shipment(&context, shipment_with_inactive_supplier().id),
+            Err(ServiceError::SupplierIsInactive)
         );
 
         context.store_id = mock_store_b().id;
@@ -242,4 +293,5 @@ mod test {
             );
         }
     }
+
 }

--- a/server/service/src/invoice/inbound_shipment/duplicate/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/mod.rs
@@ -187,6 +187,9 @@ mod test {
                     purchase_order_line_id: None,
                     linked_invoice_id: None,
                     linked_invoice_line_id: None,
+                    location_id: None,
+                    batch: None,
+                    expiry_date: None,
                     ..source_line.clone()
                 }
             );

--- a/server/service/src/invoice/inbound_shipment/duplicate/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/mod.rs
@@ -1,0 +1,65 @@
+use crate::activity_log::activity_log_entry;
+use crate::invoice::query::get_invoice;
+use crate::service_provider::ServiceContext;
+use repository::{
+    ActivityLogType, Invoice, InvoiceLineRowRepository, InvoiceRowRepository, RepositoryError,
+};
+
+mod generate;
+mod validate;
+
+use generate::{generate, GenerateResult};
+use validate::validate;
+
+#[derive(Debug, PartialEq)]
+pub enum DuplicateInboundShipmentError {
+    InvoiceDoesNotExist,
+    NotThisStoreInvoice,
+    NotAnInboundShipment,
+    NewlyCreatedInvoiceDoesNotExist,
+    DatabaseError(RepositoryError),
+}
+type OutError = DuplicateInboundShipmentError;
+
+pub fn duplicate_inbound_shipment(
+    ctx: &ServiceContext,
+    source_id: String,
+) -> Result<Invoice, OutError> {
+    let invoice = ctx
+        .connection
+        .transaction_sync(|connection| {
+            let source_invoice = validate(connection, &ctx.store_id, &source_id)?;
+            let GenerateResult {
+                new_invoice,
+                new_lines,
+            } = generate(connection, &ctx.store_id, &ctx.user_id, source_invoice)?;
+
+            InvoiceRowRepository::new(connection).upsert_one(&new_invoice)?;
+
+            let invoice_line_row_repository = InvoiceLineRowRepository::new(connection);
+            for line in new_lines.iter() {
+                invoice_line_row_repository.upsert_one(line)?;
+            }
+
+            activity_log_entry(
+                ctx,
+                ActivityLogType::InvoiceCreated,
+                Some(new_invoice.id.clone()),
+                None,
+                None,
+            )?;
+
+            get_invoice(ctx, None, &new_invoice.id, None)
+                .map_err(OutError::DatabaseError)?
+                .ok_or(OutError::NewlyCreatedInvoiceDoesNotExist)
+        })
+        .map_err(|error| error.to_inner_error())?;
+
+    Ok(invoice)
+}
+
+impl From<RepositoryError> for DuplicateInboundShipmentError {
+    fn from(error: RepositoryError) -> Self {
+        DuplicateInboundShipmentError::DatabaseError(error)
+    }
+}

--- a/server/service/src/invoice/inbound_shipment/duplicate/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/mod.rs
@@ -187,9 +187,6 @@ mod test {
                     purchase_order_line_id: None,
                     linked_invoice_id: None,
                     linked_invoice_line_id: None,
-                    location_id: None,
-                    batch: None,
-                    expiry_date: None,
                     ..source_line.clone()
                 }
             );

--- a/server/service/src/invoice/inbound_shipment/duplicate/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/mod.rs
@@ -63,3 +63,133 @@ impl From<RepositoryError> for DuplicateInboundShipmentError {
         DuplicateInboundShipmentError::DatabaseError(error)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use repository::{
+        mock::{
+            mock_inbound_shipment_a, mock_inbound_shipment_a_invoice_lines,
+            mock_outbound_shipment_e, mock_store_a, mock_store_b, mock_user_account_a,
+            MockDataInserts,
+        },
+        test_db::setup_all,
+        InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow, InvoiceStatus,
+    };
+
+    use crate::service_provider::ServiceProvider;
+
+    use super::DuplicateInboundShipmentError;
+
+    type ServiceError = DuplicateInboundShipmentError;
+
+    #[actix_rt::test]
+    async fn duplicate_inbound_shipment_errors() {
+        let (_, _, connection_manager, _) =
+            setup_all("duplicate_inbound_shipment_errors", MockDataInserts::all()).await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let mut context = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+        let service = service_provider.invoice_service;
+
+        // InvoiceDoesNotExist
+        assert_eq!(
+            service.duplicate_inbound_shipment(&context, "does_not_exist".to_string()),
+            Err(ServiceError::InvoiceDoesNotExist)
+        );
+
+        // NotAnInboundShipment
+        assert_eq!(
+            service.duplicate_inbound_shipment(&context, mock_outbound_shipment_e().id),
+            Err(ServiceError::NotAnInboundShipment)
+        );
+
+        context.store_id = mock_store_b().id;
+        assert_eq!(
+            service.duplicate_inbound_shipment(&context, mock_inbound_shipment_a().id),
+            Err(ServiceError::NotThisStoreInvoice)
+        );
+    }
+
+    #[actix_rt::test]
+    async fn duplicate_inbound_shipment_success() {
+        let (_, connection, connection_manager, _) =
+            setup_all("duplicate_inbound_shipment_success", MockDataInserts::all()).await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+        let service = service_provider.invoice_service;
+
+        let source = mock_inbound_shipment_a();
+
+        let duplicate = service
+            .duplicate_inbound_shipment(&context, source.id.clone())
+            .unwrap();
+        let new_invoice = duplicate.invoice_row;
+
+        assert_ne!(new_invoice.id, source.id);
+        assert_ne!(new_invoice.invoice_number, source.invoice_number);
+
+        assert_eq!(
+            new_invoice,
+            InvoiceRow {
+                id: new_invoice.id.clone(),
+                invoice_number: new_invoice.invoice_number,
+                created_datetime: new_invoice.created_datetime,
+                user_id: Some(mock_user_account_a().id),
+                status: InvoiceStatus::New,
+                comment: Some(format!(
+                    "Copied from shipment #{} (Sort comment test Ac)",
+                    source.invoice_number
+                )),
+                on_hold: false,
+                expected_delivery_date: None,
+                requisition_id: None,
+                purchase_order_id: None,
+                allocated_datetime: None,
+                picked_datetime: None,
+                shipped_datetime: None,
+                delivered_datetime: None,
+                received_datetime: None,
+                verified_datetime: None,
+                cancelled_datetime: None,
+                backdated_datetime: None,
+                linked_invoice_id: None,
+                original_shipment_id: None,
+                is_cancellation: false,
+                ..source.clone()
+            }
+        );
+
+        let source_lines = mock_inbound_shipment_a_invoice_lines();
+        let new_lines = InvoiceLineRowRepository::new(&connection)
+            .find_many_by_invoice_id(&new_invoice.id)
+            .unwrap();
+        assert_eq!(new_lines.len(), source_lines.len());
+
+        for new_line in &new_lines {
+            let source_line = source_lines
+                .iter()
+                .find(|line| line.item_id == new_line.item_id)
+                .unwrap();
+            assert_ne!(new_line.id, source_line.id);
+            assert_eq!(
+                new_line,
+                &InvoiceLineRow {
+                    id: new_line.id.clone(),
+                    invoice_id: new_invoice.id.clone(),
+                    stock_line_id: None,
+                    received_number_of_packs: None,
+                    status: None,
+                    purchase_order_line_id: None,
+                    linked_invoice_id: None,
+                    linked_invoice_line_id: None,
+                    ..source_line.clone()
+                }
+            );
+        }
+    }
+}

--- a/server/service/src/invoice/inbound_shipment/duplicate/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/mod.rs
@@ -21,17 +21,24 @@ pub enum DuplicateInboundShipmentError {
 }
 type OutError = DuplicateInboundShipmentError;
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct DuplicateInboundShipment {
+    pub invoice: Invoice,
+    pub skipped_item_count: usize,
+}
+
 pub fn duplicate_inbound_shipment(
     ctx: &ServiceContext,
     source_id: String,
-) -> Result<Invoice, OutError> {
-    let invoice = ctx
+) -> Result<DuplicateInboundShipment, OutError> {
+    let result = ctx
         .connection
-        .transaction_sync(|connection| {
+        .transaction_sync(|connection| -> Result<DuplicateInboundShipment, OutError> {
             let source_invoice = validate(connection, &ctx.store_id, &source_id)?;
             let GenerateResult {
                 new_invoice,
                 new_lines,
+                skipped_item_count,
             } = generate(connection, &ctx.store_id, &ctx.user_id, source_invoice)?;
 
             InvoiceRowRepository::new(connection).upsert_one(&new_invoice)?;
@@ -49,13 +56,18 @@ pub fn duplicate_inbound_shipment(
                 None,
             )?;
 
-            get_invoice(ctx, None, &new_invoice.id, None)
+            let invoice = get_invoice(ctx, None, &new_invoice.id, None)
                 .map_err(OutError::DatabaseError)?
-                .ok_or(OutError::NewlyCreatedInvoiceDoesNotExist)
+                .ok_or(OutError::NewlyCreatedInvoiceDoesNotExist)?;
+
+            Ok(DuplicateInboundShipment {
+                invoice,
+                skipped_item_count,
+            })
         })
         .map_err(|error| error.to_inner_error())?;
 
-    Ok(invoice)
+    Ok(result)
 }
 
 impl From<RepositoryError> for DuplicateInboundShipmentError {
@@ -68,12 +80,13 @@ impl From<RepositoryError> for DuplicateInboundShipmentError {
 mod test {
     use repository::{
         mock::{
-            mock_inbound_shipment_a, mock_inbound_shipment_a_invoice_lines,
-            mock_outbound_shipment_e, mock_store_a, mock_store_b, mock_user_account_a,
-            MockDataInserts,
+            common::FullMockMasterList, mock_inbound_shipment_a,
+            mock_inbound_shipment_a_invoice_lines, mock_outbound_shipment_e, mock_store_a,
+            mock_store_b, mock_user_account_a, MockData, MockDataInserts,
         },
-        test_db::setup_all,
-        InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow, InvoiceStatus,
+        test_db::{setup_all, setup_all_with_data},
+        InvoiceLineRow, InvoiceLineRowRepository, InvoiceRow, InvoiceStatus, MasterListLineRow,
+        MasterListNameJoinRow, MasterListRow,
     };
 
     use crate::service_provider::ServiceProvider;
@@ -81,6 +94,33 @@ mod test {
     use super::DuplicateInboundShipmentError;
 
     type ServiceError = DuplicateInboundShipmentError;
+
+    fn master_list_visible_to_store_a(items: &[&str]) -> FullMockMasterList {
+        let master_list_id = "duplicate_is_in_ml".to_string();
+        FullMockMasterList {
+            master_list: MasterListRow {
+                id: master_list_id.clone(),
+                name: "duplicate_is_in_ml".to_string(),
+                code: "duplicate_is_in_ml".to_string(),
+                is_active: true,
+                ..Default::default()
+            },
+            joins: vec![MasterListNameJoinRow {
+                id: "duplicate_is_in_ml_join".to_string(),
+                master_list_id: master_list_id.clone(),
+                name_id: mock_store_a().name_id,
+            }],
+            lines: items
+                .iter()
+                .map(|item_id| MasterListLineRow {
+                    id: format!("duplicate_is_in_ml_{item_id}"),
+                    item_id: item_id.to_string(),
+                    master_list_id: master_list_id.clone(),
+                    ..Default::default()
+                })
+                .collect(),
+        }
+    }
 
     #[actix_rt::test]
     async fn duplicate_inbound_shipment_errors() {
@@ -114,8 +154,15 @@ mod test {
 
     #[actix_rt::test]
     async fn duplicate_inbound_shipment_success() {
-        let (_, connection, connection_manager, _) =
-            setup_all("duplicate_inbound_shipment_success", MockDataInserts::all()).await;
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "duplicate_inbound_shipment_success",
+            MockDataInserts::all(),
+            MockData {
+                full_master_lists: vec![master_list_visible_to_store_a(&["item_a"])],
+                ..Default::default()
+            },
+        )
+        .await;
 
         let service_provider = ServiceProvider::new(connection_manager);
         let context = service_provider
@@ -128,7 +175,9 @@ mod test {
         let duplicate = service
             .duplicate_inbound_shipment(&context, source.id.clone())
             .unwrap();
-        let new_invoice = duplicate.invoice_row;
+        // item_b was skipped (not visible)
+        assert_eq!(duplicate.skipped_item_count, 1);
+        let new_invoice = duplicate.invoice.invoice_row;
 
         assert_ne!(new_invoice.id, source.id);
         assert_ne!(new_invoice.invoice_number, source.invoice_number);
@@ -168,7 +217,8 @@ mod test {
         let new_lines = InvoiceLineRowRepository::new(&connection)
             .find_many_by_invoice_id(&new_invoice.id)
             .unwrap();
-        assert_eq!(new_lines.len(), source_lines.len());
+        assert_eq!(new_lines.len(), 1);
+        assert!(new_lines.iter().all(|line| line.item_id != "item_b"));
 
         for new_line in &new_lines {
             let source_line = source_lines

--- a/server/service/src/invoice/inbound_shipment/duplicate/validate.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/validate.rs
@@ -1,4 +1,5 @@
 use crate::invoice::{check_invoice_exists, check_invoice_type, check_store};
+use crate::validate::get_other_party;
 use repository::{InvoiceRow, InvoiceType, StorageConnection};
 
 use super::DuplicateInboundShipmentError;
@@ -18,6 +19,13 @@ pub fn validate(
 
     if !check_invoice_type(&source_invoice, InvoiceType::InboundShipment) {
         return Err(NotAnInboundShipment);
+    }
+
+    let supplier_is_active = get_other_party(connection, store_id, &source_invoice.name_id)?
+        .map(|supplier| supplier.is_visible())
+        .unwrap_or(false);
+    if !supplier_is_active {
+        return Err(SupplierIsInactive);
     }
 
     Ok(source_invoice)

--- a/server/service/src/invoice/inbound_shipment/duplicate/validate.rs
+++ b/server/service/src/invoice/inbound_shipment/duplicate/validate.rs
@@ -1,0 +1,24 @@
+use crate::invoice::{check_invoice_exists, check_invoice_type, check_store};
+use repository::{InvoiceRow, InvoiceType, StorageConnection};
+
+use super::DuplicateInboundShipmentError;
+
+pub fn validate(
+    connection: &StorageConnection,
+    store_id: &str,
+    source_id: &str,
+) -> Result<InvoiceRow, DuplicateInboundShipmentError> {
+    use DuplicateInboundShipmentError::*;
+
+    let source_invoice = check_invoice_exists(source_id, connection)?.ok_or(InvoiceDoesNotExist)?;
+
+    if !check_store(&source_invoice, store_id) {
+        return Err(NotThisStoreInvoice);
+    }
+
+    if !check_invoice_type(&source_invoice, InvoiceType::InboundShipment) {
+        return Err(NotAnInboundShipment);
+    }
+
+    Ok(source_invoice)
+}

--- a/server/service/src/invoice/inbound_shipment/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/mod.rs
@@ -27,6 +27,9 @@ pub use self::update::*;
 pub mod delete;
 pub use self::delete::*;
 
+pub mod duplicate;
+pub use self::duplicate::*;
+
 pub mod batch;
 pub use self::batch::*;
 

--- a/server/service/src/invoice/mod.rs
+++ b/server/service/src/invoice/mod.rs
@@ -114,6 +114,14 @@ pub trait InvoiceServiceTrait: Sync + Send {
         delete_inbound_shipment(ctx, input, expected_type)
     }
 
+    fn duplicate_inbound_shipment(
+        &self,
+        ctx: &ServiceContext,
+        source_id: String,
+    ) -> Result<Invoice, DuplicateInboundShipmentError> {
+        duplicate_inbound_shipment(ctx, source_id)
+    }
+
     fn insert_outbound_shipment(
         &self,
         ctx: &ServiceContext,

--- a/server/service/src/invoice/mod.rs
+++ b/server/service/src/invoice/mod.rs
@@ -118,7 +118,7 @@ pub trait InvoiceServiceTrait: Sync + Send {
         &self,
         ctx: &ServiceContext,
         source_id: String,
-    ) -> Result<Invoice, DuplicateInboundShipmentError> {
+    ) -> Result<DuplicateInboundShipment, DuplicateInboundShipmentError> {
         duplicate_inbound_shipment(ctx, source_id)
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12159

# 👩🏻‍💻 What does this PR do?
Endpoint to duplicate an inbound shipment. 
Exceptions not copied: 
- Status: Always set to `New`
- Number: New number
- Comment: Copied from source, prepended with "Copied from shipment #[source number] ( [original comment] )
- On hold: false
- Linked requisition & linked PO not copied.
- All the datetimes
- Lines
   - Any linked fields
   - stock line id cleared
   - status cleared
   - received num packs cleared
- Says batch info is to be copied, but even if you order the same item again why would they be same batch unless the warehouse ships the same batch cause they still had some left.. same for expiry?

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Use GraphQL to call endpoint and test it duplicates

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

