### PR TITLE
chunk insert based on parameter limits for postgres / sqlite

### DIFF
--- a/server/repository/src/db_diesel/sync_buffer.rs
+++ b/server/repository/src/db_diesel/sync_buffer.rs
@@ -189,6 +189,25 @@ pub struct SyncBufferRowInsert {
     pub reference_id: Option<String>,
 }
 
+/// Number of columns inserted per `SyncBufferRowInsert` (keep in sync with the
+/// struct above). Used to bound the insert batch under the bind-parameter limit.
+const SYNC_BUFFER_COLUMNS: usize = 12;
+/// The active backend's limit on bind parameters per statement. Mirrors the
+/// backend selection in `db_diesel` (postgres feature wins when both are on).
+///
+/// Only the postgres value matters in practice. Postgres inserts every row in
+/// one statement (`rows * columns` parameters), so a large batch can go over
+/// 65535. On SQLite, diesel inserts one row at a time (12 parameters each), so
+/// this limit is never reached — the SQLite value is here is for consistency
+#[cfg(feature = "postgres")]
+const MAX_BIND_PARAMS: usize = 65535;
+#[cfg(not(feature = "postgres"))]
+const MAX_BIND_PARAMS: usize = 32766;
+/// Rows per insert statement, so `rows * columns` stays under the limit. A large
+/// pull batch (e.g. remote_pull = 10000 → 120k params) would otherwise overflow
+/// a single insert.
+const INSERT_CHUNK_SIZE: usize = MAX_BIND_PARAMS / SYNC_BUFFER_COLUMNS;
+
 impl From<SyncBufferRow> for SyncBufferRowInsert {
     fn from(row: SyncBufferRow) -> Self {
         SyncBufferRowInsert {
@@ -227,14 +246,14 @@ impl<'a> SyncBufferRepository<'a> {
         SyncBufferRepository { connection }
     }
 
-    /// The only insertion path. Cursor is auto-assigned per row.
+    /// The only insertion path. Cursor is auto-assigned per row. Chunked to stay
+    /// under the bind-parameter limit (see `INSERT_CHUNK_SIZE`).
     pub fn insert_many(&self, rows: &[SyncBufferRowInsert]) -> Result<(), RepositoryError> {
-        if rows.is_empty() {
-            return Ok(());
+        for chunk in rows.chunks(INSERT_CHUNK_SIZE) {
+            diesel::insert_into(sync_buffer::table)
+                .values(chunk)
+                .execute(self.connection.lock().connection())?;
         }
-        diesel::insert_into(sync_buffer::table)
-            .values(rows)
-            .execute(self.connection.lock().connection())?;
         Ok(())
     }
 
@@ -501,7 +520,8 @@ mod test {
 
         // Unfiltered count includes the unsupported table
         assert_eq!(
-            repo.count_pending(1, SyncVersion::V5V6, None, None).unwrap(),
+            repo.count_pending(1, SyncVersion::V5V6, None, None)
+                .unwrap(),
             3
         );
 


### PR DESCRIPTION

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12154

# 👩🏻‍💻 What does this PR do?

Inserts sync buffer records in chunks during pull step based on batch size limits for pg / sqlite

## 💌 Any notes for the reviewer?

Sqlite doesn't actually matter since diesel inserts them sequentially under the hood, but kept it similar for consistency.

The frontend fixes for cleaner error rendering will be in a different PR. Also, perhaps need to perform similar chunking for changelog's batch_insert at some point, but not a showstopper since it's only called in two places and both those places, explicitly with only two rows to be inserted.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] set up coms for v7 (with dataset large enough to see the issue)
- [ ] initialise roms against coms with postgres and have remote pull batch size under sync settings around 10000
- [ ] Roms should initialise with no issues during pull

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

