### PR TITLE
12259 2.20 UX/UI part 01

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/Footer/StocktakeLockButton.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/Footer/StocktakeLockButton.tsx
@@ -11,10 +11,10 @@ import { useStocktakeOld } from '../../api';
 export const StocktakeLockButton: FC = () => {
   const t = useTranslation();
   const isDisabled = useStocktakeOld.utils.isDisabled();
-  const { isLocked, status, update } = useStocktakeOld.document.fields([
-    'isLocked',
-    'status',
-  ]);
+  const { isLocked, status, update } = useStocktakeOld.document.fields(
+    ['isLocked', 'status'],
+    0
+  );
 
   const message = isLocked
     ? t('messages.not-on-hold-description')

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -96,6 +96,7 @@ export const BatchTable = ({
           <CheckBoxCell
             isError={!!errors[row.original.id]}
             cell={cell}
+            disabled={disabled}
             updateFn={value =>
               update({ id: row.original.id, countThisLine: value })
             }
@@ -311,6 +312,7 @@ export const PricingTable = ({
         Cell: ({ cell, row }) => (
           <CheckBoxCell
             cell={cell}
+            disabled={disabled}
             updateFn={value =>
               update({ id: row.original.id, countThisLine: value })
             }
@@ -408,6 +410,7 @@ export const LocationTable = ({
         Cell: ({ cell, row }) => (
           <CheckBoxCell
             cell={cell}
+            disabled={disabled}
             updateFn={value =>
               update({ id: row.original.id, countThisLine: value })
             }

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -147,6 +147,7 @@ export const BatchTable = ({
             <DateTimePickerInput
               value={value}
               disabled={disabled || !row.original.countThisLine}
+              disableFuture
               onChange={date =>
                 update({
                   id: row.original.id,
@@ -549,7 +550,7 @@ const getPackSizeChangePatch = (
   const shouldClearSellPrice =
     row.item.defaultPackSize !== newPackSize &&
     row.item.itemStoreProperties?.defaultSellPricePerPack ===
-      row.sellPricePerPack;
+    row.sellPricePerPack;
 
   return {
     id: row.id,
@@ -571,7 +572,7 @@ const getCountedPacksChangePatch = (
   const keepReason =
     typeof row.countedNumberOfPacks === 'number' &&
     countedPacks > row.snapshotNumberOfPacks ===
-      row.countedNumberOfPacks > row.snapshotNumberOfPacks;
+    row.countedNumberOfPacks > row.snapshotNumberOfPacks;
 
   return {
     id: row.id,

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTabs.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTabs.tsx
@@ -53,7 +53,7 @@ export const StocktakeLineEditTabs: FC<
       <TabContext value={currentTab}>
         <TabKeybindings
           tabs={[Tabs.Batch, Tabs.Pricing, Tabs.Other]}
-          onAdd={onAddLine}
+          onAdd={isDisabled ? undefined : onAddLine}
           setCurrentTab={setCurrentTab}
         />
         <Box

--- a/client/packages/inventory/src/Stocktake/api/hooks/document/useStocktakeFields.ts
+++ b/client/packages/inventory/src/Stocktake/api/hooks/document/useStocktakeFields.ts
@@ -10,7 +10,8 @@ import { useStocktakeApi } from '../utils/useStocktakeApi';
 export const useStocktakeFields = <
   KeyOfStocktake extends keyof StocktakeFragment,
 >(
-  keys: KeyOfStocktake | KeyOfStocktake[]
+  keys: KeyOfStocktake | KeyOfStocktake[],
+  timeout?: number
 ): FieldSelectorControl<StocktakeFragment, KeyOfStocktake> => {
   const stocktakeId = useStocktakeId();
   const { mutateAsync } = useUpdateStocktake();
@@ -22,6 +23,7 @@ export const useStocktakeFields = <
     () => api.get.byId(stocktakeId),
     (patch: Partial<StocktakeFragment>) =>
       mutateAsync({ ...patch, id: data?.id ?? '' }),
-    keys
+    keys,
+    timeout
   );
 };

--- a/client/packages/invoices/src/InboundShipment/DetailView/ScanInputModal.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/ScanInputModal.tsx
@@ -469,6 +469,7 @@ export const ScanInputModal = ({
             <DatePicker
               value={draftState.manufactureDate}
               disabled={isLoading}
+              disableFuture
               onChange={value =>
                 setDraftState(current => ({
                   ...current,

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -677,6 +677,7 @@ export const InboundLineEditCards = ({
             <DateTimePickerInput
               value={value}
               disabled={isDisabled}
+              disableFuture
               onChange={date =>
                 updateDraftLine({
                   id: row.original.id,

--- a/client/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/client/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { ComponentProps, useState } from 'react';
 import {
   Autocomplete,
   CloseIcon,
@@ -97,15 +97,6 @@ export const LocationSearchInput = ({
 
   const [filter, setFilter] = useState<LocationFilter>(LocationFilter.All);
 
-  // Refs let the memoised Paper slot read fresh values without
-  // changing the component identity (which would remount the slot).
-  const filterRef = useRef(filter);
-  filterRef.current = filter;
-  const setFilterRef = useRef(setFilter);
-  setFilterRef.current = setFilter;
-  const onChangeRef = useRef(onChange);
-  onChangeRef.current = onChange;
-
   const hasVolumeFilter = typeof volumeRequired === 'number';
 
   const {
@@ -125,25 +116,6 @@ export const LocationSearchInput = ({
   const locations = data?.nodes || [];
   const showRemoveOption =
     includeRemoveOption && (locations.length > 0 || !!selectedLocation);
-
-  const paperSlot = useMemo(() => {
-    if (!hasVolumeFilter && !showRemoveOption) return undefined;
-    return ({
-      children,
-      ...paperProps
-    }: React.ComponentProps<typeof Paper> & { children?: React.ReactNode }) => (
-      <Paper {...paperProps} sx={{ minWidth: '300px' }}>
-        {hasVolumeFilter && (
-          <LocationFilters
-            filter={filterRef.current}
-            setFilter={setFilterRef.current}
-          />
-        )}
-        {children}
-        {showRemoveOption && <StickyRemoveButton onChangeRef={onChangeRef} />}
-      </Paper>
-    );
-  }, [hasVolumeFilter, showRemoveOption]);
 
   // Filter locations based on selected filter
   const filteredLocations = locations.filter(location => {
@@ -228,9 +200,19 @@ export const LocationSearchInput = ({
       placeholder={placeholder}
       isOptionEqualToValue={(option, value) => option.value === value?.value}
       slots={{
-        paper: paperSlot,
+        paper:
+          hasVolumeFilter || showRemoveOption
+            ? (LocationPaper as React.ComponentType)
+            : undefined,
       }}
       slotProps={{
+        paper: {
+          hasVolumeFilter,
+          showRemoveOption,
+          filter,
+          setFilter,
+          onRemove: onChange,
+        } as LocationPaperProps,
         listbox: { style: { maxHeight: '35vh' } },
       }}
     />
@@ -242,10 +224,36 @@ export const formatLocationLabel = (location: LocationRowFragment) => {
   return `${name}${locationType ? ` (${locationType.name})` : ''}`;
 };
 
+type LocationPaperProps = ComponentProps<typeof Paper> & {
+  hasVolumeFilter: boolean;
+  showRemoveOption: boolean;
+  filter: LocationFilter;
+  setFilter: (filter: LocationFilter) => void;
+  onRemove: (location: LocationRowFragment | null) => void;
+};
+
+const LocationPaper = ({
+  children,
+  hasVolumeFilter,
+  showRemoveOption,
+  filter,
+  setFilter,
+  onRemove,
+  ...paperProps
+}: LocationPaperProps) => (
+  <Paper {...paperProps} sx={{ minWidth: '300px' }}>
+    {hasVolumeFilter && (
+      <LocationFilters filter={filter} setFilter={setFilter} />
+    )}
+    {children}
+    {showRemoveOption && <StickyRemoveButton onChange={onRemove} />}
+  </Paper>
+);
+
 const StickyRemoveButton = ({
-  onChangeRef,
+  onChange,
 }: {
-  onChangeRef: React.RefObject<(location: LocationRowFragment | null) => void>;
+  onChange: (location: LocationRowFragment | null) => void;
 }) => {
   const t = useTranslation();
 
@@ -254,7 +262,7 @@ const StickyRemoveButton = ({
       onMouseDown={e => {
         e.stopPropagation();
         e.preventDefault();
-        onChangeRef.current?.(null);
+        onChange(null);
       }}
       sx={{
         display: 'inline-flex',

--- a/client/packages/system/src/Location/Components/LocationSearchInput.tsx
+++ b/client/packages/system/src/Location/Components/LocationSearchInput.tsx
@@ -108,27 +108,6 @@ export const LocationSearchInput = ({
 
   const hasVolumeFilter = typeof volumeRequired === 'number';
 
-  const paperSlot = useMemo(() => {
-    if (!hasVolumeFilter && !includeRemoveOption) return undefined;
-    return ({
-      children,
-      ...paperProps
-    }: React.ComponentProps<typeof Paper> & { children?: React.ReactNode }) => (
-      <Paper {...paperProps} sx={{ minWidth: '300px' }}>
-        {hasVolumeFilter && (
-          <LocationFilters
-            filter={filterRef.current}
-            setFilter={setFilterRef.current}
-          />
-        )}
-        {children}
-        {includeRemoveOption && (
-          <StickyRemoveButton onChangeRef={onChangeRef} />
-        )}
-      </Paper>
-    );
-  }, [hasVolumeFilter, includeRemoveOption]);
-
   const {
     query: { data, isLoading },
   } = useLocationList(
@@ -144,6 +123,27 @@ export const LocationSearchInput = ({
   );
 
   const locations = data?.nodes || [];
+  const showRemoveOption =
+    includeRemoveOption && (locations.length > 0 || !!selectedLocation);
+
+  const paperSlot = useMemo(() => {
+    if (!hasVolumeFilter && !showRemoveOption) return undefined;
+    return ({
+      children,
+      ...paperProps
+    }: React.ComponentProps<typeof Paper> & { children?: React.ReactNode }) => (
+      <Paper {...paperProps} sx={{ minWidth: '300px' }}>
+        {hasVolumeFilter && (
+          <LocationFilters
+            filter={filterRef.current}
+            setFilter={setFilterRef.current}
+          />
+        )}
+        {children}
+        {showRemoveOption && <StickyRemoveButton onChangeRef={onChangeRef} />}
+      </Paper>
+    );
+  }, [hasVolumeFilter, showRemoveOption]);
 
   // Filter locations based on selected filter
   const filteredLocations = locations.filter(location => {
@@ -187,17 +187,17 @@ export const LocationSearchInput = ({
   // Same goes if the location is not valid given the location type restriction
   const selectedLocationOption: LocationOption | null = selectedLocation
     ? {
-        value: selectedLocation.id,
-        label: formatLocationLabel(selectedLocation),
-        code: selectedLocation.code,
-        volumeUsed: getVolumeUsedLabel(selectedLocation),
-      }
+      value: selectedLocation.id,
+      label: formatLocationLabel(selectedLocation),
+      code: selectedLocation.code,
+      volumeUsed: getVolumeUsedLabel(selectedLocation),
+    }
     : null;
 
   const isInvalidLocation = !!selectedLocation
     ? checkInvalidLocationLines(restrictedToLocationTypeId ?? null, [
-        { location: selectedLocation },
-      ])
+      { location: selectedLocation },
+    ])
     : null;
 
   const errorStyles = {

--- a/client/packages/system/src/Manage/IndicatorsDemographics/DetailView/columns.tsx
+++ b/client/packages/system/src/Manage/IndicatorsDemographics/DetailView/columns.tsx
@@ -81,6 +81,7 @@ export const useIndicatorsDemographicsColumns = ({
           accessorFn: row => row[yearOffset],
           header: `${t('label.year')} ${yearOffset}`,
           columnType: ColumnType.Number,
+          size: 150,
           Header: ({ column }) => <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
             {column.columnDef.header}
             <NumericTextInput

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -360,6 +360,7 @@ export const StockLineForm = ({
                   Input={
                     <DateTimePickerInput
                       value={DateUtils.getNaiveDate(draft.manufactureDate)}
+                      disableFuture
                       onChange={date =>
                         onUpdate({
                           manufactureDate: date

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
@@ -209,6 +209,7 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         }
         ServiceError::IncorrectLocationType => BadUserInput(formatted_error),
         ServiceError::WrongInboundShipmentType => BadUserInput(formatted_error),
+        ServiceError::CannotSetManufactureDateInFuture => BadUserInput(formatted_error),
     };
 
     Err(graphql_error.extend())

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
@@ -254,6 +254,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         ServiceError::UpdatedLineDoesNotExist => InternalError(formatted_error),
         ServiceError::IncorrectLocationType => BadUserInput(formatted_error),
         ServiceError::WrongInboundShipmentType => BadUserInput(formatted_error),
+        ServiceError::CannotSetManufactureDateInFuture => BadUserInput(formatted_error),
     };
 
     Err(graphql_error.extend())

--- a/server/graphql/stock_line/src/mutations/update.rs
+++ b/server/graphql/stock_line/src/mutations/update.rs
@@ -172,6 +172,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         ServiceError::UpdatedStockNotFound => InternalError(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::IncorrectLocationType => BadUserInput(formatted_error),
+        ServiceError::CannotSetManufactureDateInFuture => BadUserInput(formatted_error),
     };
 
     Err(graphql_error.extend())

--- a/server/graphql/stocktake_line/src/mutations/insert.rs
+++ b/server/graphql/stocktake_line/src/mutations/insert.rs
@@ -148,6 +148,7 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::InternalError(err) => InternalError(err),
         ServiceError::IncorrectLocationType => BadUserInput(formatted_error),
+        ServiceError::CannotSetManufactureDateInFuture => BadUserInput(formatted_error),
     };
 
     Err(graphql_error.extend())

--- a/server/graphql/stocktake_line/src/mutations/update.rs
+++ b/server/graphql/stocktake_line/src/mutations/update.rs
@@ -213,6 +213,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         | ServiceError::VvmStatusDoesNotExist
         | ServiceError::ProgramDoesNotExist => BadUserInput(formatted_error),
         ServiceError::IncorrectLocationType => BadUserInput(formatted_error),
+        ServiceError::CannotSetManufactureDateInFuture => BadUserInput(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::InternalError(err) => InternalError(err),
     };

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -126,6 +126,7 @@ pub enum InsertStockInLineError {
     PurchaseOrderLineIdRequired,
     PurchaseOrderLineDoesNotExist,
     WrongInboundShipmentType,
+    CannotSetManufactureDateInFuture,
 }
 
 impl From<RepositoryError> for InsertStockInLineError {

--- a/server/service/src/invoice_line/stock_in_line/insert/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/validate.rs
@@ -9,8 +9,8 @@ use crate::{
         validate::{check_item_exists, check_line_exists, check_number_of_packs},
     },
     validate::{
-        check_other_party, check_other_party_store_is_disabled, CheckOtherPartyType,
-        OtherPartyErrors,
+        check_date_is_not_in_future, check_other_party, check_other_party_store_is_disabled,
+        CheckOtherPartyType, OtherPartyErrors,
     },
     NullableUpdate,
 };
@@ -33,6 +33,12 @@ pub fn validate(
     }
     if !check_number_of_packs(Some(input.number_of_packs)) {
         return Err(NumberOfPacksBelowZero);
+    }
+
+    if let Some(manufacture_date) = &input.manufacture_date {
+        if !check_date_is_not_in_future(manufacture_date) {
+            return Err(CannotSetManufactureDateInFuture);
+        }
     }
 
     let item = check_item_exists(connection, &input.item_id)?.ok_or(ItemNotFound)?;

--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -137,6 +137,7 @@ pub enum UpdateStockInLineError {
     CannotEditCostPrice,
     ReasonOptionDoesNotExist,
     ReasonOptionTypeInvalid,
+    CannotSetManufactureDateInFuture,
 }
 
 impl From<RepositoryError> for UpdateStockInLineError {

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -13,8 +13,8 @@ use crate::{
         },
     },
     validate::{
-        check_other_party, check_other_party_store_is_disabled, CheckOtherPartyType,
-        OtherPartyErrors,
+        check_date_is_not_in_future, check_other_party, check_other_party_store_is_disabled,
+        CheckOtherPartyType, OtherPartyErrors,
     },
     NullableUpdate,
 };
@@ -43,6 +43,15 @@ pub fn validate(
     }
     if !check_number_of_packs(input.number_of_packs) {
         return Err(NumberOfPacksBelowZero);
+    }
+
+    if let Some(NullableUpdate {
+        value: Some(manufacture_date),
+    }) = &input.manufacture_date
+    {
+        if !check_date_is_not_in_future(manufacture_date) {
+            return Err(CannotSetManufactureDateInFuture);
+        }
     }
 
     let item = check_item_option(&input.item_id, connection)?;

--- a/server/service/src/stock_line/update.rs
+++ b/server/service/src/stock_line/update.rs
@@ -5,7 +5,7 @@ use crate::{
     check_item_variant_exists, check_location_exists, check_location_type_is_valid,
     common::{check_stock_line_exists, CommonStockLineError},
     service_provider::ServiceContext,
-    validate::{check_other_party, CheckOtherPartyType, OtherPartyErrors},
+    validate::{check_date_is_not_in_future, check_other_party, CheckOtherPartyType, OtherPartyErrors},
     NullableUpdate, SingleRecordError,
 };
 use chrono::{NaiveDate, Utc};
@@ -54,6 +54,7 @@ pub enum UpdateStockLineError {
     StockMovementNotFound,
     VVMStatusDoesNotExist,
     IncorrectLocationType,
+    CannotSetManufactureDateInFuture,
 }
 
 pub fn update_stock_line(
@@ -108,6 +109,15 @@ fn validate(
             CommonStockLineError::StockLineDoesNotBelongToStore => StockDoesNotBelongToStore,
             CommonStockLineError::DatabaseError(error) => DatabaseError(error),
         })?;
+
+    if let Some(NullableUpdate {
+        value: Some(manufacture_date),
+    }) = &input.manufacture_date
+    {
+        if !check_date_is_not_in_future(manufacture_date) {
+            return Err(CannotSetManufactureDateInFuture);
+        }
+    }
 
     if let Some(NullableUpdate {
         value: Some(ref location),

--- a/server/service/src/stocktake_line/insert/mod.rs
+++ b/server/service/src/stocktake_line/insert/mod.rs
@@ -62,6 +62,7 @@ pub enum InsertStocktakeLineError {
     ProgramDoesNotExist,
     StockLineReducedBelowZero(StockLine),
     IncorrectLocationType,
+    CannotSetManufactureDateInFuture,
 }
 
 pub fn insert_stocktake_line(
@@ -313,6 +314,25 @@ mod stocktake_line_test {
             )
             .unwrap_err();
         assert_eq!(error, InsertStocktakeLineError::StocktakeIsLocked);
+
+        // error CannotSetManufactureDateInFuture
+        let stocktake_a = mock_stocktake_a();
+        let error = service
+            .insert_stocktake_line(
+                &context,
+                InsertStocktakeLine {
+                    id: uuid(),
+                    stocktake_id: stocktake_a.id,
+                    item_id: Some(mock_item_a().id),
+                    manufacture_date: NaiveDate::from_ymd_opt(9999, 1, 1),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert_eq!(
+            error,
+            InsertStocktakeLineError::CannotSetManufactureDateInFuture
+        );
 
         // check CannotEditFinalised
         let stocktake_finalised = mock_stocktake_finalised();

--- a/server/service/src/stocktake_line/insert/validate.rs
+++ b/server/service/src/stocktake_line/insert/validate.rs
@@ -7,7 +7,10 @@ use crate::{
     stocktake_line::validate::{
         check_active_adjustment_reasons, check_reason_is_valid, check_stock_line_reduced_below_zero,
     },
-    validate::{check_other_party, check_store_id_matches, CheckOtherPartyType, OtherPartyErrors},
+    validate::{
+        check_date_is_not_in_future, check_other_party, check_store_id_matches,
+        CheckOtherPartyType, OtherPartyErrors,
+    },
     NullableUpdate,
 };
 use repository::{
@@ -44,6 +47,12 @@ pub fn validate(
 
     if stocktake.is_locked {
         return Err(StocktakeIsLocked);
+    }
+
+    if let Some(manufacture_date) = &input.manufacture_date {
+        if !check_date_is_not_in_future(manufacture_date) {
+            return Err(CannotSetManufactureDateInFuture);
+        }
     }
 
     if let Some(vvm_status_id) = &input.vvm_status_id {

--- a/server/service/src/stocktake_line/update/mod.rs
+++ b/server/service/src/stocktake_line/update/mod.rs
@@ -55,6 +55,7 @@ pub enum UpdateStocktakeLineError {
     StockLineReducedBelowZero(StockLine),
     IncorrectLocationType,
     VvmStatusDoesNotExist,
+    CannotSetManufactureDateInFuture,
 }
 
 pub fn update_stocktake_line(
@@ -266,6 +267,25 @@ mod stocktake_line_test {
             )
             .unwrap_err();
         assert_eq!(error, UpdateStocktakeLineError::LocationDoesNotExist);
+
+        // error: CannotSetManufactureDateInFuture
+        let stocktake_line_a = mock_stocktake_line_a();
+        let error = service
+            .update_stocktake_line(
+                &context,
+                UpdateStocktakeLine {
+                    id: stocktake_line_a.id,
+                    manufacture_date: Some(NullableUpdate {
+                        value: NaiveDate::from_ymd_opt(9999, 1, 1),
+                    }),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert_eq!(
+            error,
+            UpdateStocktakeLineError::CannotSetManufactureDateInFuture
+        );
 
         // error: VvmStatusDoesNotExist
         let stocktake_line_a = mock_stocktake_line_a();

--- a/server/service/src/stocktake_line/update/validate.rs
+++ b/server/service/src/stocktake_line/update/validate.rs
@@ -8,7 +8,10 @@ use crate::{
         check_snapshot_matches_current_count, check_stock_line_reduced_below_zero,
         check_stocktake_line_exist, stocktake_reduction_amount,
     },
-    validate::{check_other_party, check_store_id_matches, CheckOtherPartyType, OtherPartyErrors},
+    validate::{
+        check_date_is_not_in_future, check_other_party, check_store_id_matches,
+        CheckOtherPartyType, OtherPartyErrors,
+    },
     NullableUpdate,
 };
 use repository::{RepositoryError, StocktakeLine, StorageConnection};
@@ -41,6 +44,15 @@ pub fn validate(
 
     if !check_store_id_matches(store_id, &stocktake.store_id) {
         return Err(InvalidStore);
+    }
+
+    if let Some(NullableUpdate {
+        value: Some(manufacture_date),
+    }) = &input.manufacture_date
+    {
+        if !check_date_is_not_in_future(manufacture_date) {
+            return Err(CannotSetManufactureDateInFuture);
+        }
     }
 
     let stock_line = match &stocktake_line_row.stock_line_id {

--- a/server/service/src/validate.rs
+++ b/server/service/src/validate.rs
@@ -1,3 +1,4 @@
+use chrono::{NaiveDate, Utc};
 use repository::{
     property::{PropertyFilter, PropertyRepository},
     EqualFilter, Name, NameFilter, NameRepository, Patient, PatientFilter, PatientRepository,
@@ -6,6 +7,10 @@ use repository::{
 
 pub fn check_store_id_matches(store_id_a: &str, store_id_b: &str) -> bool {
     store_id_a == store_id_b
+}
+
+pub fn check_date_is_not_in_future(date: &NaiveDate) -> bool {
+    date <= &Utc::now().naive_utc().date()
 }
 
 pub fn check_store_exists(


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12259

# 👩🏻‍💻 What does this PR do?
Part 1 of the UI/UX changes spliced from parent issue. 
This PR: 
- Makes year cells in demographics have fixed size
- Don't show remove option for locations if there are no locations to remove 
- Disable being able to enter a manufacturer date in the future
- Make isLocked have no debounce so inputs disabled straight away 
- Don't allow users to tick/untick count this line if stocktake on hold
- Refactor location paper to not use ref

<img width="1106" height="580" alt="Screenshot 2026-06-25 at 07 55 29" src="https://github.com/user-attachments/assets/08dc2abe-548c-4ce3-832d-03bee3152469" />
<img width="1103" height="583" alt="Screenshot 2026-06-25 at 07 55 14" src="https://github.com/user-attachments/assets/28681398-d8e8-4af2-ad21-239526102b42" />
<img width="929" height="174" alt="Screenshot 2026-06-25 at 07 54 51" src="https://github.com/user-attachments/assets/b402a550-cf32-4baf-a405-1393ab32daf7" />
<img width="398" height="253" alt="Screenshot 2026-06-25 at 07 56 31" src="https://github.com/user-attachments/assets/f06fe34f-3052-4a66-8159-a39fab6634bf" />


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Different resolutions for demographics
- [ ] Remove option doesn't appear when there's no locations
- [ ] Can't enter manufacturer date in the future
- [ ] Can't tick/untick count this line if stocktake is on hold
- [ ] Can tick/untick count this line if stocktake is not on hold

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

