### PR TITLE
12278 2.20 UX/UI part 03

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2286,7 +2286,7 @@
   "messages.detect-scanner": "To identify your scanner, try scanning the barcode above",
   "messages.device": "Device:",
   "messages.do-not-use-variant": "Don't use a variant as a template",
-  "messages.download-first-warning": "Please download your current translations first to ensure you don't lose them.",
+  "messages.download-first-warning": "Please export your current translations first to ensure you don't lose them.",
   "messages.edit-service-charges": "Edit service charges",
   "messages.empty-unallocated-lines_one": "{{count}} of the selected placeholder lines has a quantity of 0. Automatic allocation will remove this line. Do you want to continue?",
   "messages.empty-unallocated-lines_other": "{{count}} of the selected placeholder lines have a quantity of 0. Automatic allocation will remove these lines. Do you want to continue?",

--- a/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Toolbar.tsx
@@ -12,6 +12,7 @@ import {
   Link,
   RouteBuilder,
   DisabledStoreNotice,
+  useDebounceCallback,
 } from '@openmsupply-client/common';
 import { AppRoute } from '@openmsupply-client/config';
 import { SupplierSearchInput } from '@openmsupply-client/system';
@@ -44,12 +45,15 @@ export const Toolbar = () => {
 
   const {
     query: { data: shipment },
+    draft,
     isDisabled,
     isExternal,
-    update: { update },
+    updatePatch,
+    update: { update, saveDraft },
   } = useInboundShipment();
 
-  const { otherParty, theirReference, purchaseOrder } = shipment || {};
+  const { otherParty, theirReference, purchaseOrder } = draft || {};
+  const debouncedSave = useDebounceCallback(saveDraft, [saveDraft]);
 
   const isTransfer = !!shipment?.linkedShipment?.id;
 
@@ -84,8 +88,10 @@ export const Toolbar = () => {
                     sx={{ width: 250 }}
                     value={theirReference ?? ''}
                     onChange={event => {
-                      update({ theirReference: event.target.value });
+                      updatePatch({ theirReference: event.target.value });
+                      debouncedSave();
                     }}
+                    onBlur={saveDraft}
                     maxRows={2}
                     minRows={1}
                     slotProps={{

--- a/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/Toolbar.tsx
@@ -63,6 +63,7 @@ export const Toolbar = () => {
                   { replace: true }
                 );
               }}
+              width={250}
             />
           }
         />

--- a/client/packages/invoices/src/Returns/CustomerDetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/Toolbar.tsx
@@ -54,6 +54,7 @@ export const Toolbar: FC = () => {
                     onChange={name => {
                       update({ otherPartyId: name?.id });
                     }}
+                    width={250}
                   />
                 }
               />

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -126,6 +126,7 @@ export const Toolbar = () => {
                   filterBy={{
                     type: { equalTo: NameNodeType.Store },
                   }}
+                  width={250}
                 />
               }
             />

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar/Toolbar.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Toolbar/Toolbar.tsx
@@ -69,6 +69,7 @@ export const Toolbar = () => {
                       onChange={newOtherParty => {
                         update({ otherParty: newOtherParty ?? undefined });
                       }}
+                      width={250}
                     />
                   }
                 />
@@ -98,6 +99,7 @@ export const Toolbar = () => {
                       value={destinationCustomer ?? null}
                       onChange={() => {}}
                       clearable
+                      width={250}
                     />
                   }
                 />

--- a/client/packages/system/src/Manage/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
+++ b/client/packages/system/src/Manage/IndicatorsDemographics/DetailView/IndicatorsDemographics.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { AppBarButtons } from './AppBarButtons';
 import {
   Box,
@@ -13,7 +13,7 @@ import {
 } from '@openmsupply-client/common';
 import { useIndicatorsDemographicsColumns } from './columns';
 import { Footer } from './Footer';
-import { useDemographicData } from '../api';
+import { GENERAL_POPULATION_ID, useDemographicData } from '../api';
 import {
   mapHeaderData,
   mapProjection,
@@ -135,11 +135,21 @@ export const IndicatorsDemographics = () => {
     draft, setter, handlePopulationChange, handleGrowthChange, headerDraft
   });
 
+  // Always have General Demographics at the top of the table
+  const rows = useMemo(() => {
+    const all = Object.values(draft);
+    return all.sort((a, b) => {
+      if (a.id === GENERAL_POPULATION_ID) return -1;
+      if (b.id === GENERAL_POPULATION_ID) return 1;
+      return 0;
+    });
+  }, [draft]);
+
   const table = useSimpleMaterialTable<Row>({
     tableId: 'indicators-demographics-table',
     columns,
     isLoading: isLoadingProjection,
-    data: Object.values(draft),
+    data: rows,
     enableRowSelection: false,
   });
 

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsModal.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsModal.tsx
@@ -217,7 +217,7 @@ export const CustomTranslationsModal = ({
               disabled={loading}
             />
             <ButtonWithIcon
-              label={t('button.download')}
+              label={t('button.export')}
               onClick={downloadTranslations}
               Icon={<DownloadIcon />}
               disabled={loading}

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsV2Modal.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsV2Modal.tsx
@@ -445,7 +445,7 @@ export const CustomTranslationsV2Modal = ({
               disabled={loading}
             />
             <ButtonWithIcon
-              label={t('button.download')}
+              label={t('button.export')}
               onClick={downloadTranslations}
               Icon={<DownloadIcon />}
               disabled={loading}

--- a/client/packages/system/src/Name/Components/CustomerSearchInput/CustomerSearchInput.tsx
+++ b/client/packages/system/src/Name/Components/CustomerSearchInput/CustomerSearchInput.tsx
@@ -15,7 +15,7 @@ interface CustomerSearchInputExtraProps {
 
 export const CustomerSearchInput = ({
   onChange,
-  width = 250,
+  width,
   value,
   disabled = false,
   clearable = false,

--- a/client/packages/system/src/Name/Components/CustomerSearchModal/CustomerSearchModal.tsx
+++ b/client/packages/system/src/Name/Components/CustomerSearchModal/CustomerSearchModal.tsx
@@ -13,6 +13,7 @@ const CustomerSearchComponent: FC<NameSearchProps> = props => {
   const t = useTranslation();
   const { height } = useWindowDimensions();
   const modalHeight = height * 0.8;
+  const isList = 'isList' in props;
 
   const input = (
     <CustomerSearchInput
@@ -20,14 +21,14 @@ const CustomerSearchComponent: FC<NameSearchProps> = props => {
       onChange={name => {
         if (name) props.onChange(name);
       }}
-      width={500}
+      width={isList ? undefined : 500}
       clearable={false}
       autoFocus
       openOnFocus
     />
   );
 
-  if ('isList' in props) {
+  if (isList) {
     return <Box padding={2}>{input}</Box>;
   }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12278

# 👩🏻‍💻 What does this PR do?
- Debounce so that inbound autosave fields don't fire api on every keystroke
- Custom translation download button renamed to export & description updated
- Full width customer selection in New Requisition modal
- Make sure general population is always first
<img width="1197" height="311" alt="custom-export" src="https://github.com/user-attachments/assets/25549b4c-a6e1-4d51-ae69-5c24a64e1581" />
<img width="699" height="696" alt="Screenshot 2026-06-25 at 12 13 53" src="https://github.com/user-attachments/assets/5b295247-c02b-4e1e-88ee-68e8025eca47" />
<img width="1894" height="410" alt="Screenshot 2026-06-25 at 12 12 45" src="https://github.com/user-attachments/assets/8ce4edf5-332d-4429-8b01-59f4c129164b" />


# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Tested debounce on inbound reference input
- [ ] Checked custom translation button and confirmation says export
- [ ] Check new requisition modal customer input is full width
- [ ] Check general population is always sorted first

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

