### PR TITLE
12172 sync v7 modal fixes

### DIFF
--- a/client/packages/common/src/ui/components/steppers/HorizontalStepper/HorizontalStepper.tsx
+++ b/client/packages/common/src/ui/components/steppers/HorizontalStepper/HorizontalStepper.tsx
@@ -33,16 +33,30 @@ interface StepperProps {
 
 type PaletteColour = Omit<PaletteColor, 'contrastText'> & { error: string };
 
+// Circle/connector geometry. Kept as constants so the connector lines stay
+// aligned to the circles (see issue #12172 - lines were sitting too high and
+// over/under-shooting the circles).
+const CIRCLE_DIAMETER = 30;
+const CIRCLE_BORDER_WIDTH = 3;
+// Outer radius of the circle, including its border. The connector should meet
+// the circle's outer edge, so this is also the horizontal inset from a step's
+// centre.
+const CIRCLE_OUTER_RADIUS = CIRCLE_DIAMETER / 2 + CIRCLE_BORDER_WIDTH; // 18px
+const CONNECTOR_THICKNESS = 4;
+// Vertical position so the line is centred on the circle.
+const CONNECTOR_TOP = CIRCLE_OUTER_RADIUS - CONNECTOR_THICKNESS / 2; // 16px
+
 const getConnector = (paletteColour: PaletteColour) => () => {
   const style = {
     '&.MuiStepConnector-root': {
-      left: 'calc(-50% + 15px)',
-      right: 'calc(50% + 15px)',
+      top: `${CONNECTOR_TOP}px`,
+      left: `calc(-50% + ${CIRCLE_OUTER_RADIUS}px)`,
+      right: `calc(50% + ${CIRCLE_OUTER_RADIUS}px)`,
     },
     [`& .${stepConnectorClasses.line}`]: {
       borderColor: paletteColour.light,
       // The width is for the connector which is significantly thicker than the default.
-      borderWidth: '4px 0 0 0',
+      borderWidth: `${CONNECTOR_THICKNESS}px 0 0 0`,
     },
     [`&.${stepConnectorClasses.active}`]: {
       [`& .${stepConnectorClasses.line}`]: {
@@ -86,11 +100,17 @@ const getCircle =
     return (
       <div
         style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
           border: 'solid',
-          borderWidth: 3,
-          width: 30,
-          height: 30,
-          borderRadius: 30,
+          // content-box: total outer size is CIRCLE_DIAMETER + 2*border, which
+          // the connector geometry constants depend on.
+          boxSizing: 'content-box',
+          borderWidth: CIRCLE_BORDER_WIDTH,
+          width: CIRCLE_DIAMETER,
+          height: CIRCLE_DIAMETER,
+          borderRadius: '50%',
           textAlign: 'center',
           fontWeight: 700,
           animation: active ? 'pulse 2s infinite' : 'none',

--- a/client/packages/host/src/components/Sync/SyncModal.tsx
+++ b/client/packages/host/src/components/Sync/SyncModal.tsx
@@ -107,7 +107,7 @@ const useHostSync = (enabled: boolean) => {
   };
 };
 
-export const SyncModal = ({ onCancel, open, width = 800 }: SyncModalProps) => {
+export const SyncModal = ({ onCancel, open, width = 900 }: SyncModalProps) => {
   const t = useTranslation();
   const navigate = useNavigate();
   const { userHasPermission } = useAuthContext();
@@ -182,10 +182,13 @@ export const SyncModal = ({ onCancel, open, width = 800 }: SyncModalProps) => {
     });
   };
 
-  const modalWidth = Math.min(width, window.innerWidth - 50);
   return (
     <BasicModal
-      width={!isExtraSmallScreen ? modalWidth : 340}
+      // BasicModal clamps to the viewport itself (min(width, 100vw - 64px)),
+      // so pass the desired width straight through. Don't re-clamp here against
+      // a window.innerWidth snapshot - with no resize listener it gets stuck at
+      // a stale narrow value when the window grows back. See issue #12172.
+      width={!isExtraSmallScreen ? width : 340}
       open={open}
       onKeyDown={e => {
         if (e.key === 'Escape') onCancel();

--- a/client/packages/host/src/components/SyncProgress/SyncProgress.tsx
+++ b/client/packages/host/src/components/SyncProgress/SyncProgress.tsx
@@ -12,6 +12,7 @@ import {
   useIsExtraSmallScreen,
   ChevronsDownIcon,
   ChevronDownIcon,
+  ClockIcon,
   DownloadIcon,
   Accordion,
   AccordionDetails,
@@ -99,7 +100,20 @@ const LinkedSyncProcesses = ({
 }) => {
   const t = useTranslation();
   return (
-    <Accordion sx={{ mt: 1 }}>
+    <Accordion
+      disableGutters
+      sx={theme => ({
+        mt: 1,
+        borderRadius: '8px',
+        // MUI rounds only the first/last child's outer corners by default; force
+        // all four to match and clip the summary/details to the rounded shape.
+        '&:first-of-type, &:last-of-type': { borderRadius: '8px' },
+        overflow: 'hidden',
+        boxShadow: theme.shadows[2],
+        // Remove MUI's default top divider pseudo-element.
+        '&:before': { display: 'none' },
+      })}
+    >
       <AccordionSummary expandIcon={<ChevronDownIcon />}>
         <Typography sx={{ fontWeight: 600 }}>
           {t('sync-status.linked-sync-requests', {
@@ -133,7 +147,7 @@ const ProgressIndicator = ({
     fontSize={12}
     color={`${colour}.light`}
     whiteSpace="nowrap"
-    minWidth="8em"
+    width="9em"
   >
     {progress ? `${progress.done} / ${progress.total}` : null}
   </Box>
@@ -146,16 +160,29 @@ type Progress = {
 
 type Step = Partial<Omit<SyncStatusWithProgressFragment, '__typename'>>;
 
-const buildStep = (
+type RawStep = {
+  labelKey: LocaleKey;
+  step: Step;
+  icon: React.ReactNode;
+};
+
+const toStepDefinition = (
   t: TypedTFunction<LocaleKey>,
   colour: StepperColour,
-  labelKey: LocaleKey,
   isError: boolean,
-  step: Step,
-  icon: React.ReactNode
+  { labelKey, step, icon }: RawStep,
+  index: number,
+  furthestStartedIndex: number
 ): StepDefinition => {
-  const completed = !!step.finished;
-  const active = !completed && !!step.started;
+  // Steps always run in order, so anything before the furthest-reached step is
+  // complete - even if its own `finished` timestamp never came back (e.g. a
+  // push with nothing to send). Deriving from progression keeps the
+  // "completed" styling consistent across every passed step, instead of only
+  // the step that happened to report a finish time. See issue #12172.
+  const isFurthest = index === furthestStartedIndex;
+  const finished = !!step.finished;
+  const completed = index < furthestStartedIndex || (isFurthest && finished);
+  const active = isFurthest && !finished;
   const isActiveAndError = isError && active;
 
   const progress = step.total
@@ -189,53 +216,63 @@ const getSteps = ({
 }): StepDefinition[] => {
   const pullDown = <ChevronsDownIcon />;
   const pushUp = <ChevronsDownIcon sx={{ transform: 'rotate(180deg)' }} />;
+  const waiting = <ClockIcon sx={{ fontSize: '18px' }} />;
   const integrate = <DownloadIcon sx={{ fontSize: '18px' }} />;
 
   const make = (
     labelKey: LocaleKey,
     step: Step | null | undefined,
     icon: React.ReactNode
-  ) => buildStep(t, colour, labelKey, isError, step ?? {}, icon);
+  ): RawStep => ({ labelKey, step: step ?? {}, icon });
 
-  const steps: StepDefinition[] = [];
+  const raws: RawStep[] = [];
 
   if (isSyncStatusV7(syncStatus)) {
     // Push and WaitForIntegration are skipped during initialisation.
     if (isOperational) {
-      steps.push(make('sync-status.push', syncStatus.push, pushUp));
-      steps.push(
+      raws.push(make('sync-status.push', syncStatus.push, pushUp));
+      raws.push(
         make(
           'sync-status.waiting-for-integration',
           syncStatus.waitingForIntegration,
-          null
+          waiting
         )
       );
     }
-    steps.push(make('sync-status.pull', syncStatus.pull, pullDown));
-    steps.push(
-      make('sync-status.integrate', syncStatus.integration, integrate)
-    );
-    return steps;
-  }
-  // V5_V6
-
-  if (!isOperational) {
-    steps.push(make('sync-status.prepare', syncStatus?.prepareInitial, null));
-  }
-  if (isOperational) {
-    if (!isCentralServer) {
-      steps.push(make('sync-status.push-v6', syncStatus?.pushV6, pushUp));
+    raws.push(make('sync-status.pull', syncStatus.pull, pullDown));
+    raws.push(make('sync-status.integrate', syncStatus.integration, integrate));
+  } else {
+    // V5_V6
+    if (!isOperational) {
+      raws.push(make('sync-status.prepare', syncStatus?.prepareInitial, null));
     }
-    steps.push(make('sync-status.push', syncStatus?.push, pushUp));
+    if (isOperational) {
+      if (!isCentralServer) {
+        raws.push(make('sync-status.push-v6', syncStatus?.pushV6, pushUp));
+      }
+      raws.push(make('sync-status.push', syncStatus?.push, pushUp));
+    }
+    raws.push(
+      make('sync-status.pull-central', syncStatus?.pullCentral, pullDown)
+    );
+    raws.push(
+      make('sync-status.pull-remote', syncStatus?.pullRemote, pullDown)
+    );
+    if (!isCentralServer) {
+      raws.push(make('sync-status.pull-v6', syncStatus?.pullV6, pullDown));
+    }
+    raws.push(
+      make('sync-status.integrate', syncStatus?.integration, integrate)
+    );
   }
-  steps.push(
-    make('sync-status.pull-central', syncStatus?.pullCentral, pullDown)
-  );
-  steps.push(make('sync-status.pull-remote', syncStatus?.pullRemote, pullDown));
-  if (!isCentralServer) {
-    steps.push(make('sync-status.pull-v6', syncStatus?.pullV6, pullDown));
-  }
-  steps.push(make('sync-status.integrate', syncStatus?.integration, integrate));
 
-  return steps;
+  // Furthest-reached step = the last one that has started.
+  let furthestStartedIndex = -1;
+  raws.forEach((raw, i) => {
+    if (raw.step.started) furthestStartedIndex = i;
+  });
+
+  return raws.map((raw, i) =>
+    toStepDefinition(t, colour, isError, raw, i, furthestStartedIndex)
+  );
 };

--- a/client/packages/host/src/components/SyncProgress/SyncProgress.tsx
+++ b/client/packages/host/src/components/SyncProgress/SyncProgress.tsx
@@ -103,7 +103,7 @@ const LinkedSyncProcesses = ({
     <Accordion
       disableGutters
       sx={theme => ({
-        mt: 1,
+        mt: 3,
         borderRadius: '8px',
         // MUI rounds only the first/last child's outer corners by default; force
         // all four to match and clip the summary/details to the rounded shape.


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12172

# 👩🏻‍💻 What does this PR do?

- Bumped the default sync modal width from **800 → 900px** so it doesn't overflow so bad on v5v6.
- Removed the redundant `Math.min(width, window.innerWidth - 50)` clamp in `SyncModal`. `window.innerWidth` was read once at render with no resize listener, so a poll re-render while the window was narrow snapshotted a small cap — which then capped `BasicModal`'s own CSS `min()` and left the modal **stuck narrow after the window grew back**. `BasicModal` already clamps to the viewport reactively via `min(width, 100vw - 64px)`, so the width is now passed straight through and resizes correctly in both directions.
- Increased the `LinkedSyncProcesses` accordion top margin from **8px → 24px** (`mt: 1` → `mt: 3`), visually separating the linked sync requests panel from the progress stepper.
- Got a clock for waiting for integration step, rather than the number 2.

Before:
<img width="1026" height="581" alt="image" src="https://github.com/user-attachments/assets/26a1084d-04e0-410b-9b85-9c0f88ca93be" />

<img width="1134" height="333" alt="image" src="https://github.com/user-attachments/assets/ba60051d-4510-4af1-aa88-c8e4fd3af0fb" />


After:
<img width="939" height="494" alt="image" src="https://github.com/user-attachments/assets/439e23c9-8612-47ee-8bca-421e5855e3fb" />

v7 remote:
<img width="611" height="365" alt="image" src="https://github.com/user-attachments/assets/9dab35fa-6f0e-4925-a985-89753cccc1ba" />

COMS:
<img width="812" height="475" alt="image" src="https://github.com/user-attachments/assets/82e14de1-8b3b-4172-af05-40589381caf8" />



## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] _(e.g.)_ Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR
- [ ] _(e.g.)_ This sample datafile: _google drive link_
- [ ] _(e.g.)_ Open a requisition with some lines
- [ ] _(e.g.)_ Make a couple invoices supplying some amount of those lines
- [ ] _(e.g.)_ Review that "issued" column is the sum of the amount already issued in invoices for this requisition

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

