### PR TITLE
#12060 Allocate numbers for legacy-synced prescriptions

### DIFF
--- a/server/repository/src/db_diesel/key_value_store.rs
+++ b/server/repository/src/db_diesel/key_value_store.rs
@@ -34,6 +34,7 @@ pub enum KeyType {
     ContactFormProcessorCursor,
     LoadPluginProcessorCursor,
     AssignRequisitionNumberProcessorCursor,
+    AssignPrescriptionNumberProcessorCursor,
     AddCentralPatientVisibilityProcessorCursor,
     RequisitionAutoFinaliseProcessorCursor,
     SupportUploadFilesProcessorCursor,

--- a/server/repository/src/migrations/v2_20_00/add_assign_prescription_number_processor_cursor_key_value_store.rs
+++ b/server/repository/src/migrations/v2_20_00/add_assign_prescription_number_processor_cursor_key_value_store.rs
@@ -1,0 +1,22 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_assign_prescription_number_processor_cursor_key_value_store"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        if cfg!(feature = "postgres") {
+            sql!(
+                connection,
+                r#"
+                    ALTER TYPE key_type ADD VALUE IF NOT EXISTS 'ASSIGN_PRESCRIPTION_NUMBER_PROCESSOR_CURSOR';
+                "#
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v2_20_00/mod.rs
+++ b/server/repository/src/migrations/v2_20_00/mod.rs
@@ -1,6 +1,7 @@
 use super::{version::Version, Migration, MigrationFragment};
 use crate::StorageConnection;
 
+mod add_assign_prescription_number_processor_cursor_key_value_store;
 mod add_in_progress_and_error_statuses_sync_message;
 mod add_invoice_received_qty_updated_activity_log_type;
 mod add_item_store_join_indexes;
@@ -38,6 +39,7 @@ impl Migration for V2_20_00 {
             Box::new(add_invoice_received_qty_updated_activity_log_type::Migrate),
             Box::new(add_stock_relocation_table::Migrate),
             Box::new(add_item_store_join_indexes::Migrate),
+            Box::new(add_assign_prescription_number_processor_cursor_key_value_store::Migrate),
         ]
     }
 }

--- a/server/service/src/processors/assign_prescription_number/assign_prescription_number.rs
+++ b/server/service/src/processors/assign_prescription_number/assign_prescription_number.rs
@@ -1,0 +1,97 @@
+use async_trait::async_trait;
+use repository::{
+    ActivityLogType, ChangelogFilter, ChangelogRow, ChangelogTableName, EqualFilter, InvoiceRow,
+    InvoiceRowRepository, InvoiceType, KeyType, NumberRowType,
+};
+
+use crate::{
+    activity_log::system_activity_log_entry,
+    cursor_controller::CursorType,
+    number::next_number,
+    processors::general_processor::{Processor, ProcessorError},
+    service_provider::{ServiceContext, ServiceProvider},
+    sync::ActiveStoresOnSite,
+};
+
+const DESCRIPTION: &str = "Assign prescription number to a prescription";
+
+pub(crate) struct AssignPrescriptionNumber;
+
+#[async_trait]
+impl Processor for AssignPrescriptionNumber {
+    fn get_description(&self) -> String {
+        DESCRIPTION.to_string()
+    }
+
+    /// Prescriptions synced from legacy mSupply (e.g. created via the FHIR/Tamanu integration)
+    /// can arrive with an invoice_number of -1 if the legacy remote site never allocated a serial
+    /// number before the store was migrated to OMS. This processor allocates a real number to them.
+    async fn try_process_record(
+        &self,
+        ctx: &ServiceContext,
+        _service_provider: &ServiceProvider,
+        changelog: &ChangelogRow,
+    ) -> Result<Option<String>, ProcessorError> {
+        let repo = InvoiceRowRepository::new(&ctx.connection);
+
+        let invoice =
+            repo.find_one_by_id(&changelog.record_id)?
+                .ok_or(ProcessorError::RecordNotFound(
+                    "Invoice".to_string(),
+                    changelog.record_id.clone(),
+                ))?;
+
+        // Only assign prescription number to prescriptions
+        if invoice.r#type != InvoiceType::Prescription {
+            return Ok(None);
+        }
+
+        // Only assign prescription number where not assigned already
+        if invoice.invoice_number != -1 {
+            return Ok(None);
+        }
+
+        let updated_invoice_row = InvoiceRow {
+            invoice_number: next_number(
+                &ctx.connection,
+                &NumberRowType::Prescription,
+                &invoice.store_id,
+            )?,
+            ..invoice.clone()
+        };
+
+        repo.upsert_one(&updated_invoice_row)?;
+        system_activity_log_entry(
+            &ctx.connection,
+            ActivityLogType::InvoiceNumberAllocated,
+            &updated_invoice_row.store_id,
+            &updated_invoice_row.id,
+        )?;
+
+        let result = format!(
+            "invoice ({}) allocated invoice_number {}",
+            updated_invoice_row.id, updated_invoice_row.invoice_number
+        );
+
+        Ok(Some(result))
+    }
+
+    fn changelogs_filter(&self, ctx: &ServiceContext) -> Result<ChangelogFilter, ProcessorError> {
+        let active_stores = ActiveStoresOnSite::get(&ctx.connection)
+            .map_err(ProcessorError::GetActiveStoresOnSiteError)?;
+
+        // Only assign prescription number to prescriptions that belong to stores on this site
+        let filter = ChangelogFilter::new()
+            .table_name(EqualFilter {
+                equal_to: Some(ChangelogTableName::Invoice),
+                ..Default::default()
+            })
+            .store_id(EqualFilter::equal_any(active_stores.store_ids()));
+
+        Ok(filter)
+    }
+
+    fn cursor_type(&self) -> CursorType {
+        CursorType::Standard(KeyType::AssignPrescriptionNumberProcessorCursor)
+    }
+}

--- a/server/service/src/processors/assign_prescription_number/mod.rs
+++ b/server/service/src/processors/assign_prescription_number/mod.rs
@@ -1,0 +1,5 @@
+mod assign_prescription_number;
+pub(crate) use self::assign_prescription_number::*;
+
+#[cfg(test)]
+mod test;

--- a/server/service/src/processors/assign_prescription_number/test.rs
+++ b/server/service/src/processors/assign_prescription_number/test.rs
@@ -1,0 +1,109 @@
+use repository::{
+    mock::{MockData, MockDataInserts},
+    InvoiceRow, InvoiceRowRepository, InvoiceType, KeyType, KeyValueStoreRow, NameRow, StoreRow,
+    Upsert,
+};
+use util::uuid::uuid;
+
+use crate::{
+    processors::ProcessorType,
+    test_helpers::{setup_all_with_data_and_service_provider, ServiceTestContext},
+};
+
+/// Prescriptions synced from legacy mSupply can arrive with an invoice_number of -1.
+/// Ensure the processor allocates a real number to them, is idempotent, and leaves
+/// non-prescription invoices untouched.
+#[tokio::test]
+async fn assigns_prescription_number_to_prescriptions() {
+    let site_id = 26;
+
+    let patient_name = NameRow {
+        id: uuid(),
+        ..Default::default()
+    };
+
+    let store_name = NameRow {
+        id: uuid(),
+        ..Default::default()
+    };
+
+    let store = StoreRow {
+        id: uuid(),
+        name_id: store_name.id.clone(),
+        site_id,
+        ..Default::default()
+    };
+
+    let site_id_settings = KeyValueStoreRow {
+        id: KeyType::SettingsSyncSiteId,
+        value_int: Some(site_id),
+        ..Default::default()
+    };
+
+    let ServiceTestContext {
+        service_provider, ..
+    } = setup_all_with_data_and_service_provider(
+        "assigns_prescription_number_to_prescriptions",
+        MockDataInserts::none().stores().names(),
+        MockData {
+            names: vec![patient_name.clone(), store_name.clone()],
+            stores: vec![store.clone()],
+            key_value_store_rows: vec![site_id_settings],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let ctx = service_provider.basic_context().unwrap();
+
+    let prescription = InvoiceRow {
+        id: uuid(),
+        invoice_number: -1,
+        name_id: patient_name.id.clone(),
+        store_id: store.id.clone(),
+        r#type: InvoiceType::Prescription,
+        ..Default::default()
+    };
+
+    // Control: a non-prescription invoice with -1 should be left untouched
+    let inbound_shipment = InvoiceRow {
+        id: uuid(),
+        invoice_number: -1,
+        name_id: patient_name.id.clone(),
+        store_id: store.id.clone(),
+        r#type: InvoiceType::InboundShipment,
+        ..Default::default()
+    };
+
+    prescription.upsert(&ctx.connection).unwrap();
+    inbound_shipment.upsert(&ctx.connection).unwrap();
+
+    // manually trigger because inserting the invoice doesn't trigger the processor
+    ctx.processors_trigger
+        .general_processor
+        .try_send(ProcessorType::AssignPrescriptionNumber)
+        .unwrap();
+    ctx.processors_trigger.await_events_processed().await;
+
+    let repo = InvoiceRowRepository::new(&ctx.connection);
+
+    let updated_prescription = repo.find_one_by_id(&prescription.id).unwrap().unwrap();
+    assert_ne!(updated_prescription.invoice_number, -1);
+
+    // Non-prescription invoice should still be -1
+    let updated_inbound = repo.find_one_by_id(&inbound_shipment.id).unwrap().unwrap();
+    assert_eq!(updated_inbound.invoice_number, -1);
+
+    // Trigger processors again to ensure it doesn't assign a new prescription number
+    ctx.processors_trigger
+        .general_processor
+        .try_send(ProcessorType::AssignPrescriptionNumber)
+        .unwrap();
+    ctx.processors_trigger.await_events_processed().await;
+
+    let re_queried_prescription = repo.find_one_by_id(&prescription.id).unwrap().unwrap();
+    assert_eq!(
+        re_queried_prescription.invoice_number,
+        updated_prescription.invoice_number
+    );
+}

--- a/server/service/src/processors/general_processor.rs
+++ b/server/service/src/processors/general_processor.rs
@@ -20,6 +20,7 @@ use crate::{
 
 use super::{
     add_central_patient_visibility::AddPatientVisibilityForCentral,
+    assign_prescription_number::AssignPrescriptionNumber,
     assign_requisition_number::AssignRequisitionNumber, contact_form::QueueContactEmailProcessor,
     load_plugin::LoadPlugin, plugin_processor::PluginProcessor,
     requisition_auto_finalise::RequisitionAutoFinaliseProcessor,
@@ -51,6 +52,7 @@ pub enum ProcessorType {
     ContactFormEmail,
     LoadPlugin,
     AssignRequisitionNumber,
+    AssignPrescriptionNumber,
     AddPatientVisibilityForCentral,
     SupportUploadFiles,
     Plugins,
@@ -64,6 +66,7 @@ impl ProcessorType {
             ProcessorType::ContactFormEmail => vec![Box::new(QueueContactEmailProcessor)],
             ProcessorType::LoadPlugin => vec![Box::new(LoadPlugin)],
             ProcessorType::AssignRequisitionNumber => vec![Box::new(AssignRequisitionNumber)],
+            ProcessorType::AssignPrescriptionNumber => vec![Box::new(AssignPrescriptionNumber)],
             ProcessorType::AddPatientVisibilityForCentral => {
                 vec![Box::new(AddPatientVisibilityForCentral)]
             }

--- a/server/service/src/processors/mod.rs
+++ b/server/service/src/processors/mod.rs
@@ -17,6 +17,7 @@ use self::transfer::{
 use general_processor::{process_records, ProcessorError};
 
 mod add_central_patient_visibility;
+mod assign_prescription_number;
 mod assign_requisition_number;
 mod contact_form;
 mod general_processor;

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -324,6 +324,9 @@ impl Synchroniser {
             .trigger_processor(ProcessorType::AssignRequisitionNumber);
 
         ctx.processors_trigger
+            .trigger_processor(ProcessorType::AssignPrescriptionNumber);
+
+        ctx.processors_trigger
             .trigger_processor(ProcessorType::Plugins);
 
         ctx.processors_trigger


### PR DESCRIPTION
Fixes #12060

# 👩🏻‍💻 What does this PR do?

Prescriptions created via the FHIR/Tamanu integration in legacy mSupply (OG) are created on the OG central server with `transact.invoice_num = -1`. The serial number is only allocated once the OG **remote** site syncs. If that remote site is offline/not syncing and the store is migrated to open-mSupply (OMS), the prescription arrives in OMS still holding `-1`, and nothing ever replaces it — so the prescription number stays `-1`.

OMS already knows how to allocate numbers for `-1` records via `next_number()` (which explicitly handles the legacy `-1` → start at `1` case), and there are existing processors that do this for response requisitions (`AssignRequisitionNumber`) and for inbound shipments during transfers (`AssignInvoiceNumberProcessor`). But **nothing covered a standalone synced prescription**.

This PR adds a new `AssignPrescriptionNumber` general processor (mirroring `AssignRequisitionNumber`). It listens to `Invoice` changelog entries for stores active on this site and, for any `Prescription`-type invoice with `invoice_number == -1`, allocates a real, store-sequential number via `next_number(.., NumberRowType::Prescription, store_id)` and writes an `InvoiceNumberAllocated` activity log entry. It's triggered after each sync.

## 💌 Any notes for the reviewer?

- **Scoped strictly to `InvoiceType::Prescription` on purpose.** Inbound shipments are *intentionally* left at `-1` until their source outbound is shipped/picked, and are allocated by the transfer processor. A blanket "allocate any `-1` invoice" processor would prematurely number transfer inbounds and break that workflow. Prescriptions are not part of the transfer workflow, so they're safe to allocate unconditionally.
- New cursor `KeyType::AssignPrescriptionNumberProcessorCursor` plus a Postgres enum migration in `v2_20_00` (mirrors the existing `add_support_upload_files_processor_cursor` migration). `postgres_latest.sql` is a pre-`v2_20_00` snapshot, so it doesn't need editing — the migration handles fresh DBs.
- Files: new `server/service/src/processors/assign_prescription_number/` module; wiring in `processors/mod.rs`, `general_processor.rs`, and `sync/synchroniser.rs`.

# 🧪 Testing

- [ ] Central Sync server with a Legacy Desktop dispensary remote site and an OMS remote site running this PR
- [ ] On the legacy site, create/alter a prescription so `transact.invoice_num = -1` (e.g. via the record browser, as in the issue repro)
- [ ] Migrate the store to the OMS site and sync
- [ ] Confirm the prescription receives a real sequential prescription number (no longer `-1`) and an `InvoiceNumberAllocated` activity log entry
- [ ] Automated: `cargo nextest run -p service assign_prescription_number` (allocation, idempotence, non-prescription invoice left untouched) and `cargo nextest run -p repository migration_2_20_00`

# 📃 Documentation

- [x] **No documentation required**: bug fix restoring expected behaviour (prescription numbers being allocated)


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
