### PR TITLE
#12328 Fix invoice_line integration for inactive items

### DIFF
--- a/server/service/src/sync/translations/invoice_line.rs
+++ b/server/service/src/sync/translations/invoice_line.rs
@@ -250,7 +250,11 @@ impl SyncTranslation for InvoiceLineTranslation {
                 )
             }
             true => {
-                let item = match ItemRowRepository::new(connection).find_active_by_id(&item_id)? {
+                // Use find_one_by_id (not find_active_by_id) here: this lookup only derives the
+                // item code for the legacy path, and an invoice line can legitimately reference an
+                // inactive item (e.g. an item deactivated by a merge). Gating on is_active caused
+                // integration to fail for lines linked to inactive items. See issue #12328.
+                let item = match ItemRowRepository::new(connection).find_one_by_id(&item_id)? {
                     Some(item) => item,
                     None => {
                         return Err(anyhow::Error::msg(format!(
@@ -620,8 +624,8 @@ mod tests {
         mock::{mock_item_a, mock_outbound_shipment_a, mock_store_b, MockData, MockDataInserts},
         system_log_row::{SystemLogRowRepository, SystemLogType},
         test_db::{setup_all, setup_all_with_data},
-        ChangelogCondition, ChangelogRepository, ContextRow, CursorAndLimit, FilterBuilder, KeyType,
-        KeyValueStoreRow, ProgramRow,
+        ChangelogCondition, ChangelogRepository, ContextRow, CursorAndLimit, FilterBuilder, ItemRow,
+        KeyType, KeyValueStoreRow, ProgramRow,
         SyncAction, SyncRecordData, RowOrDelete,
     };
     use serde_json::json;
@@ -868,5 +872,97 @@ mod tests {
                 "expected message to mention the record id"
             );
         }
+    }
+
+    /// An invoice line can legitimately reference an inactive item (e.g. an item deactivated by a
+    /// merge). On the legacy path (empty `om_item_code`) the translator looks the item up to derive
+    /// its code; that lookup must NOT gate on is_active, otherwise integration fails. Regression
+    /// test for issue #12328.
+    #[actix_rt::test]
+    async fn test_invoice_line_integrates_inactive_item() {
+        let translator = InvoiceLineTranslation {};
+        let (_, connection, _, _) = setup_all_with_data(
+            "test_invoice_line_integrates_inactive_item",
+            MockDataInserts::none()
+                .units()
+                .items()
+                .names()
+                .stores()
+                .currencies(),
+            MockData {
+                invoices: vec![mock_outbound_shipment_a()],
+                // Inactive item the invoice line will reference.
+                items: vec![ItemRow {
+                    id: "inactive_item".to_string(),
+                    name: "Inactive Item".to_string(),
+                    code: "INACTIVE_CODE".to_string(),
+                    is_active: false,
+                    ..Default::default()
+                }],
+                key_value_store_rows: vec![KeyValueStoreRow {
+                    id: KeyType::SettingsSyncSiteId,
+                    value_int: Some(mock_store_b().site_id),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        // No `om_item_code` -> legacy path -> item is looked up to derive the code.
+        let sync_record = SyncBufferRow {
+            table_name: "trans_line".to_string(),
+            record_id: "TRANS_LINE_INACTIVE_ITEM".to_string(),
+            data: SyncRecordData(
+                serde_json::from_str(
+                    r#"{
+                "ID": "TRANS_LINE_INACTIVE_ITEM",
+                "transaction_ID": "outbound_shipment_a",
+                "item_ID": "inactive_item",
+                "item_name": "Inactive Item",
+                "item_line_ID": "",
+                "batch": "",
+                "expiry_date": "0000-00-00",
+                "pack_size": 1,
+                "cost_price": 10,
+                "sell_price": 20,
+                "quantity": 1,
+                "type": "stock_out",
+                "location_ID": "",
+                "note": "",
+                "optionID": "0",
+                "vaccine_vial_monitor_status_ID": "",
+                "donor_id": "",
+                "linked_trans_line_ID": "",
+                "linked_transact_id": "",
+                "volume_per_pack": 0,
+                "foreign_currency_price": 0
+            }"#,
+                )
+                .unwrap(),
+            ),
+            action: SyncAction::Upsert,
+            ..Default::default()
+        };
+
+        let result = translator
+            .try_translate_from_upsert_sync_record(&connection, &sync_record)
+            .unwrap();
+
+        let PullTranslateResult::IntegrationOperations(ops) = result else {
+            panic!("{}", format!("expected IntegrationOperations, got {result:?}"));
+        };
+        let debug = format!("{ops:?}");
+        // Code is derived from the inactive item, and the line still references it.
+        assert!(
+            debug.contains("INACTIVE_CODE"),
+            "{}",
+            format!("expected item code to be derived from inactive item; got:\n{debug}")
+        );
+        assert!(
+            debug.contains("inactive_item"),
+            "{}",
+            format!("expected line to reference inactive item; got:\n{debug}")
+        );
     }
 }


### PR DESCRIPTION
Fixes #12328

# 👩🏻‍💻 What does this PR do?

The `invoice_line` (`trans_line`) sync translator failed to integrate invoice lines linked to **inactive** items.

On the legacy path (when the incoming record has no `om_item_code`), the translator looks the item up to derive its code. That lookup used `find_active_by_id`, which returns `None` for inactive items, so integration failed with `Failed to get item: <id>`.

Inactive items legitimately occur — e.g. an item deactivated by a merge — so lines referencing them must still integrate.

**Change:** in `server/service/src/sync/translations/invoice_line.rs`, the legacy-path item lookup now uses `find_one_by_id` instead of `find_active_by_id`. The lookup only reads the item's `code`; its active status is irrelevant here, and the `item_id` is stored on the row unconditionally either way.

# 💌 Any notes for the reviewer?

- One-line behavioural change (`find_active_by_id` → `find_one_by_id`) plus a regression test.
- Added test `test_invoice_line_integrates_inactive_item`: seeds an inactive item, feeds a legacy-path `trans_line` record (empty `om_item_code`) referencing it, and asserts translation succeeds with the code derived from the inactive item.
- No divergence from the issue — it asks to remove the `find_active_by_id` gate, which is exactly what this does.

# 🧪 Testing

- [ ] `cargo nextest run -p service sync::translations::invoice_line` passes (4 tests, including the new regression test)
- [ ] Sync an invoice line that references an inactive item (e.g. an item deactivated by a merge) from a legacy site into an OMS site, and confirm the line integrates rather than erroring with "Failed to get item"

# 📃 Documentation

- [x] **No documentation required**: bug fix, not a change in intended behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
