### PR TITLE
9320 'Placeholder quantity has been auto-allocated' message even when no placeholder lines present in Outbound Shipment

### DIFF
--- a/client/packages/invoices/src/StockOut/useAllocationContext.ts
+++ b/client/packages/invoices/src/StockOut/useAllocationContext.ts
@@ -182,16 +182,27 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
       allocateIn,
     });
 
-    // If no quantity has yet been allocated, attempt to allocate the placeholder on initialise
-    if (allocatedQuantity === 0) {
+    // If nothing has been allocated yet but there's a placeholder quantity,
+    // attempt to allocate it against available stock on initialise
+    if (allocatedQuantity === 0 && (get().placeholderUnits ?? 0) > 0) {
       reallocateLines(format, t);
-      set(state => ({
-        ...state,
-        alerts: [
-          ...state.alerts,
-          { message: t('messages.auto-allocated-lines'), severity: 'warning' },
-        ],
-      }));
+
+      const allocatedAfterReallocation = getAllocatedQuantity({
+        draftLines: get().draftLines,
+        allocateIn,
+      });
+      if (allocatedAfterReallocation > 0) {
+        set(state => ({
+          ...state,
+          alerts: [
+            ...state.alerts,
+            {
+              message: t('messages.auto-allocated-lines'),
+              severity: 'warning',
+            },
+          ],
+        }));
+      }
     }
   },
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #9320

# 👩🏻‍💻 What does this PR do?
Only show message if there is a placeholder line and auto-allocation was successful

# 🧪 Tested
- Tested when adding new item to outbound and there's no placeholder
- Tested when auto-allocated because a new stock line was introduced for a placeholder

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

