### PR TITLE
#12253 Internal order: fix double-INSERT when adding item

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -77,7 +77,8 @@ export const RequestLineEditModal = ({
   const nextDisabled =
     (!hasNext && mode === ModalMode.Update) ||
     !currentItem ||
-    isEditingRequested;
+    isEditingRequested ||
+    isLoading;
 
   const deletePreviousLine = () => {
     const shouldDelete = shouldDeleteLine(mode, draft?.id, isDisabled);
@@ -152,7 +153,7 @@ export const RequestLineEditModal = ({
       okButton={
         <DialogButton
           variant="ok"
-          disabled={!currentItem || isEditingRequested}
+          disabled={!currentItem || isEditingRequested || isLoading}
           onClick={async () => {
             if (requisition.status === RequisitionNodeStatus.Sent) {
               onClose();

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   FnUtils,
   QuantityUtils,
@@ -74,6 +74,7 @@ export const useDraftRequisitionLine = (
   const { lines } = useRequest.line.list(item?.id);
   const { data } = useRequest.document.get();
   const { mutateAsync: saveMutation, isPending: isLoading } = useRequest.line.save();
+  const isSavingRef = useRef(false);
 
   const [draft, setDraft] = useState<DraftRequestLine | null>(null);
   useEffect(() => {
@@ -100,8 +101,19 @@ export const useDraftRequisitionLine = (
   }, []);
 
   const save = useCallback(async () => {
-    if (draft) {
+    if (!draft) return null;
+    // Guard against concurrent saves: the modal auto-saves new lines on creation
+    // and the user's OK click can call save() again before the first one resolves.
+    // Without this, both calls take the INSERT path (draft.isCreated still true)
+    // and the server rejects the second with RequisitionLineAlreadyExists.
+    if (isSavingRef.current) return null;
+    isSavingRef.current = true;
+    try {
       const result = await saveMutation(draft);
+
+      if (draft.isCreated) {
+        setDraft(current => (current ? { ...current, isCreated: false } : null));
+      }
 
       setIsReasonsError(false);
       if (result?.__typename === 'UpdateRequestRequisitionLineError') {
@@ -128,9 +140,9 @@ export const useDraftRequisitionLine = (
       return {
         data: result,
       };
+    } finally {
+      isSavingRef.current = false;
     }
-
-    return null;
   }, [draft, saveMutation]);
 
   return {

--- a/client/packages/system/src/Item/DetailView/DetailView.tsx
+++ b/client/packages/system/src/Item/DetailView/DetailView.tsx
@@ -4,6 +4,7 @@ import {
   AlertModal,
   RouteBuilder,
   useNavigate,
+  useParams,
   useTranslation,
   Box,
   useBreadcrumbs,
@@ -27,9 +28,10 @@ export const ItemDetailView = () => {
   const navigate = useNavigate();
   const { setCustomBreadcrumbs } = useBreadcrumbs();
   const isCentralServer = useIsCentralServerApi();
+  const { id: paramId } = useParams();
   const {
     byId: { data, isLoading },
-  } = useItem();
+  } = useItem(paramId);
 
   React.useEffect(() => {
     setCustomBreadcrumbs({ 1: data?.name ?? '' });

--- a/client/packages/system/src/Item/DetailView/Toolbar/Statistics.tsx
+++ b/client/packages/system/src/Item/DetailView/Toolbar/Statistics.tsx
@@ -3,6 +3,7 @@ import {
   Grid,
   StatsPanel,
   useFormatNumber,
+  useParams,
   useTranslation,
   usePreferences,
   RouteBuilder,
@@ -13,9 +14,10 @@ import { AppRoute } from '@openmsupply-client/config';
 export const Statistics = () => {
   const t = useTranslation();
   const formatNumber = useFormatNumber();
+  const { id: paramId } = useParams();
   const {
     byId: { data },
-  } = useItem();
+  } = useItem(paramId);
   const { manageVaccinesInDoses } = usePreferences();
   const { stats, isVaccine, doses } = data || {};
 

--- a/client/packages/system/src/Item/api/hooks/useItem.ts
+++ b/client/packages/system/src/Item/api/hooks/useItem.ts
@@ -1,12 +1,10 @@
-import { ItemNodeType, useParams, useQuery } from '@openmsupply-client/common';
+import { ItemNodeType, useQuery } from '@openmsupply-client/common';
 import { useItemGraphQL } from '../useItemGraphQL';
 import { useItemApi } from './useItemApi';
 import { useItemsByFilter } from './useItems';
 
 export function useItem(id?: string) {
-  const { id: paramId = '' } = useParams();
-
-  const itemId = id || paramId;
+  const itemId = id ?? '';
 
   const { data, isLoading, error } = useGetById(itemId);
   const { data: stockLinesFromItem, isLoading: stockLinesIsLoading } =


### PR DESCRIPTION
Fixes #12253

# 👩🏻‍💻 What does this PR do?

Two bug fixes in the Internal Order **Add item** flow.

**1. Double-INSERT race (primary)**

The modal auto-saves new lines on creation (to populate chart data), and the user's OK click can call `save()` again before the first one resolves. Both calls take the INSERT path (`draft.isCreated` is still `true`) and the server rejects the second with `RequisitionLineAlreadyExists`. The user sees the generic "Unable to update requisition" toast.

Three defensive changes in `RequestLineEdit/hooks.tsx` + `RequestLineEditModal.tsx`:
- A `useRef` guard makes concurrent `save()` calls bail out.
- After a successful insert, `draft.isCreated` is flipped locally so any later click before the items refetch lands takes the UPDATE path.
- OK and Next are disabled while the save mutation is pending.

**2. `useItem()` route-param fallback (secondary)**

`useItem(id?: string)` in `system/src/Item/api/hooks/useItem.ts` was silently falling back to `useParams().id` whenever the supplied id was `undefined`, `null`, or `''` (because of `||` not `??`). On non-item routes that meant firing an `itemById` query keyed on a requisition / invoice / stocktake id, producing a noisy `Query data cannot be undefined` warning every time a line-edit modal opened with no item selected.

- Dropped the fallback. `useItem('')` now disables the query via the existing `enabled: !!itemId`.
- The two callers that intentionally relied on the fallback (`Item/DetailView/DetailView.tsx`, `Item/DetailView/Toolbar/Statistics.tsx`) now read `useParams()` themselves.
- Audited the other 9 call sites; nothing else relied on the fallback. Three callers (`StockItemSearchInputWithStats`, `useDraftInboundLines`, `useDraftStocktakeLines`) that previously passed `''` to mean "no item" now correctly disable the query instead of firing it with the wrong id.

## 💌 Any notes for the reviewer?

- The double-INSERT race only repros reliably on a slow network — the local dev DB is fast enough that the auto-save usually completes before the user's OK click. The fix is therefore correct-by-construction (the ref guard makes concurrent saves impossible regardless of timing) plus visual feedback via `isLoading` → disabled buttons.
- The issue called out a third improvement — surfacing the actual server error in the toast instead of "Unable to update requisition". With the race fixed users shouldn't hit this anymore, so I deferred it. Happy to add in a follow-up if you'd like.
- The `useItem` change keeps the signature `id?: string` for backward compat — there's no compile-time safety net if anyone adds a new bare caller expecting the route fallback. Felt like the right trade-off vs. renaming/breaking every existing call site.

# 🧪 Testing

- [ ] Open an internal order in draft status
- [ ] Click **Add item** and pick any item from the picker — exactly one line is added, no error toast
- [ ] Repeat with rapid OK clicks (especially on a throttled network) — same result, no `RequisitionLineAlreadyExists` in the console
- [ ] Open browser devtools; opening the Add item modal no longer logs `Query data cannot be undefined ... ["item", <storeId>, "<requisitionId>"]`
- [ ] Navigate to **Catalogue → Items → any item**. Detail page renders, breadcrumb shows item name, statistics toolbar (Stock on hand / AMC / Months of stock) renders — this is the route that previously used the silent paramId fallback
- [ ] Sanity-check Inbound Service Lines / Outbound Service Lines modals still load (they were bare `useItem()` callers but only ever used `serviceItem`, so should be unchanged)

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.
