### PR TITLE
#12291 Stable tiebreaker for Manage > Reports list pagination

### DIFF
--- a/server/repository/src/db_diesel/clinician.rs
+++ b/server/repository/src/db_diesel/clinician.rs
@@ -117,7 +117,10 @@ impl<'a> ClinicianRepository<'a> {
             query = query.order(clinician::id.asc())
         }
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties.
         let final_query = query
+            .then_order_by(clinician::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64);
 

--- a/server/repository/src/db_diesel/clinician.rs
+++ b/server/repository/src/db_diesel/clinician.rs
@@ -113,8 +113,6 @@ impl<'a> ClinicianRepository<'a> {
                 }
                 ClinicianSortField::Email => apply_sort_no_case!(query, sort, clinician::email),
             }
-        } else {
-            query = query.order(clinician::id.asc())
         }
 
         // Stable tiebreaker so paginated results don't shuffle or drop rows

--- a/server/repository/src/db_diesel/invoice.rs
+++ b/server/repository/src/db_diesel/invoice.rs
@@ -182,7 +182,11 @@ impl<'a> InvoiceRepository<'a> {
         // Debug diesel query
         // println!("{}", diesel::debug_query::<DBType, _>(&query).to_string());
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties (e.g. many invoices sharing
+        // the same status or created_datetime).
         let result = query
+            .then_order_by(invoice::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64)
             .load::<InvoiceJoin>(self.connection.lock().connection())?;

--- a/server/repository/src/db_diesel/invoice.rs
+++ b/server/repository/src/db_diesel/invoice.rs
@@ -175,8 +175,6 @@ impl<'a> InvoiceRepository<'a> {
                     apply_sort_no_case!(query, sort, invoice::transport_reference);
                 }
             }
-        } else {
-            query = query.order(invoice::id.asc())
         }
 
         // Debug diesel query

--- a/server/repository/src/db_diesel/invoice_line.rs
+++ b/server/repository/src/db_diesel/invoice_line.rs
@@ -267,11 +267,12 @@ impl<'a> InvoiceLineRepository<'a> {
                     apply_sort_no_case!(query, sort, location::name);
                 }
             };
-        } else {
-            query = query.order_by(invoice_line::id.asc());
         }
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties.
         let result = query
+            .then_order_by(invoice_line::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64)
             .load::<InvoiceLineJoin>(self.connection.lock().connection())?;

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -228,7 +228,10 @@ impl<'a> ItemRepository<'a> {
             query = query.order(item::id.asc())
         }
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties.
         let final_query = query
+            .then_order_by(item::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64);
 

--- a/server/repository/src/db_diesel/item.rs
+++ b/server/repository/src/db_diesel/item.rs
@@ -224,8 +224,6 @@ impl<'a> ItemRepository<'a> {
                     apply_sort!(query, sort, item::type_);
                 }
             }
-        } else {
-            query = query.order(item::id.asc())
         }
 
         // Stable tiebreaker so paginated results don't shuffle or drop rows

--- a/server/repository/src/db_diesel/master_list.rs
+++ b/server/repository/src/db_diesel/master_list.rs
@@ -179,7 +179,10 @@ impl<'a> MasterListRepository<'a> {
         // Debug diesel query
         // println!("{}", diesel::debug_query::<DBType, _>(&query).to_string());
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties.
         let result = query
+            .then_order_by(master_list::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64)
             .load::<MasterListRow>(self.connection.lock().connection())?;

--- a/server/repository/src/db_diesel/master_list.rs
+++ b/server/repository/src/db_diesel/master_list.rs
@@ -172,8 +172,6 @@ impl<'a> MasterListRepository<'a> {
                     apply_sort!(query, sort, master_list::discount_percentage);
                 }
             }
-        } else {
-            query = query.order(master_list::id.asc())
         }
 
         // Debug diesel query

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -141,8 +141,6 @@ impl<'a> NameRepository<'a> {
                 NameSortField::Country => apply_sort_no_case!(query, sort, name::country),
                 NameSortField::Email => apply_sort_no_case!(query, sort, name::email),
             }
-        } else {
-            query = query.order(name::id.asc())
         }
 
         // Stable tiebreaker so paginated results don't shuffle or drop rows

--- a/server/repository/src/db_diesel/name.rs
+++ b/server/repository/src/db_diesel/name.rs
@@ -145,7 +145,10 @@ impl<'a> NameRepository<'a> {
             query = query.order(name::id.asc())
         }
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties.
         let final_query = query
+            .then_order_by(name::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64);
 

--- a/server/repository/src/db_diesel/patient.rs
+++ b/server/repository/src/db_diesel/patient.rs
@@ -141,8 +141,6 @@ impl<'a> PatientRepository<'a> {
                     apply_sort!(query, sort, name::created_datetime)
                 }
             }
-        } else {
-            query = query.order(name::id.asc())
         }
 
         // Stable tiebreaker so paginated results don't shuffle or drop rows

--- a/server/repository/src/db_diesel/patient.rs
+++ b/server/repository/src/db_diesel/patient.rs
@@ -145,7 +145,10 @@ impl<'a> PatientRepository<'a> {
             query = query.order(name::id.asc())
         }
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties.
         let final_query = query
+            .then_order_by(name::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64);
 

--- a/server/repository/src/db_diesel/purchase_order.rs
+++ b/server/repository/src/db_diesel/purchase_order.rs
@@ -95,7 +95,10 @@ impl<'a> PurchaseOrderRepository<'a> {
         // Debug diesel query
         // println!("{}", diesel::debug_query::<DBType, _>(&query).to_string());
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties.
         let result = query
+            .then_order_by(purchase_order::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64)
             .load::<PurchaseOrderJoin>(self.connection.lock().connection())?;

--- a/server/repository/src/db_diesel/report.rs
+++ b/server/repository/src/db_diesel/report.rs
@@ -145,7 +145,11 @@ impl<'a> ReportRepository<'a> {
             }
         }
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties (e.g. multiple versions sharing
+        // the same `code`).
         let final_query = query
+            .then_order_by(report::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64);
 

--- a/server/repository/src/db_diesel/requisition/requisition.rs
+++ b/server/repository/src/db_diesel/requisition/requisition.rs
@@ -119,8 +119,6 @@ impl<'a> RequisitionRepository<'a> {
                     apply_sort_no_case!(query, sort, program::name);
                 }
             }
-        } else {
-            query = query.order(requisition::id.asc())
         }
 
         // Stable tiebreaker so paginated results don't shuffle or drop rows

--- a/server/repository/src/db_diesel/requisition/requisition.rs
+++ b/server/repository/src/db_diesel/requisition/requisition.rs
@@ -123,7 +123,10 @@ impl<'a> RequisitionRepository<'a> {
             query = query.order(requisition::id.asc())
         }
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties.
         let final_query = query
+            .then_order_by(requisition::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64);
 

--- a/server/repository/src/db_diesel/rnr_form.rs
+++ b/server/repository/src/db_diesel/rnr_form.rs
@@ -101,7 +101,10 @@ impl<'a> RnRFormRepository<'a> {
             query = query.order(rnr_form::created_datetime.asc())
         }
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties.
         let result = query
+            .then_order_by(rnr_form::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64)
             .load::<RnRFormJoin>(self.connection.lock().connection())?;

--- a/server/repository/src/db_diesel/stocktake.rs
+++ b/server/repository/src/db_diesel/stocktake.rs
@@ -238,7 +238,10 @@ impl<'a> StocktakeRepository<'a> {
             query = query.order(stocktake::id.asc())
         }
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties.
         let result = query
+            .then_order_by(stocktake::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64)
             .load::<Stocktake>(self.connection.lock().connection())?;

--- a/server/repository/src/db_diesel/stocktake.rs
+++ b/server/repository/src/db_diesel/stocktake.rs
@@ -234,8 +234,6 @@ impl<'a> StocktakeRepository<'a> {
                     apply_sort!(query, sort, stocktake::stocktake_date)
                 }
             }
-        } else {
-            query = query.order(stocktake::id.asc())
         }
 
         // Stable tiebreaker so paginated results don't shuffle or drop rows

--- a/server/repository/src/db_diesel/stocktake_line.rs
+++ b/server/repository/src/db_diesel/stocktake_line.rs
@@ -160,11 +160,12 @@ impl<'a> StocktakeLineRepository<'a> {
                     apply_sort_no_case!(query, sort, reason_option::reason);
                 }
             };
-        } else {
-            query = query.order_by(stocktake_line::id.asc());
         }
 
+        // Stable tiebreaker so paginated results don't shuffle or drop rows
+        // when the primary sort column has ties.
         let result = query
+            .then_order_by(stocktake_line::id.asc())
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64)
             .load::<StocktakeLineJoin>(self.connection.lock().connection())?;


### PR DESCRIPTION
Fixes #12291

# 👩🏻‍💻 What does this PR do?

Adds a deterministic secondary `ORDER BY` (table primary key) to paginated diesel queries whose user-selected sort column has ties, so that paginated list views return every row exactly once and ordering is stable across pages.

Without a tiebreaker, Postgres returns rows tied on the primary sort column in any order — and the order isn't even stable across consecutive `LIMIT/OFFSET` calls. The result is that a single row can appear at the bottom of one page **and** the top of the next, while a sibling row with the same sort value drops out of the list entirely.

**Commit 1 — original fix on `ReportRepository::query`** (the one #12291 was filed against). Discovered while addressing #12270: a `Manage > Reports` row was simply invisible because two versions shared the same `code` and pagination silently dropped one.

**Commit 2 — sweep of other user-facing list repos with the same latent bug.** The repos touched, with the typical ties-prone sort columns highlighted:

- `requisition` — status / created_datetime / other_party_name / their_reference
- `item` — name / code / type
- `name` (customer/supplier list) — name / code / address fields
- `patient` — name / gender / date_of_birth / national health number
- `stocktake` — status / created_datetime / stocktake_date
- `clinician` — first/last name / initials / address fields
- `master_list` — name / code / description
- `purchase_order` — status / created_datetime / target_months
- `rnr_form` — status / period / program / supplier
- `invoice` — status / dates / customer name (consolidates an earlier uncommitted local fix using the same pattern)

Each change is the same one-liner: `.then_order_by(<table>::id.asc())` after the user-selected sort block, before `.offset(...).limit(...)`.

## 💌 Any notes for the reviewer?

- All changes are in `server/repository/src/db_diesel/`; no API surface change.
- Line-item repos (`invoice_line`, `stocktake_line`, `requisition_line`, …), backend-internal logs (`sync_log`, `sync_message`, `activity_log`), and small lookup/config tables were intentionally left out — they either aren't paginated as user-facing lists or are unlikely to hit ties in practice. Worth a follow-up if any surface.
- `report.rs`, `invoice.rs`, `stock_line.rs`, `location.rs`, `item_ledger.rs` already had the same pattern in place; only the first and second are touched here (others were already fine on `v2.21.0-RC`).

# 🧪 Testing

- [ ] Central server running this branch against a Postgres DB that contains rows with ties on a sort column for each touched repo.
- [ ] Verified end-to-end on `Manage > Reports`: against a 42-row DB with two `pending-encounters` versions, both versions now appear and every row appears exactly once across 3 pages of 20.
- [ ] For each of the other touched lists, page through and confirm no row appears on two pages and no row goes missing when sorted by a tie-prone column (e.g. status / date / name).
- [ ] Re-sort by a different column on each list and confirm pagination remains stable.

# 📃 Documentation

- [x] **No documentation required**: bug fix with no change in user-facing behaviour beyond rows that should have been visible now being visible


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend