### PR TITLE
#12169 Re-init plugins on auth/sync change and reconcile deletions

### DIFF
--- a/client/packages/common/src/plugins/pluginProvider.ts
+++ b/client/packages/common/src/plugins/pluginProvider.ts
@@ -83,46 +83,53 @@ const stampAndValidatePages = (
   return { ...bundle, pages: validated };
 };
 
+// Merge and validate every cached bundle into the flat `plugins` shape used by
+// the rest of the app. Duplicate detection runs across the merged set, so the
+// `seen` set is rebuilt on each call rather than carried in state.
+const buildPlugins = (cachedPluginBundles: {
+  [code: string]: Plugins;
+}): Plugins => {
+  const seen = new Set<string>();
+  return Object.entries(cachedPluginBundles).reduce((acc, [bundleCode, bundle]) => {
+    // `configuration` is per-plugin (looked up by code from
+    // cachedPluginBundles) and must not be merged across bundles —
+    // deep-merging two plugins' configurations would corrupt them.
+    const { configuration: _configuration, ...mergeable } =
+      stampAndValidatePages(bundle, bundleCode, seen);
+    return mergeWith(acc, mergeable, (a, b) =>
+      isArray(a) ? a.concat(b) : undefined
+    );
+  }, {});
+};
+
 // PLUGIN PROVIDER
 type PluginProvider = {
   plugins: Plugins;
   cachedPluginBundles: { [code: string]: Plugins };
-  addPluginBundle: (bundle: Plugins, code: string) => void;
+  setPluginBundles: (bundles: { code: string; bundle: Plugins }[]) => void;
 };
 
 export const usePluginProvider = create<PluginProvider>(set => {
   return {
     plugins: {},
     cachedPluginBundles: {},
-    addPluginBundle: (pluginBundle, code) => {
+    // Replace the entire set of cached bundles. Both the remote and local
+    // plugin init load a complete list in one pass and call this to reconcile
+    // the store against it, so a plugin deleted on the central server (absent
+    // from the fetched list) disappears after a sync rather than lingering
+    // until a full page reload. See issues #12169 / #11988.
+    setPluginBundles: bundles => {
       set(state => {
-        // Cache plugin bundles by code, to support hot reloading
-        const cachedPluginBundles = {
-          ...state.cachedPluginBundles,
-          [code]: pluginBundle,
-        };
-
-        // Re-validate every cached bundle on each registration. Duplicate
-        // detection runs across the merged set, so the `seen` set is rebuilt
-        // each time rather than carried in state.
-        const seen = new Set<string>();
-        const plugins = Object.entries(cachedPluginBundles).reduce(
-          (acc, [bundleCode, bundle]) => {
-            // `configuration` is per-plugin (looked up by code from
-            // cachedPluginBundles) and must not be merged across bundles —
-            // deep-merging two plugins' configurations would corrupt them.
-            const { configuration: _configuration, ...mergeable } =
-              stampAndValidatePages(bundle, bundleCode, seen);
-            return mergeWith(acc, mergeable, (a, b) =>
-              isArray(a) ? a.concat(b) : undefined
-            );
+        const cachedPluginBundles = bundles.reduce<{ [code: string]: Plugins }>(
+          (acc, { code, bundle }) => {
+            acc[code] = bundle;
+            return acc;
           },
           {}
         );
-
         return {
           ...state,
-          plugins,
+          plugins: buildPlugins(cachedPluginBundles),
           cachedPluginBundles,
         };
       });
@@ -180,18 +187,30 @@ export const fetchPlugin = (
 declare const __webpack_init_sharing__: (shareScope: string) => Promise<void>;
 declare const __webpack_share_scopes__: Record<string, unknown>;
 
+// Tracks the bundle hash currently loaded for each plugin code. Used to detect
+// when a plugin has been updated on the server (same code, new hash) so we can
+// re-fetch it rather than reusing the stale module already on `window`.
+const loadedPluginHashes: Record<string, string> = {};
+
 export const loadRemotePlugin = async (
   pluginNode: FrontendPluginMetadataNode
 ): Promise<Plugins> => {
   try {
-    // Check if this plugin has already been loaded
-    if (!(pluginNode.code in window)) {
+    // Re-fetch when the plugin isn't loaded yet, or when its bundle hash has
+    // changed (i.e. the plugin was updated on the server). Keying only on
+    // `code in window` would reuse the old in-memory module and never pick up
+    // updates. See issue #12169.
+    const isCurrentlyLoaded =
+      pluginNode.code in window &&
+      loadedPluginHashes[pluginNode.code] === pluginNode.hash;
+    if (!isCurrentlyLoaded) {
       // Initializes the shared scope. Fills it with known provided modules from this build and all remotes
       await __webpack_init_sharing__('default');
       // Fetch the plugin app
       const fetchedContainer = await fetchPlugin(pluginNode);
       // Initialize the plugin app
       await fetchedContainer.init(__webpack_share_scopes__['default']);
+      loadedPluginHashes[pluginNode.code] = pluginNode.hash;
     }
     // `container` is the plugin app
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/client/packages/common/src/plugins/types.ts
+++ b/client/packages/common/src/plugins/types.ts
@@ -43,7 +43,7 @@ export type PluginPage = {
   route: string;
   Component: React.ComponentType;
   menu: PluginPageMenu;
-  // Stamped by the host in pluginProvider.ts#addPluginBundle. Plugins should
+  // Stamped by the host in pluginProvider.ts (stampAndValidatePages). Plugins should
   // not set this; it is optional on the type only so plugin bundles compile.
   pluginCode?: string;
 };

--- a/client/packages/host/src/useInitPlugins.ts
+++ b/client/packages/host/src/useInitPlugins.ts
@@ -1,5 +1,7 @@
 import {
   loadRemotePlugin,
+  Plugins,
+  useAuthContext,
   usePluginProvider,
   usePlugins,
 } from '@openmsupply-client/common';
@@ -9,20 +11,28 @@ import { useEffect } from 'react';
 declare const LOCAL_PLUGINS: { pluginPath: string; pluginCode: string }[];
 
 export const useInitPlugins = () => {
-  const { addPluginBundle } = usePluginProvider();
+  const { setPluginBundles } = usePluginProvider();
   const { query } = usePlugins();
+  const { token, storeId, lastSuccessfulSync } = useAuthContext();
 
   const initRemotePlugins = async () => {
     const plugins = await query();
 
+    const bundles: { code: string; bundle: Plugins }[] = [];
     for (const plugin of plugins) {
       const pluginBundle = await loadRemotePlugin(plugin);
-      addPluginBundle(pluginBundle, plugin.code);
+      bundles.push({ code: plugin.code, bundle: pluginBundle });
     }
+
+    // Replace the whole set rather than adding incrementally, so a plugin
+    // deleted on the central server (and thus absent from `plugins`) is dropped
+    // from the store once a sync re-runs this. See issue #12169 / #11988.
+    setPluginBundles(bundles);
   };
 
   // For hot reloading in dev mode plugins will be loaded from ./plugin folder
   const initLocalPlugins = async () => {
+    const bundles: { code: string; bundle: Plugins }[] = [];
     for (const plugin of LOCAL_PLUGINS) {
       // This command must be located in 'host', tried in common and webpack throws an error
       // "Critical dependency: the request of a dependency is an expression"
@@ -33,11 +43,25 @@ export const useInitPlugins = () => {
         /* webpackExclude: /operations.graphql/ */
         `../../plugins/${plugin.pluginPath}/src/plugin.tsx`
       );
-      addPluginBundle(pluginBundle.default, plugin.pluginCode);
+      bundles.push({ code: plugin.pluginCode, bundle: pluginBundle.default });
     }
+    setPluginBundles(bundles);
   };
+  // Local (dev) plugins are loaded from disk and don't depend on auth, so load
+  // them once on mount.
   useEffect(() => {
-    if (process.env['NODE_ENV'] === 'production') initRemotePlugins();
-    else initLocalPlugins();
+    if (process.env['NODE_ENV'] !== 'production') initLocalPlugins();
   }, []);
+
+  // Remote plugins are re-fetched whenever the auth context changes - on
+  // login, store switch, or after a successful sync (lastSuccessfulSync). This
+  // ensures newly uploaded or updated plugins appear without a full page
+  // reload (previously only triggered by switching languages, which calls
+  // navigate(0)). See issue #12169.
+  useEffect(() => {
+    if (process.env['NODE_ENV'] !== 'production') return;
+    if (!token || !storeId) return;
+    initRemotePlugins();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token, storeId, lastSuccessfulSync]);
 };

--- a/client/packages/system/src/Manage/Plugins/ListView/ListView.tsx
+++ b/client/packages/system/src/Manage/Plugins/ListView/ListView.tsx
@@ -98,9 +98,16 @@ export const PluginsList = () => {
         Cell: ({ row }) =>
           isCentralServer &&
           cachedPluginBundles[row.original.code]?.configuration ? (
-            <SettingsIcon
-              fontSize="small"
-              titleAccess={t('title.configure-plugin')}
+            <IconButton
+              icon={<SettingsIcon fontSize="small" />}
+              label={t('title.configure-plugin')}
+              onClick={e => {
+                // Stop propagation so the row's onRowClick doesn't also fire
+                // (both open the same modal); wrapping in IconButton also keeps
+                // this icon vertically aligned with the delete button.
+                e.stopPropagation();
+                setConfiguringPluginCode(row.original.code);
+              }}
             />
           ) : null,
       },
@@ -115,7 +122,12 @@ export const PluginsList = () => {
             icon={<DeleteIcon />}
             label={t('button.delete')}
             disabled={uninstallLoading}
-            onClick={() => onDelete(row.original)}
+            onClick={e => {
+              // Stop the click bubbling up to the row's onRowClick, which would
+              // otherwise also open the plugin's configuration modal.
+              e.stopPropagation();
+              onDelete(row.original);
+            }}
           />
         ),
       },


### PR DESCRIPTION
Fixes #12169

# 👩🏻‍💻 What does this PR do?

Frontend plugins were initialised only **once**, on app mount (`useInitPlugins`, `useEffect(..., [])`). Because open-mSupply is a SPA, logging out/in or syncing never remounts the React root, so plugins were never re-fetched. The only thing that helped was switching languages — because the language selector calls `navigate(0)`, a full page reload. That answers the issue's open question: *language switch = full page reload; login/sync = client-side navigation*.

Changes:

1. **Re-init on auth/sync change** (`useInitPlugins.ts`) — remote plugins are re-fetched whenever the auth context changes: on **login**, **store switch**, and after a successful **sync** (keyed on `token`, `storeId`, `lastSuccessfulSync`). The sync trigger delivers the issue's "ideal: immediately" outcome.

2. **Reconcile deletions** (`pluginProvider.ts`) — the store's additive `addPluginBundle` was replaced with `setPluginBundles`, which replaces the whole cached set. Both the remote and local plugin init load a complete list in one pass, so reconciling against it means a plugin **deleted** on the central server disappears after a sync instead of lingering until a full page reload.

3. **Hash-aware reload** (`pluginProvider.ts`, `loadRemotePlugin`) — the skip-check previously short-circuited on `code in window`, reusing the stale in-memory module forever. It now tracks the loaded hash per plugin code and re-fetches when the hash changes, working with the existing `?v=<hash>` cache-buster, so **updates** to an existing plugin take effect.

4. **Plugin row UI fixes** (`ListView.tsx`) — clicking the delete (trash) icon also opened the configuration modal because the click bubbled to the row's `onRowClick`; the handler now stops propagation. The configure (gear) icon is wrapped in an `IconButton` so it lines up vertically with the delete button and is directly clickable.

## 💌 Any notes for the reviewer?

- The plugin-loading path uses module federation, which is hard to exercise in unit tests — please verify on a real central + remote setup using the `bundle.json` attached to the issue.
- **Scope / overlap with #11988:** that issue covers plugin deletion not syncing to a remote, plus the same trash/gear UI nits. The deletion fix here is the **client-side** half (the backend deletion already syncs — confirmed because a full page reload via language switch makes the plugin disappear). The trash/gear UI fixes (item 4) are also folded in here since they surfaced while testing this. Coordinate with the #11988 assignee to avoid duplicate work.
- Based on `v2.20.0-RC` (matches the issue milestone).

# 🧪 Testing

**Remote site (production build) — the main scenario:**
- [ ] Central server + an OMS remote site running this branch
- [ ] Upload the issue's `bundle.json` to central → sync central → sync remote
- [ ] Confirm the plugin (daily tally) appears on the remote **after sync**, without switching languages
- [ ] Update the plugin bundle on central → sync → confirm the change appears (hash-based reload)
- [ ] Delete the plugin on central → sync remote → confirm it **disappears** without a language switch
- [ ] Log out / log in and switch store — confirm plugins refresh appropriately

**Dev mode (local plugins):**
- [ ] Run the client in dev with one or more local plugins in `client/packages/host/plugins`
- [ ] Confirm local plugins still load on startup and hot-reload on edit (init now uses `setPluginBundles`)

**Plugin admin UI (central server):**
- [ ] Manage → Plugins: click the trash icon → only the delete confirmation appears (config modal does not also open)
- [ ] Confirm the gear and trash icons are vertically aligned; clicking the gear opens the config modal

# 📃 Documentation

- [ ] **No documentation required**: bug fix, no change in intended behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
