### PR TITLE
#12191 Flip leftover RTL icons (comment, report, file, help)

### DIFF
--- a/client/packages/common/src/ui/icons/File.tsx
+++ b/client/packages/common/src/ui/icons/File.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
+import { SvgIconProps } from '@mui/material/SvgIcon';
+import { RtlFlipIcon } from './RtlFlipIcon';
 
 export const FileIcon = (props: SvgIconProps): JSX.Element => {
   const combinedProps: SvgIconProps = {
@@ -10,7 +11,7 @@ export const FileIcon = (props: SvgIconProps): JSX.Element => {
     ...props,
   };
   return (
-    <SvgIcon
+    <RtlFlipIcon
       {...combinedProps}
       viewBox="0 0 24 24"
       strokeWidth="2"
@@ -22,6 +23,6 @@ export const FileIcon = (props: SvgIconProps): JSX.Element => {
       <line x1="16" y1="13" x2="8" y2="13"></line>
       <line x1="16" y1="17" x2="8" y2="17"></line>
       <polyline points="10 9 9 9 8 9"></polyline>{' '}
-    </SvgIcon>
+    </RtlFlipIcon>
   );
 };

--- a/client/packages/common/src/ui/icons/Help.tsx
+++ b/client/packages/common/src/ui/icons/Help.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
+import { SvgIconProps } from '@mui/material/SvgIcon';
+import { RtlFlipIcon } from './RtlFlipIcon';
 
 export const HelpIcon = (props: SvgIconProps): JSX.Element => {
   return (
-    <SvgIcon
+    <RtlFlipIcon
       {...props}
       style={{
         fill: 'none',
@@ -20,6 +21,6 @@ export const HelpIcon = (props: SvgIconProps): JSX.Element => {
         stroke="currentColor"
       ></path>
       <line x1="12" y1="17" x2="12.01" y2="17" stroke="currentColor"></line>
-    </SvgIcon>
+    </RtlFlipIcon>
   );
 };

--- a/client/packages/common/src/ui/icons/Invoice.tsx
+++ b/client/packages/common/src/ui/icons/Invoice.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
+import { SvgIconProps } from '@mui/material/SvgIcon';
+import { RtlFlipIcon } from './RtlFlipIcon';
 
 export const InvoiceIcon = (props: SvgIconProps): JSX.Element => {
   const combinedProps: SvgIconProps = {
@@ -10,12 +11,12 @@ export const InvoiceIcon = (props: SvgIconProps): JSX.Element => {
     ...props,
   };
   return (
-    <SvgIcon {...combinedProps} viewBox="0 0 24 24" strokeWidth="2">
+    <RtlFlipIcon {...combinedProps} viewBox="0 0 24 24" strokeWidth="2">
       <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
       <polyline points="14 2 14 8 20 8"></polyline>
       <line x1="16" y1="13" x2="8" y2="13"></line>
       <line x1="16" y1="17" x2="8" y2="17"></line>
       <polyline points="10 9 9 9 8 9"></polyline>
-    </SvgIcon>
+    </RtlFlipIcon>
   );
 };

--- a/client/packages/common/src/ui/icons/MessageSquare.tsx
+++ b/client/packages/common/src/ui/icons/MessageSquare.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
+import { SvgIconProps } from '@mui/material/SvgIcon';
+import { RtlFlipIcon } from './RtlFlipIcon';
 
 export const MessageSquareIcon = (props: SvgIconProps): JSX.Element => {
   return (
-    <SvgIcon
+    <RtlFlipIcon
       {...props}
       sx={{
         strokeWidth: 2,
@@ -16,6 +17,6 @@ export const MessageSquareIcon = (props: SvgIconProps): JSX.Element => {
       viewBox="0 0 24 24"
     >
       <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
-    </SvgIcon>
+    </RtlFlipIcon>
   );
 };

--- a/client/packages/common/src/ui/icons/RtlFlipIcon.tsx
+++ b/client/packages/common/src/ui/icons/RtlFlipIcon.tsx
@@ -6,10 +6,13 @@ import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
  * (Arabic, Dari, Pashto).
  *
  * Use this instead of `SvgIcon` only for icons whose meaning is directional —
- * arrows, external-link, list, sidebar, truck, search, the mSupply man, etc.
- * Non-directional symbols (checkmark, help, info, translate, settings...) must
+ * arrows, external-link, list, truck, search, the mSupply man, the
+ * comment/speech bubble, the folded-corner document, etc. The help/question-mark
+ * icon is also flipped: Arabic's question mark glyph is itself mirrored (؟), so a
+ * flipped "?" is what RTL readers expect.
+ * Other non-directional symbols (checkmark, info, translate, settings...) must
  * keep using `SvgIcon` directly, otherwise they render reversed (a backwards
- * tick / question mark / "A文" glyph).
+ * tick / "A文" glyph).
  *
  * The flip is driven by the active theme `direction`, so it follows the
  * language automatically and is a no-op in LTR. Any caller-provided `sx` is

--- a/client/packages/common/src/ui/icons/Sidebar.tsx
+++ b/client/packages/common/src/ui/icons/Sidebar.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { SvgIconProps } from '@mui/material/SvgIcon';
-import { RtlFlipIcon } from './RtlFlipIcon';
+import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 
 export const SidebarIcon = (props: SvgIconProps): JSX.Element => {
   return (
-    <RtlFlipIcon
+    <SvgIcon
       {...props}
       style={{
         fill: 'none',
@@ -17,6 +16,6 @@ export const SidebarIcon = (props: SvgIconProps): JSX.Element => {
     >
       <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
       <line x1="9" y1="3" x2="9" y2="21"></line>
-    </RtlFlipIcon>
+    </SvgIcon>
   );
 };


### PR DESCRIPTION
Fixes #12191

# 👩🏻‍💻 What does this PR do?

#12055 introduced the `RtlFlipIcon` wrapper and routed directional icons through it for RTL languages (Arabic/Dari/Pashto), but a few were missed. This PR mirrors them:

- **Comment** (`MessageSquareIcon`) — the speech-bubble tail now points the correct way.
- **Report / document** (`InvoiceIcon`) — the folded-corner document icon used by the report list cards now mirrors.
- **File** (`FileIcon`) — same folded-corner document glyph used in attachment lists; flipped for consistency.
- **Help / question mark** (`HelpIcon`) — now flipped, covering both the nav "Help" entry and confirmation modals. This reverses the earlier "keep upright" decision: Arabic's question mark glyph is itself mirrored (؟), so a flipped "?" is what RTL readers expect.

It also **un-flips** the sidebar / "More" panel-toggle icon (`SidebarIcon`): mirroring it (added in #12055) looked wrong, so it now renders the same in LTR and RTL.

The `RtlFlipIcon` doc comment was updated to reflect both changes (help is now in the "flip" list; sidebar removed).

## 💌 Any notes for the reviewer?

- The flip is driven by the active theme `direction`, so every change is a no-op in LTR — no call sites changed, only the icon component internals.
- Two intentional divergences from the issue checklist:
  - **Help icon**: the issue asks to flip it, which *reverses* #12055's explicit decision to keep the question mark upright. Confirmed correct for Arabic (؟).
  - **"More" icon**: the issue listed it, but `SidebarIcon` was already flipped by #12055. On review that mirroring was wrong, so this PR reverts it rather than "fixing" it — net effect is the icon stops flipping.
- `ReportsIcon` (the pie-chart nav icon) and `MenuDotsIcon` (symmetric three dots) were left untouched — neither is the icon shown in the issue screenshots.

# 🧪 Testing

- [ ] In an RTL language (Arabic / Dari / Pashto), check the icons listed in the issue mirror correctly — see #12191.
- [ ] Confirm they still render normally in an LTR language.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
