### PR TITLE
12350 Fix DB migration crash on existing asset_property row (storage_capacity_5c-ic)

### DIFF
--- a/server/repository/src/migrations/v2_19_00/add_storage_capacity_5c_to_insulated_containers.rs
+++ b/server/repository/src/migrations/v2_19_00/add_storage_capacity_5c_to_insulated_containers.rs
@@ -10,13 +10,16 @@ impl MigrationFragment for Migrate {
     fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
         // Add the storage_capacity_5c property for the insulated containers category
         // (previously only existed for cold rooms (-cr) and refrigerators/freezers (-fr)).
+        // ON CONFLICT DO NOTHING: asset_property syncs down from central, so the row may
+        // already exist before this migration runs.
         sql!(
             connection,
             r#"
             INSERT INTO asset_property (id, key, name, value_type, allowed_values, asset_class_id, asset_category_id)
             SELECT 'storage_capacity_5c-ic', 'storage_capacity_5c', 'Storage capacity +5 °C (litres)', 'FLOAT', NULL, asset_class_id, asset_category_id
             FROM asset_property
-            WHERE id = 'temperature_monitoring_device-ic';
+            WHERE id = 'temperature_monitoring_device-ic'
+            ON CONFLICT (id) DO NOTHING;
             "#
         )?;
 


### PR DESCRIPTION

<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12350

# 👩🏻‍💻 What does this PR do?
Makes the v2.19.0 add_storage_capacity_5c_to_insulated_containers fragment migration idempotent so it no longer crashes when the storage_capacity_5c-ic asset_property row already exists.

The migration did a plain INSERT of that row, assuming it was always absent. But asset_property syncs down (upsert) from OmSupply central, so on sites that had already received the row from central before running the migration, the INSERT hit a primary-key collision (row already exists) and the entire upgrade aborted — the server wouldn't start.

The fix appends ON CONFLICT (id) DO NOTHING to the INSERT ... SELECT. This works identically on SQLite (≥ 3.24; the bundled engine is 3.50.x) and Postgres (≥ 9.5), so no dialect branching is needed. The migration's second UPDATE block was already idempotent via its WHERE properties NOT LIKE '%"storage_capacity_5c"%' guards, so only the INSERT was changed.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Build/run on both SQLite and Postgres
- [ ] On a site that already has the storage_capacity_5c-ic row in asset_property (e.g. synced down from central, or insert it manually): start the server and confirm migrations complete without the row already exists error
- [ ] On a clean site without the row: start the server and confirm the migration still inserts the row correctly (no regression)
- [ ] Confirm the catalogue-item properties JSON UPDATE block still applies as before (idempotent — running twice changes nothing)
- [ ] Reproduce the original crash on develop/pre-fix to confirm this PR resolves it

# 📃 Documentation

- [x] No documentation required: bug fix, no change in user-facing behaviour


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

