### PR TITLE
#12193 Fix internal order filters cut off in portrait mode

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -143,12 +143,14 @@ export const Toolbar = () => {
           flex={1}
           flexDirection="column"
           gap={1}
-          justifyContent="flex-end"
-          alignItems="flex-end"
+          sx={{
+            justifyContent: { xs: 'flex-start', md: 'flex-end' },
+            alignItems: { xs: 'flex-start', md: 'flex-end' },
+          }}
         >
           <InputWithLabelRow
             label={t('label.min-months-of-stock')}
-            labelWidth={'250px'}
+            labelProps={{ sx: { width: { xs: '120px', md: '250px' } } }}
             Input={
               <Autocomplete
                 disabled={isDisabled || isProgram}
@@ -192,7 +194,7 @@ export const Toolbar = () => {
           />
           <InputWithLabelRow
             label={t('label.max-months-of-stock')}
-            labelWidth={'250px'}
+            labelProps={{ sx: { width: { xs: '120px', md: '250px' } } }}
             Input={
               <Autocomplete
                 disabled={isDisabled || isProgram}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -72,7 +72,11 @@ export const Toolbar = () => {
         flexDirection: 'column',
       }}
     >
-      <Grid container flexWrap="nowrap">
+      <Grid
+        container
+        flexWrap="nowrap"
+        sx={{ flexDirection: { xs: 'column', md: 'row' } }}
+      >
         <Grid display="flex" flex={1} flexDirection="column" gap={1}>
           {otherParty && (
             <InputWithLabelRow
@@ -144,7 +148,7 @@ export const Toolbar = () => {
         >
           <InputWithLabelRow
             label={t('label.min-months-of-stock')}
-            labelWidth={'350px'}
+            labelWidth={'250px'}
             Input={
               <Autocomplete
                 disabled={isDisabled || isProgram}
@@ -188,7 +192,7 @@ export const Toolbar = () => {
           />
           <InputWithLabelRow
             label={t('label.max-months-of-stock')}
-            labelWidth={'350px'}
+            labelWidth={'250px'}
             Input={
               <Autocomplete
                 disabled={isDisabled || isProgram}

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -42,14 +42,22 @@ export const Toolbar = () => {
     <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
       <Grid
         container
-        flexDirection="row"
         display="flex"
         flex={1}
-        alignItems="flex-end"
         gap={1}
+        sx={{
+          flexDirection: { xs: 'column', md: 'row' },
+          alignItems: { xs: 'flex-start', md: 'flex-end' },
+        }}
       >
         <Grid display="flex" flex={1}>
-          <Box display="flex" flexDirection="row" gap={4}>
+          <Box
+            display="flex"
+            sx={{
+              flexDirection: { xs: 'column', md: 'row' },
+              gap: { xs: 1, md: 4 },
+            }}
+          >
             <Box display="flex" flex={1} flexDirection="column" gap={1}>
               {otherParty && (
                 <InputWithLabelRow


### PR DESCRIPTION
Fixes #12193

<img width="300" align="right" alt="image" src="https://github.com/user-attachments/assets/80e98a89-94a6-4b71-b591-c955a50a6c84" />

# 👩🏻‍💻 What does this PR do?

The internal order and customer requisition detail toolbars forced their filters into a single non-wrapping row, so on a tablet in portrait (~800px) they overflowed and got clipped.

- Stack the toolbar columns vertically below the `md` breakpoint so filters wrap and stay visible; desktop layout is unchanged.
- Narrow the MOS label width from 350px to 250px so those rows fit.

Layout-only changes (responsive MUI `sx`).

## 💌 Any notes for the reviewer?

Also applied the same fix to the customer requisition toolbar (same pattern) — easy to scope back to internal orders only if preferred.

# 🧪 Testing

- [ ] Open an internal order, resize to ~800px wide (or tablet portrait), confirm all filters are visible
- [ ] Confirm desktop layout (≥1025px) is unchanged
- [ ] Same check on a customer requisition

# 📃 Documentation

- [x] **No documentation required**: bug fix with no change in behaviour
