### PR TITLE
12010 printing of stock movements

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -8965,6 +8965,7 @@ export enum ReportContext {
   Report = 'REPORT',
   Requisition = 'REQUISITION',
   Resource = 'RESOURCE',
+  StockMovement = 'STOCK_MOVEMENT',
   Stocktake = 'STOCKTAKE',
   SupplierReturn = 'SUPPLIER_RETURN',
 }

--- a/client/packages/inventory/src/StockMovement/ListView/Footer.tsx
+++ b/client/packages/inventory/src/StockMovement/ListView/Footer.tsx
@@ -1,13 +1,24 @@
-import React, { memo } from 'react';
+import React, { memo, useState } from 'react';
 import {
   Action,
   ActionsFooter,
   DeleteIcon,
+  PrinterIcon,
+  PrintFormat,
+  ReportContext,
+  LocaleKey,
   useTranslation,
   AppFooterPortal,
   useDeleteConfirmation,
   StockRelocationNodeStatus,
 } from '@openmsupply-client/common';
+import {
+  ReportOption,
+  ReportRowFragment,
+  SelectReportModal,
+  usePrintReport,
+  useReportList,
+} from '@openmsupply-client/system';
 import { StockMovementRowFragment, useDeleteStockMovements } from '../api';
 
 export const FooterComponent = ({
@@ -19,6 +30,33 @@ export const FooterComponent = ({
 }) => {
   const t = useTranslation();
   const { deleteStockMovements } = useDeleteStockMovements();
+
+  const { data: reportData } = useReportList({
+    context: ReportContext.StockMovement,
+  });
+  const { printAsync, isPrinting } = usePrintReport();
+  const [showReportSelector, setShowReportSelector] = useState(false);
+
+  const reports = reportData?.nodes ?? [];
+
+  const reportOptions: ReportOption[] = reports.map(report => ({
+    ...report,
+    label: t(`report-code.${report.code}` as LocaleKey, report.name),
+  }));
+
+  const printReport = (
+    report: ReportRowFragment,
+    format: PrintFormat = PrintFormat.Html
+  ) => {
+    printAsync({
+      reportId: report.id,
+      dataId: '',
+      args: { relocationIds: selectedRows.map(row => row.id) },
+      format,
+    });
+  };
+
+  const onPrint = () => setShowReportSelector(true);
 
   const confirmAndDelete = useDeleteConfirmation({
     selectedRows,
@@ -46,22 +84,37 @@ export const FooterComponent = ({
       icon: <DeleteIcon />,
       onClick: confirmAndDelete,
     },
+    {
+      label: t('button.print'),
+      icon: <PrinterIcon />,
+      onClick: onPrint,
+      loading: isPrinting,
+    },
   ];
 
   return (
-    <AppFooterPortal
-      Content={
-        <>
-          {selectedRows.length !== 0 && (
-            <ActionsFooter
-              actions={actions}
-              selectedRowCount={selectedRows.length}
-              resetRowSelection={resetRowSelection}
-            />
-          )}
-        </>
-      }
-    />
+    <>
+      <AppFooterPortal
+        Content={
+          <>
+            {selectedRows.length !== 0 && (
+              <ActionsFooter
+                actions={actions}
+                selectedRowCount={selectedRows.length}
+                resetRowSelection={resetRowSelection}
+              />
+            )}
+          </>
+        }
+      />
+      {showReportSelector && (
+        <SelectReportModal
+          reportOptions={reportOptions}
+          onSelectReport={(report, format) => printReport(report, format)}
+          onClose={() => setShowReportSelector(false)}
+        />
+      )}
+    </>
   );
 };
 

--- a/client/packages/inventory/src/StockMovement/ListView/StockMovementModal.tsx
+++ b/client/packages/inventory/src/StockMovement/ListView/StockMovementModal.tsx
@@ -11,12 +11,15 @@ import {
   useConfirmationModal,
   StockRelocationNodeStatus,
   ModalMode,
+  ReportContext,
+  PrinterIcon,
 } from '@openmsupply-client/common';
-import { DialogButton, FlatButton } from '@common/components';
+import { DialogButton, FlatButton, LoadingButton } from '@common/components';
 import { useDialog } from '@common/hooks';
 import { FormControlLabel, Radio } from '@mui/material';
 import {
   LocationSearchInput,
+  ReportSelector,
   StockItemSearchInput,
 } from '@openmsupply-client/system';
 import {
@@ -78,7 +81,9 @@ export const StockMovementModal = ({
 
   const [failedLineIds, setFailedLineIds] = useState<string[]>([]);
   const [createdIds, setCreatedIds] = useState<string[] | null>(null);
-  const [isSwitchingMode, setIsSwitchingMode] = useState<SelectionMode | null>(null);
+  const [isSwitchingMode, setIsSwitchingMode] = useState<SelectionMode | null>(
+    null
+  );
 
   const linesForError = (errorNode: {
     stockLineId?: string;
@@ -88,8 +93,7 @@ export const StockMovementModal = ({
       line =>
         (!!errorNode.stockLineId &&
           line.fromStockLineId === errorNode.stockLineId) ||
-        (!!errorNode.locationId &&
-          line.toLocation?.id === errorNode.locationId)
+        (!!errorNode.locationId && line.toLocation?.id === errorNode.locationId)
     );
 
   const showLineError = (errorNode: {
@@ -181,50 +185,52 @@ export const StockMovementModal = ({
     linesToMove.length > 0 &&
     linesToMove.every(isValid);
 
-  const onCreate = async () => {
+  const saveDraft = async (): Promise<string[] | null> => {
+    if (createdIds) return createdIds;
     setFailedLineIds([]);
     try {
-      // Reuse the already created movements on a finalise retry
-      let ids = createdIds;
-      if (!ids) {
-        const result = await insert({
-          lines: linesToMove.map(line => ({
-            fromStockLineId: line.fromStockLineId,
-            fromNumberOfPacks: line.fromNumberOfPacks ?? 0,
-            toLocationId: line.toLocation?.id,
-            toPackSize: line.toPackSize ?? line.fromPackSize,
-          })),
-        });
-        if (result.__typename === 'InsertStockRelocationError') {
-          showLineError(result.error);
-          return;
-        }
-        ids = result.ids;
-        setCreatedIds(ids);
-      }
-      const relocationIds = ids;
-      getCreateFinaliseConfirmation({
-        onConfirm: async () => {
-          try {
-            const finaliseResult = await finalise(relocationIds);
-            if (finaliseResult.__typename === 'UpdateStockRelocationError') {
-              showLineError(finaliseResult.error);
-              return;
-            }
-            success(t('messages.stock-movement-finalised'))();
-            onClose();
-          } catch (e) {
-            error((e as Error).message)();
-          }
-        },
-        onCancel: () => {
-          success(t('messages.stock-movement-created'))();
-          onClose();
-        },
+      const result = await insert({
+        lines: linesToMove.map(line => ({
+          fromStockLineId: line.fromStockLineId,
+          fromNumberOfPacks: line.fromNumberOfPacks ?? 0,
+          toLocationId: line.toLocation?.id,
+          toPackSize: line.toPackSize ?? line.fromPackSize,
+        })),
       });
+      if (result.__typename === 'InsertStockRelocationError') {
+        showLineError(result.error);
+        return null;
+      }
+      setCreatedIds(result.ids);
+      return result.ids;
     } catch (e) {
       error((e as Error).message)();
+      return null;
     }
+  };
+
+  const onCreate = async () => {
+    const relocationIds = await saveDraft();
+    if (!relocationIds) return;
+    getCreateFinaliseConfirmation({
+      onConfirm: async () => {
+        try {
+          const finaliseResult = await finalise(relocationIds);
+          if (finaliseResult.__typename === 'UpdateStockRelocationError') {
+            showLineError(finaliseResult.error);
+            return;
+          }
+          success(t('messages.stock-movement-finalised'))();
+          onClose();
+        } catch (e) {
+          error((e as Error).message)();
+        }
+      },
+      onCancel: () => {
+        success(t('messages.stock-movement-created'))();
+        onClose();
+      },
+    });
   };
 
   const onSave = async (status?: StockRelocationNodeStatus) => {
@@ -274,6 +280,38 @@ export const StockMovementModal = ({
     });
   };
 
+  const renderReportSelector = () => {
+    if (isEdit) {
+      if (!movement) return undefined;
+      return (
+        <ReportSelector
+          context={ReportContext.StockMovement}
+          dataId={movement.id}
+          extraArguments={{ relocationIds: [movement.id] }}
+        />
+      );
+    }
+    return (
+      <ReportSelector
+        context={ReportContext.StockMovement}
+        dataId={createdIds?.[0] ?? ''}
+        extraArguments={{ relocationIds: createdIds ?? [] }}
+        CustomButton={({ onPrint }) => (
+          <LoadingButton
+            startIcon={<PrinterIcon />}
+            label={t('button.print')}
+            disabled={!canSave}
+            isLoading={isSaving}
+            onClick={async () => {
+              const ids = await saveDraft();
+              if (ids) onPrint();
+            }}
+          />
+        )}
+      />
+    );
+  };
+
   const title = isEdit
     ? isDisabled
       ? t('label.stock-movement')
@@ -320,6 +358,7 @@ export const StockMovementModal = ({
           />
         )
       }
+      reportSelector={renderReportSelector()}
     >
       <Box display="flex" flexDirection="column" gap={2}>
         {!isEdit && (

--- a/client/packages/inventory/src/StockMovement/ListView/StockMovementModal.tsx
+++ b/client/packages/inventory/src/StockMovement/ListView/StockMovementModal.tsx
@@ -80,7 +80,7 @@ export const StockMovementModal = ({
   const { delete: deleteMovement, isDeleting } = useDeleteStockMovement();
 
   const [failedLineIds, setFailedLineIds] = useState<string[]>([]);
-  const [createdIds, setCreatedIds] = useState<string[] | null>(null);
+  const [savedLines, setSavedLines] = useState<Record<string, string>>({});
   const [isSwitchingMode, setIsSwitchingMode] = useState<SelectionMode | null>(
     null
   );
@@ -186,23 +186,50 @@ export const StockMovementModal = ({
     linesToMove.every(isValid);
 
   const saveDraft = async (): Promise<string[] | null> => {
-    if (createdIds) return createdIds;
     setFailedLineIds([]);
     try {
-      const result = await insert({
-        lines: linesToMove.map(line => ({
-          fromStockLineId: line.fromStockLineId,
+      // Update already-created lines, collecting the rest to insert
+      const nextSaved: Record<string, string> = {};
+      const toInsert: DraftStockMovementLine[] = [];
+      for (const line of linesToMove) {
+        const relocationId = savedLines[line.id];
+        if (!relocationId) {
+          toInsert.push(line);
+          continue;
+        }
+        nextSaved[line.id] = relocationId;
+        const result = await update({
+          id: relocationId,
           fromNumberOfPacks: line.fromNumberOfPacks ?? 0,
-          toLocationId: line.toLocation?.id,
           toPackSize: line.toPackSize ?? line.fromPackSize,
-        })),
-      });
-      if (result.__typename === 'InsertStockRelocationError') {
-        showLineError(result.error);
-        return null;
+          toLocationId: { value: line.toLocation?.id ?? null },
+        });
+        if (result.__typename === 'UpdateStockRelocationError') {
+          showLineError(result.error);
+          return null;
+        }
       }
-      setCreatedIds(result.ids);
-      return result.ids;
+
+      if (toInsert.length) {
+        const result = await insert({
+          lines: toInsert.map(line => ({
+            fromStockLineId: line.fromStockLineId,
+            fromNumberOfPacks: line.fromNumberOfPacks ?? 0,
+            toLocationId: line.toLocation?.id,
+            toPackSize: line.toPackSize ?? line.fromPackSize,
+          })),
+        });
+        if (result.__typename === 'InsertStockRelocationError') {
+          showLineError(result.error);
+          return null;
+        }
+        toInsert.forEach((line, index) => {
+          nextSaved[line.id] = result.ids[index] ?? '';
+        });
+      }
+
+      setSavedLines(nextSaved);
+      return Object.values(nextSaved);
     } catch (e) {
       error((e as Error).message)();
       return null;
@@ -291,17 +318,18 @@ export const StockMovementModal = ({
         />
       );
     }
+    const savedRelocationIds = Object.values(savedLines);
     return (
       <ReportSelector
         context={ReportContext.StockMovement}
-        dataId={createdIds?.[0] ?? ''}
-        extraArguments={{ relocationIds: createdIds ?? [] }}
+        dataId={savedRelocationIds[0] ?? ''}
+        extraArguments={{ relocationIds: savedRelocationIds }}
         CustomButton={({ onPrint }) => (
           <LoadingButton
             startIcon={<PrinterIcon />}
             label={t('button.print')}
             disabled={!canSave}
-            isLoading={isSaving}
+            isLoading={isSaving || isUpdating}
             onClick={async () => {
               const ids = await saveDraft();
               if (ids) onPrint();

--- a/client/packages/inventory/src/StockMovement/ListView/StockMovementModal.tsx
+++ b/client/packages/inventory/src/StockMovement/ListView/StockMovementModal.tsx
@@ -25,6 +25,7 @@ import {
 import {
   StockMovementRowFragment,
   useDeleteStockMovement,
+  useDeleteStockMovements,
   useFinaliseStockMovements,
   useInsertStockMovement,
   useUpdateStockMovement,
@@ -78,6 +79,8 @@ export const StockMovementModal = ({
   const { update, isUpdating } = useUpdateStockMovement();
   const { finalise, isFinalising } = useFinaliseStockMovements();
   const { delete: deleteMovement, isDeleting } = useDeleteStockMovement();
+  const { deleteStockMovements, isDeleting: isDeletingDraft } =
+    useDeleteStockMovements();
 
   const [failedLineIds, setFailedLineIds] = useState<string[]>([]);
   const [savedLines, setSavedLines] = useState<Record<string, string>>({});
@@ -187,7 +190,15 @@ export const StockMovementModal = ({
 
   const saveDraft = async (): Promise<string[] | null> => {
     setFailedLineIds([]);
+    const currentLineIds = new Set(linesToMove.map(line => line.id));
+
     try {
+      // Delete movements whose line has since been removed
+      const toDelete = Object.entries(savedLines)
+        .filter(([lineId]) => !currentLineIds.has(lineId))
+        .map(([, relocationId]) => relocationId);
+      if (toDelete.length) await deleteStockMovements(toDelete);
+
       // Update already-created lines, collecting the rest to insert
       const nextSaved: Record<string, string> = {};
       const toInsert: DraftStockMovementLine[] = [];
@@ -329,7 +340,7 @@ export const StockMovementModal = ({
             startIcon={<PrinterIcon />}
             label={t('button.print')}
             disabled={!canSave}
-            isLoading={isSaving || isUpdating}
+            isLoading={isSaving || isUpdating || isDeletingDraft}
             onClick={async () => {
               const ids = await saveDraft();
               if (ids) onPrint();

--- a/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
+++ b/client/packages/system/src/Report/components/ReportArgumentsModal.tsx
@@ -29,7 +29,7 @@ export type ReportArgumentsModalProps = {
   /** Modal is shown if there is an argument schema present */
   report: ReportRowFragment | undefined;
   printFormat?: PrintFormat;
-  extraArguments?: Record<string, string | number | undefined>;
+  extraArguments?: Record<string, string | number | string[] | undefined>;
   onReset: () => void;
   onArgumentsSelected: (
     report: ReportRowFragment,

--- a/client/packages/system/src/Report/components/ReportSelector.tsx
+++ b/client/packages/system/src/Report/components/ReportSelector.tsx
@@ -21,7 +21,7 @@ interface ReportSelectorProps {
   subContext?: string;
   dataId: string;
   queryParams?: ReportListParams;
-  extraArguments?: Record<string, string | number | undefined>;
+  extraArguments?: Record<string, string | number | string[] | undefined>;
   sort?: PrintReportSortInput;
   CustomButton?: (props: {
     onPrint: (e?: React.MouseEvent<HTMLButtonElement>) => void;

--- a/client/packages/system/src/Report/components/index.ts
+++ b/client/packages/system/src/Report/components/index.ts
@@ -1,3 +1,4 @@
 export * from './ReportSelector';
 export * from './ReportArgumentsModal';
 export * from './ExportSelector';
+export * from './SelectReportModal';

--- a/server/graphql/reports/src/reports.rs
+++ b/server/graphql/reports/src/reports.rs
@@ -57,6 +57,7 @@ pub enum ReportContext {
     PurchaseOrder,
     SupplierReturn,
     CustomerReturn,
+    StockMovement,
 }
 
 #[derive(InputObject, Clone)]

--- a/server/repository/src/db_diesel/report_row.rs
+++ b/server/repository/src/db_diesel/report_row.rs
@@ -35,6 +35,8 @@ pub enum ContextType {
     PurchaseOrder,
     SupplierReturn,
     CustomerReturn,
+    /// OG "replenishment"
+    StockMovement,
 }
 
 table! {

--- a/server/repository/src/migrations/v2_20_00/add_stock_movement_report_context.rs
+++ b/server/repository/src/migrations/v2_20_00/add_stock_movement_report_context.rs
@@ -1,0 +1,22 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_stock_movement_report_context"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                    ALTER TYPE context_type ADD VALUE 'STOCK_MOVEMENT';
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_20_00/mod.rs
+++ b/server/repository/src/migrations/v2_20_00/mod.rs
@@ -9,6 +9,7 @@ mod add_plugin_data_datetime_field;
 mod add_plugin_data_indexes;
 mod add_received_number_of_packs_to_invoice_line;
 mod add_shipment_variance_reason_option_type;
+mod add_stock_movement_report_context;
 mod add_stock_relocation_table;
 mod add_stocktake_edited_activity_log_type;
 mod add_support_upload_files_processor_cursor_key_value_store;
@@ -37,6 +38,7 @@ impl Migration for V2_20_00 {
             Box::new(add_shipment_variance_reason_option_type::Migrate),
             Box::new(add_invoice_received_qty_updated_activity_log_type::Migrate),
             Box::new(add_stock_relocation_table::Migrate),
+            Box::new(add_stock_movement_report_context::Migrate),
             Box::new(add_item_store_join_indexes::Migrate),
         ]
     }

--- a/standard_forms/generated/standard_forms.json
+++ b/standard_forms/generated/standard_forms.json
@@ -831,6 +831,59 @@
       "excel_template_buffer": null
     },
     {
+      "id": "stock-movement_2_20_0_false",
+      "name": "Stock Movement",
+      "description": null,
+      "template": {
+        "index": {
+          "template": "template.html",
+          "header": "header.html",
+          "footer": null,
+          "query": [
+            "stock-movement.graphql"
+          ],
+          "convert_data": null,
+          "convert_data_type": "Extism"
+        },
+        "entries": {
+          "header.html": {
+            "type": "TeraTemplate",
+            "data": {
+              "output": "Html",
+              "template": "<table class=\"header_image_section\" style=\"width: 100%;height: 98%;\">\n  <tr>\n    {% if data.store.logo %}\n    <th style=\"text-align:start;width:10%;height:70%;\">\n      <img class=\"logo\" src=\"{{ data.store.logo }}\" />\n    </th>\n    {% endif %}\n    <th style=\"text-align:start;width:30%;\">\n      <span style=\"font-weight:bold;\">{{ data.store.storeName }}</span><br>\n      <span style=\"font-size:6pt;\">{{ data.store.name.address1 }}</span><br>\n      <span style=\"font-size:6pt;\">{{ data.store.name.address2 }}</span><br>\n      <span style=\"font-size:6pt;\">\n        {{t(k=\"label.phone\",f=\"Telephone\")}}: {{ data.store.name.phone }}\n      </span><br>\n      <span style=\"font-size:6pt;\">\n        {{t(k=\"label.email\",f=\"Email\")}}: {{ data.store.name.email }}\n      </span>\n      <br>\n      <br>\n    </th>\n    <th style=\"text-align:end;width:60%;font-size:24pt;\">\n      {{ t(k=\"label.stock-movements\", f=\"Stock movements\") }}<br>\n    </th>\n  </tr>\n</table>\n\n<div class=\"header_image_section\" style=\"display: flex; flex-direction: column;\">\n  <div style=\"display: flex; justify-content: flex-end;\">\n    {{t(k=\"label.date\", f=\"Date\")}}: {{ now() | date(format=\"%d/%m/%Y\") }}\n  </div>\n</div>\n"
+            }
+          },
+          "stock-movement.graphql": {
+            "type": "GraphGLQuery",
+            "data": {
+              "query": "query StockMovement($storeId: String!, $relocationIds: [String!]) {\n  stockRelocations(\n    storeId: $storeId\n    filter: { id: { equalAny: $relocationIds } }\n  ) {\n    ... on StockRelocationConnector {\n      totalCount\n      nodes {\n        id\n        itemCode\n        itemName\n        batch\n        expiryDate\n        numberOfPacks\n        fromPackSize\n        toPackSize\n        status\n        createdDatetime\n        fromLocation {\n          code\n          name\n        }\n        toLocation {\n          code\n          name\n        }\n      }\n    }\n  }\n  store(id: $storeId) {\n    ... on StoreNode {\n      id\n      code\n      storeName\n      logo\n      name(storeId: $storeId) {\n        address1\n        address2\n        phone\n        email\n      }\n    }\n  }\n}\n",
+              "variables": null
+            }
+          },
+          "style.css": {
+            "type": "Resource",
+            "data": "@media print {\n  @page {\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\n\nbody > table {\n  width: 100%;\n  padding: 2em;\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\n.header_image_section {\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 8pt;\n}\n\n.body_section {\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  text-align: left;\n}\n\n.body_section tr.body_column_label th {\n  border-bottom: 0.5px solid black;\n  text-align: left;\n  vertical-align: bottom;\n}\n\n.body_value td {\n  border-bottom: 0.5px solid black;\n}\n\n/* Numeric columns are right-aligned */\n.pack,\n.packs {\n  text-align: right;\n}\n\n/* Manual-entry columns for warehouse staff */\n.done {\n  width: 40px;\n  text-align: center;\n}\n\n.moved-on {\n  width: 70px;\n}\n"
+          },
+          "template.html": {
+            "type": "TeraTemplate",
+            "data": {
+              "output": "Html",
+              "template": "<style>\n    {% include \"style.css\" %}\n</style>\n\n<body>\n    <table class=\"body_section\" cellpadding=\"2\" cellspacing=\"0\">\n        <tr class=\"body_column_label\">\n            <th class=\"item\">{{t(k=\"label.item-name\",f=\"Item name\")}}</th>\n            <th class=\"batch\">{{t(k=\"label.batch\",f=\"Batch\")}}</th>\n            <th class=\"expiry\">{{t(k=\"label.expiry\",f=\"Expiry\")}}</th>\n            <th class=\"pack\">{{t(k=\"label.from-pack-size\",f=\"From pack size\")}}</th>\n            <th class=\"location\">{{t(k=\"label.from-location\",f=\"From location\")}}</th>\n            <th class=\"packs\">{{t(k=\"label.from-number-of-packs\",f=\"From number of packs\")}}</th>\n            <th class=\"location\">{{t(k=\"label.to-location\",f=\"To location\")}}</th>\n            <th class=\"packs\">{{t(k=\"label.to-number-of-packs\",f=\"To number of packs\")}}</th>\n            <th class=\"pack\">{{t(k=\"label.to-pack-size\",f=\"To pack size\")}}</th>\n            <th class=\"done\">{{t(k=\"label.done\",f=\"Done\")}}</th>\n            <th class=\"moved-on\">{{t(k=\"label.moved-on\",f=\"Moved on\")}}</th>\n        </tr>\n        {% for movement in data.stockRelocations.nodes %}\n        <tr class=\"body_value\">\n            <td class=\"item\">{{ movement.itemCode }} {{ movement.itemName }}</td>\n            <td class=\"batch\">{{ movement.batch }}</td>\n            <td class=\"expiry\">\n                {% if movement.expiryDate %}{{ movement.expiryDate | date(format=\"%d/%m/%Y\") }}{% endif %}\n            </td>\n            <td class=\"pack\">{{ movement.fromPackSize }}</td>\n            <td class=\"location\">\n                {% if movement.fromLocation %}{{ movement.fromLocation.code }}{% endif %}\n            </td>\n            <td class=\"packs\">{{ movement.numberOfPacks }}</td>\n            <td class=\"location\">\n                {% if movement.toLocation %}{{ movement.toLocation.code }}{% endif %}\n            </td>\n            <td class=\"packs\">\n                {% if movement.toPackSize and movement.toPackSize > 0 %}{{ movement.numberOfPacks * movement.fromPackSize / movement.toPackSize }}{% endif %}\n            </td>\n            <td class=\"pack\">{{ movement.toPackSize }}</td>\n            <td class=\"done\"></td>\n            <td class=\"moved-on\"></td>\n        </tr>\n        {% endfor %}\n    </table>\n</body>\n"
+            }
+          }
+        }
+      },
+      "context": "STOCK_MOVEMENT",
+      "sub_context": null,
+      "argument_schema_id": null,
+      "comment": null,
+      "is_custom": false,
+      "version": "2.20.0",
+      "code": "stock-movement",
+      "form_schema": null,
+      "excel_template_buffer": null
+    },
+    {
       "id": "stock-take-detail-view_2_6_4_false",
       "name": "Stocktake",
       "description": null,

--- a/standard_forms/stock-movement/latest/report-manifest.json
+++ b/standard_forms/stock-movement/latest/report-manifest.json
@@ -1,0 +1,12 @@
+{
+  "is_custom": false,
+  "version": "2.20.0",
+  "code": "stock-movement",
+  "context": "STOCK_MOVEMENT",
+  "name": "Stock Movement",
+  "queries": {
+    "gql": "stock-movement.graphql"
+  },
+  "arguments": {},
+  "header": "header.html"
+}

--- a/standard_forms/stock-movement/latest/src/header.html
+++ b/standard_forms/stock-movement/latest/src/header.html
@@ -1,0 +1,31 @@
+<table class="header_image_section" style="width: 100%;height: 98%;">
+  <tr>
+    {% if data.store.logo %}
+    <th style="text-align:start;width:10%;height:70%;">
+      <img class="logo" src="{{ data.store.logo }}" />
+    </th>
+    {% endif %}
+    <th style="text-align:start;width:30%;">
+      <span style="font-weight:bold;">{{ data.store.storeName }}</span><br>
+      <span style="font-size:6pt;">{{ data.store.name.address1 }}</span><br>
+      <span style="font-size:6pt;">{{ data.store.name.address2 }}</span><br>
+      <span style="font-size:6pt;">
+        {{t(k="label.phone",f="Telephone")}}: {{ data.store.name.phone }}
+      </span><br>
+      <span style="font-size:6pt;">
+        {{t(k="label.email",f="Email")}}: {{ data.store.name.email }}
+      </span>
+      <br>
+      <br>
+    </th>
+    <th style="text-align:end;width:60%;font-size:24pt;">
+      {{ t(k="label.stock-movements", f="Stock movements") }}<br>
+    </th>
+  </tr>
+</table>
+
+<div class="header_image_section" style="display: flex; flex-direction: column;">
+  <div style="display: flex; justify-content: flex-end;">
+    {{t(k="label.date", f="Date")}}: {{ now() | date(format="%d/%m/%Y") }}
+  </div>
+</div>

--- a/standard_forms/stock-movement/latest/src/stock-movement.graphql
+++ b/standard_forms/stock-movement/latest/src/stock-movement.graphql
@@ -1,0 +1,44 @@
+query StockMovement($storeId: String!, $relocationIds: [String!]) {
+  stockRelocations(
+    storeId: $storeId
+    filter: { id: { equalAny: $relocationIds } }
+  ) {
+    ... on StockRelocationConnector {
+      totalCount
+      nodes {
+        id
+        itemCode
+        itemName
+        batch
+        expiryDate
+        numberOfPacks
+        fromPackSize
+        toPackSize
+        status
+        createdDatetime
+        fromLocation {
+          code
+          name
+        }
+        toLocation {
+          code
+          name
+        }
+      }
+    }
+  }
+  store(id: $storeId) {
+    ... on StoreNode {
+      id
+      code
+      storeName
+      logo
+      name(storeId: $storeId) {
+        address1
+        address2
+        phone
+        email
+      }
+    }
+  }
+}

--- a/standard_forms/stock-movement/latest/src/style.css
+++ b/standard_forms/stock-movement/latest/src/style.css
@@ -1,0 +1,62 @@
+@media print {
+  @page {
+    @bottom-right {
+      font-family: Tahoma;
+      font-size: 8pt;
+      /* do not allow formatter to add a line break in the content */
+      /* prettier-ignore*/
+      content: '{{t(k="report.page",f="Page")}} ' counter(page) ' {{t(k="report.of",f="of")}} ' counter(pages);
+    }
+  }
+}
+
+body > table {
+  width: 100%;
+  padding: 2em;
+}
+
+.logo {
+  display: block;
+  height: 96px;
+}
+
+.header_image_section {
+  width: 100%;
+  font-family: Tahoma;
+  font-size: 8pt;
+  border-bottom: 0.5px solid black;
+  padding-top: 8pt;
+}
+
+.body_section {
+  width: 100%;
+  font-family: Tahoma;
+  font-size: 8pt;
+  text-align: left;
+}
+
+.body_section tr.body_column_label th {
+  border-bottom: 0.5px solid black;
+  text-align: left;
+  vertical-align: bottom;
+}
+
+.body_value td {
+  border-bottom: 0.5px solid black;
+}
+
+/* Numeric columns are right-aligned */
+.pack,
+.packs {
+  text-align: right;
+}
+
+/* Manual-entry columns for warehouse staff */
+.done {
+  width: 40px;
+  text-align: center;
+}
+
+.moved-on {
+  width: 70px;
+}

--- a/standard_forms/stock-movement/latest/src/template.html
+++ b/standard_forms/stock-movement/latest/src/template.html
@@ -1,0 +1,44 @@
+<style>
+    {% include "style.css" %}
+</style>
+
+<body>
+    <table class="body_section" cellpadding="2" cellspacing="0">
+        <tr class="body_column_label">
+            <th class="item">{{t(k="label.item-name",f="Item name")}}</th>
+            <th class="batch">{{t(k="label.batch",f="Batch")}}</th>
+            <th class="expiry">{{t(k="label.expiry",f="Expiry")}}</th>
+            <th class="pack">{{t(k="label.from-pack-size",f="From pack size")}}</th>
+            <th class="location">{{t(k="label.from-location",f="From location")}}</th>
+            <th class="packs">{{t(k="label.from-number-of-packs",f="From number of packs")}}</th>
+            <th class="location">{{t(k="label.to-location",f="To location")}}</th>
+            <th class="packs">{{t(k="label.to-number-of-packs",f="To number of packs")}}</th>
+            <th class="pack">{{t(k="label.to-pack-size",f="To pack size")}}</th>
+            <th class="done">{{t(k="label.done",f="Done")}}</th>
+            <th class="moved-on">{{t(k="label.moved-on",f="Moved on")}}</th>
+        </tr>
+        {% for movement in data.stockRelocations.nodes %}
+        <tr class="body_value">
+            <td class="item">{{ movement.itemCode }} {{ movement.itemName }}</td>
+            <td class="batch">{{ movement.batch }}</td>
+            <td class="expiry">
+                {% if movement.expiryDate %}{{ movement.expiryDate | date(format="%d/%m/%Y") }}{% endif %}
+            </td>
+            <td class="pack">{{ movement.fromPackSize }}</td>
+            <td class="location">
+                {% if movement.fromLocation %}{{ movement.fromLocation.code }}{% endif %}
+            </td>
+            <td class="packs">{{ movement.numberOfPacks }}</td>
+            <td class="location">
+                {% if movement.toLocation %}{{ movement.toLocation.code }}{% endif %}
+            </td>
+            <td class="packs">
+                {% if movement.toPackSize and movement.toPackSize > 0 %}{{ movement.numberOfPacks * movement.fromPackSize / movement.toPackSize }}{% endif %}
+            </td>
+            <td class="pack">{{ movement.toPackSize }}</td>
+            <td class="done"></td>
+            <td class="moved-on"></td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12010

# 👩🏻‍💻 What does this PR do?
Implement printing for stock movements in the modal and in the footer. One thing, had to save lines when print is clicked, so the cancel button in the "new" modal is kinda useless now unless the lines will save as new when the user presses print. Also had to update handling for deletes and updates since there's a mixture of "new"/"non-existent" lines in db when the user clicks print

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Multi-select rows and click print in footer
- [ ] Should consolidate into one report
- [ ] Click print in modal 
- [ ] Any updates/deletes to lines after user presses print should update/delete

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

