### PR TITLE
12207 user permission store routing

### DIFF
--- a/server/repository/src/db_diesel/changelog/generate_changelog.rs
+++ b/server/repository/src/db_diesel/changelog/generate_changelog.rs
@@ -326,6 +326,30 @@ impl VVMStatusLogRow {
     }
 }
 
+impl UserPermissionRow {
+    pub(crate) fn generate_changelog(
+        row_or_id: RowOrId<UserPermissionRow>,
+        con: &StorageConnection,
+        action: RowActionType,
+        source_site_id: SourceSiteId,
+    ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &UserPermissionRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
+        Ok(ChangeLogInsertRow {
+            table_name: ChangelogTableName::UserPermission,
+            record_id: row.id.clone(),
+            row_action: action,
+            store_id: row.store_id.clone(),
+            source_site_id: source_site_id.get_id(con)?,
+            ..Default::default()
+        })
+    }
+}
+
 // ==========================================================================
 // Lines that inherit their parent's changelog
 // --------------------------------------------------------------------------
@@ -1906,23 +1930,6 @@ impl UserAccountRow {
     ) -> Result<ChangeLogInsertRow, RepositoryError> {
         Ok(ChangeLogInsertRow {
             table_name: ChangelogTableName::UserAccount,
-            record_id,
-            row_action: action,
-            source_site_id: source_site_id.get_id(con)?,
-            ..Default::default()
-        })
-    }
-}
-
-impl UserPermissionRow {
-    pub(crate) fn generate_changelog(
-        record_id: String,
-        con: &StorageConnection,
-        action: RowActionType,
-        source_site_id: SourceSiteId,
-    ) -> Result<ChangeLogInsertRow, RepositoryError> {
-        Ok(ChangeLogInsertRow {
-            table_name: ChangelogTableName::UserPermission,
             record_id,
             row_action: action,
             source_site_id: source_site_id.get_id(con)?,

--- a/server/repository/src/db_diesel/changelog/sync_style.rs
+++ b/server/repository/src/db_diesel/changelog/sync_style.rs
@@ -484,7 +484,7 @@ impl ChangelogTableName {
                 transport: V5,
             },
             UserPermission => SyncStyle {
-                authoring: vec![Central],
+                authoring: vec![Remote],
                 distribution: vec![D::Remote],
                 transport: V5,
             },

--- a/server/repository/src/db_diesel/changelog/sync_styles.md
+++ b/server/repository/src/db_diesel/changelog/sync_styles.md
@@ -98,6 +98,7 @@ One row per table, grouped by matrix cell (distribution-set and transport, with 
 | `TemperatureBreach` | RemoteOwned | Remote | v5 |
 | `TemperatureLog` | RemoteOwned | Remote | v5 |
 | `VVMStatusLog` | RemoteOwned | RemoteOwned | v5 |
+| `UserPermission` | Remote | Remote | v5 |
 | `SyncMessage` | Anyone | Central + Remote | v5 |
 | `Requisition` | RemoteOwned + Transfer | RemoteOwned + Transfer | v5 |
 | `RequisitionLine` | RemoteOwned + Transfer | RemoteOwned + Transfer | v5 |
@@ -148,7 +149,6 @@ One row per table, grouped by matrix cell (distribution-set and transport, with 
 | `StorePreference` | Central | Central | v5 |
 | `Unit` | Central | Central | v5 |
 | `UserAccount` | Central | Central | v5 |
-| `UserPermission` | Central | Remote | v5 |
 | `UserStoreJoin` | Central | Central | v5 |
 | `VVMStatus` | Central | Central | v5 |
 | `AncillaryItem` | Central | Central | v6 |
@@ -193,7 +193,7 @@ One row per table, grouped by matrix cell (distribution-set and transport, with 
 - **RemoteOwned + Transfer + Patient · RemoteOwned + Transfer + Patient · v5** (`Invoice`, `InvoiceLine`) — adds patient routing on top of RemoteOwned+Transfer; an invoice also follows its patient (prescriptions only) through name-store-join.
 - **RemoteOwned · RemoteOwned · v6** (`RnrForm`, `RnrFormLine`) — site-owned data on the OMS-native transport. Central does not author edits; the return path is suppressed except at initialisation.
 - **Remote + Patient · Remote + Patient · v6** (`Encounter`, `Vaccination`, `ContactTrace`) — store-scoped clinical records that should also follow the patient. Each row carries the authoring store *and* the patient. The `Remote` clause delivers it to the owning site; the `Patient` clause delivers it to every other site that knows the patient. Authoring is `Remote` (not `RemoteOwned`): the owning site keeps accepting updates even after it has initialised.
-- **Central · Remote · v5** (`UserPermission`) — central-authored, store-scoped data on the legacy transport. Central manages the record (any remote push is rejected) but routes each row only to the site that owns the referenced store, on every cycle.
+- **Remote · Remote · v5** (`UserPermission`) — store-scoped permission data on the legacy transport. The owning remote site may author and push permission changes — central accepts a push when the row's store is active on the source site — and central may also edit them. Each row routes only to the site that owns the referenced store, and on **every** cycle (the `Remote` distribution clause, not `RemoteOwned`) precisely because central legitimately authors edits to push back.
 - **Central · Central · v5** (`Abbreviation`, `Barcode`, …) — central data still served from legacy 4D. This bucket also acts as a catch-all for tables that exist in the changelog but haven't been classified into a more specific cell yet.
 - **Central · Central · v6** (`AncillaryItem`, `AssetCatalogueItem`, …) — authored on OMS central, fans out to every v6 site. A few of these (notably `NameOmsFields`) also allow remote → central writebacks. Some (notably the vaccine-course family) are re-published to legacy 4D so v5-only stores still receive them (see §7).
 - **Central + Remote · Central + Remote · v6** (`PluginData`, `Preference`) — store-or-global data on the OMS-native transport. If the record carries a store it routes to the owning site (the Remote clause); if it doesn't it broadcasts to every site (the Central clause). Authoring is `Central + Remote`, so both central and the owning site may edit.
@@ -238,7 +238,7 @@ When a record is mutated, a changelog row is generated. The patterns differ by w
 | Pattern | Tables (examples) | What the changelog records |
 |---|---|---|
 | Store + transfer-store | `Invoice`, `Requisition`, `RnrForm`, `NameStoreJoin` | The row's own store, plus the store backing a referenced name (resolved from the name's home store). Used for both store-owner routing and Transfer routing. `Invoice` additionally tags prescriptions with the patient id so they also route via Patient. |
-| Store only | `StockLine`, `Stocktake`, `Location`, `PurchaseOrder`, `Preference`, `Sensor`, `TemperatureBreach`, `TemperatureLog`, `VVMStatusLog`, `LocationMovement`, `ActivityLog`, `ContactForm`, `Asset`, `PluginData`, `VaccineCourseStoreConfig`, `ClinicianStoreJoin`, `IndicatorValue`, `ItemStoreJoin` | Just the row's own store. |
+| Store only | `StockLine`, `Stocktake`, `Location`, `PurchaseOrder`, `Preference`, `Sensor`, `TemperatureBreach`, `TemperatureLog`, `VVMStatusLog`, `LocationMovement`, `ActivityLog`, `ContactForm`, `Asset`, `PluginData`, `VaccineCourseStoreConfig`, `ClinicianStoreJoin`, `IndicatorValue`, `ItemStoreJoin`, `UserPermission` | Just the row's own store. |
 | Destination store | `SyncMessage` | The message's destination store (when set) is copied to the changelog's `store_id`, which makes the hybrid Remote + broadcast routing work — Remote for messages addressed to a specific store, broadcast for fanout messages. |
 | Line inherits parent | `InvoiceLine` ← `Invoice`, `StocktakeLine` ← `Stocktake`, `RequisitionLine` ← `Requisition`, `RnrFormLine` ← `RnrForm` | The line's changelog is built from the parent's, then `table_name` and `record_id` are overridden to point at the line. Guarantees parent and line stay aligned for store / transfer-store / patient / source-site, so they route together. |
 | Line emits parent **and** child | `PurchaseOrderLine` → `PurchaseOrder` (upsert) + `PurchaseOrderLine` | Mutating a line also emits a changelog for the parent, so the parent re-syncs and is always at least as fresh as its children on the receiver. The parent entry is always an upsert, even when the line is a delete. |

--- a/server/repository/src/db_diesel/user_permission_row.rs
+++ b/server/repository/src/db_diesel/user_permission_row.rs
@@ -1,4 +1,5 @@
 use super::StorageConnection;
+use crate::db_diesel::changelog::changelog::RowOrId;
 use crate::diesel_macros::diesel_string_enum;
 use crate::repository_error::RepositoryError;
 use crate::{ChangelogRepository, ChangelogSyncType, Delete, RowActionType, SourceSiteId, Upsert};
@@ -185,7 +186,7 @@ impl<'a> UserPermissionRowRepository<'a> {
     pub fn upsert_one(&self, row: &UserPermissionRow) -> Result<(), RepositoryError> {
         self._upsert_one(row)?;
         let changelog = UserPermissionRow::generate_changelog(
-            row.id.clone(),
+            RowOrId::Row(row),
             self.connection,
             RowActionType::Upsert,
             SourceSiteId::CurrentSiteId,
@@ -223,13 +224,13 @@ impl<'a> UserPermissionRowRepository<'a> {
     }
 
     pub fn delete(&self, id: &str) -> Result<(), RepositoryError> {
-        self._delete(id)?;
         let changelog = UserPermissionRow::generate_changelog(
-            id.to_string(),
+            RowOrId::Id(id),
             self.connection,
             RowActionType::Delete,
             SourceSiteId::CurrentSiteId,
         )?;
+        self._delete(id)?;
         ChangelogRepository::new(self.connection).insert(&changelog)
     }
 }
@@ -247,7 +248,7 @@ impl Delete for UserPermissionRowDelete {
         let changelog = match sync_type {
             ChangelogSyncType::SyncTypeV5V6 { source_site_id } => {
                 UserPermissionRow::generate_changelog(
-                    self.0.clone(),
+                    RowOrId::Id(&self.0),
                     con,
                     RowActionType::Delete,
                     SourceSiteId::SourceSiteId(source_site_id),
@@ -279,7 +280,7 @@ impl Upsert for UserPermissionRow {
 
         let changelog = match sync_type {
             ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
-                self.id.clone(),
+                RowOrId::Row(self),
                 con,
                 RowActionType::Upsert,
                 SourceSiteId::SourceSiteId(source_site_id),

--- a/server/repository/src/migrations/v3_00_00/mod.rs
+++ b/server/repository/src/migrations/v3_00_00/mod.rs
@@ -21,6 +21,7 @@ mod create_site_table;
 mod migrate_user_permission_to_deterministic_id;
 mod partition_changelog_by_cursor;
 mod populate_changelog_with_rows_for_sync_v7_tables;
+mod populate_routed_changelog_for_sync_v7_tables;
 mod populate_sync_version;
 mod rebuild_sync_buffer;
 mod remove_add_central_patient_visibility_processor_cursor;
@@ -66,6 +67,7 @@ impl Migration for V3_00_00 {
             Box::new(seed_sync_request_user_tables::Migrate),
             Box::new(add_legacy_goods_received_link_fields::Migrate),
             Box::new(remove_add_central_patient_visibility_processor_cursor::Migrate),
+            Box::new(populate_routed_changelog_for_sync_v7_tables::Migrate),
         ]
     }
 }

--- a/server/repository/src/migrations/v3_00_00/populate_changelog_with_rows_for_sync_v7_tables.rs
+++ b/server/repository/src/migrations/v3_00_00/populate_changelog_with_rows_for_sync_v7_tables.rs
@@ -49,7 +49,6 @@ impl MigrationFragment for Migrate {
             "store_preference",
             "unit",
             "user_account",
-            "user_permission",
             "user_store_join",
             "vvm_status",
         ];

--- a/server/repository/src/migrations/v3_00_00/populate_changelog_with_rows_for_sync_v7_tables.rs
+++ b/server/repository/src/migrations/v3_00_00/populate_changelog_with_rows_for_sync_v7_tables.rs
@@ -25,7 +25,6 @@ impl MigrationFragment for Migrate {
             "item",
             "item_category_join",
             "item_direction",
-            "item_store_join",
             "item_warning_join",
             "location_type",
             "master_list",

--- a/server/repository/src/migrations/v3_00_00/populate_routed_changelog_for_sync_v7_tables.rs
+++ b/server/repository/src/migrations/v3_00_00/populate_routed_changelog_for_sync_v7_tables.rs
@@ -9,8 +9,11 @@ impl MigrationFragment for Migrate {
     }
 
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
-        // Seed store-routed tables' existing rows into the changelog with their store_id,
-        // so sync v7 routes them to the owning store's site instead of broadcasting.
+        // Ensure each row in these store-routed tables has a changelog entry carrying its
+        // store_id, so sync v7 routes them to the owning store's site instead of broadcasting.
+        // Upsert by hand (no unique key on (table_name, record_id) to drive ON CONFLICT):
+        // UPDATE fills store_id on a changelog row that already exists; INSERT adds a row
+        // for any record that has no changelog row yet.
         const ROUTED_TABLES: &[(&str, &str)] = &[
             ("user_permission", "t.store_id"),
             ("item_store_join", "t.store_id"),
@@ -19,14 +22,24 @@ impl MigrationFragment for Migrate {
         let mut sql = String::new();
         for (table, store_expr) in ROUTED_TABLES {
             sql.push_str(&format!(
-                "INSERT INTO changelog (table_name, record_id, row_action, source_site_id, store_id) \
+                "UPDATE changelog \
+                 SET store_id = {store_expr} \
+                 FROM {table} t \
+                 WHERE changelog.table_name = '{table}' \
+                     AND changelog.record_id = CAST(t.id AS TEXT) \
+                     AND changelog.store_id IS NULL; \
+                 INSERT INTO changelog (table_name, record_id, row_action, source_site_id, store_id) \
                  SELECT '{table}', CAST(t.id AS TEXT), 'UPSERT', \
                      COALESCE( \
                          (SELECT value_int FROM key_value_store WHERE id = 'SETTINGS_SYNC_CENTRAL_SERVER_SITE_ID'), \
                          0 \
                      ), \
                      {store_expr} \
-                 FROM {table} t;\n"
+                 FROM {table} t \
+                 WHERE NOT EXISTS ( \
+                     SELECT 1 FROM changelog c \
+                     WHERE c.table_name = '{table}' AND c.record_id = CAST(t.id AS TEXT) \
+                 );\n"
             ));
         }
 
@@ -66,7 +79,8 @@ mod tests {
         })
         .await;
 
-        // id is rewritten to a deterministic uuid by an earlier v3 fragment, so assert on store_id.
+        // Context-bound permission keeps a stable id (the deterministic-id fragment skips
+        // it), so we can key on it. Both upsert paths are exercised in sequence after migrating.
         connection
             .lock()
             .connection()
@@ -79,8 +93,9 @@ mod tests {
                     ('store_x', 'store_x_name', 'STORE_X', 1);
                 INSERT INTO user_account (id, username, hashed_password) VALUES
                     ('user_x', 'user_x', 'hash');
+                INSERT INTO context (id, name) VALUES ('context_x', 'context_x');
                 INSERT INTO user_permission (id, user_id, store_id, permission, context_id) VALUES
-                    ('perm_x', 'user_x', 'store_x', 'STORE_ACCESS', NULL);
+                    ('perm_x', 'user_x', 'store_x', 'DOCUMENT_QUERY', 'context_x');
                 INSERT INTO key_value_store (id, value_int) VALUES
                     ('SETTINGS_SYNC_CENTRAL_SERVER_SITE_ID', 42);
                 "#,
@@ -90,19 +105,40 @@ mod tests {
         migrate(&connection, Some(version.clone()), MigrationConfig::default()).unwrap();
         assert_eq!(get_database_version(&connection), version);
 
-        let perm = changelog::table
-            .filter(changelog::table_name.eq("user_permission"))
-            .select((
-                changelog::row_action,
-                changelog::store_id,
-                changelog::source_site_id,
-            ))
-            .load::<(String, Option<String>, Option<i32>)>(connection.lock().connection())
-            .unwrap();
+        let load = || {
+            changelog::table
+                .filter(changelog::table_name.eq("user_permission"))
+                .filter(changelog::record_id.eq("perm_x"))
+                .select((
+                    changelog::row_action,
+                    changelog::store_id,
+                    changelog::source_site_id,
+                ))
+                .load::<(String, Option<String>, Option<i32>)>(connection.lock().connection())
+                .unwrap()
+        };
+
+        // INSERT path: record with no changelog row is seeded with its store_id.
         assert_eq!(
-            perm,
+            load(),
             vec![("UPSERT".to_string(), Some("store_x".to_string()), Some(42))],
-            "user_permission changelog should carry its store_id"
+            "record without a changelog row should get a routed row inserted"
+        );
+
+        // UPDATE path: a DB that seeded this row store_id-less (back when these tables were
+        // in populate_changelog_with_rows_for_sync_v7_tables); re-running backfills it in
+        // place, no duplicate.
+        diesel::update(changelog::table.filter(changelog::record_id.eq("perm_x")))
+            .set(changelog::store_id.eq(None::<String>))
+            .execute(connection.lock().connection())
+            .unwrap();
+
+        super::Migrate.migrate(&connection).unwrap();
+
+        assert_eq!(
+            load(),
+            vec![("UPSERT".to_string(), Some("store_x".to_string()), Some(42))],
+            "store_id-less changelog row should be backfilled in place, not duplicated"
         );
     }
 }

--- a/server/repository/src/migrations/v3_00_00/populate_routed_changelog_for_sync_v7_tables.rs
+++ b/server/repository/src/migrations/v3_00_00/populate_routed_changelog_for_sync_v7_tables.rs
@@ -13,6 +13,7 @@ impl MigrationFragment for Migrate {
         // so sync v7 routes them to the owning store's site instead of broadcasting.
         const ROUTED_TABLES: &[(&str, &str)] = &[
             ("user_permission", "t.store_id"),
+            ("item_store_join", "t.store_id"),
         ];
 
         let mut sql = String::new();

--- a/server/repository/src/migrations/v3_00_00/populate_routed_changelog_for_sync_v7_tables.rs
+++ b/server/repository/src/migrations/v3_00_00/populate_routed_changelog_for_sync_v7_tables.rs
@@ -1,0 +1,107 @@
+use crate::migrations::*;
+use diesel::connection::SimpleConnection;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "populate_routed_changelog_for_sync_v7_tables"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // Seed store-routed tables' existing rows into the changelog with their store_id,
+        // so sync v7 routes them to the owning store's site instead of broadcasting.
+        const ROUTED_TABLES: &[(&str, &str)] = &[
+            ("user_permission", "t.store_id"),
+        ];
+
+        let mut sql = String::new();
+        for (table, store_expr) in ROUTED_TABLES {
+            sql.push_str(&format!(
+                "INSERT INTO changelog (table_name, record_id, row_action, source_site_id, store_id) \
+                 SELECT '{table}', CAST(t.id AS TEXT), 'UPSERT', \
+                     COALESCE( \
+                         (SELECT value_int FROM key_value_store WHERE id = 'SETTINGS_SYNC_CENTRAL_SERVER_SITE_ID'), \
+                         0 \
+                     ), \
+                     {store_expr} \
+                 FROM {table} t;\n"
+            ));
+        }
+
+        connection.lock().connection().batch_execute(&sql)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        migrations::{v2_18_00::V2_18_00, v3_00_00::V3_00_00, *},
+        test_db::*,
+    };
+    use diesel::{connection::SimpleConnection, prelude::*, RunQueryDsl};
+
+    table! {
+        changelog (cursor) {
+            cursor -> BigInt,
+            table_name -> Text,
+            record_id -> Text,
+            row_action -> Text,
+            store_id -> Nullable<Text>,
+            source_site_id -> Nullable<Integer>,
+        }
+    }
+
+    #[actix_rt::test]
+    async fn test_populate_routed_changelog_for_sync_v7_tables() {
+        let previous_version = V2_18_00.version();
+        let version = V3_00_00.version();
+
+        let SetupResult { connection, .. } = setup_test(SetupOption {
+            db_name: "migration_populate_routed_changelog_v7_tables",
+            version: Some(previous_version.clone()),
+            ..Default::default()
+        })
+        .await;
+
+        // id is rewritten to a deterministic uuid by an earlier v3 fragment, so assert on store_id.
+        connection
+            .lock()
+            .connection()
+            .batch_execute(
+                r#"
+                INSERT INTO name (id, type, is_customer, is_supplier, code, name) VALUES
+                    ('store_x_name', 'FACILITY', true, false, 'STX', 'Store X');
+                INSERT INTO name_link (id, name_id) VALUES ('store_x_name', 'store_x_name');
+                INSERT INTO store (id, name_link_id, code, site_id) VALUES
+                    ('store_x', 'store_x_name', 'STORE_X', 1);
+                INSERT INTO user_account (id, username, hashed_password) VALUES
+                    ('user_x', 'user_x', 'hash');
+                INSERT INTO user_permission (id, user_id, store_id, permission, context_id) VALUES
+                    ('perm_x', 'user_x', 'store_x', 'STORE_ACCESS', NULL);
+                INSERT INTO key_value_store (id, value_int) VALUES
+                    ('SETTINGS_SYNC_CENTRAL_SERVER_SITE_ID', 42);
+                "#,
+            )
+            .unwrap();
+
+        migrate(&connection, Some(version.clone()), MigrationConfig::default()).unwrap();
+        assert_eq!(get_database_version(&connection), version);
+
+        let perm = changelog::table
+            .filter(changelog::table_name.eq("user_permission"))
+            .select((
+                changelog::row_action,
+                changelog::store_id,
+                changelog::source_site_id,
+            ))
+            .load::<(String, Option<String>, Option<i32>)>(connection.lock().connection())
+            .unwrap();
+        assert_eq!(
+            perm,
+            vec![("UPSERT".to_string(), Some("store_x".to_string()), Some(42))],
+            "user_permission changelog should carry its store_id"
+        );
+    }
+}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12207

# 👩🏻‍💻 What does this PR do?

Seed existing user_permission and item_store_join rows into the changelog with their store_id, so sync v7 routes them to the owning store's site instead of broadcasting to all sites.

Changes

- New migration populate_routed_changelog_for_sync_v7_tables that inserts changelog rows carrying store_id for store-routed tables; removes these tables from the broadcast (populate_changelog_with_rows_for_sync_v7_tables) migration.
- UserPermissionRow::generate_changelog now populates store_id and takes a RowOrId (so deletes fetch the row before it's removed) instead of a bare id.
- UserPermission authoring style changed from Central to Remote.


<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?


When the issue was found, claude also picked up on `program_enrolment`, `program_event` and `contact_trace` tables that didn't seed a store id. They're rebuilt locally on each site from the synced document table, so they don't sync as rows and don't need changelog entries

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Dev Tested

Central (postgres) and remote (sqlite) on main (2.19) → upgraded to 3.0

Central:
- [x] All user permissions for all stores are in changelog and have a store_id — each store's set is added on completion of the migration
- [x] All item store joins have store_id in changelog
- [x] No sync buffer errors for user permissions (user_store) or item_store_join tables
Remote:
- [x] All user permissions have only the remote store id in changelog
- [x] All item store joins have only the remote store id in changelog

Added and removed user permissions for the remote store, sync via OMS Central →
- [x] See permissions remove and re-add (both DB queries and in the UI)
- [x] See sync buffer rows populate in central DB
- [x] No new sync buffer errors

Upsert testing (postgres):
- [x] Wiped the changelog rows for both tables and re-ran migration -> all store ids filled
- [x] Wiped the store_ids and re-ran migration -> same number of rows, all store ids filled
- [x] With all changelog rows complete, re-ran migration -> same number of rows, no duplicates

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

