### PR TITLE
refactor(sync-v7): rename disable_remote_site_auth → relax_hardware_id_token_checks

### DIFF
--- a/server/cli/src/load_test.rs
+++ b/server/cli/src/load_test.rs
@@ -591,7 +591,7 @@ impl LoadTest {
                         central_pull: 512,
                     },
                     disable_integration_transaction: false,
-                    disable_remote_site_auth: false,
+                    relax_hardware_id_token_checks: false,
                 }),
                 logging: None,
                 backup: None,

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -21,9 +21,8 @@
 #     ] # Used to set the allowed Origin in Cross Origin Request Security
 #   base_dir: "app_data"
 # sync:
-#   # The credential fields below (url/username/password_sha256/interval_seconds) are all-or-nothing:
-#   # set them all to configure upstream sync, or omit them all to carry only flags such as
-#   # `disable_remote_site_auth` (e.g. on a central server). A partial set is a startup error.
+#   # url/username/password_sha256/interval_seconds are all-or-nothing: set them all, or omit them
+#   # all to carry only flags (e.g. on a central server). A partial set is a startup error.
 #   url: "http://localhost:2048"
 #   username: "demo"
 #   # 'd74ff0ee8da3b9806b18c877dbf29bbde50b5bd8e4dad7a3a725000feb82e8f1' = 'pass'
@@ -36,11 +35,10 @@
 #   # Set to true to disable the outer transaction during integration. This can prevent PostgreSQL
 #   # from exhausting max_locks_per_transaction during large store migrations. Use with caution.
 #   disable_integration_transaction: false
-#   # Central server only. Set to true to skip v7 remote-site auth checks: the hardware-id match
-#   # and, during token issuance, the hardware-id match and "token already allocated" guard (so a
-#   # site can re-pair from a new machine without an admin reset). Site name + password are still
-#   # required. For recovery/migration only — leave false in normal operation.
-#   disable_remote_site_auth: false
+#   # Central server only. Relax the v7 hardware-id and "token already allocated" guards so a site
+#   # can re-pair from a new machine without an admin reset (name + password still required). For
+#   # recovery/migration only — leave false in normal operation.
+#   relax_hardware_id_token_checks: false
 # database:
 #   host: "localhost"
 #   port: 5432

--- a/server/graphql/general/src/mutations/common.rs
+++ b/server/graphql/general/src/mutations/common.rs
@@ -21,7 +21,7 @@ impl SyncSettingsInput {
             interval_seconds: self.interval_seconds,
             batch_size: Default::default(),
             disable_integration_transaction: false,
-            disable_remote_site_auth: false,
+            relax_hardware_id_token_checks: false,
         }
     }
 }

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -162,13 +162,13 @@ pub async fn start_server(
         .as_ref()
         .map(|s| s.disable_integration_transaction)
         .unwrap_or(false);
-    let disable_remote_site_auth = settings
+    let relax_hardware_id_token_checks = settings
         .sync
         .as_ref()
-        .map(|s| s.disable_remote_site_auth)
+        .map(|s| s.relax_hardware_id_token_checks)
         .unwrap_or(false);
-    if disable_remote_site_auth {
-        log::warn!("disable_remote_site_auth is set — v7 remote-site hardware-id/token checks are DISABLED");
+    if relax_hardware_id_token_checks {
+        log::warn!("relax_hardware_id_token_checks is set — v7 hardware-id/token guards are RELAXED");
     }
     let service_provider = Data::new(ServiceProvider::new_with_triggers(
         connection_manager.clone(),
@@ -180,7 +180,7 @@ pub async fn start_server(
         subscription_trigger,
         batch_size,
         disable_integration_transaction,
-        disable_remote_site_auth,
+        relax_hardware_id_token_checks,
     ));
     let loaders = get_loaders(&connection_manager, service_provider.clone()).await;
     let certificates = Certificates::try_load(&settings.server).unwrap();
@@ -456,8 +456,7 @@ pub async fn start_server(
 
     // CHECK SYNC STATUS
     info!("Checking sync status..");
-    // A `sync:` block may carry only flags (e.g. `disable_remote_site_auth`) without upstream-sync
-    // credentials — treat such a block as "no sync settings" for the credential/seed/auth logic.
+    // A flags-only `sync:` block (no credentials) counts as "no sync settings" here.
     let yaml_sync_settings = settings
         .sync
         .clone()

--- a/server/service/src/service_provider.rs
+++ b/server/service/src/service_provider.rs
@@ -213,7 +213,7 @@ pub struct ServiceProvider {
     // Yaml only fields ----- Not stored in KV store
     pub(crate) batch_size: BatchSize,
     pub(crate) disable_integration_transaction: bool,
-    pub(crate) disable_remote_site_auth: bool,
+    pub(crate) relax_hardware_id_token_checks: bool,
 }
 
 pub struct ServiceContext {
@@ -224,7 +224,7 @@ pub struct ServiceContext {
     pub store_id: String,
     pub batch_size: BatchSize,
     pub disable_integration_transaction: bool,
-    pub disable_remote_site_auth: bool,
+    pub relax_hardware_id_token_checks: bool,
 }
 
 impl ServiceProvider {
@@ -258,7 +258,7 @@ impl ServiceProvider {
         subscription_trigger: SubscriptionTriggerHandle,
         batch_size: BatchSize,
         disable_integration_transaction: bool,
-        disable_remote_site_auth: bool,
+        relax_hardware_id_token_checks: bool,
     ) -> Self {
         ServiceProvider {
             connection_manager: connection_manager.clone(),
@@ -341,7 +341,7 @@ impl ServiceProvider {
             shipping_method_service: Box::new(ShippingMethodService {}),
             subscription_trigger,
             disable_integration_transaction,
-            disable_remote_site_auth,
+            relax_hardware_id_token_checks,
         }
     }
 
@@ -355,7 +355,7 @@ impl ServiceProvider {
             frontend_plugins_cache: self.frontend_plugins_cache.clone(),
             batch_size: self.batch_size.clone(),
             disable_integration_transaction: self.disable_integration_transaction,
-            disable_remote_site_auth: self.disable_remote_site_auth,
+            relax_hardware_id_token_checks: self.relax_hardware_id_token_checks,
         })
     }
 
@@ -371,7 +371,7 @@ impl ServiceProvider {
             frontend_plugins_cache: self.frontend_plugins_cache.clone(),
             batch_size: self.batch_size.clone(),
             disable_integration_transaction: self.disable_integration_transaction,
-            disable_remote_site_auth: self.disable_remote_site_auth,
+            relax_hardware_id_token_checks: self.relax_hardware_id_token_checks,
         })
     }
 
@@ -388,7 +388,7 @@ impl ServiceProvider {
             frontend_plugins_cache: self.frontend_plugins_cache.clone(),
             batch_size: self.batch_size.clone(),
             disable_integration_transaction: self.disable_integration_transaction,
-            disable_remote_site_auth: self.disable_remote_site_auth,
+            relax_hardware_id_token_checks: self.relax_hardware_id_token_checks,
         })
     }
 
@@ -409,7 +409,7 @@ impl ServiceContext {
             frontend_plugins_cache: FrontendPluginCache::new(),
             batch_size: BatchSize::default(),
             disable_integration_transaction: false,
-            disable_remote_site_auth: false,
+            relax_hardware_id_token_checks: false,
         }
     }
 }

--- a/server/service/src/settings_service.rs
+++ b/server/service/src/settings_service.rs
@@ -41,7 +41,7 @@ pub trait SettingsServiceTrait: Sync + Send {
 
         let batch_size = ctx.batch_size.clone();
         let disable_integration_transaction = ctx.disable_integration_transaction;
-        let disable_remote_site_auth = ctx.disable_remote_site_auth;
+        let relax_hardware_id_token_checks = ctx.relax_hardware_id_token_checks;
 
         // `?` inside this closure would result in closure returning `None`
         let make_settings = || {
@@ -52,7 +52,7 @@ pub trait SettingsServiceTrait: Sync + Send {
                 interval_seconds: interval_seconds? as u64,
                 batch_size,
                 disable_integration_transaction,
-                disable_remote_site_auth,
+                relax_hardware_id_token_checks,
             })
         };
 

--- a/server/service/src/sync/settings.rs
+++ b/server/service/src/sync/settings.rs
@@ -8,11 +8,8 @@ pub(crate) static SYNC_V6_VERSION: u32 = 5; // bumped for 2.9.02 (adding new typ
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
 #[serde(try_from = "SyncSettingsRaw")]
 pub struct SyncSettings {
-    // The core upstream-sync credentials are all-or-nothing: a `sync:` block must set all of
-    // url/username/password_sha256/interval_seconds together (upstream sync configured), or omit
-    // them all (a flags-only block, e.g. just `disable_remote_site_auth`). A partial set is a
-    // configuration error — see the `TryFrom` impl below. Use `has_core_sync_settings()` to tell a
-    // configured block from a flags-only one.
+    // url/username/password_sha256/interval_seconds are all-or-nothing (validated in `TryFrom`);
+    // `has_core_sync_settings()` reports whether they're set.
     pub url: String,
     pub username: String,
     pub password_sha256: String,
@@ -23,17 +20,14 @@ pub struct SyncSettings {
     /// Disable the outer transaction wrapping integration. Set to true if PostgreSQL runs out of
     /// shared memory (max_locks_per_transaction) during large initial syncs.
     pub disable_integration_transaction: bool,
-    /// When true, the central server skips v7 remote-site auth checks: the hardware-id match
-    /// (on every pull/push/status) and, during token issuance, the hardware-id match and the
-    /// "token already allocated" guard (a fresh token is minted, overwriting any existing one).
-    /// Site name + password are still required. Defaults to false. Only affects v7; intended for
-    /// recovery/migration, not normal operation.
-    pub disable_remote_site_auth: bool,
+    /// On a central server, relax the v7 hardware-id and token guards so a site can re-pair from a
+    /// new machine without an admin reset: skips the hardware-id match and the "token already
+    /// allocated" check. Site name, password and token are still verified. For recovery/migration.
+    pub relax_hardware_id_token_checks: bool,
 }
 
-/// Raw deserialization shape for [`SyncSettings`]. The four upstream-sync credential fields are
-/// optional here so they can be validated as a group (all set, or all omitted) in `TryFrom`,
-/// while the standalone flags (`batch_size`, `disable_*`) can appear on their own.
+/// Deserialization shape for [`SyncSettings`]: credential fields are optional so `TryFrom` can
+/// validate them as a group (all set, or all omitted).
 #[derive(Deserialize)]
 struct SyncSettingsRaw {
     #[serde(default)]
@@ -49,7 +43,7 @@ struct SyncSettingsRaw {
     #[serde(default)]
     disable_integration_transaction: bool,
     #[serde(default)]
-    disable_remote_site_auth: bool,
+    relax_hardware_id_token_checks: bool,
 }
 
 impl TryFrom<SyncSettingsRaw> for SyncSettings {
@@ -63,12 +57,11 @@ impl TryFrom<SyncSettingsRaw> for SyncSettings {
             interval_seconds,
             batch_size,
             disable_integration_transaction,
-            disable_remote_site_auth,
+            relax_hardware_id_token_checks,
         } = raw;
 
-        // url/username/password_sha256/interval_seconds are all-or-nothing: either upstream sync is
-        // fully configured, or the block carries only flags. A partial set is rejected so a typo or
-        // a half-filled `sync:` block fails loudly at startup instead of silently dropping fields.
+        // Credentials are all-or-nothing: reject a partial set so a half-filled `sync:` block fails
+        // loudly at startup instead of silently dropping fields.
         let (url, username, password_sha256, interval_seconds) =
             match (url, username, password_sha256, interval_seconds) {
                 (Some(url), Some(username), Some(password_sha256), Some(interval_seconds)) => {
@@ -90,7 +83,7 @@ impl TryFrom<SyncSettingsRaw> for SyncSettings {
             interval_seconds,
             batch_size,
             disable_integration_transaction,
-            disable_remote_site_auth,
+            relax_hardware_id_token_checks,
         })
     }
 }
@@ -123,10 +116,8 @@ impl SyncSettings {
         !equal
     }
 
-    /// Whether the core sync settings (url, username, password) are set. A `sync:` yaml block may
-    /// legitimately contain only flags (e.g. `disable_remote_site_auth`) without configuring
-    /// upstream sync — for that case this returns false and callers should treat the block as
-    /// "sync not configured" for credential / seeding / auth purposes.
+    /// Whether the core sync credentials (url, username, password) are set; a `sync:` block may
+    /// instead carry only flags, which callers treat as "sync not configured".
     pub fn has_core_sync_settings(&self) -> bool {
         !self.url.is_empty() && !self.username.is_empty() && !self.password_sha256.is_empty()
     }
@@ -136,20 +127,18 @@ impl SyncSettings {
 mod tests {
     use super::*;
 
-    // The credential fields are all-or-nothing. This guards the TryFrom validation: a half-filled
-    // `sync:` block must be rejected, not silently completed with blanks.
     #[test]
     fn partial_credentials_are_rejected() {
-        // url + username, but no password/interval — a partial credential set.
+        // Partial credential set (no password/interval) is rejected.
         let err = serde_yaml::from_str::<SyncSettings>("url: http://x\nusername: y\n")
             .unwrap_err()
             .to_string();
         assert!(err.contains("all together"), "unexpected error: {err}");
 
-        // Flags-only block (no credentials at all) is allowed.
+        // A flags-only block is allowed.
         let flags_only =
-            serde_yaml::from_str::<SyncSettings>("disable_remote_site_auth: true\n").unwrap();
-        assert!(flags_only.disable_remote_site_auth);
+            serde_yaml::from_str::<SyncSettings>("relax_hardware_id_token_checks: true\n").unwrap();
+        assert!(flags_only.relax_hardware_id_token_checks);
         assert!(!flags_only.has_core_sync_settings());
 
         // All four credentials present is allowed.

--- a/server/service/src/sync/sync_status/test.rs
+++ b/server/service/src/sync/sync_status/test.rs
@@ -571,7 +571,7 @@ async fn run_server_and_sync(
             central_pull: 1,
         },
         disable_integration_transaction: false,
-        disable_remote_site_auth: false,
+        relax_hardware_id_token_checks: false,
     };
 
     let synchroniser =

--- a/server/service/src/sync/test/integration/central_server_configurations.rs
+++ b/server/service/src/sync/test/integration/central_server_configurations.rs
@@ -155,7 +155,7 @@ impl ConfigureCentralServer {
                 // and a small number makes integration tests super slow
                 batch_size: Default::default(),
                 disable_integration_transaction: false,
-                disable_remote_site_auth: false,
+                relax_hardware_id_token_checks: false,
             },
             new_site_properties,
         })

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -93,20 +93,17 @@ pub async fn get_token(
     tokio::task::spawn_blocking(move || {
         let ctx = service_provider.basic_context()?;
 
-        // When `disable_remote_site_auth` is set, skip the "token already allocated" guard
-        // (mint a fresh token, overwriting any existing one) and the hardware-id match, so a
-        // site can re-pair from a new machine without an admin reset. Site name + password
-        // were still verified above.
-        let disable_auth = ctx.disable_remote_site_auth;
+        // name + password were verified above; relaxing here lets a site re-pair from a new machine.
+        let relax_checks = ctx.relax_hardware_id_token_checks;
 
         ctx.connection
             .transaction_sync(|connection| {
-                if !disable_auth && site.token.is_some() {
+                if !relax_checks && site.token.is_some() {
                     return Err(SyncError::TokenAlreadyAllocated);
                 }
 
                 let hardware_id = match &site.hardware_id {
-                    Some(existing) if !disable_auth && existing != &input.hardware_id => {
+                    Some(existing) if !relax_checks && existing != &input.hardware_id => {
                         return Err(SyncError::HardwareIdMismatch);
                     }
                     _ => input.hardware_id.clone(),
@@ -249,10 +246,8 @@ fn validate(
     let site =
         get_site_by_token(&ctx.connection, &common.token)?.ok_or(SyncError::TokenNotFound)?;
 
-    // The token (above) identifies the site and is always required. The hardware-id match
-    // pins the site to a machine; it can be disabled for recovery/migration via the
-    // `disable_remote_site_auth` sync setting.
-    if !ctx.disable_remote_site_auth {
+    // The token above already identified the site; the hardware-id match is the relaxable part.
+    if !ctx.relax_hardware_id_token_checks {
         match site.hardware_id.as_deref() {
             Some(id) if id == common.hardware_id => {}
             _ => return Err(SyncError::HardwareIdMismatch),
@@ -768,16 +763,15 @@ mod tests {
     }
 
     #[actix_rt::test]
-    async fn get_token_with_disable_remote_site_auth_skips_token_and_hardware_id_guards() {
+    async fn get_token_with_relaxed_checks_skips_token_and_hardware_id_guards() {
         let (_, connection, connection_manager, _) =
-            setup_all("get_token_disable_remote_site_auth", MockDataInserts::none()).await;
+            setup_all("get_token_relaxed_checks", MockDataInserts::none()).await;
         test_util_set_is_central_server(true);
         KeyValueStoreRepository::new(&connection)
             .set_i32(KeyType::SettingsSyncSiteId, Some(CENTRAL_SITE_ID))
             .unwrap();
 
-        // Site already has a token AND a different hardware id — normally get_token rejects with
-        // TokenAlreadyAllocated / HardwareIdMismatch.
+        // Site already has a token AND a different hardware id — normally rejected.
         let site = test_site(&connection, Some("existing_token".to_string()));
         SiteRowRepository::new(&connection)
             .upsert(&SiteRow {
@@ -787,13 +781,12 @@ mod tests {
             .unwrap();
 
         let mut sp = ServiceProvider::new(connection_manager);
-        sp.disable_remote_site_auth = true;
+        sp.relax_hardware_id_token_checks = true;
         let sp = Arc::new(sp);
 
         let output = get_token(sp, input()).await.unwrap();
 
-        // A fresh token is minted (overwriting the old one) and the hardware id is overwritten
-        // with the incoming one.
+        // A fresh token and the incoming hardware id overwrite the stored ones.
         assert!(!output.token.is_empty());
         assert_ne!(output.token, "existing_token");
         let stored = SiteRowRepository::new(&connection)
@@ -805,16 +798,16 @@ mod tests {
     }
 
     #[actix_rt::test]
-    async fn validate_with_disable_remote_site_auth_ignores_hardware_id_mismatch() {
+    async fn validate_with_relaxed_checks_ignores_hardware_id_mismatch() {
         let (_, connection, connection_manager, _) =
-            setup_all("validate_disable_remote_site_auth", MockDataInserts::none()).await;
+            setup_all("validate_relaxed_checks", MockDataInserts::none()).await;
         test_util_set_is_central_server(true);
         KeyValueStoreRepository::new(&connection)
             .set_i32(KeyType::SettingsSyncSiteId, Some(CENTRAL_SITE_ID))
             .unwrap();
         test_site(&connection, None);
 
-        // Allocate a token normally (auth enabled).
+        // Allocate a token normally.
         let sp = Arc::new(ServiceProvider::new(connection_manager.clone()));
         let allocated = get_token(sp, input()).await.unwrap();
 
@@ -824,19 +817,19 @@ mod tests {
             version: Version::from_package_json(),
         };
 
-        // With auth enabled a mismatched hardware id is rejected.
+        // A mismatched hardware id is normally rejected.
         let sp = Arc::new(ServiceProvider::new(connection_manager.clone()));
         let err = validate(&sp, &wrong_hw).err().unwrap();
         assert!(matches!(err, SyncError::HardwareIdMismatch));
 
-        // With disable_remote_site_auth the mismatch is ignored.
+        // With the checks relaxed the mismatch is ignored.
         let mut sp = ServiceProvider::new(connection_manager);
-        sp.disable_remote_site_auth = true;
+        sp.relax_hardware_id_token_checks = true;
         let sp = Arc::new(sp);
         let (site, _) = validate(&sp, &wrong_hw).unwrap();
         assert_eq!(site.id, 1);
 
-        // The token still identifies the site, so an unknown token is rejected even with auth off.
+        // The token still identifies the site, so an unknown token is still rejected.
         let err = validate(
             &sp,
             &Common {


### PR DESCRIPTION
## What this does

Follow-up to review feedback on #12202. Two scoped changes, **no behavioural change**:

**1. Renames the `disable_remote_site_auth` sync setting → `relax_hardware_id_token_checks`.**
The old name read as "disable all auth" and overlapped conceptually with the existing `SiteAuth` type. The new name reflects what the flag actually does on a central server: it relaxes the v7 hardware-id match (in `get_token` and `validate`) and the "token already allocated" guard, so a site can re-pair from a new machine — while site **name, password and token remain enforced**. The `disable_auth` local in `get_token` is renamed to `relax_checks` to match.

**2. Trims the code/doc comments added in #12202** (~21 net lines), leaning on the now self-documenting name, and drops the confusing "upstream" wording flagged in review.

Applied across all 10 files: the yaml setting, `SyncSettings`/`SyncSettingsRaw` + `TryFrom`, `ServiceProvider`/`ServiceContext` and callers, `example.yaml`, and the two new tests (names/bodies).

## Verification
- `cargo check -p service --tests` ✅
- `cargo nextest run -p service partial_credentials_are_rejected` ✅ — confirms the serde round-trip works with the renamed YAML key

> **Stacked on #12202.** This targets the feature branch `feat/12050/yaml-sync-setting-disable-site-auth`, so the diff is only the refactor commit. Merging here lands the rename into the feature branch, which then flows through #12202 → `v3.0.0-RC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEbmmz4WozWEdJ3zYeoQsB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEbmmz4WozWEdJ3zYeoQsB)_