### PR TITLE
12174 Stock movement: warn if changes will be lost

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2073,6 +2073,7 @@
   "messages.confirm-cancel-prescription": "Cancelling this prescription cannot be undone",
   "messages.confirm-change-campaign-or-program": "This will change the campaign or program for all selected lines",
   "messages.confirm-change-location": "This will change the location of all selected lines",
+  "messages.confirm-change-selection-mode": "Changing this option will clear the currently selected items. Do you want to continue?",
   "messages.confirm-changing-from-new": "Note: changing from 'New' will remove any lines with zero quantity.",
   "messages.confirm-close-purchase-order-lines_few": "This will permanently close {{count}} lines from this purchase order. Once closed you cannot receive any more stock against these lines.",
   "messages.confirm-close-purchase-order-lines_many": "This will permanently close {{count}} lines from this purchase order. Once closed you cannot receive any more stock against these lines.",

--- a/client/packages/inventory/src/StockMovement/ListView/StockMovementModal.tsx
+++ b/client/packages/inventory/src/StockMovement/ListView/StockMovementModal.tsx
@@ -12,7 +12,7 @@ import {
   StockRelocationNodeStatus,
   ModalMode,
 } from '@openmsupply-client/common';
-import { DialogButton } from '@common/components';
+import { DialogButton, FlatButton } from '@common/components';
 import { useDialog } from '@common/hooks';
 import { FormControlLabel, Radio } from '@mui/material';
 import {
@@ -78,6 +78,7 @@ export const StockMovementModal = ({
 
   const [failedLineIds, setFailedLineIds] = useState<string[]>([]);
   const [createdIds, setCreatedIds] = useState<string[] | null>(null);
+  const [isSwitchingMode, setIsSwitchingMode] = useState<SelectionMode | null>(null);
 
   const linesForError = (errorNode: {
     stockLineId?: string;
@@ -133,6 +134,20 @@ export const StockMovementModal = ({
     buttonLabel: t('button.finalise'),
     cancelButtonLabel: t('button.cancel'),
   });
+
+  const onSwitchMode = (nextMode: SelectionMode) => {
+    if (nextMode === selectionMode) return;
+    if (lines.length === 0) {
+      switchMode(nextMode);
+      return;
+    }
+    setIsSwitchingMode(nextMode);
+  };
+
+  const confirmSwitchMode = () => {
+    if (isSwitchingMode) switchMode(isSwitchingMode);
+    setIsSwitchingMode(null);
+  };
 
   const resultingToPacks = (line: DraftStockMovementLine) => {
     const toPackSize = line.toPackSize ?? line.fromPackSize;
@@ -308,22 +323,51 @@ export const StockMovementModal = ({
     >
       <Box display="flex" flexDirection="column" gap={2}>
         {!isEdit && (
-          <RadioGroup
-            row
-            value={selectionMode}
-            onChange={(_, value) => switchMode(value as SelectionMode)}
-          >
-            <FormControlLabel
-              value="byItem"
-              control={<Radio />}
-              label={t('label.select-by-item')}
-            />
-            <FormControlLabel
-              value="byLocation"
-              control={<Radio />}
-              label={t('label.select-by-location')}
-            />
-          </RadioGroup>
+          <Box sx={{ position: 'relative' }}>
+            <RadioGroup
+              row
+              value={selectionMode}
+              onChange={(_, value) => onSwitchMode(value as SelectionMode)}
+            >
+              <FormControlLabel
+                value="byItem"
+                control={<Radio />}
+                label={t('label.select-by-item')}
+              />
+              <FormControlLabel
+                value="byLocation"
+                control={<Radio />}
+                label={t('label.select-by-location')}
+              />
+            </RadioGroup>
+            {isSwitchingMode && (
+              <Alert
+                severity="warning"
+                sx={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  zIndex: 1,
+                }}
+                action={
+                  <Box>
+                    <FlatButton
+                      color="inherit"
+                      label={t('button.cancel')}
+                      onClick={() => setIsSwitchingMode(null)}
+                    />
+                    <FlatButton
+                      label={t('button.continue')}
+                      onClick={confirmSwitchMode}
+                    />
+                  </Box>
+                }
+              >
+                {t('messages.confirm-change-selection-mode')}
+              </Alert>
+            )}
+          </Box>
         )}
 
         {!isEdit && selectionMode === 'byLocation' && (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12174

# 👩🏻‍💻 What does this PR do?
Alert the user that the lines will be gone if they swap modes. New-ish design, would love to hear opinions. 

https://github.com/user-attachments/assets/ccdc2953-e93a-4695-a85c-74a8d9454519

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Select an item to have lines added to stock movement
- [ ] Change to select by location
- [ ] See alert
- [ ] Click continue -> Lines gone and mode swapped
- [ ] Clicking cancel -> lines should still be there mode not swapped

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

