### PR TITLE
#12142 Add sign-off section to outbound shipment forms

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2992,5 +2992,7 @@
   "warning.insufficient-recent-stocktake-items": "You have not completed stocktake(s) containing at least {{ minItems }} items within the last {{maxAge}} days. Your stock levels may not be accurate. Are you sure that you want to continue?",
   "warning.manual-store-requisition": "Entering a requisition for this store may result in duplicates if the store also submits an internal order.",
   "warning.nothing-to-supply": "Nothing left to supply!",
-  "warning.requested-exceeds-suggested": "Your requested quantity is higher than the suggested"
+  "warning.requested-exceeds-suggested": "Your requested quantity is higher than the suggested",
+  "label.completed-by": "Completed by",
+  "label.signature": "Signature"
 }

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -958,6 +958,7 @@
   "label.comment-for-supplier": "Comment (for supplier)",
   "label.comments-required": "Comments required",
   "label.communication-charge": "Communications charge",
+  "label.completed-by": "Completed by",
   "label.configure-supply-level": "Configure supply levels",
   "label.confirmation-date": "Confirmation date",
   "label.confirmed": "Confirmed",
@@ -1652,6 +1653,7 @@
   "label.show-products-not-at-risk": "Show products not at risk",
   "label.show-zeroed-lines": "Show lines where counted quantity is zero",
   "label.showing": "Showing",
+  "label.signature": "Signature",
   "label.site": "Site:",
   "label.snapshot": "Snapshot",
   "label.snapshot-num-of-packs": "Packs snapshot",
@@ -2992,7 +2994,5 @@
   "warning.insufficient-recent-stocktake-items": "You have not completed stocktake(s) containing at least {{ minItems }} items within the last {{maxAge}} days. Your stock levels may not be accurate. Are you sure that you want to continue?",
   "warning.manual-store-requisition": "Entering a requisition for this store may result in duplicates if the store also submits an internal order.",
   "warning.nothing-to-supply": "Nothing left to supply!",
-  "warning.requested-exceeds-suggested": "Your requested quantity is higher than the suggested",
-  "label.completed-by": "Completed by",
-  "label.signature": "Signature"
+  "warning.requested-exceeds-suggested": "Your requested quantity is higher than the suggested"
 }

--- a/standard_forms/generated/standard_forms.json
+++ b/standard_forms/generated/standard_forms.json
@@ -280,14 +280,14 @@
       "excel_template_buffer": null
     },
     {
-      "id": "outbound-invoice-landscape-with-logo_2_6_6_false",
+      "id": "outbound-invoice-landscape-with-logo_2_6_7_false",
       "name": "Outbound Shipment (landscape)",
       "description": null,
       "template": {
         "index": {
           "template": "template.html",
           "header": "header.html",
-          "footer": null,
+          "footer": "footer.html",
           "query": [
             "outbound.graphql"
           ],
@@ -295,6 +295,13 @@
           "convert_data_type": "Extism"
         },
         "entries": {
+          "footer.html": {
+            "type": "TeraTemplate",
+            "data": {
+              "output": "Html",
+              "template": "<div class=\"signoff\">\n    <div class=\"signoff-col\">\n        <p class=\"signoff-heading\">{{t(k=\"label.completed-by\", f=\"Completed by\")}}</p>\n        <div class=\"signoff-field\">\n            <span class=\"signoff-label\">{{t(k=\"label.name\", f=\"Name\")}}</span>\n            <span class=\"signoff-line\"></span>\n        </div>\n        <div class=\"signoff-field\">\n            <span class=\"signoff-label\">{{t(k=\"label.signature\", f=\"Signature\")}}</span>\n            <span class=\"signoff-line\"></span>\n        </div>\n        <div class=\"signoff-field\">\n            <span class=\"signoff-label\">{{t(k=\"label.date\", f=\"Date\")}}</span>\n            <span class=\"signoff-line\"></span>\n        </div>\n    </div>\n\n    <div class=\"signoff-col\">\n        <p class=\"signoff-heading\">{{t(k=\"label.verified-by\", f=\"Verified by\")}}</p>\n        <div class=\"signoff-field\">\n            <span class=\"signoff-label\">{{t(k=\"label.name\", f=\"Name\")}}</span>\n            <span class=\"signoff-line\"></span>\n        </div>\n        <div class=\"signoff-field\">\n            <span class=\"signoff-label\">{{t(k=\"label.signature\", f=\"Signature\")}}</span>\n            <span class=\"signoff-line\"></span>\n        </div>\n        <div class=\"signoff-field\">\n            <span class=\"signoff-label\">{{t(k=\"label.date\", f=\"Date\")}}</span>\n            <span class=\"signoff-line\"></span>\n        </div>\n    </div>\n</div>\n"
+            }
+          },
           "header.html": {
             "type": "TeraTemplate",
             "data": {
@@ -311,7 +318,7 @@
           },
           "style.css": {
             "type": "Resource",
-            "data": "@media print {\n  @page {\n    size: A4 landscape;\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\n.header_image_section,\n.header_supplied_section,\n.header_date_section,\n.body_section,\n.body_total_section {\n  margin-inline-start: 8px;\n  width: 100%;\n}\n\n.header_supplied_section {\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.header-space-between {\n  display: flex;\n  justify-content: space-between;\n}\n\n.header_image_section {\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 8pt;\n  font-family: Tahoma;\n}\n\n.header_date_section {\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.header_section_field_right {\n  text-align: end;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.header_section_field_left {\n  text-align: start;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.line_number,\n.quantity,\n.pack,\n.sell_price,\n.cost_price,\n.total_quantity,\n.total_extension {\n  text-align: right;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.expiry {\n  text-align: end;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.item_code,\n.item_name,\n.batch {\n  text-align: start;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.body_section,\n.body_total_section {\n  width: 100%;\n  font-family: Tahoma;\n}\n\n.body_total_section {\n  font-weight: bold;\n}\n\n.body_section tr.body_column_label th {\n  border-bottom: 0.5px solid black;\n}\n\n.body_value td {\n  border-bottom: 0.5px solid black;\n}\n\nhr {\n  width: 100%;\n  margin-inline-start: 8px;\n  border: 0.1px solid black;\n}\n\n.batch-wrap {\n  word-break: break-word;\n}\n"
+            "data": "@media print {\n  @page {\n    size: A4 landscape;\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\n.header_image_section,\n.header_supplied_section,\n.header_date_section,\n.body_section,\n.body_total_section {\n  margin-inline-start: 8px;\n  width: 100%;\n}\n\n.header_supplied_section {\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.header-space-between {\n  display: flex;\n  justify-content: space-between;\n}\n\n.header_image_section {\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 8pt;\n  font-family: Tahoma;\n}\n\n.header_date_section {\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.header_section_field_right {\n  text-align: end;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.header_section_field_left {\n  text-align: start;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.line_number,\n.quantity,\n.pack,\n.sell_price,\n.cost_price,\n.total_quantity,\n.total_extension {\n  text-align: right;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.expiry {\n  text-align: end;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.item_code,\n.item_name,\n.batch {\n  text-align: start;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.body_section,\n.body_total_section {\n  width: 100%;\n  font-family: Tahoma;\n}\n\n.body_total_section {\n  font-weight: bold;\n}\n\n.body_section tr.body_column_label th {\n  border-bottom: 0.5px solid black;\n}\n\n.body_value td {\n  border-bottom: 0.5px solid black;\n}\n\nhr {\n  width: 100%;\n  margin-inline-start: 8px;\n  border: 0.1px solid black;\n}\n\n.batch-wrap {\n  word-break: break-word;\n}\n\n.signoff {\n  width: 100%;\n  margin-inline-start: 8px;\n  margin-top: 40px;\n  display: flex;\n  justify-content: space-between;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.signoff-col {\n  width: 45%;\n  border-top: 0.5px solid black;\n  padding-top: 6px;\n}\n\n.signoff-heading {\n  font-weight: bold;\n  margin: 0 0 4px 0;\n}\n\n.signoff-field {\n  display: flex;\n  align-items: flex-end;\n  margin-top: 14px;\n}\n\n.signoff-label {\n  white-space: nowrap;\n  margin-inline-end: 6px;\n}\n\n.signoff-line {\n  flex: 1;\n  border-bottom: 0.5px solid black;\n}\n"
           },
           "template.html": {
             "type": "TeraTemplate",
@@ -327,7 +334,7 @@
       "argument_schema_id": null,
       "comment": null,
       "is_custom": false,
-      "version": "2.6.6",
+      "version": "2.6.7",
       "code": "outbound-invoice-landscape-with-logo",
       "form_schema": null,
       "excel_template_buffer": null
@@ -393,14 +400,14 @@
       "excel_template_buffer": null
     },
     {
-      "id": "outbound-invoice-portrait-with-logo_2_6_5_false",
+      "id": "outbound-invoice-portrait-with-logo_2_6_6_false",
       "name": "Outbound Shipment (portrait)",
       "description": null,
       "template": {
         "index": {
           "template": "template.html",
           "header": "header.html",
-          "footer": null,
+          "footer": "footer.html",
           "query": [
             "picklist.graphql"
           ],
@@ -408,6 +415,13 @@
           "convert_data_type": "Extism"
         },
         "entries": {
+          "footer.html": {
+            "type": "TeraTemplate",
+            "data": {
+              "output": "Html",
+              "template": "<div class=\"signoff\">\n    <div class=\"signoff-col\">\n        <p class=\"signoff-heading\">{{t(k=\"label.completed-by\", f=\"Completed by\")}}</p>\n        <div class=\"signoff-field\">\n            <span class=\"signoff-label\">{{t(k=\"label.name\", f=\"Name\")}}</span>\n            <span class=\"signoff-line\"></span>\n        </div>\n        <div class=\"signoff-field\">\n            <span class=\"signoff-label\">{{t(k=\"label.signature\", f=\"Signature\")}}</span>\n            <span class=\"signoff-line\"></span>\n        </div>\n        <div class=\"signoff-field\">\n            <span class=\"signoff-label\">{{t(k=\"label.date\", f=\"Date\")}}</span>\n            <span class=\"signoff-line\"></span>\n        </div>\n    </div>\n\n    <div class=\"signoff-col\">\n        <p class=\"signoff-heading\">{{t(k=\"label.verified-by\", f=\"Verified by\")}}</p>\n        <div class=\"signoff-field\">\n            <span class=\"signoff-label\">{{t(k=\"label.name\", f=\"Name\")}}</span>\n            <span class=\"signoff-line\"></span>\n        </div>\n        <div class=\"signoff-field\">\n            <span class=\"signoff-label\">{{t(k=\"label.signature\", f=\"Signature\")}}</span>\n            <span class=\"signoff-line\"></span>\n        </div>\n        <div class=\"signoff-field\">\n            <span class=\"signoff-label\">{{t(k=\"label.date\", f=\"Date\")}}</span>\n            <span class=\"signoff-line\"></span>\n        </div>\n    </div>\n</div>\n"
+            }
+          },
           "header.html": {
             "type": "TeraTemplate",
             "data": {
@@ -424,7 +438,7 @@
           },
           "style.css": {
             "type": "Resource",
-            "data": "@media print {\n  @page {\n    size: portrait;\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\n.header_image_section,\n.header_supplied_section,\n.header_date_section,\n.body_section,\n.body_total_section {\n  margin-inline-start: 8px;\n  width: 100%;\n}\n\n.header_supplied_section {\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.header-space-between {\n  display: flex;\n  justify-content: space-between;\n}\n\n.header_image_section {\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 8pt;\n  font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;\n}\n\n.header_date_section {\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.header_section_field_right {\n  text-align: end;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.header_section_field_left {\n  text-align: start;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.line_number,\n.quantity,\n.pack {\n  text-align: right;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.expiry {\n  text-align: end;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.location_code,\n.item_name,\n.batch,\n.issued {\n  text-align: start;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.body_section,\n.body_total_section {\n  width: 98%;\n  font-family: Tahoma;\n}\n\n.body_section tr.body_column_label th {\n  border-bottom: 0.5px solid black;\n}\n\n.body_value td {\n  border-bottom: 0.5px solid black;\n}\n\nhr {\n  width: 100%;\n  margin-inline-start: 8px;\n  border: 0.1px solid black;\n}\n\n.batch-wrap {\n  word-break: break-word;\n}\n"
+            "data": "@media print {\n  @page {\n    size: portrait;\n    @bottom-right {\n      font-family: Tahoma;\n      font-size: 8pt;\n      /* do not allow formatter to add a line break in the content */\n      /* prettier-ignore*/\n      content: '{{t(k=\"report.page\",f=\"Page\")}} ' counter(page) ' {{t(k=\"report.of\",f=\"of\")}} ' counter(pages);\n    }\n  }\n}\n\n.logo {\n  display: block;\n  height: 96px;\n}\n\n.header_image_section,\n.header_supplied_section,\n.header_date_section,\n.body_section,\n.body_total_section {\n  margin-inline-start: 8px;\n  width: 100%;\n}\n\n.header_supplied_section {\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.header-space-between {\n  display: flex;\n  justify-content: space-between;\n}\n\n.header_image_section {\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 8pt;\n  font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;\n}\n\n.header_date_section {\n  width: 100%;\n  font-family: Tahoma;\n  font-size: 8pt;\n  border-bottom: 0.5px solid black;\n  padding-top: 1pt;\n}\n\n.header_section_field_right {\n  text-align: end;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.header_section_field_left {\n  text-align: start;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.line_number,\n.quantity,\n.pack {\n  text-align: right;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.expiry {\n  text-align: end;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.location_code,\n.item_name,\n.batch,\n.issued {\n  text-align: start;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.body_section,\n.body_total_section {\n  width: 98%;\n  font-family: Tahoma;\n}\n\n.body_section tr.body_column_label th {\n  border-bottom: 0.5px solid black;\n}\n\n.body_value td {\n  border-bottom: 0.5px solid black;\n}\n\nhr {\n  width: 100%;\n  margin-inline-start: 8px;\n  border: 0.1px solid black;\n}\n\n.batch-wrap {\n  word-break: break-word;\n}\n\n.signoff {\n  width: 98%;\n  margin-inline-start: 8px;\n  margin-top: 40px;\n  display: flex;\n  justify-content: space-between;\n  font-family: Tahoma;\n  font-size: 8pt;\n}\n\n.signoff-col {\n  width: 45%;\n  border-top: 0.5px solid black;\n  padding-top: 6px;\n}\n\n.signoff-heading {\n  font-weight: bold;\n  margin: 0 0 4px 0;\n}\n\n.signoff-field {\n  display: flex;\n  align-items: flex-end;\n  margin-top: 14px;\n}\n\n.signoff-label {\n  white-space: nowrap;\n  margin-inline-end: 6px;\n}\n\n.signoff-line {\n  flex: 1;\n  border-bottom: 0.5px solid black;\n}\n"
           },
           "template.html": {
             "type": "TeraTemplate",
@@ -440,7 +454,7 @@
       "argument_schema_id": null,
       "comment": null,
       "is_custom": false,
-      "version": "2.6.5",
+      "version": "2.6.6",
       "code": "outbound-invoice-portrait-with-logo",
       "form_schema": null,
       "excel_template_buffer": null

--- a/standard_forms/outbound-invoice-landscape-with-logo/latest/report-manifest.json
+++ b/standard_forms/outbound-invoice-landscape-with-logo/latest/report-manifest.json
@@ -1,6 +1,6 @@
 {
   "is_custom": false,
-  "version": "2.6.6",
+  "version": "2.6.7",
   "code": "outbound-invoice-landscape-with-logo",
   "context": "OUTBOUND_SHIPMENT",
   "name": "Outbound Shipment (landscape)",
@@ -8,5 +8,6 @@
     "gql": "outbound.graphql"
   },
   "arguments": {},
-  "header": "header.html"
+  "header": "header.html",
+  "footer": "footer.html"
 }

--- a/standard_forms/outbound-invoice-landscape-with-logo/latest/src/footer.html
+++ b/standard_forms/outbound-invoice-landscape-with-logo/latest/src/footer.html
@@ -1,0 +1,33 @@
+<div class="signoff">
+    <div class="signoff-col">
+        <p class="signoff-heading">{{t(k="label.completed-by", f="Completed by")}}</p>
+        <div class="signoff-field">
+            <span class="signoff-label">{{t(k="label.name", f="Name")}}</span>
+            <span class="signoff-line"></span>
+        </div>
+        <div class="signoff-field">
+            <span class="signoff-label">{{t(k="label.signature", f="Signature")}}</span>
+            <span class="signoff-line"></span>
+        </div>
+        <div class="signoff-field">
+            <span class="signoff-label">{{t(k="label.date", f="Date")}}</span>
+            <span class="signoff-line"></span>
+        </div>
+    </div>
+
+    <div class="signoff-col">
+        <p class="signoff-heading">{{t(k="label.verified-by", f="Verified by")}}</p>
+        <div class="signoff-field">
+            <span class="signoff-label">{{t(k="label.name", f="Name")}}</span>
+            <span class="signoff-line"></span>
+        </div>
+        <div class="signoff-field">
+            <span class="signoff-label">{{t(k="label.signature", f="Signature")}}</span>
+            <span class="signoff-line"></span>
+        </div>
+        <div class="signoff-field">
+            <span class="signoff-label">{{t(k="label.date", f="Date")}}</span>
+            <span class="signoff-line"></span>
+        </div>
+    </div>
+</div>

--- a/standard_forms/outbound-invoice-landscape-with-logo/latest/src/style.css
+++ b/standard_forms/outbound-invoice-landscape-with-logo/latest/src/style.css
@@ -119,3 +119,40 @@ hr {
 .batch-wrap {
   word-break: break-word;
 }
+
+.signoff {
+  width: 100%;
+  margin-inline-start: 8px;
+  margin-top: 40px;
+  display: flex;
+  justify-content: space-between;
+  font-family: Tahoma;
+  font-size: 8pt;
+}
+
+.signoff-col {
+  width: 45%;
+  border-top: 0.5px solid black;
+  padding-top: 6px;
+}
+
+.signoff-heading {
+  font-weight: bold;
+  margin: 0 0 4px 0;
+}
+
+.signoff-field {
+  display: flex;
+  align-items: flex-end;
+  margin-top: 14px;
+}
+
+.signoff-label {
+  white-space: nowrap;
+  margin-inline-end: 6px;
+}
+
+.signoff-line {
+  flex: 1;
+  border-bottom: 0.5px solid black;
+}

--- a/standard_forms/outbound-invoice-portrait-with-logo/latest/report-manifest.json
+++ b/standard_forms/outbound-invoice-portrait-with-logo/latest/report-manifest.json
@@ -1,6 +1,6 @@
 {
   "is_custom": false,
-  "version": "2.6.5",
+  "version": "2.6.6",
   "code": "outbound-invoice-portrait-with-logo",
   "context": "OUTBOUND_SHIPMENT",
   "name": "Outbound Shipment (portrait)",
@@ -8,5 +8,6 @@
     "gql": "picklist.graphql"
   },
   "arguments": {},
-  "header": "header.html"
+  "header": "header.html",
+  "footer": "footer.html"
 }

--- a/standard_forms/outbound-invoice-portrait-with-logo/latest/src/footer.html
+++ b/standard_forms/outbound-invoice-portrait-with-logo/latest/src/footer.html
@@ -1,0 +1,33 @@
+<div class="signoff">
+    <div class="signoff-col">
+        <p class="signoff-heading">{{t(k="label.completed-by", f="Completed by")}}</p>
+        <div class="signoff-field">
+            <span class="signoff-label">{{t(k="label.name", f="Name")}}</span>
+            <span class="signoff-line"></span>
+        </div>
+        <div class="signoff-field">
+            <span class="signoff-label">{{t(k="label.signature", f="Signature")}}</span>
+            <span class="signoff-line"></span>
+        </div>
+        <div class="signoff-field">
+            <span class="signoff-label">{{t(k="label.date", f="Date")}}</span>
+            <span class="signoff-line"></span>
+        </div>
+    </div>
+
+    <div class="signoff-col">
+        <p class="signoff-heading">{{t(k="label.verified-by", f="Verified by")}}</p>
+        <div class="signoff-field">
+            <span class="signoff-label">{{t(k="label.name", f="Name")}}</span>
+            <span class="signoff-line"></span>
+        </div>
+        <div class="signoff-field">
+            <span class="signoff-label">{{t(k="label.signature", f="Signature")}}</span>
+            <span class="signoff-line"></span>
+        </div>
+        <div class="signoff-field">
+            <span class="signoff-label">{{t(k="label.date", f="Date")}}</span>
+            <span class="signoff-line"></span>
+        </div>
+    </div>
+</div>

--- a/standard_forms/outbound-invoice-portrait-with-logo/latest/src/style.css
+++ b/standard_forms/outbound-invoice-portrait-with-logo/latest/src/style.css
@@ -112,3 +112,40 @@ hr {
 .batch-wrap {
   word-break: break-word;
 }
+
+.signoff {
+  width: 98%;
+  margin-inline-start: 8px;
+  margin-top: 40px;
+  display: flex;
+  justify-content: space-between;
+  font-family: Tahoma;
+  font-size: 8pt;
+}
+
+.signoff-col {
+  width: 45%;
+  border-top: 0.5px solid black;
+  padding-top: 6px;
+}
+
+.signoff-heading {
+  font-weight: bold;
+  margin: 0 0 4px 0;
+}
+
+.signoff-field {
+  display: flex;
+  align-items: flex-end;
+  margin-top: 14px;
+}
+
+.signoff-label {
+  white-space: nowrap;
+  margin-inline-end: 6px;
+}
+
+.signoff-line {
+  flex: 1;
+  border-bottom: 0.5px solid black;
+}


### PR DESCRIPTION
Fixes #12142

# 👩🏻‍💻 What does this PR do?
<img height="350" alt="Screenshot 2026-06-23 at 5 11 35 pm" src="https://github.com/user-attachments/assets/ab8e317f-f6fc-44d6-86d8-ae4565bf5d2a" />
<img height="350" alt="Screenshot 2026-06-23 at 5 11 45 pm" src="https://github.com/user-attachments/assets/1f424be9-a699-4a6e-b92c-408f9ee1bd8c" />

Adds a sign-off section to the bottom of the **Outbound Shipment (portrait)** and **Outbound Shipment (landscape)** print documents. The section has two columns — **Completed by** and **Verified by** — each capturing **Name**, **Signature** and **Date**.

Previously these documents had no sign-off area, so sites annotated printouts by hand or kept separate paper records to confirm handover and receipt of stock.

Implementation:
- New `src/footer.html` on both forms, referenced via `"footer": "footer.html"` in each `report-manifest.json`. This reuses the existing Pick List footer pattern — the footer is rendered in the page `<tfoot>`.
- New `.signoff*` styles in each form's `style.css` (Tahoma 8pt, two columns with a top rule and underlined Name/Signature/Date fields).
- Added `label.completed-by` and `label.signature` translation keys to `en/common.json` (`label.name`, `label.date`, `label.verified-by` already existed). Labels use `t()` with English fallbacks.
- Bumped form versions (portrait `2.6.5 → 2.6.6`, landscape `2.6.6 → 2.6.7`) and regenerated `standard_forms/generated/standard_forms.json` so the change upserts on server startup.

Verified locally by rendering the server's HTML structure (the `thead/tbody/tfoot` paging table) with the form styles + footer and mock data — the layout matches the example screenshots in the issue.

## 💌 Any notes for the reviewer?

- **Wording**: the issue text describes "Sign-off 1 / Sign-off 2"; I used **Completed by / Verified by** to match the format in the issue author's example screenshots (the author noted wording could change).
- **Per-page repeat**: the footer renders in the page `<tfoot>`, so on a multi-page shipment the sign-off appears at the bottom of every page. This is consistent with the existing Pick List footer behaviour and matches the single-page examples in the issue.
- **Scope**: limited to the two outbound shipment forms (the concrete ask). The issue's broader idea of a standard sign-off across *all* operational printouts is left as a follow-up — the Pick List already has its own sign-off and is untouched here.
- Touches `standard_forms/` plus one `en/common.json` translation file only; no server/client code paths affected.

# 🧪 Testing

- [ ] Build reports: `cd server && cargo run --bin remote_server_cli build-reports`
- [ ] Upsert: `cargo run --bin remote_server_cli upsert-reports --overwrite` (or just start the server, which upserts embedded forms on startup)
- [ ] Open an Outbound Shipment with several lines → **Print** → choose **Outbound Shipment (portrait)**
- [ ] Confirm the sign-off block (Completed by / Verified by, each with Name / Signature / Date) appears at the bottom of the document
- [ ] Repeat with **Outbound Shipment (landscape)**

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: additive change to existing standard forms, no change in behaviour elsewhere
- [ ] **These areas should be updated or checked**:
  1.
  2.
