### PR TITLE
#8659 Skip invalid document registry configs instead of failing list

### DIFF
--- a/server/repository/src/db_diesel/document_registry.rs
+++ b/server/repository/src/db_diesel/document_registry.rs
@@ -91,15 +91,30 @@ impl<'a> DocumentRegistryRepository<'a> {
             query = query.order(document_registry::id.asc())
         }
 
-        let result: Result<Vec<DocumentRegistry>, RepositoryError> = query
+        // A single registry with an invalid config or schema must not take down the
+        // whole list (which would, for example, blank the program picker in reports
+        // with no error shown to the user). Skip and log the offending row instead.
+        // See https://github.com/msupply-foundation/open-msupply/issues/8659
+        let result = query
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64)
             .load::<DocumentRegistrySchemaJoin>(self.connection.lock().connection())?
             .into_iter()
-            .map(to_domain)
+            .filter_map(|join| {
+                let id = join.0.id.clone();
+                match to_domain(join) {
+                    Ok(registry) => Some(registry),
+                    Err(err) => {
+                        log::error!(
+                            "Skipping document registry '{id}' with invalid config/schema: {err:?}"
+                        );
+                        None
+                    }
+                }
+            })
             .collect();
 
-        result
+        Ok(result)
     }
 
     pub fn create_filtered_query(filter: Option<DocumentRegistryFilter>) -> BoxedDocRegistryQuery {

--- a/server/repository/src/db_diesel/document_registry_config.rs
+++ b/server/repository/src/db_diesel/document_registry_config.rs
@@ -121,5 +121,23 @@ pub struct NextEncounterEvent {
 pub struct DocumentRegistryConfig {
     #[serde(rename = "nextEncounter")]
     pub next_encounter: Option<NextEncounterEnum>,
+    // A config without events is valid (e.g. `{}`), so default to an empty list
+    // rather than failing to deserialise on a missing field.
+    #[serde(default)]
     pub events: Vec<EventConfigEnum>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DocumentRegistryConfig;
+
+    #[test]
+    fn deserialises_empty_config() {
+        // An empty config object must deserialise (events defaults to empty) rather
+        // than erroring on a missing `events` field. See issue #8659.
+        let config: DocumentRegistryConfig =
+            serde_json::from_str("{}").expect("empty config should deserialise");
+        assert_eq!(config.next_encounter, None);
+        assert!(config.events.is_empty());
+    }
 }


### PR DESCRIPTION
Fixes #8659

# 👩🏻‍💻 What does this PR do?

The `documentRegistries` query deserialises each row's `config` (and form schema) into typed structs and `collect()`s into a single `Result`. So if **one** registry has a config that fails to deserialise, the **entire query errors**. The frontend renders that error as an empty list — so a single bad row silently blanks the program picker (e.g. the Reports → *Pending Encounters* filter dialog) for every user with access to that context, with no error shown. This is exactly the behaviour described in the issue.

Two changes, both in the repository layer:

- `DocumentRegistryConfig.events` is now `#[serde(default)]`, so an empty config (`{}`) deserialises to an empty event list instead of erroring on the missing field.
- The list query now **skips and logs** any registry whose config/schema fails to deserialise, rather than failing the whole query — so the valid registries still load. This matches the issue's preferred behaviour: *"show all the programs/enrolments we can and log this error."*

## 💌 Any notes for the reviewer?

- Root cause is a write/read mismatch: the sync translator stores `config` as raw, unvalidated JSON ([`document_registry.rs` translation](server/service/src/sync/translations/document_registry.rs)), while the read path ([`db_diesel/document_registry.rs`](server/repository/src/db_diesel/document_registry.rs)) deserialises strictly into `DocumentRegistryConfig`. Either change alone fixes the reported symptom; together they're defensive against any malformed config arriving from sync.
- Offending rows are dropped from the list and logged at error level. The issue also floated surfacing an error in the UI as an alternative — not done here, since degrade-and-log matches the issue's stated preference and avoids breaking the picker. Can add UI surfacing as a follow-up if preferred.
- No API/GraphQL schema changes; scoped to the repository crate.
- How this surfaced: the sync integration test `DocumentRegistryTester` ([`server/service/src/sync/test/integration/central/document_registry.rs:49`](server/service/src/sync/test/integration/central/document_registry.rs#L49)) upserts a program-enrolment registry with `config: "{}"`. That suite pushes records to whatever central server it runs against, so the row persists afterwards and breaks the program picker. With this PR `config: "{}"` is now valid, so that test data is no longer a landmine (the test could optionally be tidied to emit `{"events":[]}` or `null`, but no longer needs to be).

# 🧪 Testing

- [ ] `cargo nextest run -p repository deserialises_empty_config` passes (added: `DocumentRegistryConfig` deserialises from `{}`)
- [ ] On a datafile with a program-enrolment document registry whose `config = '{}'` (e.g. left behind by the `DocumentRegistryTester` sync integration test): open Reports → *Pending Encounters* → the Program dropdown lists the valid program(s) instead of showing "No options"
- [ ] Server log shows a skip/error line for any genuinely un-parseable registry, rather than the whole query failing

# 📃 Documentation

- [ ] **No documentation required**: bug fix, no user-facing change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

