### PR TITLE
Memoize material-react-table options to cut table re-render cost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ server/target-postgres/
 
 # Playwright MCP scratch logs / page dumps
 .playwright-mcp/
+
+# Local performance/profiling scratch
+.scratch/

--- a/client/packages/common/src/ui/layout/tables/useBaseMaterialTable.tsx
+++ b/client/packages/common/src/ui/layout/tables/useBaseMaterialTable.tsx
@@ -6,7 +6,7 @@ import {
   MRT_TableOptions,
   useMaterialReactTable,
 } from 'material-react-table';
-import { Row } from '@tanstack/table-core';
+import { Row, RowModel, Table } from '@tanstack/table-core';
 import { useIntlUtils, useTranslation } from '@common/intl';
 import { ColumnDef } from './types';
 import { useMaterialTableColumns } from './useMaterialTableColumns';
@@ -195,6 +195,53 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     />
   );
 
+  // Stable identities for the row-model factories. These are pure (they only
+  // read their `table`/`row` argument), so an empty dep list is safe — and it
+  // stops MaterialReactTable seeing a brand-new factory on every render, which
+  // can make it recompute the expanded row model unnecessarily.
+  const getRowCanExpand = React.useCallback(
+    (row: Row<T>) => row.getLeafRows().length > 1,
+    []
+  );
+
+  const getExpandedRowModel = React.useCallback(
+    (table: Table<T>) => (): RowModel<T> => {
+      const rowModel = table.getPreExpandedRowModel();
+
+      // Rows should contain all visible rows, including group rows and their children (if expanded)
+      const rows: Row<T>[] = [];
+
+      const handleRow = (row: Row<T>) => {
+        rows.push(row);
+
+        if (row.subRows?.length > 1 && row.getIsExpanded()) {
+          row.subRows.forEach(handleRow);
+        }
+      };
+
+      rowModel.rows.forEach(handleRow);
+
+      // We can't pass rowModel.flatRows directly as for some reason rows come in duplicated when there's grouping and no sorting applied
+      // I think this is a bug in tanstack table
+      const flatRows: Row<T>[] = [];
+
+      const seenRowIds = new Set<string>();
+      rowModel.flatRows.forEach(row => {
+        if (!seenRowIds.has(row.id)) {
+          flatRows.push(row);
+          seenRowIds.add(row.id);
+        }
+      });
+
+      return {
+        rows,
+        flatRows,
+        rowsById: rowModel.rowsById,
+      };
+    },
+    []
+  );
+
   const displayOptions = useTableDisplayOptions({
     renderSettingsMenu,
     hasColumnFilters,
@@ -254,41 +301,8 @@ export const useBaseMaterialTable = <T extends MRT_RowData>({
     groupedColumnMode: false,
 
     // These options are needed to stop groups with only 1 child being expandable - we only want groups to be expandable if they have multiple children
-    getRowCanExpand: row => row.getLeafRows().length > 1,
-    getExpandedRowModel: table => () => {
-      const rowModel = table.getPreExpandedRowModel();
-
-      // Rows should contain all visible rows, including group rows and their children (if expanded)
-      const rows: Row<T>[] = [];
-
-      const handleRow = (row: Row<T>) => {
-        rows.push(row);
-
-        if (row.subRows?.length > 1 && row.getIsExpanded()) {
-          row.subRows.forEach(handleRow);
-        }
-      };
-
-      rowModel.rows.forEach(handleRow);
-
-      // We can't pass rowModel.flatRows directly as for some reason rows come in duplicated when there's grouping and no sorting applied
-      // I think this is a bug in tanstack table
-      const flatRows: Row<T>[] = [];
-
-      const seenRowIds = new Set<string>();
-      rowModel.flatRows.forEach(row => {
-        if (!seenRowIds.has(row.id)) {
-          flatRows.push(row);
-          seenRowIds.add(row.id);
-        }
-      });
-
-      return {
-        rows,
-        flatRows,
-        rowsById: rowModel.rowsById,
-      };
-    },
+    getRowCanExpand,
+    getExpandedRowModel,
 
     // Disable selection Toolbar, we use our own custom footer for this
     positionToolbarAlertBanner: 'none',

--- a/client/packages/common/src/ui/layout/tables/useMaterialTableColumns.tsx
+++ b/client/packages/common/src/ui/layout/tables/useMaterialTableColumns.tsx
@@ -69,8 +69,18 @@ export const useMaterialTableColumns = <T extends MRT_RowData>(
             : physicalAlignment === 'center'
               ? 'center'
               : 'right'; // text: the start edge is on the right in RTL
+        // Build the body-cell-props chain into a LOCAL variable rather than
+        // mutating `col`. Mutating the caller's column object leaks the wrapped
+        // function back into the (often memoised) source `omsColumns`, so a
+        // re-run would double-wrap it, and it gives every render a fresh
+        // function identity on shared objects. The final value is spread into
+        // the returned column below (after `...col`) so it still wins.
+        let bodyCellProps = col.muiTableBodyCellProps;
         if (alignment) {
-          col.muiTableBodyCellProps = params => {
+          // Alignment styling replaces any inherited cell props (this matches
+          // the prior behaviour, where the assignment overwrote
+          // col.muiTableBodyCellProps before the merge step below).
+          bodyCellProps = params => {
             return mergeCellProps(
               {
                 sx: {
@@ -98,10 +108,10 @@ export const useMaterialTableColumns = <T extends MRT_RowData>(
         }
 
         // Merge any custom cell props with defaults
-        const cellProps = col.muiTableBodyCellProps;
-        if (cellProps) {
-          col.muiTableBodyCellProps = params => {
-            return mergeCellProps(cellProps, params);
+        if (bodyCellProps) {
+          const inner = bodyCellProps;
+          bodyCellProps = params => {
+            return mergeCellProps(inner, params);
           };
         }
 
@@ -148,6 +158,10 @@ export const useMaterialTableColumns = <T extends MRT_RowData>(
           enableSorting: col.enableSorting ?? false,
           enableColumnFilter: col.enableColumnFilter ?? false,
           ...col,
+          // Spread the locally-built cell-props chain last so it overrides the
+          // raw `col.muiTableBodyCellProps` (which we intentionally did not
+          // mutate above).
+          ...(bodyCellProps ? { muiTableBodyCellProps: bodyCellProps } : {}),
         };
       });
 

--- a/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
+++ b/client/packages/common/src/ui/layout/tables/useTableDisplayOptions.tsx
@@ -55,22 +55,47 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
   const { focusedRowId, containerRef, rowVirtualizerRef, handleKeyDown } =
     useTableKeyboardNavigation<T>(onRowClick);
 
-  // shared between the table body and head to ensure consistent padding
-  const padding = (
-    density: 'compact' | 'comfortable' | 'spacious',
-    columnSize?: number
-  ) =>
-    density === 'compact'
-      ? '0.2rem 0.5rem'
-      : density === 'comfortable'
-        ? columnSize && columnSize < 100
-          ? '0.35rem 0.25rem' // Reduce the padding when column is narrow
-          : '0.35rem 0.5rem'
-        : columnSize && columnSize < 100
-          ? '0.8rem 0.6rem'
-          : '0.8rem';
+  // The options object below is memoised so MaterialReactTable receives stable
+  // callback identities across data/state re-renders (e.g. pagination) instead
+  // of ~20 freshly-allocated inline callbacks every render. Inputs whose
+  // identity changes every render (caller callbacks, the per-render
+  // settings-menu / grouping closures from useBaseMaterialTable, the keyboard
+  // handler) are read through a "latest value" ref, so the memoised callbacks
+  // stay stable while still invoking the current closure. Values that genuinely
+  // affect render output but change rarely (focus, grouping, mobile, language)
+  // are memo dependencies instead.
+  const latestRef = React.useRef<{
+    renderSettingsMenu: (table: MRT_TableInstance<T>) => React.ReactNode;
+    onRowClick?: (row: T, isCtrlClick: boolean) => void;
+    toggleGrouped?: () => void;
+    getIsPlaceholderRow: (row: MRT_Row<T>) => boolean;
+    getIsRestrictedRow: (row: MRT_Row<T>) => boolean;
+    muiTableBodyRowProps: MRT_TableOptions<T>['muiTableBodyRowProps'];
+    handleKeyDown: (e: React.KeyboardEvent, table: MRT_TableInstance<T>) => void;
+  }>({
+    renderSettingsMenu,
+    onRowClick,
+    toggleGrouped,
+    getIsPlaceholderRow,
+    getIsRestrictedRow,
+    muiTableBodyRowProps,
+    handleKeyDown,
+  });
+  latestRef.current = {
+    renderSettingsMenu,
+    onRowClick,
+    toggleGrouped,
+    getIsPlaceholderRow,
+    getIsRestrictedRow,
+    muiTableBodyRowProps,
+    handleKeyDown,
+  };
 
-  return {
+  const hasOnRowClick = !!onRowClick;
+  const hasToggleGrouped = !!toggleGrouped;
+
+  return React.useMemo<Partial<MRT_TableOptions<T>>>(
+    () => ({
     rowVirtualizerInstanceRef: rowVirtualizerRef,
     // Add description to column menu
     renderColumnActionsMenuItems: ({ internalColumnMenuItems, column }) => {
@@ -105,10 +130,10 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
     // Add grouping toggle and settings menu to toolbar
     renderToolbarInternalActions: ({ table }) => (
       <>
-        {toggleGrouped && !isMobile && (
+        {hasToggleGrouped && !isMobile && (
           <IconButton
             icon={isGrouped ? <ExpandIcon /> : <CollapseIcon />}
-            onClick={toggleGrouped}
+            onClick={() => latestRef.current.toggleGrouped?.()}
             label={groupByLabel ?? t('label.group-by-item')}
             sx={iconButtonProps}
           />
@@ -117,7 +142,7 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
         {hasColumnFilters && <MRT_ToggleFiltersButton table={table} />}
         <MRT_ShowHideColumnsButton table={table} />
         {!isMobile && <MRT_ToggleFullScreenButton table={table} />}
-        {renderSettingsMenu(table)}
+        {latestRef.current.renderSettingsMenu(table)}
       </>
     ),
 
@@ -141,7 +166,8 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
     muiTableContainerProps: ({ table }) => ({
       ref: containerRef,
       tabIndex: 0,
-      onKeyDown: (e: React.KeyboardEvent) => handleKeyDown(e, table),
+      onKeyDown: (e: React.KeyboardEvent) =>
+        latestRef.current.handleKeyDown(e, table),
       sx: {
         flex: 1,
         display: 'flex',
@@ -245,21 +271,22 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
 
     muiTableBodyRowProps: params => {
       const { row, table } = params;
+      const rowPropsInput = latestRef.current.muiTableBodyRowProps;
       const customProps =
-        typeof muiTableBodyRowProps === 'function'
-          ? muiTableBodyRowProps(params)
-          : muiTableBodyRowProps;
+        typeof rowPropsInput === 'function'
+          ? rowPropsInput(params)
+          : rowPropsInput;
 
       const isFocused = row.id === focusedRowId;
 
       const defaultProps: MRT_TableOptions<T>['muiTableBodyRowProps'] = {
-        ...(onRowClick
+        ...(hasOnRowClick
           ? {
               onClick: (e: React.MouseEvent<HTMLTableRowElement>) => {
                 const isCtrlClick = e.getModifierState(
                   EnvUtils.os === 'Mac OS' ? 'Meta' : 'Control'
                 );
-                onRowClick(row.original, isCtrlClick);
+                latestRef.current.onRowClick?.(row.original, isCtrlClick);
               },
             }
           : {}),
@@ -276,7 +303,7 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
             backgroundColor: theme => alpha(theme.palette.gray.pale, 0.4),
           },
           fontStyle: row.getCanExpand() ? 'italic' : 'normal',
-          cursor: onRowClick ? 'pointer' : 'default',
+          cursor: hasOnRowClick ? 'pointer' : 'default',
           ...(isFocused
             ? {
                 backgroundColor: theme =>
@@ -301,9 +328,9 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
         fontWeight: 400,
         opacity: 1,
         alignItems: 'flex-end',
-        color: getIsPlaceholderRow(row)
+        color: latestRef.current.getIsPlaceholderRow(row)
           ? 'secondary.light'
-          : getIsRestrictedRow(row)
+          : latestRef.current.getIsRestrictedRow(row)
             ? 'gray.main'
             : undefined,
 
@@ -394,8 +421,39 @@ export const useTableDisplayOptions = <T extends MRT_RowData>({
         },
       },
     },
-  };
+    }),
+    [
+      t,
+      collapsedRotation,
+      focusedRowId,
+      isGrouped,
+      hasToggleGrouped,
+      hasOnRowClick,
+      groupByLabel,
+      isMobile,
+      hasColumnFilters,
+      containerRef,
+      rowVirtualizerRef,
+    ]
+  );
 };
+
+// shared between the table body and head to ensure consistent padding.
+// Pure (depends only on its arguments), so it lives at module scope and can be
+// referenced from the memoised options object without being a dependency.
+const padding = (
+  density: 'compact' | 'comfortable' | 'spacious',
+  columnSize?: number
+) =>
+  density === 'compact'
+    ? '0.2rem 0.5rem'
+    : density === 'comfortable'
+      ? columnSize && columnSize < 100
+        ? '0.35rem 0.25rem' // Reduce the padding when column is narrow
+        : '0.35rem 0.5rem'
+      : columnSize && columnSize < 100
+        ? '0.8rem 0.6rem'
+        : '0.8rem';
 
 const iconButtonProps = {
   width: '40px',

--- a/client/packages/system/src/Item/ListView/ListView.tsx
+++ b/client/packages/system/src/Item/ListView/ListView.tsx
@@ -33,14 +33,21 @@ export const ItemListView = () => {
   });
   const { data, isError, isLoading } = useVisibleOrOnHandItems(queryParams);
 
-  // required to have correct type for UnitsAndDosesCell
-  const rows = (data?.nodes ?? []).map(row => ({
-    ...row,
-    item: {
-      doses: row.doses,
-      isVaccine: row.isVaccine,
-    },
-  }));
+  // required to have correct type for UnitsAndDosesCell.
+  // Memoised on the query result so we don't hand MaterialReactTable a brand
+  // new `data` array on every unrelated re-render (which makes it recompute its
+  // row models and rebuild rows).
+  const rows = useMemo(
+    () =>
+      (data?.nodes ?? []).map(row => ({
+        ...row,
+        item: {
+          doses: row.doses,
+          isVaccine: row.isVaccine,
+        },
+      })),
+    [data?.nodes]
+  );
 
   const columns = useMemo(
     (): ColumnDef<


### PR DESCRIPTION
A frontend performance change to the shared table layer. No linked issue — exploratory work from profiling the v2.9 → v2.20 `material-react-table` migration regression. (A separate Bugsnag dev-profiling tweak will follow in its own PR.)

# 👩🏻‍💻 What does this PR do?

The shared table hooks rebuilt MRT's options object — including ~20 inline `mui*Props` / `render*` callbacks — on every render. Fresh identities every render defeat reconciliation and `React.memo`, so on each interaction React tears down and rebuilds the table's DOM subtree (`createElement` / `insertRule` / `removeChild`) instead of reconciling rows. Stabilising the identities lets React reconcile and lets emotion reuse cached classes.

- `useTableDisplayOptions`: wrap the returned options object in `useMemo`. Inputs whose identity changes every render (caller callbacks, the per-render settings-menu / grouping closures, the keyboard handler) are read through a "latest value" ref, so the memoised callbacks stay stable while still invoking the current closure; render-affecting primitives (focus, grouping, mobile, language) are memo deps. `padding()` moved to module scope.
- `useBaseMaterialTable`: `useCallback` the `getExpandedRowModel` / `getRowCanExpand` row-model factories (pure, empty deps).
- `useMaterialTableColumns`: stop mutating the caller's column objects; build the body-cell-props chain into a local and spread it last (behaviour preserved exactly).
- `Item/ListView`: `useMemo` the `rows` array so MRT isn't handed a new `data` reference on every unrelated re-render.

## 💌 Any notes for the reviewer?

- **Shared layer → broad blast radius.** These hooks back all ~91 tables (via `usePaginatedMaterialTable` / `useSimpleMaterialTable` / `useNonPaginatedMaterialTable`). `useTableDisplayOptions` has a single consumer (`useBaseMaterialTable`).
- **Riskiest change: `useTableDisplayOptions`** and its "latest value" ref pattern. Audited all 19 memoised callbacks: no stale closures, behaviour preserved (row-click, keyboard nav, focus highlight, group toggle, settings menu, placeholder/restricted styling). `t` from `useTranslation` is treated as stable here (existing column `useMemo`s already rely on it); worst case if it weren't = the memo rebuilds each render (perf no-op, never a correctness bug).
- **`useMaterialTableColumns`** no longer mutates the caller's column objects — please sanity-check nothing relied on that side effect.
- **Scope of the win (be aware):** the gain lands on *re-renders of an already-open table* (page/sort/filter on a mounted list). The **very first** cold interaction after a page load is **not** improved — emotion's cache is cold and the 20 rows genuinely swap. A follow-up will investigate making per-cell `sx` produce stable, cacheable class names to also cut that fixed cost. (Row virtualization was ruled out: at 100 vs 20 rows/page the `insertRule` cost is ~1,540 ms fixed + ~48 ms/row, so it doesn't help small tables.)
- No automated tests cover these hooks (validated by type-check + eslint + manual profiling — see below).

# 📊 Results (measured, 8× CPU throttle, production build on the Rust server)

Headline: when the table **reconciles**, the table-rebuild storm is eliminated.

| Metric (item list, "Go to page 2") | Before | After |
|---|---:|---:|
| `insertRule` self-CPU in the interaction (the #1 cost) | ~2,460 ms | **0 ms** when reconciling |
| `removeChild` (DOM teardown) | ~860 ms | ~23 ms when reconciling |
| Pagination INP (reconcile path) | never < 6,100 ms | **~1,100 ms** (best clean reconcile) |
| Cold first pagination after a fresh load | ~6,200 ms | ~6,300 ms (unchanged — see scope note) |

Caveat: absolute ms were captured under host-CPU contention so they're noisy run-to-run; the reliable, reproducible signal is structural — `insertRule` → 0 and `removeChild` collapse whenever React reconciles instead of rebuilding.

# 🧪 Testing

**✅ Already done**
- [x] `yarn re-compile` (tsc `--noEmit` on the host project) — passes clean
- [x] ESLint on all changed files — no new warnings (2 pre-existing `exhaustive-deps` warnings unrelated to this change)
- [x] Code audit of all 19 memoised callbacks in `useTableDisplayOptions` — no stale closures; behaviour preserved
- [x] Manual profiling on the production build (`localhost:8000`, 8× CPU): captured before/after on `/catalogue/items` + `/distribution/outbound-shipment` pagination and outbound/stocktake detail loads — results above
- [x] Exercised manually without regressions: item-list & outbound-list pagination, outbound/stocktake detail load, detail field-edit, column sort, rows-per-page change

**🔲 Suggested for the reviewer**
- [ ] Open `/catalogue/items` (or any list): page through it, sort, toggle column visibility, group-by — behaviour unchanged
- [ ] Keyboard-navigate rows (Arrow Up/Down, Enter to open, Escape) — focused-row highlight still works
- [ ] Open the table settings menu — reset to default, and (as a central-server admin) save as global default
- [ ] Row-click navigation and ctrl/cmd-click still work
- [ ] A modal / simple table (e.g. an outbound shipment line edit) still renders and edits correctly

# 📃 Documentation

- [ ] **No documentation required**: performance refactor with no user-facing behaviour change

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
