### PR TITLE
11193 reduce noise in the logs

### DIFF
--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -46,6 +46,8 @@
 #   filename: remote_server.log
 #   max_file_count: 10
 #   max_file_size: 1
+##   log every GraphQL request/response (default true); set false to suppress this noise
+#   log_graphql_queries: true
 # backup: # see cli backup/restore
 #   backup_dir: "~/Documents/omSupply_backup"
 #   pg_bin_dir: "/Applications/Postgres.app/Contents/Versions/16/bin"  # Optional
@@ -62,4 +64,3 @@
 #   interval: 60 # in seconds
 # features:
 #   stock_movement: true
-

--- a/server/graphql/lib.rs
+++ b/server/graphql/lib.rs
@@ -400,7 +400,7 @@ impl GraphqlSchema {
         let initialisation_builder = InitialisationSchema::build(
             InitialisationQueries,
             InitialisationMutations,
-            InitialisationSubscriptions::default(),
+            InitialisationSubscriptions,
         )
         .data(service_provider.clone())
         .data(subscription_broadcast.clone())

--- a/server/graphql/lib.rs
+++ b/server/graphql/lib.rs
@@ -351,6 +351,17 @@ pub struct GraphSchemaData {
     pub subscription_broadcast: broadcast::Sender<ResolvedSubscription>,
 }
 
+fn with_request_logger<Q, M, S>(
+    builder: async_graphql::SchemaBuilder<Q, M, S>,
+    enabled: bool,
+) -> async_graphql::SchemaBuilder<Q, M, S> {
+    if enabled {
+        builder.extension(GraphQLRequestLogger)
+    } else {
+        builder
+    }
+}
+
 impl GraphqlSchema {
     pub fn new(data: GraphSchemaData, operational_status: OperationalStatus) -> GraphqlSchema {
         let GraphSchemaData {
@@ -364,19 +375,25 @@ impl GraphqlSchema {
         } = data;
         let subscription_broadcast = Data::new(subscription_broadcast);
 
+        // Setting for logging graphQL
+        let log_graphql_queries = settings
+            .logging
+            .as_ref()
+            .map(|logging| logging.log_graphql_queries())
+            .unwrap_or(true);
+
         // Self requester schema is a copy of operational schema, used for reports
         // needs to be available as data in operational schema
-        let self_requester_schema =
+        let self_requester_builder =
             OperationalSchema::build(Queries::new(), Mutations::new(), Subscriptions::default())
                 .data(connection_manager.clone())
                 .data(loader_registry.clone())
                 .data(service_provider.clone())
                 .data(auth.clone())
                 .data(settings.clone())
-                .data(validated_plugins.clone())
-                .extension(GraphQLRequestLogger)
-                .finish();
-        // Self requester does not need loggers
+                .data(validated_plugins.clone());
+        let self_requester_schema =
+            with_request_logger(self_requester_builder, log_graphql_queries).finish();
 
         // Shared operational status across all schemas
         let operational_status_ref = Data::new(RwLock::new(operational_status.clone()));
@@ -393,8 +410,8 @@ impl GraphqlSchema {
                 .data(subscription_broadcast.clone())
                 // Add self requester to operational
                 .data(Data::new(SelfRequestImpl::new_boxed(self_requester_schema)))
-                .data(operational_status_ref.clone())
-                .extension(GraphQLRequestLogger);
+                .data(operational_status_ref.clone());
+        let operational_builder = with_request_logger(operational_builder, log_graphql_queries);
 
         // Initialisation schema should ony need service_provider
         let initialisation_builder = InitialisationSchema::build(
@@ -522,7 +539,6 @@ async fn graphql_playground() -> HttpResponse {
 
 // TODO remove this and just do reqwest query to self
 /// Used for reports
-
 struct SelfRequestImpl {
     schema: OperationalSchema,
 }

--- a/server/graphql/lib.rs
+++ b/server/graphql/lib.rs
@@ -405,14 +405,12 @@ impl GraphqlSchema {
         .data(service_provider.clone())
         .data(subscription_broadcast.clone())
         .data(operational_status_ref.clone())
-        .data(subscription_broadcast.clone())
-        .extension(GraphQLRequestLogger);
+        .data(subscription_broadcast.clone());
 
         let migration_builder =
             MigrationSchema::build(MigrationQueries, EmptyMutation, EmptySubscription)
                 .data(service_provider.clone())
-                .data(operational_status_ref.clone())
-                .extension(GraphQLRequestLogger);
+                .data(operational_status_ref.clone());
 
         GraphqlSchema {
             operational: operational_builder.finish(),

--- a/server/server/src/schedule_plugin.rs
+++ b/server/server/src/schedule_plugin.rs
@@ -1,6 +1,6 @@
-use service::backend_plugin::{plugin_provider::PluginInstance, types::schedule};
 use chrono::{Duration, NaiveDateTime, Utc};
 use repository::PluginType;
+use service::backend_plugin::{plugin_provider::PluginInstance, types::schedule};
 use std::collections::HashMap;
 use tokio::task::JoinHandle;
 use util::format_error;
@@ -19,9 +19,10 @@ impl SchedulePluginRunner {
         Default::default()
     }
 
-    async fn run(&mut self) {
+    async fn run(&mut self) -> usize {
         let plugins = PluginInstance::get_all(PluginType::Schedule);
         let now = Utc::now().naive_utc();
+        let mut ran = 0;
 
         for plugin in plugins {
             let due = self
@@ -33,6 +34,8 @@ impl SchedulePluginRunner {
             if !due {
                 continue;
             }
+
+            ran += 1;
 
             // `call_async` runs the plugin (the whole boajs interpreter, plus any
             // `fetch`/`use_graphql` http calls it makes) on the blocking pool, so it doesn't
@@ -47,6 +50,8 @@ impl SchedulePluginRunner {
 
             self.next_run.insert(plugin.code.clone(), next);
         }
+
+        ran
     }
 }
 
@@ -57,8 +62,10 @@ pub fn spawn() -> JoinHandle<()> {
             tokio::time::interval(std::time::Duration::from_secs(SCHEDULE_PLUGIN_POLL_SECS));
         loop {
             interval.tick().await;
-            runner.run().await;
-            log::info!("Schedule plugin runner complete");
+            let ran = runner.run().await;
+            if ran > 0 {
+                log::debug!("Schedule plugin runner ran {ran} plugin(s)");
+            }
         }
     })
 }

--- a/server/server/src/scheduled_tasks.rs
+++ b/server/server/src/scheduled_tasks.rs
@@ -19,7 +19,6 @@ async fn scheduled_task_runner(service_provider: Arc<ServiceProvider>, interval_
 
     loop {
         interval.tick().await;
-        log::debug!("Processing Scheduled Tasks");
         if CentralServerConfig::is_central_server() {
             // Email sending is only supported on the central server
             let send_emails = service_provider

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -154,9 +154,15 @@ pub struct LoggingSettings {
     pub max_file_count: Option<i64>,
     /// Max logfile size in MB
     pub max_file_size: Option<usize>,
+    /// Log every GraphQL request/response
+    pub log_graphql_queries: Option<bool>,
 }
 
 impl LoggingSettings {
+    pub fn log_graphql_queries(&self) -> bool {
+        self.log_graphql_queries.unwrap_or(true)
+    }
+
     pub fn new(mode: LogMode, level: Level) -> Self {
         LoggingSettings {
             mode,
@@ -165,6 +171,7 @@ impl LoggingSettings {
             filename: None,
             max_file_count: None,
             max_file_size: None,
+            log_graphql_queries: None,
         }
     }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11193

# 👩🏻‍💻 What does this PR do?
Reduces noise in logs by: 
- Getting rid of the Processing Scheduled Tasks debug log. Tasks should have their own logging when they run
- Plugin runner complete log now will only show if actually ran plugin
- Don't show GraphQL logs when initialising
- YAML preference to hide GraphQL logs all together

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Not seeing logs when initialising
- [ ] Setting log_graphql_queries yaml setting to false and not seeing logs for GraphQL
- [ ] Setting above to true and seeing logs for GraphQL 
- [ ] Not seeing `Processing Scheduled Tasks` every 60 seconds
- [ ] Not seeing plugin runner log often either

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

