### PR TITLE
12248 the sync records button (badge) does not gets cleared in standalone version

### DIFF
--- a/client/packages/common/src/api/SubscriptionClient.ts
+++ b/client/packages/common/src/api/SubscriptionClient.ts
@@ -4,6 +4,28 @@ import { getAuthCookie } from '../authentication/AuthContext';
 let subscriptionClient: Client | null = null;
 let currentUrl: string | null = null;
 
+// Tracks whether the WebSocket is actually connected, with listeners notified
+// on change
+let isConnected = false;
+const connectionListeners = new Set<(connected: boolean) => void>();
+
+const setConnected = (connected: boolean) => {
+  if (isConnected === connected) return;
+  isConnected = connected;
+  connectionListeners.forEach(listener => listener(connected));
+};
+
+export const getConnectionState = (): boolean => isConnected;
+
+export const subscribeToConnectionState = (
+  listener: (connected: boolean) => void
+): (() => void) => {
+  connectionListeners.add(listener);
+  return () => {
+    connectionListeners.delete(listener);
+  };
+};
+
 /**
  * Get or create a shared graphql-ws subscription client.
  * Lazily connects on first subscription; reconnects automatically.
@@ -22,6 +44,7 @@ export const getSubscriptionClient = (httpUrl: string): Client => {
   }
 
   currentUrl = wsUrl;
+  setConnected(false);
   subscriptionClient = createClient({
     url: wsUrl,
     lazy: true,
@@ -37,6 +60,10 @@ export const getSubscriptionClient = (httpUrl: string): Client => {
     },
   });
 
+  subscriptionClient.on('connected', () => setConnected(true));
+  subscriptionClient.on('closed', () => setConnected(false));
+  subscriptionClient.on('error', () => setConnected(false));
+
   return subscriptionClient;
 };
 
@@ -50,7 +77,6 @@ export const reconnectSubscriptionClient = () => {
     subscriptionClient.terminate();
   }
 };
-
 
 function httpToWsUrl(httpUrl: string): string {
   // Replace /graphql suffix if present, then convert protocol

--- a/client/packages/common/src/api/hooks/useSubscription.ts
+++ b/client/packages/common/src/api/hooks/useSubscription.ts
@@ -3,8 +3,10 @@ import { DocumentNode, print } from 'graphql';
 import { useGql } from '../GqlContext';
 import { useAuthContext } from '../../authentication/AuthContext';
 import {
+  getConnectionState,
   getSubscriptionClient,
   reconnectSubscriptionClient,
+  subscribeToConnectionState,
 } from '../SubscriptionClient';
 
 interface UseSubscriptionOptions<TSubscription, TData> {
@@ -49,16 +51,23 @@ export const useSubscription = <TSubscription, TData>({
   enabled = true,
   requireAuth = true,
   select,
-}: UseSubscriptionOptions<TSubscription, TData>): UseSubscriptionResult<TData> => {
+}: UseSubscriptionOptions<
+  TSubscription,
+  TData
+>): UseSubscriptionResult<TData> => {
   const { client: gqlClient } = useGql();
   const { token } = useAuthContext();
-  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [isConnected, setIsConnected] = useState(getConnectionState);
   const [data, setData] = useState<TData | undefined>(undefined);
   const unsubscribeRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
+    setIsConnected(getConnectionState());
+    return subscribeToConnectionState(setIsConnected);
+  }, []);
+
+  useEffect(() => {
     if (!enabled || (requireAuth && !token)) {
-      setIsSubscribed(false);
       setData(undefined);
       return;
     }
@@ -75,8 +84,6 @@ export const useSubscription = <TSubscription, TData>({
 
     let disposed = false;
 
-    setIsSubscribed(true);
-
     unsubscribeRef.current = wsClient.subscribe(
       {
         query: print(document),
@@ -90,13 +97,11 @@ export const useSubscription = <TSubscription, TData>({
         },
         error: () => {
           if (!disposed) {
-            setIsSubscribed(false);
             setData(undefined);
           }
         },
         complete: () => {
           if (!disposed) {
-            setIsSubscribed(false);
             setData(undefined);
           }
         },
@@ -105,7 +110,6 @@ export const useSubscription = <TSubscription, TData>({
 
     return () => {
       disposed = true;
-      setIsSubscribed(false);
       setData(undefined);
       if (unsubscribeRef.current) {
         unsubscribeRef.current();
@@ -114,6 +118,8 @@ export const useSubscription = <TSubscription, TData>({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, document, token]);
+
+  const isSubscribed = isConnected && enabled && (!requireAuth || !!token);
 
   return { isSubscribed, data };
 };

--- a/client/packages/common/src/api/hooks/useSubscription.ts
+++ b/client/packages/common/src/api/hooks/useSubscription.ts
@@ -119,6 +119,8 @@ export const useSubscription = <TSubscription, TData>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, document, token]);
 
+  // Active only when the socket is connected, the caller has enabled it, and
+  // a token is present.
   const isSubscribed = isConnected && enabled && (!requireAuth || !!token);
 
   return { isSubscribed, data };

--- a/client/packages/electron/package.json
+++ b/client/packages/electron/package.json
@@ -2,7 +2,7 @@
   "name": "@openmsupply-client/electron",
   "productName": "Open mSupply",
   "//": "Version is updated from the root package.json when electron is built, see the 'make' script below",
-  "version": "2.16.00-develop",
+  "version": "3.00.00-RC",
   "description": "Client for Open mSupply running on local network",
   "main": "./.webpack/main",
   "scripts": {


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12248

# 👩🏻‍💻 What does this PR do?
This PR fixes the sync badge not clearing on standalone. isSubscribed stayed stuck in true since it retries forever when a socket can't connect, which disables the polling fallback for sync info

https://github.com/user-attachments/assets/97784f09-db1f-4321-b3aa-9b16d75f3756



# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Tested that electron standalone cleared sync badge

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

