### PR TITLE
11604 Inbound shipments: Item volume is not auto populating for default pack size

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/utils.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/utils.ts
@@ -23,6 +23,8 @@ const createDraftInboundLine = ({
   expiryDate,
 }: CreateDraftInboundLineParams): DraftInboundLine => {
   const { defaultPackSize = 1, itemStoreProperties } = item || {};
+  const volumePerPack =
+    'volumePerPack' in item ? (item.volumePerPack ?? 0.0) : 0.0;
   const draftLine: DraftInboundLine = {
     __typename: 'InvoiceLineNode',
     totalAfterTax: 0,
@@ -42,7 +44,7 @@ const createDraftInboundLine = ({
     type,
     item,
     itemName: item.name,
-    volumePerPack: 0.0,
+    volumePerPack,
     shippedPackSize: defaultPackSize,
     ...seed,
   };


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11604

# 👩🏻‍💻 What does this PR do?
Pre-populate volume per pack in Inbound with item's volume per pack

# 🧪 Tested
- That inbound's item's volume per pack is pre-populated with item's volume per pack

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

