### PR TITLE
#12325 Sync patient data when store is moved to another site

### DIFF
--- a/docs/content/docs/sync/v7/_index.md
+++ b/docs/content/docs/sync/v7/_index.md
@@ -762,6 +762,8 @@ Draft: Front end will know the status, if initialised or not, and can change syn
 
 When a store is moved to a remote site, we need to re-sync all of its data. This poses a challenge since we don’t want to re-sync data for other stores we have active on the site, so full re-initialisation is out of the question. Instead we ask the central server to filter by this store’s id (rather than all stores active on the site), pull those records, and integrate them — using a **temporary cursor that starts at 0** so we get the store’s full history, not just changes since the main cursor.
 
+The `data_for_store` filter covers three routes: store-scoped (`Remote`/`RemoteOwned`) records by `store_id`, `Transfer` records by `transfer_store_id`, and `Patient`-scoped records (patient `Name`, encounters, vaccinations, documents, etc.) for patients **visible at this store** (via `name_store_join`). The patient route is scoped to the store rather than the whole destination site, so only patients this store can actually see are re-pulled — without it a moved store would arrive missing its patient data.
+
 This is generalised into the **`sync_request`** mechanism: an *auxiliary* (a.k.a. special) sync run, parameterised by its own pull/push filter and cursor, that runs **after** the normal main sync each tick. Anything that needs to backfill a subset of records — a transferred store, a re-synced patient, or a newly-added table after a v7 migration (see [Re-sync after a v7 migration](#re-sync-after-v7-migration)) — is expressed as a `sync_request` row.
 
 **Mechanism**

--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -405,6 +405,18 @@ create_condition!(
                 .select(patient_name_links.field(name_link::id).nullable())
         )
     )),
+    // Patients visible at a specific store (via name_store_join), rather than at a whole site.
+    // Used by `data_for_store` to re-sync a moved store's patient data without pulling every
+    // patient on the destination site. Mirrors `patient_site_id` but constrains on the
+    // name_store_join's store_id directly instead of the joined store's site_id.
+    (patient_store_id, subquery: String, |for_store| changelog_with_links::patient_link_id.is_not_null().and(
+        changelog_with_links::patient_link_id.eq_any(
+            name_store_join::table
+                .inner_join(patient_name_links.on(name_store_join::name_id.eq(patient_name_links.field(name_link::id))))
+                .filter(name_store_join::store_id.eq(for_store))
+                .select(patient_name_links.field(name_link::id).nullable())
+        )
+    )),
     // Resolve a patient by their (resolved) name_id: match changelog rows whose patient_link_id
     // points at any name_link row resolving to that name_id.
     //   changelog.patient_link_id IN (SELECT name_link.id FROM name_link WHERE name_link.name_id = $patient_id)
@@ -512,6 +524,7 @@ impl ChangelogFilter {
         let mut store_scoped_table_names = Remote.get_table_names_for_distribution(None);
         store_scoped_table_names.extend(RemoteOwned.get_table_names_for_distribution(None));
         let transfer_table_names = Transfer.get_table_names_for_distribution(None);
+        let patient_table_names = Patient.get_table_names_for_distribution(None);
 
         C::Or(vec![
             C::And(vec![
@@ -521,6 +534,14 @@ impl ChangelogFilter {
             C::And(vec![
                 C::table_name::any(transfer_table_names),
                 C::transfer_store_id::equal(store_id.to_string()),
+            ]),
+            // Patient-scoped data for patients visible at this store. Without this, a moved
+            // store would arrive on the destination site missing its patients' data (#12325).
+            // Scoped to the store (via name_store_join) rather than the whole site, so we only
+            // re-pull patients this store can actually see.
+            C::And(vec![
+                C::table_name::any(patient_table_names),
+                C::patient_store_id::matching(store_id.to_string()),
             ]),
         ])
     }

--- a/server/repository/src/db_diesel/changelog/test.rs
+++ b/server/repository/src/db_diesel/changelog/test.rs
@@ -933,6 +933,73 @@ async fn test_changelog_outgoing_patient_sync_records() {
     assert_eq!(outgoing_results.len(), 0);
 }
 
+/// When a store is moved to another site we re-sync it via `data_for_store`. That
+/// filter must include patient-scoped data for patients visible at the moved store
+/// (via name_store_join), otherwise the store arrives missing its patient data (#12325).
+/// It must NOT pull patient data for patients the store can't see.
+#[actix_rt::test]
+async fn test_data_for_store_includes_patient_data() {
+    let (_, connection, _, _) = test_db::setup_all(
+        "test_data_for_store_includes_patient_data",
+        MockDataInserts::all(),
+    )
+    .await;
+
+    let repo = ChangelogRepository::new(&connection);
+
+    // patient2 has a name_store_join to store_a (mock_patient_store_join_b), and none to store_b.
+    // Author the vaccination (a Patient-distribution table) at store_c, so it reaches store_a
+    // only via the patient route — not via store_c's own (Remote) store_id route.
+    let cursor_before = repo.max_cursor().unwrap() as i64;
+    let vaccination = VaccinationRow {
+        id: "mock_vax_id".to_string(),
+        patient_id: "patient2".to_string(),
+        store_id: "store_c".to_string(),
+        vaccine_course_dose_id: "vaccine_course_a_dose_a".to_string(),
+        user_id: "user_account_a".to_string(),
+        ..Default::default()
+    };
+    VaccinationRowRepository::new(&connection)
+        .upsert_one(&vaccination)
+        .unwrap();
+
+    // Re-syncing store_a should include the vaccination (patient2 is visible at store_a).
+    let outgoing_results = repo
+        .query(
+            ChangelogFilter::data_for_store("store_a"),
+            CursorAndLimit {
+                cursor: cursor_before,
+                limit: 1000,
+            },
+        )
+        .unwrap()
+        .rows;
+    assert!(
+        outgoing_results
+            .iter()
+            .any(|r| r.record_id == vaccination.id),
+        "data_for_store(store_a) should include patient2's vaccination"
+    );
+
+    // Re-syncing store_b should NOT include it — patient2 is not visible at store_b.
+    let outgoing_results = repo
+        .query(
+            ChangelogFilter::data_for_store("store_b"),
+            CursorAndLimit {
+                cursor: cursor_before,
+                limit: 1000,
+            },
+        )
+        .unwrap()
+        .rows;
+    assert!(
+        !outgoing_results
+            .iter()
+            .any(|r| r.record_id == vaccination.id),
+        "data_for_store(store_b) should not include patient2's vaccination"
+    );
+}
+
 /// Concurrent-tx race: while connection A is mid-transaction with a changelog
 /// row in flight, an observer on connection B (same manager) should see
 /// `max_cursor()` clamped below A's tracked boundary and `query()` must not


### PR DESCRIPTION
Fixes #12325

# 👩🏻‍💻 What does this PR do?

When a store is moved to another site, the auxiliary ("special") sync re-syncs that store's data via the `data_for_store` changelog filter. That filter only covered store-scoped (`Remote`/`RemoteOwned`) records by `store_id` and `Transfer` records by `transfer_store_id` — it omitted patient-scoped data. As a result a moved store arrived on the destination site **missing its patients' data** (patient `Name`, encounters, vaccinations, documents, program enrolments, prescription invoices, etc.).

This PR adds a patient route to `data_for_store`:

- New `patient_store_id` changelog query condition (`server/repository/src/db_diesel/changelog/changelog.rs`) — the per-store analog of the existing `patient_site_id`. It matches changelog rows whose `patient_link_id` resolves to a patient visible at a **specific store** via `name_store_join`, rather than at the whole site.
- `data_for_store` now OR's in `Patient`-distribution tables filtered by `patient_store_id::matching(store_id)`. Scoping to the store (not the whole destination site) means we only re-pull patients the moved store can actually see.
- Updated the v7 sync design doc to describe the three routes `data_for_store` covers.

## 💌 Any notes for the reviewer?

- The new condition mirrors `patient_site_id` exactly, swapping the `store.site_id` filter for a direct `name_store_join.store_id` filter — no new join shape.
- Because `patient_store_id` requires a non-null `patient_link_id`, central (keyless) `Name` rows are correctly excluded from the patient route; only patient-scoped rows match.
- This reuses the same patient-routing mechanism (`patient_link_id` on the changelog row) that `patient_data_for_site` already relies on, so the approach is consistent with existing patient sync.
- The `data_for_store` public signature is unchanged; the only caller (`sync_v7/translations/store.rs`) needs no change.

# 🧪 Testing

Covered by a new repository unit test, `test_data_for_store_includes_patient_data`, which passes on both **SQLite** and **Postgres**:

- [ ] `cd server && cargo nextest run -p repository changelog` (SQLite)
- [ ] `cd server && cargo nextest run --profile=ci-postgres --features=postgres -p repository changelog` (Postgres)
- [ ] The test authors a vaccination for `patient2` (visible at `store_a`, authored at `store_c`) and asserts `data_for_store("store_a")` includes it (patient route) while `data_for_store("store_b")` excludes it (patient2 not visible at store_b).

End-to-end: move a store with associated patients to another site and confirm patient data (names, encounters, vaccinations, prescriptions) is present at the destination site after the auxiliary sync runs.

# 📃 Documentation

- [x] **These areas should be updated or checked**:
  1. `docs/content/docs/sync/v7/_index.md` — updated the "Store re-syncs" section to document that `data_for_store` covers store-scoped, transfer, and patient-scoped routes (patient route scoped per-store via `name_store_join`).
