### PR TITLE
11329 do not print labels for prescription lines with zero quantity

### DIFF
--- a/client/packages/common/src/authentication/api/operations.generated.ts
+++ b/client/packages/common/src/authentication/api/operations.generated.ts
@@ -273,6 +273,7 @@ export type PreferencesQuery = {
     invoiceStatusOptions: Array<Types.InvoiceNodeStatus>;
     itemMarginOverridesSupplierMargin: boolean;
     showIndicativePriceInRequisitions: boolean;
+    doNotPrintPlaceholderLineLabels: boolean;
     isGaps: boolean;
     globalTableConfigs: any;
     warnWhenMissingRecentStocktake: {
@@ -546,6 +547,7 @@ export const PreferencesDocument = gql`
       invoiceStatusOptions
       itemMarginOverridesSupplierMargin
       showIndicativePriceInRequisitions
+      doNotPrintPlaceholderLineLabels
       isGaps
       globalTableConfigs
       backdating {

--- a/client/packages/common/src/authentication/api/operations.graphql
+++ b/client/packages/common/src/authentication/api/operations.graphql
@@ -226,6 +226,7 @@ query preferences($storeId: String!) {
     invoiceStatusOptions
     itemMarginOverridesSupplierMargin
     showIndicativePriceInRequisitions
+    doNotPrintPlaceholderLineLabels
     isGaps
     globalTableConfigs
     backdating {

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2617,6 +2617,7 @@
   "preference.daysInMonth": "Days in a month",
   "preference.disableManualReturns": "Disable manual returns",
   "preference.displayPopulationBasedForecasting": "Display population based forecasting",
+  "preference.doNotPrintPlaceholderLineLabels": "Do not print labels for placeholder (zero quantity) prescription lines",
   "preference.expiredStockIssueThreshold": "Expired stock issue threshold (days)",
   "preference.expiredStockPreventIssue": "Prevent issuing expired stock",
   "preference.externalInboundShipmentLinesMustBeAuthorised": "Inbound shipment (external) lines must be authorised",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -7147,6 +7147,7 @@ export enum PreferenceKey {
   DaysInMonth = 'daysInMonth',
   DisableManualReturns = 'disableManualReturns',
   DisplayPopulationBasedForecasting = 'displayPopulationBasedForecasting',
+  DoNotPrintPlaceholderLineLabels = 'doNotPrintPlaceholderLineLabels',
   ExpiredStockIssueThreshold = 'expiredStockIssueThreshold',
   ExpiredStockPreventIssue = 'expiredStockPreventIssue',
   ExternalInboundShipmentLinesMustBeAuthorised = 'externalInboundShipmentLinesMustBeAuthorised',
@@ -7219,6 +7220,7 @@ export type PreferencesNode = {
   daysInMonth: Scalars['Float']['output'];
   disableManualReturns: Scalars['Boolean']['output'];
   displayPopulationBasedForecasting: Scalars['Boolean']['output'];
+  doNotPrintPlaceholderLineLabels: Scalars['Boolean']['output'];
   expiredStockIssueThreshold: Scalars['Int']['output'];
   expiredStockPreventIssue: Scalars['Boolean']['output'];
   externalInboundShipmentLinesMustBeAuthorised: Scalars['Boolean']['output'];
@@ -11877,6 +11879,7 @@ export type UpsertPreferencesInput = {
   daysInMonth?: InputMaybe<Scalars['Float']['input']>;
   disableManualReturns?: InputMaybe<Array<BoolStorePrefInput>>;
   displayPopulationBasedForecasting?: InputMaybe<Scalars['Boolean']['input']>;
+  doNotPrintPlaceholderLineLabels?: InputMaybe<Array<BoolStorePrefInput>>;
   expiredStockIssueThreshold?: InputMaybe<Scalars['Int']['input']>;
   expiredStockPreventIssue?: InputMaybe<Scalars['Boolean']['input']>;
   externalInboundShipmentLinesMustBeAuthorised?: InputMaybe<

--- a/client/packages/invoices/src/Prescriptions/DetailView/hooks/usePrinter.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/hooks/usePrinter.tsx
@@ -1,13 +1,18 @@
 import React, { useState } from 'react';
 import { useLabelPrinterSettings } from '../../api/hooks/useLabelPrinterSettings';
 import { Environment } from '@openmsupply-client/config/src';
-import { useAuthContext, usePrinter } from '@openmsupply-client/common';
+import {
+  useAuthContext,
+  usePreferences,
+  usePrinter,
+} from '@openmsupply-client/common';
 import { PrescriptionLineFragment, PrescriptionFragment } from '../../api';
 import { groupItems, generateLabel } from './utils';
 
 export const usePrintLabels = () => {
   const { data: settings } = useLabelPrinterSettings();
   const { store } = useAuthContext();
+  const { doNotPrintPlaceholderLineLabels } = usePreferences();
   const [printerExists, setPrinterExists] = useState(false);
 
   const {
@@ -28,7 +33,7 @@ export const usePrintLabels = () => {
     }
 
     const storeName = store?.name ?? '';
-    const items = groupItems(lines);
+    const items = groupItems(lines, doNotPrintPlaceholderLineLabels ?? false);
     const labels = generateLabel(items, prescription, storeName);
 
     print({

--- a/client/packages/invoices/src/Prescriptions/DetailView/hooks/utils.test.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/hooks/utils.test.tsx
@@ -388,6 +388,69 @@ describe('generate labels from prescribed items', () => {
 
     expect(generated).toEqual(expected);
   });
+  it('will not print a label for a placeholder line when placeholder labels are disabled', () => {
+    const placeholder = createTestLine({
+      id: '1',
+      itemId: '1',
+      itemName: 'Ibuprofen',
+      note: 'first item note',
+      numberOfPacks: 0,
+      packSize: 100,
+    });
+    const two = createTestLine({
+      id: '2',
+      itemId: '2',
+      itemName: 'Amoxicillin',
+      note: 'second item note',
+      numberOfPacks: 3,
+      packSize: 100,
+    });
+
+    const draftPrescriptionLines = [placeholder, two];
+    const generate = groupItems(draftPrescriptionLines, true);
+
+    const labelTwo = {
+      id: '2',
+      sum: 300,
+      itemDirections: 'second item note',
+      unitName: 'tablet',
+      name: 'Amoxicillin',
+      warning: '',
+    };
+
+    const expected = [labelTwo];
+    const generated = generate;
+
+    expect(generated).toEqual(expected);
+  });
+
+  it('will print a label for a placeholder line by default', () => {
+    const placeholder = createTestLine({
+      id: '1',
+      itemId: '1',
+      itemName: 'Ibuprofen',
+      note: 'first item note',
+      numberOfPacks: 0,
+      packSize: 100,
+    });
+
+    const draftPrescriptionLines = [placeholder];
+    const generated = groupItems(draftPrescriptionLines);
+
+    const expected = [
+      {
+        id: '1',
+        sum: 0,
+        itemDirections: 'first item note',
+        unitName: 'tablet',
+        name: 'Ibuprofen',
+        warning: '',
+      },
+    ];
+
+    expect(generated).toEqual(expected);
+  });
+
   /* **********************************************************
      input lines:
     [{

--- a/client/packages/invoices/src/Prescriptions/DetailView/hooks/utils.tsx
+++ b/client/packages/invoices/src/Prescriptions/DetailView/hooks/utils.tsx
@@ -17,12 +17,17 @@ interface Label {
 }
 
 export const groupItems = (
-  lines: PrescriptionLineFragment[]
+  lines: PrescriptionLineFragment[],
+  doNotPrintPlaceholderLineLabels = false
 ): ItemDetails[] => {
   const linesByItem: { [key: string]: PrescriptionLineFragment[] } = {};
 
-  // groups all batches of an item by id
+  // Groups all batches of an item by id. Ignore placeholder lines if store
+  // preference for this is turned on
   lines.forEach(line => {
+    if (doNotPrintPlaceholderLineLabels && line.numberOfPacks * line.packSize <= 0) {
+      return;
+    }
     const { id } = line.item;
     if (!linesByItem[id]) {
       linesByItem[id] = [];

--- a/server/graphql/preference/src/upsert.rs
+++ b/server/graphql/preference/src/upsert.rs
@@ -111,6 +111,7 @@ pub struct UpsertPreferencesInput {
     pub store_custom_colour: Option<Vec<StringStorePrefInput>>,
     pub invoice_status_options: Option<Vec<InvoiceStatusOptionsInput>>,
     pub show_indicative_price_in_requisitions: Option<Vec<BoolStorePrefInput>>,
+    pub do_not_print_placeholder_line_labels: Option<Vec<BoolStorePrefInput>>,
 }
 
 pub fn upsert_preferences(
@@ -179,6 +180,7 @@ impl UpsertPreferencesInput {
             invoice_status_options,
             external_inbound_shipment_lines_must_be_authorised,
             show_indicative_price_in_requisitions,
+            do_not_print_placeholder_line_labels,
         } = self;
 
         UpsertPreferences {
@@ -279,6 +281,9 @@ impl UpsertPreferencesInput {
                     .as_ref()
                     .map(|i| i.iter().map(|i| i.to_domain()).collect()),
             show_indicative_price_in_requisitions: show_indicative_price_in_requisitions
+                .as_ref()
+                .map(|i| i.iter().map(|i| i.to_domain()).collect()),
+            do_not_print_placeholder_line_labels: do_not_print_placeholder_line_labels
                 .as_ref()
                 .map(|i| i.iter().map(|i| i.to_domain()).collect()),
         }

--- a/server/graphql/types/src/types/preferences.rs
+++ b/server/graphql/types/src/types/preferences.rs
@@ -226,6 +226,10 @@ impl PreferencesNode {
             .collect();
         Ok(statuses)
     }
+
+    pub async fn do_not_print_placeholder_line_labels(&self) -> Result<bool> {
+        self.load_preference(&self.preferences.do_not_print_placeholder_line_labels)
+    }
 }
 
 impl PreferencesNode {
@@ -315,6 +319,7 @@ pub enum PreferenceKey {
     WarnWhenMissingRecentStocktake,
     InvoiceStatusOptions,
     ShowIndicativePriceInRequisitions,
+    DoNotPrintPlaceholderLineLabels,
 }
 
 #[derive(Enum, Copy, Clone, Debug, Eq, PartialEq)]

--- a/server/service/src/preference/mod.rs
+++ b/server/service/src/preference/mod.rs
@@ -68,6 +68,7 @@ pub trait PreferenceServiceTrait: Sync + Send {
             warn_when_missing_recent_stocktake,
             store_custom_colour,
             invoice_status_options,
+            do_not_print_placeholder_line_labels,
         } = self.get_preference_provider();
 
         let input = AppendIfTypeInputs {
@@ -146,6 +147,7 @@ pub trait PreferenceServiceTrait: Sync + Send {
         append_if_type(store_custom_colour, &mut prefs, &input)?;
         append_if_type(warn_when_missing_recent_stocktake, &mut prefs, &input)?;
         append_if_type(invoice_status_options, &mut prefs, &input)?;
+        append_if_type(do_not_print_placeholder_line_labels, &mut prefs, &input)?;
 
         Ok(prefs)
     }

--- a/server/service/src/preference/preferences/do_not_print_placeholder_line_labels.rs
+++ b/server/service/src/preference/preferences/do_not_print_placeholder_line_labels.rs
@@ -1,0 +1,19 @@
+use crate::preference::{PrefKey, Preference, PreferenceType, PreferenceValueType};
+
+pub struct DoNotPrintPlaceholderLineLabels;
+
+impl Preference for DoNotPrintPlaceholderLineLabels {
+    type Value = bool;
+
+    fn key(&self) -> PrefKey {
+        PrefKey::DoNotPrintPlaceholderLineLabels
+    }
+
+    fn preference_type(&self) -> PreferenceType {
+        PreferenceType::Store
+    }
+
+    fn value_type(&self) -> PreferenceValueType {
+        PreferenceValueType::Boolean
+    }
+}

--- a/server/service/src/preference/preferences/mod.rs
+++ b/server/service/src/preference/preferences/mod.rs
@@ -74,6 +74,8 @@ pub mod global_table_configs;
 pub use global_table_configs::*;
 pub mod backdating;
 pub use backdating::*;
+pub mod do_not_print_placeholder_line_labels;
+pub use do_not_print_placeholder_line_labels::*;
 
 pub struct PreferenceProvider {
     // Global preferences
@@ -122,6 +124,7 @@ pub struct PreferenceProvider {
     pub store_custom_colour: StoreCustomColour,
     pub invoice_status_options: InvoiceStatusOptions,
     pub show_indicative_price_in_requisitions: ShowIndicativePriceInRequisitions,
+    pub do_not_print_placeholder_line_labels: DoNotPrintPlaceholderLineLabels,
 }
 
 pub fn get_preference_provider() -> PreferenceProvider {
@@ -172,5 +175,6 @@ pub fn get_preference_provider() -> PreferenceProvider {
         warn_when_missing_recent_stocktake: WarnWhenMissingRecentStocktake,
         invoice_status_options: InvoiceStatusOptions,
         show_indicative_price_in_requisitions: ShowIndicativePriceInRequisitions,
+        do_not_print_placeholder_line_labels: DoNotPrintPlaceholderLineLabels,
     }
 }

--- a/server/service/src/preference/types.rs
+++ b/server/service/src/preference/types.rs
@@ -55,6 +55,7 @@ pub enum PrefKey {
     WarnWhenMissingRecentStocktake,
     InvoiceStatusOptions,
     ShowIndicativePriceInRequisitions,
+    DoNotPrintPlaceholderLineLabels,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/server/service/src/preference/upsert.rs
+++ b/server/service/src/preference/upsert.rs
@@ -63,6 +63,7 @@ pub struct UpsertPreferences {
     pub store_custom_colour: Option<Vec<StorePrefUpdate<String>>>,
     pub invoice_status_options: Option<Vec<StorePrefUpdate<Vec<InvoiceStatus>>>>,
     pub show_indicative_price_in_requisitions: Option<Vec<StorePrefUpdate<bool>>>,
+    pub do_not_print_placeholder_line_labels: Option<Vec<StorePrefUpdate<bool>>>,
 }
 
 pub fn upsert_preferences(
@@ -116,6 +117,7 @@ pub fn upsert_preferences(
         store_custom_colour: store_custom_colour_input,
         invoice_status_options: invoice_status_options_input,
         show_indicative_price_in_requisitions: show_indicative_price_in_requisitions_input,
+        do_not_print_placeholder_line_labels: do_not_print_placeholder_line_labels_input,
     }: UpsertPreferences,
 ) -> Result<(), UpsertPreferenceError> {
     let PreferenceProvider {
@@ -161,6 +163,7 @@ pub fn upsert_preferences(
         invoice_status_options,
         external_inbound_shipment_lines_must_be_authorised,
         show_indicative_price_in_requisitions,
+        do_not_print_placeholder_line_labels,
     }: PreferenceProvider = get_preference_provider();
 
     ctx.connection
@@ -355,6 +358,10 @@ pub fn upsert_preferences(
 
             if let Some(input) = show_indicative_price_in_requisitions_input {
                 upsert_store_input(connection, show_indicative_price_in_requisitions, input)?;
+            }
+
+            if let Some(input) = do_not_print_placeholder_line_labels_input {
+                upsert_store_input(connection, do_not_print_placeholder_line_labels, input)?;
             }
 
             Ok(())


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11329

# 👩🏻‍💻 What does this PR do?
This PR adds the store preference `do not print placeholder line labels`, and filters out placeholder lines when printing if preference is on 

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Don't have a printer to test, but added a test in frontend to check if placeholder lines are filtered out when preference is on

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

