### PR TITLE
perf(login): stop full-page re-render on every keystroke

### DIFF
--- a/client/packages/host/src/components/Login/Login.tsx
+++ b/client/packages/host/src/components/Login/Login.tsx
@@ -1,16 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  ArrowRightIcon,
   useTranslation,
   useInterval,
-  LoadingButton,
   useHostContext,
   useAuthContext,
   LocalStorage,
   useFormatDateTime,
   BoxedErrorWithDetails,
 } from '@openmsupply-client/common';
-import { LoginTextInput } from './LoginTextInput';
 import { useLoginForm } from './hooks';
 import { LoginLayout } from './LoginLayout';
 import { LoginStoreSelectorPanel } from './LoginStoreSelectorPanel';
@@ -26,20 +23,16 @@ export const Login = ({ fullSize = true }: { fullSize?: boolean }) => {
     theme: LocalStorage.getItem('/theme/customhash') ?? '',
   };
   const { data: displaySettings } = useHost.settings.displaySettings(hashInput);
-  const passwordRef = React.useRef<HTMLInputElement>(null);
   const {
-    isValid,
-    password,
-    setPassword,
-    username,
-    setUsername,
-    isLoggingIn,
     onLogin,
+    isLoggingIn,
     error,
     siteName,
     showStoreSelector,
     dismissStoreSelector,
-  } = useLoginForm(passwordRef, fullSize);
+    storeSelectorUsername,
+    mostRecentUsername,
+  } = useLoginForm(fullSize);
   const [timeoutRemaining, setTimeoutRemaining] = useState(
     error?.timeoutRemaining ?? 0
   );
@@ -160,53 +153,12 @@ export const Login = ({ fullSize = true }: { fullSize?: boolean }) => {
         <LoginStoreSelectorPanel
           open={showStoreSelector}
           onSelected={dismissStoreSelector}
-          username={username}
+          username={storeSelectorUsername}
         />
       }
-      UsernameInput={
-        <LoginTextInput
-          fullWidth
-          label={t('heading.username')}
-          value={username}
-          disabled={isLoggingIn}
-          onChange={e => setUsername(e.target.value)}
-          slotProps={{
-            htmlInput: {
-              autoComplete: 'username',
-              name: 'username',
-            },
-          }}
-          autoFocus
-        />
-      }
-      PasswordInput={
-        <LoginTextInput
-          fullWidth
-          label={t('heading.password')}
-          type="password"
-          value={password}
-          disabled={isLoggingIn}
-          onChange={e => setPassword(e.target.value)}
-          slotProps={{
-            htmlInput: {
-              autoComplete: 'current-password',
-              name: 'password',
-            },
-          }}
-          inputRef={passwordRef}
-        />
-      }
-      LoginButton={
-        <LoadingButton
-          shouldShrink={false}
-          isLoading={isLoggingIn}
-          onClick={onLogin}
-          variant="outlined"
-          endIcon={<ArrowRightIcon />}
-          disabled={!isValid}
-          label={t('button.login')}
-        />
-      }
+      onLogin={onLogin}
+      isLoggingIn={isLoggingIn}
+      mostRecentUsername={mostRecentUsername}
       ErrorMessage={
         error &&
         loginError.error !== '' && (
@@ -218,9 +170,6 @@ export const Login = ({ fullSize = true }: { fullSize?: boolean }) => {
           />
         )
       }
-      onLogin={async () => {
-        if (isValid) await onLogin();
-      }}
       SiteInfo={<SiteInfo siteName={siteName} />}
       fullSize={fullSize}
     />

--- a/client/packages/host/src/components/Login/LoginLayout.tsx
+++ b/client/packages/host/src/components/Login/LoginLayout.tsx
@@ -1,48 +1,53 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
+  ArrowRightIcon,
   Box,
+  LoadingButton,
   Stack,
   Typography,
   useTranslation,
 } from '@openmsupply-client/common';
 import { LoginIcon } from './LoginIcon';
+import { LoginTextInput } from './LoginTextInput';
 import { Theme } from '@common/styles';
 import { AppVersion } from '../AppVersion';
 import { LanguageButton } from '../LanguageButton';
 
-export type LoginLayoutProps = {
-  UsernameInput: React.ReactNode;
-  PasswordInput: React.ReactNode;
-  LoginButton: React.ReactNode;
+// LoginIcon runs media-query / theme / local-storage hooks; memoising it keeps
+// it from re-rendering while the user types into the form fields below it.
+const MemoLoginIcon = React.memo(LoginIcon);
+
+export type LoginFormProps = {
+  onLogin: (username: string, password: string) => Promise<void>;
+  isLoggingIn: boolean;
+  mostRecentUsername?: string;
   ErrorMessage: React.ReactNode;
-  SiteInfo: React.ReactNode;
-  onLogin: () => Promise<void>;
   fullSize: boolean;
+};
+
+export type LoginLayoutProps = LoginFormProps & {
+  SiteInfo: React.ReactNode;
   StoreSelector?: React.ReactNode;
   showStoreSelector?: boolean;
 };
 
 export const LoginLayout = ({
-  UsernameInput,
-  PasswordInput,
-  LoginButton,
+  onLogin,
+  isLoggingIn,
+  mostRecentUsername,
   ErrorMessage,
   SiteInfo,
-  onLogin,
   fullSize,
   StoreSelector,
   showStoreSelector = false,
 }: LoginLayoutProps) => {
   const t = useTranslation();
-
   const loginForm = (
     <LoginForm
-      UsernameInput={UsernameInput}
-      PasswordInput={PasswordInput}
-      LoginButton={LoginButton}
-      ErrorMessage={ErrorMessage}
-      SiteInfo={SiteInfo}
       onLogin={onLogin}
+      isLoggingIn={isLoggingIn}
+      mostRecentUsername={mostRecentUsername}
+      ErrorMessage={ErrorMessage}
       fullSize={fullSize}
     />
   );
@@ -153,32 +158,87 @@ export const LoginLayout = ({
 };
 
 const LoginForm = ({
-  UsernameInput,
-  PasswordInput,
-  LoginButton,
-  ErrorMessage,
   onLogin,
+  isLoggingIn,
+  mostRecentUsername,
+  ErrorMessage,
   fullSize,
-}: LoginLayoutProps) => {
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
-    if (e.key === 'Enter') {
-      onLogin();
-    }
+}: LoginFormProps) => {
+  const t = useTranslation();
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const isValid = !!username && !!password;
+
+  const submit = async () => {
+    if (!isValid) return;
+    await onLogin(username, password);
+    setPassword('');
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
+    if (e.key === 'Enter') submit();
+  };
+
+  // Pre-fill the most recently used username (arrives asynchronously) and move
+  // focus to the password field.
+  useEffect(() => {
+    if (mostRecentUsername && !username) {
+      setUsername(mostRecentUsername);
+      setTimeout(() => passwordRef.current?.focus(), 100);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mostRecentUsername]);
+
   return (
-    <form onSubmit={onLogin} onKeyDown={handleKeyDown}>
+    <form onSubmit={e => e.preventDefault()} onKeyDown={handleKeyDown}>
       <Stack spacing={fullSize ? 5 : 2}>
         {fullSize && (
           <Box display="flex" justifyContent="center">
-            <LoginIcon />
+            <MemoLoginIcon />
           </Box>
         )}
-        {UsernameInput}
-        {PasswordInput}
+        <LoginTextInput
+          fullWidth
+          label={t('heading.username')}
+          value={username}
+          disabled={isLoggingIn}
+          onChange={e => setUsername(e.target.value)}
+          slotProps={{
+            htmlInput: {
+              autoComplete: 'username',
+              name: 'username',
+            },
+          }}
+          autoFocus
+        />
+        <LoginTextInput
+          fullWidth
+          label={t('heading.password')}
+          type="password"
+          value={password}
+          disabled={isLoggingIn}
+          onChange={e => setPassword(e.target.value)}
+          slotProps={{
+            htmlInput: {
+              autoComplete: 'current-password',
+              name: 'password',
+            },
+          }}
+          inputRef={passwordRef}
+        />
         {ErrorMessage}
         <Box display="flex" justifyContent="flex-end">
-          {LoginButton}
+          <LoadingButton
+            shouldShrink={false}
+            isLoading={isLoggingIn}
+            onClick={submit}
+            variant="outlined"
+            endIcon={<ArrowRightIcon />}
+            disabled={!isValid}
+            label={t('button.login')}
+          />
         </Box>
       </Stack>
     </form>

--- a/client/packages/host/src/components/Login/hooks.ts
+++ b/client/packages/host/src/components/Login/hooks.ts
@@ -1,5 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { create } from 'zustand';
+import { useCallback, useEffect, useState } from 'react';
 import { AppRoute } from '@openmsupply-client/config';
 import {
   AuthenticationError,
@@ -13,87 +12,63 @@ import {
   useQueryClient,
 } from '@openmsupply-client/common';
 
-interface LoginForm {
-  error?: AuthenticationError;
-  password: string;
-  username: string;
-  setError: (error?: AuthenticationError) => void;
-  setPassword: (password: string) => void;
-  setUsername: (username: string) => void;
-}
-
 interface State {
   from?: Location;
 }
 
-export const useLoginFormState = create<LoginForm>(set => ({
-  error: undefined,
-  password: '',
-  username: '',
-
-  setError: (error?: AuthenticationError) =>
-    set(state => ({ ...state, error })),
-  setPassword: (password: string) => set(state => ({ ...state, password })),
-  setUsername: (username: string) => set(state => ({ ...state, username })),
-}));
-
-export const useLoginForm = (
-  passwordRef: React.RefObject<HTMLInputElement | null>,
-  navigateOnSuccess = true
-) => {
-  const state = useLoginFormState();
+export const useLoginForm = (navigateOnSuccess = true) => {
   const { data: initStatus } = useInitialisationStatus();
   const navigate = useNavigate();
   const location = useLocation();
   const { mostRecentUsername, login, isLoggingIn } = useAuthContext();
   const queryClient = useQueryClient();
   const authApi = useAuthApi();
-  const { password, setPassword, setUsername, username, error, setError } =
-    state;
+
+  const [error, setError] = useState<AuthenticationError | undefined>();
   const [showStoreSelector, setShowStoreSelector] = useState(false);
+  const [storeSelectorUsername, setStoreSelectorUsername] = useState('');
   const [loginRedirectFrom, setLoginRedirectFrom] = useState('/');
 
-  const onLogin = async () => {
-    setError();
-    const { error, token } = await login(username.trim(), password);
-    setError(error);
-    setPassword('');
-    if (!token) return;
+  // Credentials are owned by the form fields (see LoginLayout). onLogin
+  // receives them as arguments so that typing never re-renders this hook's
+  // consumer (and therefore never re-renders the whole login page).
+  const onLogin = useCallback(
+    async (username: string, password: string) => {
+      setError(undefined);
+      const trimmedUsername = username.trim();
+      const { error, token } = await login(trimmedUsername, password);
+      setError(error);
+      if (!token) return;
 
-    if (!navigateOnSuccess) return;
+      if (!navigateOnSuccess) return;
 
-    const locationState = location.state as State | undefined;
-    const redirectTo = locationState?.from?.pathname || `/`;
-    setLoginRedirectFrom(redirectTo);
+      const locationState = location.state as State | undefined;
+      const redirectTo = locationState?.from?.pathname || `/`;
+      setLoginRedirectFrom(redirectTo);
 
-    const userDetails = queryClient.getQueryData<{
-      stores?: { nodes?: { id: string; isDisabled?: boolean }[] };
-    }>(authApi.keys.me(token));
-    const enabledStoreCount =
-      userDetails?.stores?.nodes?.filter(s => !s.isDisabled).length ?? 0;
-    const skipPrefs = LocalStorage.getItem('/login/skip-store-selector') ?? {};
-    const optedOut = !!skipPrefs[username.trim().toLowerCase()];
+      const userDetails = queryClient.getQueryData<{
+        stores?: { nodes?: { id: string; isDisabled?: boolean }[] };
+      }>(authApi.keys.me(token));
+      const enabledStoreCount =
+        userDetails?.stores?.nodes?.filter(s => !s.isDisabled).length ?? 0;
+      const skipPrefs =
+        LocalStorage.getItem('/login/skip-store-selector') ?? {};
+      const optedOut = !!skipPrefs[trimmedUsername.toLowerCase()];
 
-    if (enabledStoreCount > 1 && !optedOut) {
-      setShowStoreSelector(true);
-    } else {
-      navigate(redirectTo, { replace: true });
-    }
-  };
+      if (enabledStoreCount > 1 && !optedOut) {
+        setStoreSelectorUsername(trimmedUsername);
+        setShowStoreSelector(true);
+      } else {
+        navigate(redirectTo, { replace: true });
+      }
+    },
+    [authApi, location, login, navigate, navigateOnSuccess, queryClient]
+  );
 
   const dismissStoreSelector = useCallback(() => {
     setShowStoreSelector(false);
     navigate(loginRedirectFrom, { replace: true });
   }, [navigate, loginRedirectFrom]);
-
-  const isValid = !!username && !!password;
-
-  React.useEffect(() => {
-    if (mostRecentUsername && !username) {
-      setUsername(mostRecentUsername);
-      setTimeout(() => passwordRef.current?.focus(), 100);
-    }
-  }, [mostRecentUsername]);
 
   useEffect(() => {
     if (!initStatus) return;
@@ -103,13 +78,13 @@ export const useLoginForm = (
   }, [initStatus]);
 
   return {
-    isValid,
     onLogin,
     isLoggingIn,
-    ...state,
     error,
     siteName: initStatus?.siteName,
     showStoreSelector,
     dismissStoreSelector,
+    storeSelectorUsername,
+    mostRecentUsername,
   };
 };


### PR DESCRIPTION
<!-- No linked issue — see "no linked issue" label. Standalone performance refactor. -->

# 👩🏻‍💻 What does this PR do?

The login form re-rendered **the entire login screen on every keystroke**. The credential state (`username`/`password`) lived in a top-level component via a global Zustand store consumed *without a selector*, and `Login` passed every child as inline JSX/closure props into an un-memoised layout — so a single keystroke re-rendered `LoginLayout`, `LoginIcon`, `AppVersion`, `SiteInfo`, `LanguageButton`, the tooltips and the store-selector panel, roughly twice over.

This PR moves the credential state **down into the form subtree** (`LoginForm`) so the component that owns the typed value is the only thing that re-renders:

- **Drop the Zustand store** (`useLoginFormState`). It had a single subscriber, so it provided no sharing benefit, and its module-global lifetime kept `username`/`password` in memory for the whole app session (which is why the compensating clear-password / prefill code existed).
- **`Login` now does pure orchestration** (error/init-status/page-title/logout) and no longer holds credentials, so the page chrome above the form stays put. `onLogin(username, password)` takes the values as arguments.
- **`LoginForm` owns `username`/`password`** via local `useState` and renders the inputs + button itself.
- **Memoise `LoginIcon`**, the one static node inside the form subtree.

### Measured with why-did-you-render (one keystroke)

| | Before | After |
|---|---|---|
| Components re-rendered | ~12 (whole page) | **1** (`LoginForm`) |
| Render passes | ~2× each | **1×** |

## 💌 Any notes for the reviewer?

- **This touches the auth path**, so the risk area is behaviour parity rather than the perf change. I verified the following still work: button validity/enabled state, most-recent-username prefill + password focus, Enter-to-submit, clear-password-on-failure, and the multi-store selector flow (`storeSelectorUsername` now carries the username to the panel).
- The inline re-auth form (`<Login fullSize={false} />` in `ErrorAlert`) uses the same components and is unaffected.
- `LoginForm` owning both fields means the password input still re-renders on a username keystroke — contained and cheap (no chrome/layout), so I left it rather than splitting each field into its own memoised component.
- `tsc` (`yarn re-compile`) passes; ESLint reports 0 errors (one pre-existing `react-hooks/exhaustive-deps` warning on the unchanged `initStatus` effect).

# 🧪 Testing

Claude wrote these and I have done them:

- [ ] Run the client and open the login page
- [ ] Type into username/password — confirm no visual regressions and (optionally via React DevTools / why-did-you-render) that only the form re-renders, not the whole page
- [ ] Confirm the **Login button enables** only when both fields are filled
- [ ] Log in successfully → redirects to the app
- [ ] Multi-store user (not opted out) → store selector panel slides in with the correct username
- [ ] Failed login → error message shown and password field cleared
- [ ] With a previously-used account → username pre-fills and focus moves to the password field
- [ ] Trigger a session timeout while logged in → the inline re-auth form still logs back in

# 📃 Documentation

- [x] **No documentation required**: no user-facing changes — internal performance refactor, behaviour preserved
