### PR TITLE
11099 stocktake] 'ok & next' doesn't work take you to the last placeholder line

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/DetailView.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/DetailView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   useEditModal,
   DetailViewSkeleton,
@@ -77,6 +77,22 @@ const DetailViewInner = () => {
       ),
     });
 
+  const getSortedItems = useCallback(
+    () =>
+      table
+        .getSortedRowModel()
+        .rows.reduce<StocktakeLineFragment['item'][]>((acc, row) => {
+          const leafRows = row.getLeafRows();
+          const rows = leafRows.length ? leafRows : [row];
+          rows.forEach(leaf => {
+            const item = leaf.original?.item;
+            if (item && !acc.some(i => i?.id === item.id)) acc.push(item);
+          });
+          return acc;
+        }, []),
+    [table]
+  );
+
   const tabs = [
     {
       Component: <MaterialTable table={table} />,
@@ -138,6 +154,7 @@ const DetailViewInner = () => {
           mode={mode}
           item={entity}
           isInitialStocktake={stocktake.isInitialStocktake}
+          getSortedItems={getSortedItems}
         />
       )}
       <StocktakeErrorModal />

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -17,7 +17,6 @@ import {
   useAppTheme,
   useMediaQuery,
   useNotification,
-  useUrlQueryParams,
   useSimplifiedTabletUI,
   ButtonWithIcon,
   PlusCircleIcon,
@@ -62,6 +61,7 @@ interface StocktakeLineEditProps {
   onClose: () => void;
   isOpen: boolean;
   isInitialStocktake: boolean;
+  getSortedItems: () => StocktakeLineFragment['item'][];
 }
 
 export const StocktakeLineEdit = ({
@@ -70,13 +70,13 @@ export const StocktakeLineEdit = ({
   onClose,
   isOpen,
   isInitialStocktake,
+  getSortedItems,
 }: StocktakeLineEditProps) => {
   const theme = useAppTheme();
   const isMediumScreen = useMediaQuery(theme.breakpoints.down(Breakpoints.lg));
   const [currentItem, setCurrentItem] = useState(item);
 
-  const { isDisabled, items, totalLineCount, lines } =
-    useStocktakeOld.line.rows();
+  const { isDisabled, items, lines } = useStocktakeOld.line.rows();
   const {
     draftLines,
     update: updateLine,
@@ -84,7 +84,7 @@ export const StocktakeLineEdit = ({
     isSaving,
     save,
     nextItem,
-  } = useStocktakeLineEdit(currentItem, items, lines);
+  } = useStocktakeLineEdit(currentItem, getSortedItems, lines);
   const { unsetError } = useStocktakeLineErrorContext();
   const update: typeof updateLine = useCallback(
     patch => {
@@ -95,11 +95,6 @@ export const StocktakeLineEdit = ({
   );
   const t = useTranslation();
   const { error } = useNotification();
-  const {
-    updatePaginationQuery,
-    queryParams: { first, offset, page },
-  } = useUrlQueryParams();
-  const hasMorePages = totalLineCount > Number(first) + Number(offset);
   // Order by newly added batch since new batches are now
   // added to the top of the stocktake list instead of the bottom
   const reversedDraftLines = [...draftLines].reverse();
@@ -202,14 +197,6 @@ export const StocktakeLineEdit = ({
       case mode === ModalMode.Update && !!nextItem:
         setCurrentItem(nextItem);
         break;
-      case mode === ModalMode.Update && hasMorePages:
-        // we are at the end of the current paginated set of items
-        // fetch more pages and set the current item to null
-        // so that we can correctly set the current item when the
-        // lines query returns
-        updatePaginationQuery(page + 1);
-        setCurrentItem(null);
-        break;
       case mode === ModalMode.Create:
         setCurrentItem(null);
         break;
@@ -234,15 +221,6 @@ export const StocktakeLineEdit = ({
   };
 
   const hasValidBatches = draftLines.length > 0;
-
-  useEffect(() => {
-    // if the pagination has been increased and items have been fetched
-    // and we are updating and the current item has been nulled
-    // then it is time to set the curren item again
-    if (mode === ModalMode.Update && !currentItem && !!items[0]?.item)
-      setCurrentItem(items[0]?.item);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [items]);
 
   const tableContent = simplifiedTabletView ? (
     <>
@@ -312,7 +290,7 @@ export const StocktakeLineEdit = ({
       onCancel={onClose}
       mode={mode}
       isOpen={isOpen}
-      hasNext={!!nextItem || hasMorePages}
+      hasNext={!!nextItem}
       isValid={hasValidBatches && !isSaving}
     >
       {isSaving ? (

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks/useNextItem.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks/useNextItem.ts
@@ -1,19 +1,18 @@
-import { StocktakeSummaryItem } from '@openmsupply-client/inventory/src/types';
+import { useState } from 'react';
 import { StocktakeLineFragment } from 'packages/inventory/src/Stocktake/api';
 
 export const useNextItem = (
-  items: StocktakeSummaryItem[],
+  getSortedItems: () => StocktakeLineFragment['item'][],
   currentItemId?: string
 ): StocktakeLineFragment['item'] | null => {
+  const [items] = useState(getSortedItems);
+
   if (!items || !currentItemId) return null;
 
-  const numberOfItems = items.length;
-  const currentIdx = items.findIndex(({ item }) => item?.id === currentItemId);
-  const nextItem = items[(currentIdx + 1) % numberOfItems];
+  const currentIdx = items.findIndex(item => item?.id === currentItemId);
+  const nextItem = items[currentIdx + 1];
 
-  if (currentIdx === -1 || currentIdx === numberOfItems - 1 || !nextItem) {
-    return null;
-  }
+  if (currentIdx === -1 || !nextItem) return null;
 
-  return nextItem.item ?? null;
+  return nextItem ?? null;
 };

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks/useStocktakeLineEdit.ts
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/hooks/useStocktakeLineEdit.ts
@@ -7,7 +7,6 @@ import { useStocktakeOld } from './../../../../api';
 import { DraftStocktakeLine, DraftLine } from '../utils';
 import { useNextItem } from './useNextItem';
 import { useDraftStocktakeLines } from './useDraftStocktakeLines';
-import { StocktakeSummaryItem } from '../../../../../types';
 import { StocktakeLineFragment } from '../../../../api';
 
 interface useStocktakeLineEditController {
@@ -21,12 +20,11 @@ interface useStocktakeLineEditController {
 
 export const useStocktakeLineEdit = (
   item: DraftStocktakeLine['item'] | null,
-  items: StocktakeSummaryItem[],
+  getSortedItems: () => StocktakeLineFragment['item'][],
   lines?: StocktakeLineFragment[]
 ): useStocktakeLineEditController => {
   const { id } = useStocktakeOld.document.fields('id');
-  const filteredItems = items.filter(item => item.item?.id === item?.id);
-  const nextItem = useNextItem(filteredItems, item?.id);
+  const nextItem = useNextItem(getSortedItems, item?.id);
   const [draftLines, setDraftLines] = useDraftStocktakeLines(item, lines);
   const { saveAndMapStructuredErrors: upsertLines, isPending: isSaving } =
     useStocktakeOld.line.save();

--- a/client/packages/invoices/src/Returns/CustomerDetailView/Tabs/Details.tsx
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/Tabs/Details.tsx
@@ -10,7 +10,6 @@ import { CustomerReturnLineFragment, useReturns } from '../../api';
 import { useCustomerReturnColumns } from '../columns';
 import { Footer } from '../Footer';
 import { CustomerReturnEditModal } from '../../modals';
-import { getNextItemId } from '../../../utils';
 
 export interface DetailsTabLineEdit {
   isOpen: boolean;
@@ -55,7 +54,24 @@ export const DetailsTab = ({ lineEdit }: DetailsTabProps) => {
       ),
     });
 
-  const nextItemId = getNextItemId(lines ?? [], lineEdit.entity);
+  // Navigate items in the order they're currently displayed in the table
+  // (respecting the user's sort), so "OK & Next" matches what the user sees.
+  const sortedItemIds = table
+    .getSortedRowModel()
+    .rows.reduce<string[]>((acc, row) => {
+      const leafRows = row.getLeafRows();
+      const rows = leafRows.length ? leafRows : [row];
+      rows.forEach(leaf => {
+        const itemId = leaf.original?.itemId;
+        if (itemId && !acc.includes(itemId)) acc.push(itemId);
+      });
+      return acc;
+    }, []);
+  const currentItemIndex = sortedItemIds.findIndex(
+    id => id === lineEdit.entity
+  );
+  const nextItemId =
+    currentItemIndex === -1 ? undefined : sortedItemIds[currentItemIndex + 1];
 
   if (!data) return null;
 

--- a/client/packages/invoices/src/Returns/SupplierDetailView/Tabs/Details.tsx
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/Tabs/Details.tsx
@@ -9,7 +9,6 @@ import {
 import { Footer } from '../Footer';
 import { SupplierReturnEditModal } from '../../modals';
 import { SupplierReturnLineFragment, useReturns } from '../../api';
-import { getNextItemId } from '../../../utils';
 import { useSupplierReturnColumns } from '../columns';
 
 export interface DetailsTabLineEdit {
@@ -55,7 +54,24 @@ export const DetailsTab = ({ lineEdit }: DetailsTabProps) => {
       ),
     });
 
-  const nextItemId = getNextItemId(lines ?? [], lineEdit.entity);
+  // Navigate items in the order they're currently displayed in the table
+  // (respecting the user's sort), so "OK & Next" matches what the user sees.
+  const sortedItemIds = table
+    .getSortedRowModel()
+    .rows.reduce<string[]>((acc, row) => {
+      const leafRows = row.getLeafRows();
+      const rows = leafRows.length ? leafRows : [row];
+      rows.forEach(leaf => {
+        const itemId = leaf.original?.itemId;
+        if (itemId && !acc.includes(itemId)) acc.push(itemId);
+      });
+      return acc;
+    }, []);
+  const currentItemIndex = sortedItemIds.findIndex(
+    id => id === lineEdit.entity
+  );
+  const nextItemId =
+    currentItemIndex === -1 ? undefined : sortedItemIds[currentItemIndex + 1];
 
   return (
     <>

--- a/client/packages/purchasing/src/purchase_order/DetailView/Tabs/General.tsx
+++ b/client/packages/purchasing/src/purchase_order/DetailView/Tabs/General.tsx
@@ -57,13 +57,6 @@ export const GeneralTab = ({ lineEdit }: GeneralTabProps) => {
     [lineEdit]
   );
 
-  const openNext = useCallback(() => {
-    const currentIndex = lines?.findIndex(line => line.id === lineEdit.entity);
-    const nextLine = lines[currentIndex + 1];
-    if (!nextLine) return;
-    lineEdit.onOpen(nextLine.id);
-  }, [lines, lineEdit]);
-
   const { table, selectedRows } =
     useNonPaginatedMaterialTable<PurchaseOrderLineFragment>({
       tableId: 'purchase-order-detail-view',
@@ -85,6 +78,22 @@ export const GeneralTab = ({ lineEdit }: GeneralTabProps) => {
 
   if (!data) return null;
 
+  // Navigate lines in the order they're currently displayed in the table
+  // (respecting the user's sort), so "OK & Next" matches what the user sees.
+  const sortedLineIds = table
+    .getSortedRowModel()
+    .rows.map(row => row.original.id);
+  const currentLineIndex = sortedLineIds.findIndex(
+    id => id === lineEdit.entity
+  );
+  const hasNext =
+    currentLineIndex !== -1 && currentLineIndex < sortedLineIds.length - 1;
+  const openNext = () => {
+    const nextId = sortedLineIds[currentLineIndex + 1];
+    if (!nextId) return;
+    lineEdit.onOpen(nextId);
+  };
+
   return (
     <>
       <MaterialTable table={table} />
@@ -101,10 +110,7 @@ export const GeneralTab = ({ lineEdit }: GeneralTabProps) => {
           mode={lineEdit.mode}
           lineId={lineEdit.entity}
           isDisabled={isDisabled}
-          hasNext={
-            lines.findIndex(line => line.id === lineEdit.entity) <
-            lines.length - 1
-          }
+          hasNext={hasNext}
           openNext={openNext}
         />
       )}

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/RequestLineEditModal.tsx
@@ -15,7 +15,7 @@ import {
   ItemWithAvailableStockFragment,
   ItemWithStatsFragment,
 } from '@openmsupply-client/system';
-import { RequestFragment, useRequest } from '../../api';
+import { RequestFragment, RequestLineFragment, useRequest } from '../../api';
 import { useDraftRequisitionLine, useNextRequestLine } from './hooks';
 import { shouldDeleteLine } from '../../../utils';
 import { RequestLineEdit } from './RequestLineEdit';
@@ -27,6 +27,7 @@ interface RequestLineEditModalProps {
   itemId: string | null;
   isOpen: boolean;
   onClose: () => void;
+  getSortedItems: () => RequestLineFragment['item'][];
 }
 
 export const RequestLineEditModal = ({
@@ -36,6 +37,7 @@ export const RequestLineEditModal = ({
   itemId,
   isOpen,
   onClose,
+  getSortedItems,
 }: RequestLineEditModalProps) => {
   const { error } = useNotification();
   const deleteLine = useRequest.line.deleteLine();
@@ -69,7 +71,7 @@ export const RequestLineEditModal = ({
   const { draft, save, update, isLoading, isReasonsError } =
     useDraftRequisitionLine(currentItem);
   const draftIdRef = useRef<string | undefined>(draft?.id);
-  const { hasNext, next } = useNextRequestLine(lines, currentItem);
+  const { hasNext, next } = useNextRequestLine(getSortedItems, currentItem);
   const [isEditingRequested, setIsEditingRequested] = useState(false);
 
   const useConsumptionData =

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit/hooks.tsx
@@ -143,26 +143,21 @@ export const useDraftRequisitionLine = (
 };
 
 export const useNextRequestLine = (
-  lines?: RequestLineFragment[],
+  getSortedItems: () => RequestLineFragment['item'][],
   currentItem?: ItemWithAvailableStockFragment | null
 ) => {
-  if (!lines || !currentItem) {
+  const [items] = useState(getSortedItems);
+
+  if (!items || !currentItem) {
     return { hasNext: false, next: null };
   }
 
-  const nextState: {
-    hasNext: boolean;
-    next: null | ItemWithAvailableStockFragment;
-  } = { hasNext: true, next: null };
-  const idx = lines.findIndex(l => l.item.id === currentItem?.id);
-  const next = lines[idx + 1];
+  const idx = items.findIndex(item => item?.id === currentItem?.id);
+  const next = items[idx + 1];
 
-  if (!next) {
-    nextState.hasNext = false;
-    return nextState;
+  if (idx === -1 || !next) {
+    return { hasNext: false, next: null };
   }
 
-  nextState.next = next.item;
-
-  return nextState;
+  return { hasNext: true, next };
 };

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/Tabs/Details.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/Tabs/Details.tsx
@@ -72,6 +72,18 @@ export const DetailsTab = ({ lineEdit }: DetailsTabProps) => {
     ),
   });
 
+  const getSortedItems = useCallback(
+    () =>
+      table
+        .getSortedRowModel()
+        .rows.reduce<RequestLineFragment['item'][]>((acc, row) => {
+          const item = row.original?.item;
+          if (item && !acc.some(i => i?.id === item.id)) acc.push(item);
+          return acc;
+        }, []),
+    [table]
+  );
+
   return (
     <>
       {plugins.requestRequisitionLine?.tableStateLoader?.map(
@@ -97,6 +109,7 @@ export const DetailsTab = ({ lineEdit }: DetailsTabProps) => {
           onClose={lineEdit.onClose}
           mode={lineEdit.mode}
           store={store}
+          getSortedItems={getSortedItems}
         />
       )}
     </>

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/ResponseEditModal.tsx
@@ -13,7 +13,7 @@ import {
   RequisitionNodeStatus,
 } from '@openmsupply-client/common';
 import { ItemWithStatsFragment } from '@openmsupply-client/system';
-import { ResponseFragment, useResponse } from '../../api';
+import { ResponseFragment, ResponseLineFragment, useResponse } from '../../api';
 import { ResponseLineEdit } from './ResponseLineEdit';
 import { useDraftRequisitionLine, useNextResponseLine } from './hooks';
 import { ResponseStoreStats } from '../ResponseStats/ResponseStoreStats';
@@ -27,6 +27,9 @@ interface ResponseLineEditModalProps {
   mode: ModalMode | null;
   isOpen: boolean;
   onClose: () => void;
+  // Items in the order they're currently displayed in the table, so
+  // "OK & Next" follows the user's sort.
+  getSortedItems: () => ResponseLineFragment['item'][];
 }
 
 export const ResponseLineEditModal = ({
@@ -36,6 +39,7 @@ export const ResponseLineEditModal = ({
   mode,
   isOpen,
   onClose,
+  getSortedItems,
 }: ResponseLineEditModalProps) => {
   const { error } = useNotification();
   const deleteLine = useResponse.line.deleteLine();
@@ -61,7 +65,7 @@ export const ResponseLineEditModal = ({
   const { draft, update, save, isLoading, isReasonsError } =
     useDraftRequisitionLine(currentItem);
   const draftIdRef = useRef<string | undefined>(draft?.id);
-  const { hasNext, next } = useNextResponseLine(lines, currentItem);
+  const { hasNext, next } = useNextResponseLine(getSortedItems, currentItem);
   const nextDisabled =
     (!hasNext && mode === ModalMode.Update) || !currentItem || isEditingSupply;
 

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/ResponseLineEdit/hooks.tsx
@@ -126,25 +126,25 @@ export const useDraftRequisitionLine = (
 };
 
 export const useNextResponseLine = (
-  lines: ResponseLineFragment[],
+  // Returns the items in the order they're currently displayed in the table,
+  // so "OK & Next" follows the user's sort instead of a fixed item-name order.
+  getSortedItems: () => ResponseLineFragment['item'][],
   currentItem?: ItemWithAvailableStockFragment | null
 ) => {
-  if (!lines || !currentItem) {
+  // Capture the display order once, when the modal opens, so navigation stays
+  // stable while the user steps through it.
+  const [items] = useState(getSortedItems);
+
+  if (!items || !currentItem) {
     return { hasNext: false, next: null };
   }
-  const nextState: {
-    hasNext: boolean;
-    next: ItemWithAvailableStockFragment | null;
-  } = { hasNext: true, next: null };
-  const idx = lines.findIndex(l => l.item.id === currentItem?.id);
-  const next = lines[idx + 1];
 
-  if (!next) {
-    nextState.hasNext = false;
-    return nextState;
+  const idx = items.findIndex(item => item?.id === currentItem?.id);
+  const next = items[idx + 1];
+
+  if (idx === -1 || !next) {
+    return { hasNext: false, next: null };
   }
 
-  nextState.next = next.item;
-
-  return nextState;
+  return { hasNext: true, next };
 };

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/Tabs/Details.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/Tabs/Details.tsx
@@ -63,6 +63,21 @@ export const DetailsTab = ({ lineEdit }: DetailsTabProps) => {
     ),
   });
 
+  // Items in the order they're currently displayed in the table (respecting the
+  // user's sort), so the line-edit modal's "OK & Next" steps through items in
+  // the same order the user sees them.
+  const getSortedItems = useCallback(
+    () =>
+      table
+        .getSortedRowModel()
+        .rows.reduce<ResponseLineFragment['item'][]>((acc, row) => {
+          const item = row.original?.item;
+          if (item && !acc.some(i => i?.id === item.id)) acc.push(item);
+          return acc;
+        }, []),
+    [table]
+  );
+
   return (
     <>
       <MaterialTable table={table} />
@@ -78,6 +93,7 @@ export const DetailsTab = ({ lineEdit }: DetailsTabProps) => {
           mode={lineEdit.mode}
           isOpen={lineEdit.isOpen}
           onClose={lineEdit.onClose}
+          getSortedItems={getSortedItems}
         />
       )}
     </>

--- a/client/packages/system/src/Location/ListView/ListView.tsx
+++ b/client/packages/system/src/Location/ListView/ListView.tsx
@@ -142,6 +142,8 @@ export const LocationListView = () => {
           isOpen={isOpen}
           onClose={onClose}
           location={entity}
+          sortBy={sortBy}
+          filterBy={filterBy}
         />
       )}
       <AppBarButtons onCreate={() => onOpen()} sortBy={sortBy} />

--- a/client/packages/system/src/Location/ListView/LocationEditModal/LocationEditModal.tsx
+++ b/client/packages/system/src/Location/ListView/LocationEditModal/LocationEditModal.tsx
@@ -12,6 +12,8 @@ import {
   NumericTextInput,
   Box,
   useNotification,
+  SortBy,
+  LocationFilterInput,
 } from '@openmsupply-client/common';
 import { LocationRowFragment, useLocationList, useLocation } from '../../api';
 import { LocationTypeInput } from '@openmsupply-client/system';
@@ -21,6 +23,10 @@ interface LocationEditModalProps {
   onClose: () => void;
 
   location: LocationRowFragment | null;
+  // The list's current sort/filter, so "OK & Next" steps through locations in
+  // the same order (and within the same filtered set) the user sees.
+  sortBy: SortBy<LocationRowFragment>;
+  filterBy: LocationFilterInput | null;
 }
 
 const createNewLocation = (
@@ -47,14 +53,17 @@ interface UseDraftLocationControl {
 
 const useDraftLocation = (
   seed: LocationRowFragment | null,
-  mode: ModalMode | null
+  mode: ModalMode | null,
+  sortBy: SortBy<LocationRowFragment>,
+  filterBy: LocationFilterInput | null
 ): UseDraftLocationControl => {
   const [location, setLocation] = useState<LocationRowFragment>(() =>
     createNewLocation(seed)
   );
   const { nextLocation } = useLocationList(
     {
-      sortBy: { key: 'name', direction: 'asc' },
+      sortBy,
+      filterBy,
     },
     location
   );
@@ -97,12 +106,14 @@ export const LocationEditModal: FC<LocationEditModalProps> = ({
   isOpen,
   onClose,
   location,
+  sortBy,
+  filterBy,
 }) => {
   const { Modal } = useDialog({ isOpen, onClose });
   const t = useTranslation();
   const { error } = useNotification();
   const { draft, onUpdate, onChangeLocation, onSave, isLoading } =
-    useDraftLocation(location, mode);
+    useDraftLocation(location, mode, sortBy, filterBy);
   const isInvalid = !draft.code.trim() || !draft.name.trim();
 
   const handleSave = async () => {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11099

# 👩🏻‍💻 What does this PR do?
Fixes ok & next not following table order in the following views:
- Stocktake
- Internal Order
- Requisition
- Supplier Returns
- Customer Returns
- Purchase ORders
- Locations


https://github.com/user-attachments/assets/9934d31f-2917-4d7e-806c-685f034531d7



# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Tested all the above views with different sorting and pressing Ok & Next

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

