### PR TITLE
12150 - null FKS on invoice lines from patient lookup

### DIFF
--- a/server/service/src/sync_v7/patient_lookup.rs
+++ b/server/service/src/sync_v7/patient_lookup.rs
@@ -1,5 +1,6 @@
 use crate::{
     service_provider::ServiceProvider,
+    sync::ActiveStoresOnSite,
     sync_v7::{
         api::{patient_data_for_site, SyncApiV7},
         validate_translate_integrate::{validate_translate_integrate_in_memory, SyncContext},
@@ -62,7 +63,14 @@ pub async fn pull_and_integrate_patient_data(
         })
         .collect();
 
-    validate_translate_integrate_in_memory(connection, &buffer_rows, SyncContext::PatientLookup)?;
+    let active_stores =
+        ActiveStoresOnSite::get(connection).map_err(|e| SyncError::Other(e.to_string()))?;
+
+    validate_translate_integrate_in_memory(
+        connection,
+        &buffer_rows,
+        SyncContext::PatientLookup { active_stores },
+    )?;
 
     Ok(nsj_id)
 }

--- a/server/service/src/sync_v7/translations/invoice_line.rs
+++ b/server/service/src/sync_v7/translations/invoice_line.rs
@@ -2,12 +2,10 @@ use repository::{syncv7::SyncRecordSerializeError, ChangeLogInsertRow, InvoiceLi
 
 use crate::sync_v7::{serde::DeserializeResult, validate_translate_integrate::SyncContext};
 
-/// Deserialise an invoice_line and, when the line belongs to a store this site
-/// doesn't own, null `stock_line_id` and `location_id` — those FKs reference
-/// records on the owning site that won't exist here.
-/// This happens when:
-/// - this site is a transfer recipient or
-/// - a patient-lookup occurred, where prescription records belong to the owning store
+// Deserialise an invoice_line, nulling `stock_line_id` and `location_id` when
+// the line is for a store this site doesn't own (a transfer recipient, or a
+// patient lookup pulling another store's data) — those FKs point at
+// stock/location on the owning site that don't exist here.
 pub(crate) fn translate_invoice_line(
     changelog_insert: ChangeLogInsertRow,
     owning_store_id: Option<&str>,
@@ -18,8 +16,9 @@ pub(crate) fn translate_invoice_line(
         .map_err(|e| SyncRecordSerializeError::SerdeError(e.to_string()))?;
 
     let belongs_to_other_site = match sync_context {
-        SyncContext::PatientLookup => true,
-        SyncContext::Remote { active_stores, .. } => owning_store_id
+        // Preserve our own store's FKs if a patient lookup re-pulls a previously joined patient.
+        SyncContext::Remote { active_stores, .. }
+        | SyncContext::PatientLookup { active_stores, .. } => owning_store_id
             .map(|store_id| !active_stores.store_ids().iter().any(|s| s == store_id))
             .unwrap_or(false),
         SyncContext::Central { .. } => false,
@@ -103,7 +102,9 @@ mod test {
     fn nulls_cross_site_fks_on_patient_lookup() {
         let input = input_row();
         let data = serde_json::to_value(&input).unwrap();
-        let ctx = SyncContext::PatientLookup;
+        let ctx = SyncContext::PatientLookup {
+            active_stores: site_with_store("our_store"),
+        };
 
         let translated_row = translated(translate_invoice_line(
             changelog_for(&input),

--- a/server/service/src/sync_v7/translations/invoice_line.rs
+++ b/server/service/src/sync_v7/translations/invoice_line.rs
@@ -2,10 +2,12 @@ use repository::{syncv7::SyncRecordSerializeError, ChangeLogInsertRow, InvoiceLi
 
 use crate::sync_v7::{serde::DeserializeResult, validate_translate_integrate::SyncContext};
 
-/// Deserialise an invoice_line and, when this site is a transfer recipient
-/// (a remote site receiving the row for a store it doesn't own), null
-/// `stock_line_id` and `location_id` — those FKs reference records on the
-/// sending site that won't exist here.
+/// Deserialise an invoice_line and, when the line belongs to a store this site
+/// doesn't own, null `stock_line_id` and `location_id` — those FKs reference
+/// records on the owning site that won't exist here.
+/// This happens when:
+/// - this site is a transfer recipient or
+/// - a patient-lookup occurred, where prescription records belong to the owning store
 pub(crate) fn translate_invoice_line(
     changelog_insert: ChangeLogInsertRow,
     owning_store_id: Option<&str>,
@@ -15,13 +17,17 @@ pub(crate) fn translate_invoice_line(
     let mut row: InvoiceLineRow = serde_json::from_value(data.clone())
         .map_err(|e| SyncRecordSerializeError::SerdeError(e.to_string()))?;
 
-    if let (SyncContext::Remote { active_stores, .. }, Some(store_id)) =
-        (sync_context, owning_store_id)
-    {
-        if !active_stores.store_ids().iter().any(|s| s == store_id) {
-            row.stock_line_id = None;
-            row.location_id = None;
-        }
+    let belongs_to_other_site = match sync_context {
+        SyncContext::PatientLookup => true,
+        SyncContext::Remote { active_stores, .. } => owning_store_id
+            .map(|store_id| !active_stores.store_ids().iter().any(|s| s == store_id))
+            .unwrap_or(false),
+        SyncContext::Central { .. } => false,
+    };
+
+    if belongs_to_other_site {
+        row.stock_line_id = None;
+        row.location_id = None;
     }
 
     Ok(vec![(Box::new(row) as Box<dyn Upsert>, changelog_insert)])
@@ -81,6 +87,23 @@ mod test {
             is_initialising: false,
             active_stores: site_with_store("our_store"),
         };
+
+        let translated_row = translated(translate_invoice_line(
+            changelog_for(&input),
+            Some("sender_store"),
+            &data,
+            &ctx,
+        ));
+
+        assert_eq!(translated_row.stock_line_id, None);
+        assert_eq!(translated_row.location_id, None);
+    }
+
+    #[test]
+    fn nulls_cross_site_fks_on_patient_lookup() {
+        let input = input_row();
+        let data = serde_json::to_value(&input).unwrap();
+        let ctx = SyncContext::PatientLookup;
 
         let translated_row = translated(translate_invoice_line(
             changelog_for(&input),

--- a/server/service/src/sync_v7/validate_translate_integrate.rs
+++ b/server/service/src/sync_v7/validate_translate_integrate.rs
@@ -26,7 +26,7 @@ pub(crate) enum SyncContext {
     },
     /// Records arrived via a patient-lookup pull. They belong to other sites'
     /// stores.
-    PatientLookup,
+    PatientLookup { active_stores: ActiveStoresOnSite },
 }
 
 #[derive(Error, Debug)]
@@ -232,7 +232,7 @@ fn validate_translate_integrate_one(
             is_initialising,
             active_stores,
         } => validate_on_remote(row, &table_name, active_stores, *is_initialising)?,
-        SyncContext::PatientLookup => {} // Patient records belong to another store
+        SyncContext::PatientLookup { .. } => {}
     };
 
     match row.action {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12150 

# 👩🏻‍💻 What does this PR do?

translate_invoice_line now nulls stock_line_id and location_id for the PatientLookup sync context, the same way it already does for Remote transfer recipients. Any invoice record (prescription) on a patient-lookup belongs to another site's store, so those FKs are never valid locally.

Included protection for removing own stores FKs in the case that a patient is looked up on a previously joined site and re-pulled

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

It is now an exhaustive match on SyncContext - `Central` explicitly doesn't null any FKs on invoices. It is more readable than adding another layer of nesting

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] On store A, create a patient and give them a prescription with some lines - some with locations (locations are store scoped and every line will have a stock line associated)
- [ ] From a remote OMS site (store B), look up that patient: new patient → enter the same name → click the upload icon on the search result.
- [ ] Lookup succeeds (previously failed with the FK error).
- [ ] In the database for store B, confirm the patient's prescription line exists with stock_line_id and location_id both NULL:

SELECT il.*
FROM invoice_line il
JOIN invoice i ON i.id = il.invoice_id
JOIN name_link nl ON nl.id = i.name_link_id
WHERE nl.name_id = '<patient_name_id>';

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

