### PR TITLE
#12227 Store-route user_store_join for sync v7

### DIFF
--- a/server/repository/src/db_diesel/changelog/generate_changelog.rs
+++ b/server/repository/src/db_diesel/changelog/generate_changelog.rs
@@ -1941,15 +1941,22 @@ impl UserAccountRow {
 
 impl UserStoreJoinRow {
     pub(crate) fn generate_changelog(
-        record_id: String,
+        row_or_id: RowOrId<UserStoreJoinRow>,
         con: &StorageConnection,
         action: RowActionType,
         source_site_id: SourceSiteId,
     ) -> Result<ChangeLogInsertRow, RepositoryError> {
+        let row = match row_or_id {
+            RowOrId::Row(row) => row,
+            RowOrId::Id(row_id) => &UserStoreJoinRowRepository::new(con)
+                .find_one_by_id(row_id)?
+                .ok_or(RepositoryError::NotFound)?,
+        };
         Ok(ChangeLogInsertRow {
             table_name: ChangelogTableName::UserStoreJoin,
-            record_id,
+            record_id: row.id.clone(),
             row_action: action,
+            store_id: Some(row.store_id.clone()),
             source_site_id: source_site_id.get_id(con)?,
             ..Default::default()
         })

--- a/server/repository/src/db_diesel/changelog/sync_style.rs
+++ b/server/repository/src/db_diesel/changelog/sync_style.rs
@@ -489,8 +489,8 @@ impl ChangelogTableName {
                 transport: V5,
             },
             UserStoreJoin => SyncStyle {
-                authoring: vec![Central],
-                distribution: vec![D::Central],
+                authoring: vec![Remote],
+                distribution: vec![D::Remote],
                 transport: V5,
             },
             VVMStatus => SyncStyle {

--- a/server/repository/src/db_diesel/changelog/sync_styles.md
+++ b/server/repository/src/db_diesel/changelog/sync_styles.md
@@ -99,6 +99,7 @@ One row per table, grouped by matrix cell (distribution-set and transport, with 
 | `TemperatureLog` | RemoteOwned | Remote | v5 |
 | `VVMStatusLog` | RemoteOwned | RemoteOwned | v5 |
 | `UserPermission` | Remote | Remote | v5 |
+| `UserStoreJoin` | Remote | Remote | v5 |
 | `SyncMessage` | Anyone | Central + Remote | v5 |
 | `Requisition` | RemoteOwned + Transfer | RemoteOwned + Transfer | v5 |
 | `RequisitionLine` | RemoteOwned + Transfer | RemoteOwned + Transfer | v5 |
@@ -149,7 +150,6 @@ One row per table, grouped by matrix cell (distribution-set and transport, with 
 | `StorePreference` | Central | Central | v5 |
 | `Unit` | Central | Central | v5 |
 | `UserAccount` | Central | Central | v5 |
-| `UserStoreJoin` | Central | Central | v5 |
 | `VVMStatus` | Central | Central | v5 |
 | `AncillaryItem` | Central | Central | v6 |
 | `AssetCatalogueItem` | Central | Central | v6 |
@@ -193,7 +193,7 @@ One row per table, grouped by matrix cell (distribution-set and transport, with 
 - **RemoteOwned + Transfer + Patient · RemoteOwned + Transfer + Patient · v5** (`Invoice`, `InvoiceLine`) — adds patient routing on top of RemoteOwned+Transfer; an invoice also follows its patient (prescriptions only) through name-store-join.
 - **RemoteOwned · RemoteOwned · v6** (`RnrForm`, `RnrFormLine`) — site-owned data on the OMS-native transport. Central does not author edits; the return path is suppressed except at initialisation.
 - **Remote + Patient · Remote + Patient · v6** (`Encounter`, `Vaccination`, `ContactTrace`) — store-scoped clinical records that should also follow the patient. Each row carries the authoring store *and* the patient. The `Remote` clause delivers it to the owning site; the `Patient` clause delivers it to every other site that knows the patient. Authoring is `Remote` (not `RemoteOwned`): the owning site keeps accepting updates even after it has initialised.
-- **Remote · Remote · v5** (`UserPermission`) — store-scoped permission data on the legacy transport. The owning remote site may author and push permission changes — central accepts a push when the row's store is active on the source site — and central may also edit them. Each row routes only to the site that owns the referenced store, and on **every** cycle (the `Remote` distribution clause, not `RemoteOwned`) precisely because central legitimately authors edits to push back.
+- **Remote · Remote · v5** (`UserPermission`, `UserStoreJoin`) — store-scoped user-access data on the legacy transport. The owning remote site may author and push changes — central accepts a push when the row's store is active on the source site — and central may also edit them. Each row routes only to the site that owns the referenced store, and on **every** cycle (the `Remote` distribution clause, not `RemoteOwned`) precisely because central legitimately authors edits to push back. In practice `UserStoreJoin` is authored on central (it originates from legacy 4D's `user_store` table); the `Remote` authoring clause simply means central would also accept a push from the owning site rather than rejecting it.
 - **Central · Central · v5** (`Abbreviation`, `Barcode`, …) — central data still served from legacy 4D. This bucket also acts as a catch-all for tables that exist in the changelog but haven't been classified into a more specific cell yet.
 - **Central · Central · v6** (`AncillaryItem`, `AssetCatalogueItem`, …) — authored on OMS central, fans out to every v6 site. A few of these (notably `NameOmsFields`) also allow remote → central writebacks. Some (notably the vaccine-course family) are re-published to legacy 4D so v5-only stores still receive them (see §7).
 - **Central + Remote · Central + Remote · v6** (`PluginData`, `Preference`) — store-or-global data on the OMS-native transport. If the record carries a store it routes to the owning site (the Remote clause); if it doesn't it broadcasts to every site (the Central clause). Authoring is `Central + Remote`, so both central and the owning site may edit.
@@ -238,7 +238,7 @@ When a record is mutated, a changelog row is generated. The patterns differ by w
 | Pattern | Tables (examples) | What the changelog records |
 |---|---|---|
 | Store + transfer-store | `Invoice`, `Requisition`, `RnrForm`, `NameStoreJoin` | The row's own store, plus the store backing a referenced name (resolved from the name's home store). Used for both store-owner routing and Transfer routing. `Invoice` additionally tags prescriptions with the patient id so they also route via Patient. |
-| Store only | `StockLine`, `Stocktake`, `Location`, `PurchaseOrder`, `Preference`, `Sensor`, `TemperatureBreach`, `TemperatureLog`, `VVMStatusLog`, `LocationMovement`, `ActivityLog`, `ContactForm`, `Asset`, `PluginData`, `VaccineCourseStoreConfig`, `ClinicianStoreJoin`, `IndicatorValue`, `ItemStoreJoin`, `UserPermission` | Just the row's own store. |
+| Store only | `StockLine`, `Stocktake`, `Location`, `PurchaseOrder`, `Preference`, `Sensor`, `TemperatureBreach`, `TemperatureLog`, `VVMStatusLog`, `LocationMovement`, `ActivityLog`, `ContactForm`, `Asset`, `PluginData`, `VaccineCourseStoreConfig`, `ClinicianStoreJoin`, `IndicatorValue`, `ItemStoreJoin`, `UserPermission`, `UserStoreJoin` | Just the row's own store. |
 | Destination store | `SyncMessage` | The message's destination store (when set) is copied to the changelog's `store_id`, which makes the hybrid Remote + broadcast routing work — Remote for messages addressed to a specific store, broadcast for fanout messages. |
 | Line inherits parent | `InvoiceLine` ← `Invoice`, `StocktakeLine` ← `Stocktake`, `RequisitionLine` ← `Requisition`, `RnrFormLine` ← `RnrForm` | The line's changelog is built from the parent's, then `table_name` and `record_id` are overridden to point at the line. Guarantees parent and line stay aligned for store / transfer-store / patient / source-site, so they route together. |
 | Line emits parent **and** child | `PurchaseOrderLine` → `PurchaseOrder` (upsert) + `PurchaseOrderLine` | Mutating a line also emits a changelog for the parent, so the parent re-syncs and is always at least as fresh as its children on the receiver. The parent entry is always an upsert, even when the line is a delete. |

--- a/server/repository/src/db_diesel/user_store_join_row.rs
+++ b/server/repository/src/db_diesel/user_store_join_row.rs
@@ -1,5 +1,6 @@
 use super::{store_row::store, user_row::user_account, StorageConnection};
 
+use crate::db_diesel::changelog::changelog::RowOrId;
 use crate::repository_error::RepositoryError;
 use crate::{ChangelogRepository, ChangelogSyncType, Delete, RowActionType, SourceSiteId, Upsert};
 
@@ -62,7 +63,7 @@ impl<'a> UserStoreJoinRowRepository<'a> {
     pub fn upsert_one(&self, row: &UserStoreJoinRow) -> Result<(), RepositoryError> {
         self._upsert_one(row)?;
         let changelog = UserStoreJoinRow::generate_changelog(
-            row.id.clone(),
+            RowOrId::Row(row),
             self.connection,
             RowActionType::Upsert,
             SourceSiteId::CurrentSiteId,
@@ -110,7 +111,7 @@ impl Upsert for UserStoreJoinRow {
 
         let changelog = match sync_type {
             ChangelogSyncType::SyncTypeV5V6 { source_site_id } => Self::generate_changelog(
-                self.id.clone(),
+                RowOrId::Row(self),
                 con,
                 RowActionType::Upsert,
                 SourceSiteId::SourceSiteId(source_site_id),
@@ -142,7 +143,7 @@ impl Delete for UserStoreJoinRowDelete {
         let changelog = match sync_type {
             ChangelogSyncType::SyncTypeV5V6 { source_site_id } => {
                 UserStoreJoinRow::generate_changelog(
-                    self.0.clone(),
+                    RowOrId::Id(&self.0),
                     con,
                     RowActionType::Delete,
                     SourceSiteId::SourceSiteId(source_site_id),

--- a/server/repository/src/migrations/v3_00_00/populate_routed_changelog_for_sync_v7_tables.rs
+++ b/server/repository/src/migrations/v3_00_00/populate_routed_changelog_for_sync_v7_tables.rs
@@ -17,6 +17,7 @@ impl MigrationFragment for Migrate {
         const ROUTED_TABLES: &[(&str, &str)] = &[
             ("user_permission", "t.store_id"),
             ("item_store_join", "t.store_id"),
+            ("user_store_join", "t.store_id"),
         ];
 
         let mut sql = String::new();
@@ -96,6 +97,8 @@ mod tests {
                 INSERT INTO context (id, name) VALUES ('context_x', 'context_x');
                 INSERT INTO user_permission (id, user_id, store_id, permission, context_id) VALUES
                     ('perm_x', 'user_x', 'store_x', 'DOCUMENT_QUERY', 'context_x');
+                INSERT INTO user_store_join (id, user_id, store_id, is_default) VALUES
+                    ('usj_x', 'user_x', 'store_x', true);
                 INSERT INTO key_value_store (id, value_int) VALUES
                     ('SETTINGS_SYNC_CENTRAL_SERVER_SITE_ID', 42);
                 "#,
@@ -105,10 +108,10 @@ mod tests {
         migrate(&connection, Some(version.clone()), MigrationConfig::default()).unwrap();
         assert_eq!(get_database_version(&connection), version);
 
-        let load = || {
+        let load = |table: &'static str, record_id: &'static str| {
             changelog::table
-                .filter(changelog::table_name.eq("user_permission"))
-                .filter(changelog::record_id.eq("perm_x"))
+                .filter(changelog::table_name.eq(table))
+                .filter(changelog::record_id.eq(record_id))
                 .select((
                     changelog::row_action,
                     changelog::store_id,
@@ -120,25 +123,38 @@ mod tests {
 
         // INSERT path: record with no changelog row is seeded with its store_id.
         assert_eq!(
-            load(),
+            load("user_permission", "perm_x"),
             vec![("UPSERT".to_string(), Some("store_x".to_string()), Some(42))],
             "record without a changelog row should get a routed row inserted"
         );
+        assert_eq!(
+            load("user_store_join", "usj_x"),
+            vec![("UPSERT".to_string(), Some("store_x".to_string()), Some(42))],
+            "user_store_join without a changelog row should get a routed row inserted"
+        );
 
-        // UPDATE path: a DB that seeded this row store_id-less (back when these tables were
-        // in populate_changelog_with_rows_for_sync_v7_tables); re-running backfills it in
+        // UPDATE path: a DB that seeded these rows store_id-less (back when these tables were
+        // in populate_changelog_with_rows_for_sync_v7_tables); re-running backfills them in
         // place, no duplicate.
-        diesel::update(changelog::table.filter(changelog::record_id.eq("perm_x")))
-            .set(changelog::store_id.eq(None::<String>))
-            .execute(connection.lock().connection())
-            .unwrap();
+        diesel::update(
+            changelog::table
+                .filter(changelog::record_id.eq("perm_x").or(changelog::record_id.eq("usj_x"))),
+        )
+        .set(changelog::store_id.eq(None::<String>))
+        .execute(connection.lock().connection())
+        .unwrap();
 
         super::Migrate.migrate(&connection).unwrap();
 
         assert_eq!(
-            load(),
+            load("user_permission", "perm_x"),
             vec![("UPSERT".to_string(), Some("store_x".to_string()), Some(42))],
             "store_id-less changelog row should be backfilled in place, not duplicated"
+        );
+        assert_eq!(
+            load("user_store_join", "usj_x"),
+            vec![("UPSERT".to_string(), Some("store_x".to_string()), Some(42))],
+            "store_id-less user_store_join changelog row should be backfilled in place, not duplicated"
         );
     }
 }


### PR DESCRIPTION
Fixes #12227

This PR is all claude generated, i asked claude to copy the #12214 but for user_store_join, i've looked at code which looks good, and equivalant to user_permission one, i haven't tested, I've just tagged this with "v3.00.00-12227--06231053" will update current test servers and do a re-sync there as tests.

Not expecting PR reviewer to do the tests, can hold off review too until we do a test with built RC

# 👩🏻‍💻 What does this PR do?

This is essentially a copy of #12214 (user_permission store-routing), applied to the `user_store_join` table.

Up until now `user_store_join` rows were broadcast to every site under sync v7, when a given row is only needed on the site whose store it references. This is one of the tables called out in #12227 ("Phase1: user store join should also be per site"). This PR seeds existing `user_store_join` rows into the changelog with their `store_id` and switches the table to store-routed, so sync v7 delivers each row only to the owning store's site.

Changes (mirroring #12214):

- `UserStoreJoinRow::generate_changelog` now populates `store_id` and takes a `RowOrId` (so deletes fetch the row before it's removed) instead of a bare id.
- `UserStoreJoin` sync style changed from `Central / Central` to `Remote / Remote`.
- `user_store_join` added to the `populate_routed_changelog_for_sync_v7_tables` migration's routed-tables list, backfilling `store_id` onto existing changelog rows.

## 💌 Any notes for the reviewer?

It's basically #12214 again — same pattern, same migration, just for `user_store_join`. Two things that differ from that PR and are worth a look:

- **`store_id` is non-nullable on `UserStoreJoinRow`** (it's `String`, not `Option<String>` like `user_permission`), so the changelog generator wraps it as `Some(row.store_id.clone())`.
- **Authoring is set to `Remote` for parity with #12214's final user_permission style.** In practice `user_store_join` originates from legacy 4D (the `user_store` translator) — no remote site authors these today — so the `Remote` authoring clause is permissive-but-inert: it just means central would accept a push from the owning site rather than rejecting it. The sync-styles doc notes this. If we'd rather match reality tightly, `Central` authoring + `Remote` distribution is the alternative.
- I left `user_store_join` in `populate_changelog_with_rows_for_sync_v7_tables` (the broadcast seed). Those rows get their `store_id` filled in by the later routed-changelog migration's UPDATE branch, so the end state is still correct (no store-id-less rows remain).

# 🧪 Testing

Migration test (`test_populate_routed_changelog_for_sync_v7_tables`) extended to cover `user_store_join` for both the INSERT (no prior changelog row) and UPDATE (backfill a store-id-less row, no duplicate) paths.

- [x] `cargo nextest run -p repository` v3_00_00 migration tests pass (SQLite)
- [ ] Postgres
- [ ] Central → remote: existing user_store_join rows land in changelog with store_id, route only to the owning store's site
- [ ] Add/remove a user_store_join for a remote store, sync via OMS Central, see it propagate without sync buffer errors

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole

# 📃 Reviewer Checklist

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)