### PR TITLE
Fix store_stock_on_hand view performance regression

### DIFF
--- a/server/repository/src/migrations/views/store_stock_on_hand.rs
+++ b/server/repository/src/migrations/views/store_stock_on_hand.rs
@@ -16,6 +16,16 @@ impl ViewMigrationFragment for ViewMigration {
     }
 
     fn rebuild_view(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // Aggregate stock_line directly, then join item once for the name. This lets
+        // SQLite push the store_id filter into the stock_line index and group in a
+        // single pass, so cost scales with the number of stock lines, not items x stores.
+        //
+        // The previous version joined the store_items view and grouped by item, which
+        // made SQLite re-scan the store's stock for every item - around 100x slower for
+        // the common item-search case (#10914).
+        //
+        // NOTE: only items that have stock (available or total > 0) appear here, so
+        // callers must default missing items to 0.
         sql!(
             connection,
             r#"
@@ -24,18 +34,26 @@ impl ViewMigrationFragment for ViewMigration {
       'n/a' AS id,
       item.id AS item_id,
       item.name AS item_name,
-      si.store_id AS store_id,
-      COALESCE(SUM(si.pack_size * si.available_number_of_packs), 0) AS available_stock_on_hand,
-      COALESCE(SUM(si.pack_size * si.total_number_of_packs), 0) AS total_stock_on_hand
+      stock.store_id AS store_id,
+      stock.available_stock_on_hand AS available_stock_on_hand,
+      stock.total_stock_on_hand AS total_stock_on_hand
     FROM
-      item
-      INNER JOIN store_items si ON si.item_id = item.id
-    WHERE
-      si.available_number_of_packs > 0 OR si.total_number_of_packs > 0
-    GROUP BY
-      item.id,
-      item.name,
-      si.store_id;
+      (
+        SELECT
+          item_link.item_id AS item_id,
+          stock_line.store_id AS store_id,
+          COALESCE(SUM(stock_line.pack_size * stock_line.available_number_of_packs), 0) AS available_stock_on_hand,
+          COALESCE(SUM(stock_line.pack_size * stock_line.total_number_of_packs), 0) AS total_stock_on_hand
+        FROM
+          stock_line
+          JOIN item_link ON item_link.id = stock_line.item_link_id
+        WHERE
+          stock_line.available_number_of_packs > 0 OR stock_line.total_number_of_packs > 0
+        GROUP BY
+          item_link.item_id,
+          stock_line.store_id
+      ) AS stock
+      JOIN item ON item.id = stock.item_id;
             "#
         )?;
 


### PR DESCRIPTION
> Targets the `v2.21.0-RC` release branch.

# 👩🏻‍💻 What does this PR do?

Rewrites the `store_stock_on_hand` SQL view to fix a severe item-search / item-list performance regression in 2.21.

The view was added in commit `aa45db589b` ("add store_stock_on_hand view without cross join", a follow-up to #10914) to avoid the `item × store` cartesian product in the legacy `stock_on_hand` view. But its shape — `item INNER JOIN store_items … GROUP BY item.id, item.name, store_id`, where `store_items` itself re-joins `item → item_link → stock_line` — runs un-materialised and makes SQLite re-scan a store's stock for **every item**.

Measured on a real tablet database (667 items, 9,044 stock lines), the outbound item-search query went from ~135 ms (2.9 / 2.19, legacy view) to ~10 s (2.21, this view). Both the stock-on-hand DataLoader and the `isVisibleOrOnHand` filter subquery go through this view, so both are affected.

This PR aggregates `stock_line` directly and joins `item` once for the name, so SQLite pushes the `store_id` filter into the stock_line index and groups in a single pass. Cost now scales with the number of stock lines, not items × stores — fast on both tablet and large central-server data shapes.

Measured on the same database:

| query | before | after |
|---|---|---|
| full-store stock on hand | ~1,000 ms | 1–5 ms |
| loader (`item_id IN (100)`) | ~110 ms | 1–3 ms |
| item-search visibility filter | ~920 ms | 4–8 ms |

## 💌 Any notes for the reviewer?

- **Output is identical** to the previous view — verified row-for-row on a real 2.21 DB (0 rows differ in either direction, same row count and totals). Same "only items with stock (available or total > 0)" semantics, so callers still default missing items to 0. Only the query plan changes.
- **Single-file change.** Views are dropped and rebuilt from this Rust fragment on startup, so existing databases pick up the corrected view automatically — no migration version bump and no `sqlite_latest.sql` edit.
- **`develop` is also affected** (the slow-view commit is an ancestor of `develop`). This PR targets `v2.21.0-RC`; the fix should also be forward-ported to `develop`.

# 🧪 Testing

- [ ] Remote site running this branch with a datafile that has plenty of stock (e.g. ~667 items / ~9,000 stock lines)
- [ ] Open an outbound shipment and open the item-search dropdown
- [ ] Confirm the item list loads quickly (was ~10 s on 2.21; should be near-instant)
- [ ] Confirm displayed available / total stock-on-hand values are unchanged vs the previous build
- [ ] Sanity-check other screens that show stock on hand (item list, etc.) still show correct values

# 📃 Documentation

- [ ] **No documentation required**: bug fix, no change in behaviour (values are identical, only faster)
