### PR TITLE
fix(sync-v7): Error display fixes

### DIFF
--- a/client/packages/common/src/ui/components/errors/BoxedErrorWithDetails.tsx
+++ b/client/packages/common/src/ui/components/errors/BoxedErrorWithDetails.tsx
@@ -89,7 +89,10 @@ export const BoxedErrorWithDetails = ({
             </Typography>
             {expand && (
               <Box>
-                <Typography sx={{ textWrap: 'wrap' }} variant="body2">
+                <Typography
+                  sx={{ textWrap: 'wrap', overflowWrap: 'break-word' }}
+                  variant="body2"
+                >
                   {!!hint && hint}
                   {!!hint && !!details && <br />}
                   {!!details && details}

--- a/client/packages/host/src/components/Initialise/Initialise.tsx
+++ b/client/packages/host/src/components/Initialise/Initialise.tsx
@@ -95,6 +95,7 @@ export const Initialise = () => {
               paddingTop: '1.5em',
             },
             flex: 1,
+            marginTop: 2,
             alignItems: 'center',
             justifyContent: 'center',
           })}
@@ -261,7 +262,7 @@ const RemoteForm: React.FC<RemoteFormProps> = ({
           />
         )}
       </Box>
-      <Box pt={4} justifyItems="center" px={isExtraSmallScreen ? 4 : 20}>
+      <Box pt={4} width="100%">
         {syncError && <BoxedErrorWithDetails {...syncError} width="100%" />}
       </Box>
     </>


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12188

# 👩🏻‍💻 What does this PR do?
Fixes styling related to error display in initialisation screen
<img width="1136" height="1466" alt="image" src="https://github.com/user-attachments/assets/3535a431-552d-44c8-a518-678917fd769d" />

<img width="1496" height="1650" alt="image" src="https://github.com/user-attachments/assets/ce135e4b-304f-4049-a0d7-baca8fec37e9" />

Other areas unaffected:
<img width="1716" height="1116" alt="image" src="https://github.com/user-attachments/assets/df369951-d848-40e8-8ee0-523f6809e1bb" />

## 💌 Any notes for the reviewer?

Added a word-break `overflowWrap: 'break-word'` for error messages. In some cases when there are large error codes that don't fit, it needs to be wrapped between the word instead of overflowing

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Set up COMS and ROMS for sync v7
- [ ] Try different error possibilities such as wrong protocol (https when coms is running http), or disconnecting coms mid way
- [ ] See errors are displayed correctly

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

