### PR TITLE
#12091 Add store code to list export filenames and Excel sheet name

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -8121,6 +8121,7 @@ export type QueriesContactsArgs = {
 export type QueriesCsvToExcelArgs = {
   csvData: Scalars['String']['input'];
   filename: Scalars['String']['input'];
+  sheetName?: InputMaybe<Scalars['String']['input']>;
   storeId: Scalars['String']['input'];
 };
 

--- a/client/packages/common/src/utils/files/FileUtils.ts
+++ b/client/packages/common/src/utils/files/FileUtils.ts
@@ -78,8 +78,8 @@ export const useDownloadFile = () => {
 export const useExportCSV = () => {
   const exportFile = useExportFile();
 
-  const exportCsv = async (data: string, title: string) => {
-    const filename = getFilename('text/csv', title);
+  const exportCsv = async (data: string, title: string, storeCode?: string) => {
+    const filename = getFilename('text/csv', title, storeCode);
     exportFile(data, 'text/csv', filename);
   };
 
@@ -180,7 +180,7 @@ const openAndroidFile = async (file: {
   }
 };
 
-const getFilename = (type?: string, title?: string) => {
+const getFilename = (type?: string, title?: string, storeCode?: string) => {
   let extension = 'txt';
   switch (type) {
     case 'text/csv':
@@ -192,7 +192,8 @@ const getFilename = (type?: string, title?: string) => {
   }
 
   const today = Formatter.toIsoString(new Date()); // to match backend datetime
-  const filename = `${today}_${title || 'export'}.${extension}`;
+  const parts = [today, storeCode, title || 'export'].filter(Boolean);
+  const filename = `${parts.join('_')}.${extension}`;
 
   return filename;
 };

--- a/client/packages/system/src/Report/api/hooks/useCsvToExcel.ts
+++ b/client/packages/system/src/Report/api/hooks/useCsvToExcel.ts
@@ -10,6 +10,7 @@ import { useReportGraphQL } from '../useReportGraphQL';
 export type CsvToExcelParams = {
   csvData: string;
   filename: string;
+  sheetName?: string;
 };
 
 export const useCsvToExcel = () => {
@@ -19,12 +20,13 @@ export const useCsvToExcel = () => {
   const downloadFile = useDownloadFile();
 
   const mutationFn = async (params: CsvToExcelParams) => {
-    const { csvData, filename } = params;
+    const { csvData, filename, sheetName } = params;
 
     const result = await reportApi.csvToExcel({
       storeId,
       csvData,
       filename,
+      sheetName,
     });
 
     if (result?.csvToExcel?.__typename === 'PrintReportNode') {

--- a/client/packages/system/src/Report/api/operations.generated.ts
+++ b/client/packages/system/src/Report/api/operations.generated.ts
@@ -119,6 +119,7 @@ export type CsvToExcelQueryVariables = Types.Exact<{
   storeId: Types.Scalars['String']['input'];
   csvData: Types.Scalars['String']['input'];
   filename: Types.Scalars['String']['input'];
+  sheetName?: Types.InputMaybe<Types.Scalars['String']['input']>;
 }>;
 
 export type CsvToExcelQuery = {
@@ -240,8 +241,18 @@ export const GenerateReportDocument = gql`
   }
 `;
 export const CsvToExcelDocument = gql`
-  query csvToExcel($storeId: String!, $csvData: String!, $filename: String!) {
-    csvToExcel(storeId: $storeId, csvData: $csvData, filename: $filename) {
+  query csvToExcel(
+    $storeId: String!
+    $csvData: String!
+    $filename: String!
+    $sheetName: String
+  ) {
+    csvToExcel(
+      storeId: $storeId
+      csvData: $csvData
+      filename: $filename
+      sheetName: $sheetName
+    ) {
       ... on PrintReportNode {
         __typename
         fileId

--- a/client/packages/system/src/Report/api/operations.graphql
+++ b/client/packages/system/src/Report/api/operations.graphql
@@ -100,8 +100,18 @@ query generateReport(
   }
 }
 
-query csvToExcel($storeId: String!, $csvData: String!, $filename: String!) {
-  csvToExcel(storeId: $storeId, csvData: $csvData, filename: $filename) {
+query csvToExcel(
+  $storeId: String!
+  $csvData: String!
+  $filename: String!
+  $sheetName: String
+) {
+  csvToExcel(
+    storeId: $storeId
+    csvData: $csvData
+    filename: $filename
+    sheetName: $sheetName
+  ) {
     ... on PrintReportNode {
       __typename
       fileId

--- a/client/packages/system/src/Report/components/ExportSelector.tsx
+++ b/client/packages/system/src/Report/components/ExportSelector.tsx
@@ -4,6 +4,7 @@ import {
   DownloadIcon,
   SplitButton,
   SplitButtonOption,
+  useAuthContext,
   useExportCSV,
   useNotification,
   useTranslation,
@@ -26,6 +27,8 @@ export const ExportSelector = ({
 }: ExportSelectorProps) => {
   const t = useTranslation();
   const { error } = useNotification();
+  const { store } = useAuthContext();
+  const storeCode = store?.code;
   const exportCSV = useExportCSV();
   const { convertCsvToExcel, isConverting } = useCsvToExcel();
 
@@ -58,10 +61,11 @@ export const ExportSelector = ({
     if (option.value === 'excel') {
       convertCsvToExcel({
         csvData: csv,
-        filename,
+        filename: storeCode ? `${storeCode}_${filename}` : filename,
+        sheetName: storeCode,
       });
     } else {
-      exportCSV(csv, filename);
+      exportCSV(csv, filename, storeCode);
     }
   };
 

--- a/server/graphql/reports/src/export.rs
+++ b/server/graphql/reports/src/export.rs
@@ -12,6 +12,7 @@ pub async fn csv_to_excel(
     store_id: String,
     csv_data: String,
     filename: String,
+    sheet_name: Option<String>,
 ) -> Result<PrintReportResponse> {
     validate_auth(
         ctx,
@@ -24,7 +25,12 @@ pub async fn csv_to_excel(
     let service_provider = ctx.service_provider();
     let service = &service_provider.report_service;
 
-    match service.csv_to_excel(&ctx.get_settings().server.base_dir, &csv_data, &filename) {
+    match service.csv_to_excel(
+        &ctx.get_settings().server.base_dir,
+        &csv_data,
+        &filename,
+        sheet_name.as_deref(),
+    ) {
         Ok(file_id) => Ok(PrintReportResponse::Response(PrintReportNode { file_id })),
         Err(err) => Err(StandardGraphqlError::InternalError(format!(
             "Failed to convert CSV to Excel: {err:?}"

--- a/server/graphql/reports/src/lib.rs
+++ b/server/graphql/reports/src/lib.rs
@@ -136,8 +136,9 @@ impl ReportQueries {
         store_id: String,
         csv_data: String,
         filename: String,
+        sheet_name: Option<String>,
     ) -> Result<PrintReportResponse> {
-        csv_to_excel(ctx, store_id, csv_data, filename).await
+        csv_to_excel(ctx, store_id, csv_data, filename, sheet_name).await
     }
 }
 

--- a/server/service/src/report/convert_to_excel.rs
+++ b/server/service/src/report/convert_to_excel.rs
@@ -10,7 +10,12 @@ use umya_spreadsheet::{
     Cell, FontSize, Spreadsheet, Worksheet,
 };
 
-pub fn csv_to_excel(base_dir: &str, csv_data: &str, filename: &str) -> Result<String, ReportError> {
+pub fn csv_to_excel(
+    base_dir: &str,
+    csv_data: &str,
+    filename: &str,
+    sheet_name: Option<&str>,
+) -> Result<String, ReportError> {
     // Parse CSV data
     let mut reader = Reader::from_reader(csv_data.as_bytes());
     let headers = reader
@@ -25,6 +30,10 @@ pub fn csv_to_excel(base_dir: &str, csv_data: &str, filename: &str) -> Result<St
 
     // Create Excel workbook
     let mut book = umya_spreadsheet::new_file();
+    if let Some(name) = sheet_name.map(sanitize_sheet_name).filter(|n| !n.is_empty()) {
+        // Failure to rename the default sheet is non-fatal — fall through with the default name.
+        let _ = book.set_sheet_name(0, &name);
+    }
     let sheet = book
         .get_sheet_mut(&0)
         .ok_or_else(|| ReportError::DocGenerationError("Failed to get worksheet".to_string()))?;
@@ -77,6 +86,21 @@ pub fn export_html_report_to_excel(
         .map_err(|err| ReportError::DocGenerationError(format!("{err}")))?;
 
     Ok(reserved_file.id)
+}
+
+/// Coerce a free-form string into a value Excel will accept as a sheet name.
+/// Excel forbids `\ / ? * [ ] :`, leading/trailing apostrophes, names longer
+/// than 31 chars, and empty names.
+fn sanitize_sheet_name(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .map(|c| match c {
+            '\\' | '/' | '?' | '*' | '[' | ']' | ':' => '_',
+            _ => c,
+        })
+        .collect();
+    let trimmed = cleaned.trim().trim_matches('\'');
+    trimmed.chars().take(31).collect()
 }
 
 /// Hold a file in the temporary directory
@@ -714,7 +738,7 @@ mod report_to_excel_test {
     fn test_csv_to_excel() {
         let csv_data = "Name,Status,Invoice Number\nHarry Potter,Picked,2\nHermione Granger,New,3\nRon Weasley,New,4\n";
 
-        let result = csv_to_excel(".", csv_data, "test_csv_export");
+        let result = csv_to_excel(".", csv_data, "test_csv_export", None);
         assert!(result.is_ok(), "CSV to Excel conversion should succeed");
 
         let file_id = result.unwrap();
@@ -750,6 +774,33 @@ mod report_to_excel_test {
         assert_eq!(get_value("A4"), "Ron Weasley");
         assert_eq!(get_value("B4"), "New");
         assert_eq!(get_value("C4"), "4");
+    }
+
+    #[test]
+    fn test_csv_to_excel_sets_sheet_name() {
+        let csv_data = "Name,Status\nHarry Potter,Picked\n";
+        let file_id =
+            csv_to_excel(".", csv_data, "test_sheet_name", Some("fsmclinic")).unwrap();
+
+        let file_service = StaticFileService::new(".").unwrap();
+        let generated_file = file_service
+            .find_file(&file_id, StaticFileCategory::Temporary)
+            .unwrap()
+            .unwrap();
+        let book = umya_spreadsheet::reader::xlsx::read(&generated_file.path).unwrap();
+        let sheet = book.get_sheet(&0).unwrap();
+        assert_eq!(sheet.get_name(), "fsmclinic");
+    }
+
+    #[test]
+    fn test_sanitize_sheet_name_strips_forbidden_chars_and_truncates() {
+        // Forbidden characters become underscores
+        assert_eq!(sanitize_sheet_name("a/b\\c?d*e[f]g:h"), "a_b_c_d_e_f_g_h");
+        // Leading/trailing apostrophes and whitespace stripped
+        assert_eq!(sanitize_sheet_name("  'name'  "), "name");
+        // Truncated to 31 chars
+        let long = "a".repeat(50);
+        assert_eq!(sanitize_sheet_name(&long).len(), 31);
     }
 
     #[test]

--- a/server/service/src/report/report_service.rs
+++ b/server/service/src/report/report_service.rs
@@ -232,8 +232,9 @@ pub trait ReportServiceTrait: Sync + Send {
         base_dir: &str,
         csv_data: &str,
         filename: &str,
+        sheet_name: Option<&str>,
     ) -> Result<String, ReportError> {
-        csv_to_excel(base_dir, csv_data, filename)
+        csv_to_excel(base_dir, csv_data, filename, sheet_name)
     }
 }
 


### PR DESCRIPTION
Fixes #12091

# 👩🏻‍💻 What does this PR do?

Adds the current store's `code` to filenames of list-view exports, so multi-store users can tell exported files apart without opening them.

- **CSV**: `2026-06-23T14:30:45.000Z_GEN_stock.csv` (was `..._stock.csv`)
- **Excel**: `20260623_143045_GEN_stock.xlsx` (was `..._stock.xlsx`), with sheet tab named `GEN` instead of `Sheet1`.

Implementation is centralised: `ExportSelector` (the shared component used by every list-view AppBar) reads `store.code` from `useAuthContext` and threads it through both export paths. ~15 screens — stock, inbound/outbound shipments, prescriptions, supplier/customer returns, purchase orders, requisitions (request + response), cold-chain equipment, asset categories, locations, patients, master lists, stocktakes — pick the change up automatically with no per-screen edits.

For the Excel path, the CSV → Excel conversion (`csv_to_excel` GraphQL query) now accepts an optional `sheetName` argument and sets the worksheet name accordingly. A small `sanitize_sheet_name` helper strips Excel-forbidden characters (`\ / ? * [ ] :`) and truncates to Excel's 31-char limit.

## 💌 Any notes for the reviewer?

- **Why store.code, not store.name?** Code is file-system safe (no spaces/punctuation), short, and matches how the issue's example filename is shaped (`stocklist_fsmclinic_2026-06-12.xlsx`). Store names can contain `/` `:` and other characters that would break the Excel backend's `format!("{id}_{file_name}")` path construction. We may follow up to switch to a sanitised `store.name` if reviewers prefer the more recognisable label — this PR keeps things minimal.
- **CSV files have no sheet concept**, so the "sheet name = store code" only manifests in the Excel export. Opening a CSV in Numbers/Excel will still show that app's default sheet tab — expected, not a bug.
- **Out of scope**: import-template downloads and failed-upload error CSVs (cold-chain, assets, purchase-order line imports, facility properties) still use `useExportCSV` directly without a `storeCode` — those aren't store-data dumps. Easy to extend later if wanted.
- **No migration / no schema change.** New `sheetName` field on the existing `csvToExcel` GraphQL query is optional, so older clients keep working.

**Files touched**

Client
- `client/packages/common/src/utils/files/FileUtils.ts` — `getFilename` / `useExportCSV` accept optional `storeCode`
- `client/packages/system/src/Report/components/ExportSelector.tsx` — central injection point
- `client/packages/system/src/Report/api/hooks/useCsvToExcel.ts` + `operations.graphql` — pass `sheetName` through to backend
- Regenerated GraphQL types

Server
- `server/service/src/report/convert_to_excel.rs` — new `sheet_name: Option<&str>` arg + `sanitize_sheet_name` helper + 2 unit tests
- `server/service/src/report/report_service.rs` + `server/graphql/reports/src/{export,lib}.rs` — plumbed `sheet_name` through trait + GraphQL

# 🧪 Testing

- [ ] Log in to any store and navigate to **Stock** list
- [ ] Click **Export → Export CSV**; confirm filename is `<timestamp>_<storecode>_stock.csv`
- [ ] Click **Export → Export Excel**; confirm filename is `<timestamp>_<storecode>_stock.xlsx` and the worksheet tab inside the file is named after the store code (e.g. `GEN`)
- [ ] Switch to a different store and re-export; confirm the new store's code now appears
- [ ] Repeat the export check on at least one other list view (e.g. Inbound Shipments, Requisitions, Cold-chain Equipment) to confirm the central change covers all list views
- [ ] Backend tests: `cd server && cargo nextest run -p service report::convert_to_excel` — 12/12 passing locally, including new `test_csv_to_excel_sets_sheet_name` and `test_sanitize_sheet_name_strips_forbidden_chars_and_truncates`
- [ ] Frontend type-check: `cd client && yarn tsc --noEmit` — clean

# 📃 Documentation

- [x] **No documentation required**: behaviour-preserving improvement to existing export — no new user-facing controls, no change in where buttons are or what data is exported.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
