### PR TITLE
Feature-gate stock movement behind a feature flag

### DIFF
--- a/client/packages/common/src/hooks/useFeatureFlags/useFeatureFlags.ts
+++ b/client/packages/common/src/hooks/useFeatureFlags/useFeatureFlags.ts
@@ -9,10 +9,8 @@
   ```yaml
     # Add any other settings you need here, e.g. database connection, sync settings etc
 
-    feature_flags:
-      table_usability_improvements: true
-      load_remote_plugins_in_dev: true
-      create_stocktake_modal_usability_improvements: true
+    features:
+      stock_movement: true
   ```
 */
 
@@ -34,5 +32,8 @@ export const useFeatureFlags = () => {
 
   return {
     ...featureFlags,
+    // Stock movement (stock relocation) feature - hidden by default while in
+    // development, can be enabled per-server via local.yaml
+    stockMovement: !!featureFlags['stock_movement'],
   };
 };

--- a/client/packages/host/src/components/Navigation/InventoryNav.tsx
+++ b/client/packages/host/src/components/Navigation/InventoryNav.tsx
@@ -7,6 +7,7 @@ import {
   RouteBuilder,
   AppNavLink,
   AppNavSection,
+  useFeatureFlags,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { useNestedNav } from './useNestedNav';
@@ -17,6 +18,7 @@ export const InventoryNav: FC = () => {
     RouteBuilder.create(AppRoute.Inventory).addWildCard().build()
   );
   const t = useTranslation();
+  const { stockMovement } = useFeatureFlags();
   const pluginLinks = usePluginNavLinksForCategory(AppRoute.Inventory);
 
   return (
@@ -48,12 +50,14 @@ export const InventoryNav: FC = () => {
               .build()}
             text={t('stocktakes')}
           />
-          <AppNavLink
-            to={RouteBuilder.create(AppRoute.Inventory)
-              .addPart(AppRoute.StockMovement)
-              .build()}
-            text={t('stock-movement')}
-          />
+          {stockMovement && (
+            <AppNavLink
+              to={RouteBuilder.create(AppRoute.Inventory)
+                .addPart(AppRoute.StockMovement)
+                .build()}
+              text={t('stock-movement')}
+            />
+          )}
           {pluginLinks}
         </List>
       </Collapse>

--- a/client/packages/host/src/routers/InventoryRouter.tsx
+++ b/client/packages/host/src/routers/InventoryRouter.tsx
@@ -1,5 +1,10 @@
 import React, { FC } from 'react';
-import { RouteBuilder, Navigate, useMatch } from '@openmsupply-client/common';
+import {
+  RouteBuilder,
+  Navigate,
+  useMatch,
+  useFeatureFlags,
+} from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 
 const StockService = React.lazy(
@@ -38,6 +43,7 @@ export const InventoryRouter: FC = () => {
   const gotoStocktakes = useMatch(fullStocktakePath);
   const gotoStockMovement = useMatch(fullStockMovementPath);
   const gotoLocations = useMatch(fullLocationPath);
+  const { stockMovement } = useFeatureFlags();
 
   if (gotoStock) {
     return <StockService />;
@@ -47,7 +53,7 @@ export const InventoryRouter: FC = () => {
     return <InventoryService />;
   }
 
-  if (gotoStockMovement) {
+  if (stockMovement && gotoStockMovement) {
     return <InventoryService />;
   }
 

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -61,5 +61,5 @@
 #   #  Can make this smaller for testing emails
 #   interval: 60 # in seconds
 # features:
-#   example_feature: true
+#   stock_movement: true
 

--- a/server/graphql/core/src/test_helpers.rs
+++ b/server/graphql/core/src/test_helpers.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, RwLock};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
 use actix_web::{
     guard,
@@ -13,7 +16,10 @@ use repository::{
     StorageConnection, StorageConnectionManager,
 };
 
-use service::{auth_data::AuthData, service_provider::ServiceProvider, token_bucket::TokenBucket};
+use service::{
+    auth_data::AuthData, service_provider::ServiceProvider, settings::Settings,
+    token_bucket::TokenBucket,
+};
 
 use crate::{
     auth_data_from_request,
@@ -24,6 +30,9 @@ pub struct TestGraphqlSettings<Q: 'static + ObjectType + Clone, M: 'static + Obj
     pub queries: Q,
     pub mutations: M,
     pub connection_manager: StorageConnectionManager,
+    /// Server settings injected into the GraphQL context. Tests can mutate
+    /// `settings.features` to exercise feature-gated resolvers.
+    pub settings: Settings,
 }
 
 pub async fn run_test_gql_query<
@@ -66,6 +75,7 @@ pub async fn run_test_gql_query<
                 .data(loader_registry_data.clone())
                 .data(service_provider_data.clone())
                 .data(auth_data.clone())
+                .data(Data::new(settings.settings.clone()))
                 .finish(),
             ))
             .service(web::resource("/graphql").guard(guard::Post()).to(
@@ -221,8 +231,16 @@ pub async fn setup_graphql_test_with_data<
     StorageConnectionManager,
     TestGraphqlSettings<Q, M>,
 ) {
-    let (mock_data, connection, connection_manager, _) =
+    let (mock_data, connection, connection_manager, database_settings) =
         setup_all_with_data(db_name, inserts, extra_mock_data).await;
+
+    // Enable feature-gated functionality by default so tests exercise the real
+    // resolvers. Individual tests can override `settings.features` to test the
+    // disabled path.
+    let settings = service::settings::test_settings(
+        database_settings,
+        Some(HashMap::from([("stock_movement".to_string(), true)])),
+    );
 
     (
         mock_data,
@@ -232,6 +250,7 @@ pub async fn setup_graphql_test_with_data<
             queries,
             mutations,
             connection_manager,
+            settings,
         },
     )
 }

--- a/server/graphql/stock_relocation/src/lib.rs
+++ b/server/graphql/stock_relocation/src/lib.rs
@@ -1,9 +1,35 @@
-use async_graphql::{Context, Object, Result};
-use graphql_core::pagination::PaginationInput;
+use async_graphql::{Context, ErrorExtensions, Object, Result};
+use graphql_core::{
+    pagination::PaginationInput, standard_graphql_error::StandardGraphqlError, ContextExt,
+};
 
 pub mod mutations;
 pub mod queries;
 pub mod types;
+
+/// Feature flag gating the stock movement (stock relocation) feature.
+/// Matches the `stock_movement` key under `features` in the server config
+/// (see also the client `useFeatureFlags` hook).
+const STOCK_MOVEMENT_FEATURE: &str = "stock_movement";
+
+/// Returns an error unless the stock movement feature is enabled in server settings.
+fn check_stock_movement_enabled(ctx: &Context<'_>) -> Result<()> {
+    let enabled = ctx
+        .get_settings()
+        .features
+        .as_ref()
+        .and_then(|features| features.get(STOCK_MOVEMENT_FEATURE).copied())
+        .unwrap_or(false);
+
+    if enabled {
+        Ok(())
+    } else {
+        Err(StandardGraphqlError::Forbidden(
+            "Stock movement feature is not enabled".to_string(),
+        )
+        .extend())
+    }
+}
 
 use mutations::{
     delete_stock_relocation, insert_stock_relocation, update_stock_relocation, DeleteInput,
@@ -25,6 +51,7 @@ impl StockRelocationQueries {
         store_id: String,
         id: String,
     ) -> Result<StockRelocationResponse> {
+        check_stock_movement_enabled(ctx)?;
         get_stock_relocation(ctx, &store_id, &id)
     }
 
@@ -36,6 +63,7 @@ impl StockRelocationQueries {
         filter: Option<StockRelocationFilterInput>,
         sort: Option<Vec<StockRelocationSortInput>>,
     ) -> Result<StockRelocationsResponse> {
+        check_stock_movement_enabled(ctx)?;
         get_stock_relocations(ctx, &store_id, page, filter, sort)
     }
 }
@@ -51,6 +79,7 @@ impl StockRelocationMutations {
         store_id: String,
         input: InsertInput,
     ) -> Result<InsertResponse> {
+        check_stock_movement_enabled(ctx)?;
         insert_stock_relocation(ctx, &store_id, input)
     }
 
@@ -60,6 +89,7 @@ impl StockRelocationMutations {
         store_id: String,
         input: UpdateInput,
     ) -> Result<UpdateResponse> {
+        check_stock_movement_enabled(ctx)?;
         update_stock_relocation(ctx, &store_id, input)
     }
 
@@ -69,6 +99,7 @@ impl StockRelocationMutations {
         store_id: String,
         input: DeleteInput,
     ) -> Result<DeleteStockRelocationResponse> {
+        check_stock_movement_enabled(ctx)?;
         delete_stock_relocation(ctx, &store_id, input)
     }
 }

--- a/server/graphql/stock_relocation/src/mutations/insert.rs
+++ b/server/graphql/stock_relocation/src/mutations/insert.rs
@@ -367,4 +367,42 @@ mod test {
             Some(service_provider(test_service, &connection_manager))
         );
     }
+
+    #[actix_rt::test]
+    async fn test_graphql_stock_relocation_feature_disabled() {
+        let (_, _, connection_manager, mut settings) = setup_graphql_test(
+            EmptyMutation,
+            StockRelocationMutations,
+            "test_graphql_stock_relocation_feature_disabled",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        // Disable the stock movement feature: the resolver should refuse the
+        // request regardless of the underlying service.
+        settings.settings.features =
+            Some(std::collections::HashMap::from([(
+                "stock_movement".to_string(),
+                false,
+            )]));
+
+        let mutation = r#"
+        mutation ($input: InsertStockRelocationInput!, $storeId: String!) {
+            insertStockRelocation(storeId: $storeId, input: $input) {
+              ... on InsertStockRelocationNode { ids }
+            }
+          }
+        "#;
+
+        let test_service = TestService(Box::new(|_| Ok(vec![])));
+        let expected_message = "Forbidden";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+    }
 }

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -50,6 +50,34 @@ fn default_base_dir() -> String {
     "app_data".to_string()
 }
 
+/// Builds a `Settings` value suitable for tests, given the `DatabaseSettings`
+/// produced by the test setup. `features` enables feature flags that gate
+/// functionality under test (e.g. `stock_movement`).
+pub fn test_settings(
+    database: DatabaseSettings,
+    features: Option<HashMap<String, bool>>,
+) -> Settings {
+    Settings {
+        server: ServerSettings {
+            port: 0,
+            danger_allow_http: false,
+            debug_no_access_control: true,
+            discovery: DiscoveryMode::Disabled,
+            cors_origins: vec![],
+            base_dir: "test_output".to_string(),
+            machine_uid: None,
+            override_is_central_server: false,
+            workers: None,
+        },
+        database,
+        sync: None,
+        logging: None,
+        backup: None,
+        mail: None,
+        features,
+    }
+}
+
 impl ServerSettings {
     pub fn address(&self) -> String {
         format!("0.0.0.0:{}", self.port)


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

The stock movement (stock relocation) feature isn't ready to be released in 2.20, but we want to keep it on the release branch rather than strip it out and re-add it later. This gates the whole feature behind a `stock_movement` feature flag (off by default) so it can ship dark and be enabled per-server.

**Frontend** (via the existing `useFeatureFlags` hook):
- New `stockMovement` flag derived from the `stock_movement` server feature flag.
- Inventory nav link is hidden unless the flag is enabled (`InventoryNav.tsx`).
- The `/inventory/stock-movement` route is blocked (falls through to Page Not Found) unless the flag is enabled (`InventoryRouter.tsx`).

**Backend** (`server/graphql/stock_relocation/src/lib.rs`):
- All five `stock_relocation` GraphQL resolvers (2 queries + 3 mutations) now call a `check_stock_movement_enabled` guard that returns `Forbidden` when the feature is disabled. This stops the API being usable even if the client gate is bypassed.

**Config / docs:**
- Updated the `features` example in `example.yaml` and the `useFeatureFlags` doc comment to show `stock_movement: true` (also corrected the stale `feature_flags:` key to `features:`, which is the actual config key).

To enable, add to `configuration/local.yaml`:

```yaml
features:
  stock_movement: true
```

## 💌 Any notes for the reviewer?

- **No code was deleted** — the feature is fully intact, just gated. This change is additive and intentionally safe to merge back into `develop` (where developers can flip the flag on); the gate can be removed entirely once the feature is ready to ship.
- The flag defaults **off**, so by default the feature is hidden on both client and server.
- Note `local.yaml`/`remote.yaml` are gitignored, so only `example.yaml` is committed as the documented template.
- The old shared `stock_movement` *views/repository* on the server (used by R&R forms, consumption/replenishment views, stock-evolution charts) are unrelated legacy infrastructure and were **not** touched.

# 🧪 Testing

- [ ] With no `features` config (default): the **Stock Movement** link does not appear under Inventory, and navigating directly to `/inventory/stock-movement` shows Page Not Found.
- [ ] Querying `stockRelocations` / calling `insertStockRelocation` etc. via GraphQL returns a `Forbidden` error.
- [ ] Add `features:\n  stock_movement: true` to `local.yaml` and restart the server: the nav link appears, the route loads the list view, and the GraphQL queries/mutations work as before.

# 📃 Documentation

- [x] **No documentation required**: feature is hidden by default; this only gates existing in-development functionality behind a flag.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
