### PR TITLE
Sanitize store code in list export filenames (follow-up #12234)

### DIFF
--- a/client/packages/common/src/utils/files/FileUtils.ts
+++ b/client/packages/common/src/utils/files/FileUtils.ts
@@ -192,11 +192,19 @@ const getFilename = (type?: string, title?: string, storeCode?: string) => {
   }
 
   const today = Formatter.toIsoString(new Date()); // to match backend datetime
-  const parts = [today, storeCode, title || 'export'].filter(Boolean);
+  const safeStoreCode = storeCode ? sanitizeForFilename(storeCode) : undefined;
+  const parts = [today, safeStoreCode, title || 'export'].filter(Boolean);
   const filename = `${parts.join('_')}.${extension}`;
 
   return filename;
 };
+
+// mSupply doesn't restrict the characters allowed in a store code, so anything
+// the user gives us has to be neutralised before it becomes part of a path or
+// download attribute. Mirrors the server's `sanitize_filename` helper.
+export const sanitizeForFilename = (value: string): string =>
+  // eslint-disable-next-line no-control-regex
+  value.replace(/[<>:"/\\|?*\x00-\x1F]/g, '');
 
 const asBase64 = async (blob: Blob): Promise<string> => {
   const reader = new FileReader();

--- a/server/service/src/report/convert_to_excel.rs
+++ b/server/service/src/report/convert_to_excel.rs
@@ -9,6 +9,7 @@ use umya_spreadsheet::{
     writer::xlsx,
     Cell, FontSize, Spreadsheet, Worksheet,
 };
+use util::sanitize_filename;
 
 pub fn csv_to_excel(
     base_dir: &str,
@@ -26,7 +27,8 @@ pub fn csv_to_excel(
         .records()
         .collect::<Result<_, _>>()
         .map_err(|e| ReportError::DocGenerationError(e.to_string()))?;
-    let reserved_file = reserve_file(base_dir, filename)?;
+    let sanitized_filename = sanitize_filename(filename.to_string());
+    let reserved_file = reserve_file(base_dir, &sanitized_filename)?;
 
     // Create Excel workbook
     let mut book = umya_spreadsheet::new_file();
@@ -801,6 +803,24 @@ mod report_to_excel_test {
         // Truncated to 31 chars
         let long = "a".repeat(50);
         assert_eq!(sanitize_sheet_name(&long).len(), 31);
+    }
+
+    #[test]
+    fn test_csv_to_excel_sanitizes_filename() {
+        // mSupply allows store codes with crazy characters — make sure they
+        // can't escape the temp dir or break the path on disk.
+        let csv_data = "Name\nHarry\n";
+        let file_id =
+            csv_to_excel(".", csv_data, "../etc/passwd_stock", Some("any")).unwrap();
+
+        let file_service = StaticFileService::new(".").unwrap();
+        let generated_file = file_service
+            .find_file(&file_id, StaticFileCategory::Temporary)
+            .unwrap()
+            .unwrap();
+        // No path separators survive — the stored name is a plain filename.
+        assert!(!generated_file.name.contains('/'));
+        assert!(!generated_file.name.contains('\\'));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #12091

Follow-up to #12234 — addresses [this review comment](https://github.com/msupply-foundation/open-msupply/pull/12234#issuecomment-4794148238).

# 👩🏻‍💻 What does this PR do?

The original PR claimed store codes were "file-system safe (no spaces/punctuation)". In practice mSupply lets users create store codes with arbitrary characters, so any of them can leak straight into the export filename. This PR closes that gap at the two boundaries where a filename actually reaches disk or the browser:

- **Server** ([`server/service/src/report/convert_to_excel.rs`](https://github.com/msupply-foundation/open-msupply/blob/v2.21.0-RC/server/service/src/report/convert_to_excel.rs)) — `csv_to_excel` now runs the incoming `filename` through the existing `util::sanitize_filename` helper before passing it to `reserve_file`, so a crazy store code embedded in the filename (e.g. `../etc/passwd_stock`) can't escape the temp dir or break the `{id}_{file_name}` path concatenation.
- **Client** ([`client/packages/common/src/utils/files/FileUtils.ts`](https://github.com/msupply-foundation/open-msupply/blob/v2.21.0-RC/client/packages/common/src/utils/files/FileUtils.ts)) — added a small exported `sanitizeForFilename` helper (mirrors the rust crate's character set: `< > : " / \ | ? *` + ASCII control chars) and applied it to the `storeCode` parameter inside `getFilename`. This covers the CSV / JSON / log export paths, which build the filename client-side and feed it straight to `link.download` without ever touching the server.

## 💌 Any notes for the reviewer?

- **Why both boundaries?** The Excel path round-trips the server (`csv_to_excel` → static-file download), so sanitizing server-side is enough for it. The CSV / JSON / log paths never hit the server — the filename is constructed in JS and given to the browser — so they need a JS sanitizer. The two helpers use the same character set deliberately.
- **`ExportSelector` is untouched on purpose.** I considered also sanitizing `storeCode` once at the source there, but it would be redundant: `getFilename` already cleans the CSV path, and the server cleans the Excel filename. Keeping the central injection point unchanged means future callers don't have to remember to sanitize themselves.
- **No behaviour change for normal store codes.** The character set only strips chars that are illegal in NTFS / ext4 filenames anyway — alphanumerics, hyphens, underscores, dots, spaces all pass through.

# 🧪 Testing

- [ ] Log in as a store whose `code` is plain alphanumerics — confirm CSV and Excel export filenames are unchanged (`<timestamp>_<storecode>_<list>.csv|xlsx`).
- [ ] Temporarily set a store code containing `/ \ : * ? " < > |` (e.g. via mSupply central) and re-export:
  - CSV: filename should have the illegal chars stripped, no extension confusion, opens cleanly.
  - Excel: filename should have the illegal chars stripped server-side; the worksheet tab still shows the sheet-name-sanitized version (existing behaviour).
- [ ] Backend tests: `cd server && cargo nextest run -p service report::convert_to_excel --test-threads=1` — 13/13 passing locally, including new `test_csv_to_excel_sanitizes_filename`.
- [ ] Frontend type-check: `cd client && yarn tsc --noEmit` — clean for the changed files.

# 📃 Documentation

- [x] **No documentation required**: hardening fix to existing export — no user-facing controls or behaviour change for legitimate store codes.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

