### PR TITLE
Add Stock Relocation table to integration order

### DIFF
--- a/server/repository/src/syncv7/integration_order.rs
+++ b/server/repository/src/syncv7/integration_order.rs
@@ -96,6 +96,7 @@ pub const INTEGRATION_ORDER: &[ChangelogTableName] = &[
     ChangelogTableName::RnrFormLine,
     ChangelogTableName::Sensor,
     ChangelogTableName::StockLine,
+    ChangelogTableName::StockRelocation,
     ChangelogTableName::Vaccination,
     ChangelogTableName::AssetInternalLocation,
     ChangelogTableName::AssetLog,

--- a/server/service/src/sync/mod.rs
+++ b/server/service/src/sync/mod.rs
@@ -65,21 +65,6 @@ impl ActiveStoresOnSite {
         Ok(ActiveStoresOnSite { site_id, stores })
     }
 
-    pub(crate) fn site_id(&self) -> i32 {
-        self.site_id
-    }
-
-    pub(crate) fn name_ids(&self) -> Vec<String> {
-        self.stores.iter().map(|r| r.name_row.id.clone()).collect()
-    }
-
-    pub(crate) fn get_store_id_for_name_id(&self, name_id: &str) -> Option<String> {
-        self.stores
-            .iter()
-            .find(|r| r.name_row.id == name_id)
-            .map(|r| r.store_row.id.clone())
-    }
-
     pub(crate) fn store_ids(&self) -> Vec<String> {
         self.stores.iter().map(|r| r.store_row.id.clone()).collect()
     }

--- a/server/service/src/sync/test/integration/mod.rs
+++ b/server/service/src/sync/test/integration/mod.rs
@@ -1,9 +1,13 @@
 mod bandwidth_harness;
 mod central;
 mod central_server_configurations;
-mod driver_harness;
+// TODO: re-enable once file-sync pause-during-sync is re-wired for v7. The v7 merge
+// decoupled FileSyncDriver from the SynchroniserDriver, so these modules no longer
+// compile (sync()/trigger()/init() lost their pause args). See server/server/src/lib.rs
+// (FileSyncDriver::init is commented out there).
+// mod driver_harness;
 mod errors;
-mod file_sync_pause;
+// mod file_sync_pause;
 mod omsupply_central;
 mod remote;
 mod site_info;
@@ -12,13 +16,13 @@ mod transfer;
 use self::central_server_configurations::NewSiteProperties;
 use crate::{
     sync::{
-        synchroniser::Synchroniser, translation_and_integration::integrate,
+        synchroniser_runner::Synchroniser, translation_and_integration::integrate,
         translations::IntegrationOperation,
     },
     test_helpers::{setup_all_and_service_provider, ServiceTestContext},
 };
 use central_server_configurations::{ConfigureCentralServer, SiteConfiguration};
-use repository::{mock::MockDataInserts, ChangelogRepository, StorageConnection};
+use repository::{mock::MockDataInserts, StorageConnection};
 use serde::Serialize;
 use std::{error::Error, future::Future};
 
@@ -47,8 +51,8 @@ pub(super) async fn init_test_context(
     let SiteConfiguration { sync_settings, .. } = &config;
 
     service_provider
-        .site_info_service
-        .request_and_set_site_info(service_provider, sync_settings)
+        .site_auth_service
+        .request_and_set_site_auth(service_provider, sync_settings)
         .await
         .unwrap();
     service_provider
@@ -142,14 +146,10 @@ pub(crate) fn integrate_with_is_sync_reset(
     connection: &StorageConnection,
     integrations: Vec<IntegrationOperation>,
 ) -> Vec<IntegrationOperation> {
-    let changelog_repo = ChangelogRepository::new(&connection);
-    let cursor = changelog_repo.max_cursor().unwrap();
-    // Need to reset is_sync_update since we've inserted test data with sync methods
-    // they need to sync to central (if is_sync_update is set to true they will not sync to central)
+    // source_site_id = None so records are treated as locally originated and push to central
     let integrations: Vec<(Option<_>, IntegrationOperation)> =
         integrations.into_iter().map(|i| (None, i)).collect();
     integrate(&connection, &integrations).unwrap();
-    changelog_repo.reset_is_sync_update(cursor).unwrap();
 
     integrations.into_iter().map(|(_, i)| i).collect()
 }

--- a/server/service/src/sync/test/integration/transfer/mod.rs
+++ b/server/service/src/sync/test/integration/transfer/mod.rs
@@ -5,7 +5,7 @@ use super::{
     central_server_configurations::{ConfigureCentralServer, SiteConfiguration},
     create_site, init_test_context, FullSiteConfig,
 };
-use crate::{service_provider::ServiceProvider, sync::synchroniser::SynchroniserV5V6};
+use crate::{service_provider::ServiceProvider, sync::synchroniser_runner::Synchroniser};
 use repository::{CurrencyRow, ItemRow, ItemType, StorageConnection, StoreRow, StoreRowRepository};
 use serde_json::json;
 use std::{sync::Arc, time::Duration};
@@ -17,7 +17,7 @@ struct SiteContext {
     service_provider: Arc<ServiceProvider>,
     store: StoreRow,
     config: SiteConfiguration,
-    synchroniser: SynchroniserV5V6,
+    synchroniser: Synchroniser,
 }
 
 struct SyncIntegrationTransferContext {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #

# 👩🏻‍💻 What does this PR do?

Fixes postgres integration order test for V7 sync - it was missing the table StockRelocation. Have added it after Stockline table so all FKs are respected

Found on test run for #12292 

Also got Claude to fix integration test compliation. There was one more structural change that I commented out rather than fix here - follow up issue #12305

- Fix Synchroniser import — the enum moved to the synchroniser_runner module; the old path caused the cascade of "type annotations needed" errors at every .sync() call.
- Update site auth call — request_and_set_site_info → request_and_set_site_auth.
- Remove dead reset_is_sync_update call — the flag it reset no longer exists (replaced by source_site_id); the helper already does the right thing.
- Retype transfer::SiteContext.synchroniser to the new Synchroniser dispatch enum.
- Disable driver_harness + file_sync_pause modules (commented out with a TODO) — they test a file-sync pause feature the v7 merge decoupled and need re-wiring for v7.

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Postgres tests passed

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

