### PR TITLE
12262 2.20 UX/UI part 02

### DIFF
--- a/client/packages/common/src/ui/layout/tables/components/UnitsAndDosesCell.tsx
+++ b/client/packages/common/src/ui/layout/tables/components/UnitsAndDosesCell.tsx
@@ -56,7 +56,8 @@ export const UnitsAndDosesCell = <T extends MRT_RowData>({
         <Typography
           sx={{
             fontSize: 'small',
-            color: 'text.secondary',
+            color: 'inherit',
+            opacity: 0.6,
             marginLeft: '4px',
           }}
         >

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditTables.tsx
@@ -194,11 +194,13 @@ export const BatchTable = ({
       {
         accessorKey: 'snapshotNumberOfPacks',
         header: t('label.snapshot-num-of-packs'),
-        columnType: ColumnType.Number,
         size: 100,
         getIsError: rowData =>
           errors[rowData.id]?.__typename ===
           'SnapshotCountCurrentCountMismatchLine',
+        Cell: ({ cell }) => (
+          <NumberInputCell cell={cell} disabled updateFn={() => { }} />
+        ),
       },
       {
         accessorKey: 'countedNumberOfPacks',

--- a/client/packages/system/src/Location/ListView/ListView.tsx
+++ b/client/packages/system/src/Location/ListView/ListView.tsx
@@ -10,7 +10,6 @@ import {
   ColumnDef,
   ColumnType,
   MaterialTable,
-  CheckCell,
 } from '@openmsupply-client/common';
 import { LocationRowFragment, useLocationList } from '../api';
 import { AppBarButtons } from './AppBarButtons';
@@ -107,7 +106,7 @@ export const LocationListView = () => {
       {
         accessorKey: 'onHold',
         header: t('label.on-hold'),
-        Cell: CheckCell,
+        columnType: ColumnType.Boolean,
         size: 110,
         enableColumnFilter: true,
         filterVariant: 'select',

--- a/client/packages/system/src/Patient/CreatePatientModal/CreatePatientModal.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/CreatePatientModal.tsx
@@ -59,8 +59,6 @@ export const CreatePatientModal = ({
     }
   }, [open, setCreateNewPatient]);
 
-  if (isLoading) return <BasicSpinner />;
-
   return (
     <Modal
       title=""
@@ -108,20 +106,29 @@ export const CreatePatientModal = ({
       slideAnimation={false}
     >
       <DetailContainer>
-        <Box display="flex" flexDirection="column" alignItems="center" gap={2}>
-          <WizardStepper
-            activeStep={getActiveStep()}
-            steps={patientSteps}
-            nowrap
-          />
-          <TabContext value={currentTab}>
-            {tabs.map(({ Component, value }) => (
-              <DetailTab value={value} key={value}>
-                {Component}
-              </DetailTab>
-            ))}
-          </TabContext>
-        </Box>
+        {isLoading ? (
+          <BasicSpinner />
+        ) : (
+          <Box
+            display="flex"
+            flexDirection="column"
+            alignItems="center"
+            gap={2}
+          >
+            <WizardStepper
+              activeStep={getActiveStep()}
+              steps={patientSteps}
+              nowrap
+            />
+            <TabContext value={currentTab}>
+              {tabs.map(({ Component, value }) => (
+                <DetailTab value={value} key={value}>
+                  {Component}
+                </DetailTab>
+              ))}
+            </TabContext>
+          </Box>
+        )}
       </DetailContainer>
     </Modal>
   );


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12262

# 👩🏻‍💻 What does this PR do?

- Align pack snapshot in stocktake with rest of inputs
- Difference in doses to inherit the parent colour
- On hold from tick to dot for locations
- Remove spinner being called before modal in the new patient creation modal
<img width="1255" height="439" alt="number-of-packs" src="https://github.com/user-attachments/assets/58d4e16b-5482-4ac1-a7bf-2620877caac1" />
<img width="1291" height="513" alt="doses-inherit-colour" src="https://github.com/user-attachments/assets/5101365d-8705-4208-830b-0e07088a3fce" />
<img width="926" height="526" alt="location-on-hold" src="https://github.com/user-attachments/assets/3d94d6bc-e8f3-405b-801c-97bda1557428" />

https://github.com/user-attachments/assets/f45099e2-b577-4128-8253-40094c93d4f9

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Checked alignment of packs snapshot
- [ ] Checked difference doses column inherits blue if placeholder
- [ ] Check location on hold is a dot
- [ ] Checked double spinner doesn't happen when clicking `New Patient` 

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

