### PR TITLE
Fix v2.21.0-RC build: make changelogs_filter async

### DIFF
--- a/server/service/src/processors/assign_prescription_number/assign_prescription_number.rs
+++ b/server/service/src/processors/assign_prescription_number/assign_prescription_number.rs
@@ -76,7 +76,10 @@ impl Processor for AssignPrescriptionNumber {
         Ok(Some(result))
     }
 
-    fn changelogs_filter(&self, ctx: &ServiceContext) -> Result<ChangelogFilter, ProcessorError> {
+    async fn changelogs_filter(
+        &self,
+        ctx: &ServiceContext,
+    ) -> Result<ChangelogFilter, ProcessorError> {
         let active_stores = ActiveStoresOnSite::get(&ctx.connection)
             .map_err(ProcessorError::GetActiveStoresOnSiteError)?;
 


### PR DESCRIPTION
No linked issue.

# 👩🏻‍💻 What does this PR do?

Fixes a build break on `v2.21.0-RC` (E0195: lifetimes do not match trait).

The `Processor::changelogs_filter` trait method became `async` in #11949, while the `AssignPrescriptionNumber` processor was added in #12060 against an older `develop` where it was still sync. Both PRs merged cleanly as text, but the sync `fn` impl no longer matches the async trait, so the `service` crate fails to compile.

This aligns the impl signature with the trait by making it `async fn`. No behavioural change.

## 💌 Any notes for the reviewer?

- Semantic (not textual) merge collision — git reported no conflict, which is why CI passed on each PR independently.
- One-line signature change; `#[async_trait]` was already on the impl block.
- We should probably enable a **merge queue** on RC branches: it rebuilds each PR against the latest target before merging, which catches exactly this class of "both green in isolation, broken together" collision.

# 🧪 Testing

- [ ] `cargo check -p service` compiles (was failing with E0195 before this change)

# 📃 Documentation

- [ ] **No documentation required**: bug fix, no change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
