### PR TITLE
12185 Enforce store ownership on plugin data update & read

### DIFF
--- a/server/graphql/plugin/src/plugin_data/query.rs
+++ b/server/graphql/plugin/src/plugin_data/query.rs
@@ -66,6 +66,10 @@ pub fn get_plugin_data(
     let mut filter = filter.map(|f| f.to_domain()).unwrap_or_default();
     filter.plugin_code = Some(EqualFilter::equal_to(plugin_code.to_owned()));
 
+    // Scope to this store's own rows + global (NULL) rows; forced server-side so
+    // a caller can't read another store's data.
+    filter.store_id = Some(EqualFilter::equal_any_or_null(vec![store_id.to_string()]));
+
     let plugin_data = service_provider
         .plugin_data_service
         .get_plugin_data(

--- a/server/service/src/plugin_data/mod.rs
+++ b/server/service/src/plugin_data/mod.rs
@@ -53,3 +53,65 @@ pub trait PluginDataServiceTrait: Sync + Send {
 
 pub struct PluginDataService {}
 impl PluginDataServiceTrait for PluginDataService {}
+
+#[cfg(test)]
+mod test {
+    use repository::{
+        mock::{mock_store_a, mock_store_b, mock_user_account_a, MockData, MockDataInserts},
+        test_db::setup_all_with_data,
+        EqualFilter, PluginDataFilter, PluginDataRow,
+    };
+
+    use crate::service_provider::ServiceProvider;
+
+    // Resolver scoping: a store sees its own + global rows, never another store's.
+    #[actix_rt::test]
+    async fn get_plugin_data_store_scoping() {
+        fn row(id: &str, store_id: Option<String>) -> PluginDataRow {
+            PluginDataRow {
+                id: id.to_string(),
+                plugin_code: "plugin_code".to_string(),
+                related_record_id: None,
+                data_identifier: "StockLine".to_string(),
+                store_id,
+                data: "test".to_string(),
+                datetime: None,
+            }
+        }
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "get_plugin_data_store_scoping",
+            MockDataInserts::all(),
+            MockData {
+                plugin_data: vec![
+                    row("own", Some(mock_store_a().id.clone())),
+                    row("other", Some(mock_store_b().id.clone())),
+                    row("global", None),
+                ],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id.clone(), mock_user_account_a().id)
+            .unwrap();
+        let service = service_provider.plugin_data_service;
+
+        let mut filter = PluginDataFilter::new();
+        filter.store_id = Some(EqualFilter::equal_any_or_null(vec![mock_store_a().id]));
+
+        let mut ids: Vec<String> = service
+            .get_plugin_data(&context, None, Some(filter), None)
+            .unwrap()
+            .rows
+            .into_iter()
+            .map(|r| r.plugin_data.id)
+            .collect();
+        ids.sort();
+
+        // Own store + global, but NOT store B's row.
+        assert_eq!(ids, vec!["global".to_string(), "own".to_string()]);
+    }
+}

--- a/server/service/src/plugin_data/update.rs
+++ b/server/service/src/plugin_data/update.rs
@@ -57,6 +57,22 @@ fn validate(
     let plugin_data = check_plugin_data_exists(ctx, &input.id)?
         .ok_or(UpdatePluginDataError::PluginDataDoesNotExist)?;
 
+    // Global rows (store_id = NULL) are central-only.
+    if plugin_data.store_id.is_none() && !CentralServerConfig::is_central_server() {
+        return Err(UpdatePluginDataError::InternalError(
+            "Central Data can only be modified from Central Server".to_string(),
+        ));
+    }
+
+    // A store may only modify its own rows.
+    if let Some(store_id) = &plugin_data.store_id {
+        if &ctx.store_id != store_id {
+            return Err(UpdatePluginDataError::InternalError(
+                "Store ID doesn't match logged in store_id".to_string(),
+            ));
+        }
+    }
+
     if input.related_record_id != plugin_data.related_record_id {
         return Err(UpdatePluginDataError::RelatedRecordDoesNotMatch);
     }
@@ -65,12 +81,6 @@ fn validate(
     }
     if input.plugin_code != plugin_data.plugin_code {
         return Err(UpdatePluginDataError::PluginCodeDoesNotMatch);
-    }
-
-    if plugin_data.store_id.is_none() && !CentralServerConfig::is_central_server() {
-        return Err(UpdatePluginDataError::InternalError(
-            "Central Data can only be modified from Central Server".to_string(),
-        ));
     }
 
     Ok(plugin_data)
@@ -195,5 +205,68 @@ mod test {
         expected.data = "hogwarts".to_string();
 
         assert_eq!(plugin_data, expected);
+    }
+
+    #[actix_rt::test]
+    async fn update_plugin_data_wrong_store() {
+        use crate::plugin_data::UpdatePluginDataError;
+        use repository::{mock::mock_store_b, PluginDataRowRepository};
+
+        // Row owned by store B.
+        fn plugin_data_donor() -> PluginDataRow {
+            PluginDataRow {
+                id: "plugin_data".to_string(),
+                plugin_code: "plugin_code".to_string(),
+                related_record_id: Some("related_record_id".to_string()),
+                data_identifier: "StockLine".to_string(),
+                store_id: Some(mock_store_b().id.clone()),
+                data: "test".to_string(),
+                datetime: None,
+            }
+        }
+
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "update_plugin_data_wrong_store",
+            MockDataInserts::all(),
+            MockData {
+                plugin_data: vec![plugin_data_donor()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        // Logged into store A, attempting to update store B's row.
+        let context = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+        let service = service_provider.plugin_data_service;
+
+        let result = service.update(
+            &context,
+            UpdatePluginData {
+                id: "plugin_data".to_string(),
+                store_id: Some(mock_store_b().id.clone()),
+                plugin_code: "plugin_code".to_string(),
+                related_record_id: Some("related_record_id".to_string()),
+                data_identifier: "StockLine".to_string(),
+                data: "tampered".to_string(),
+                datetime: None,
+            },
+        );
+
+        assert_eq!(
+            result,
+            Err(UpdatePluginDataError::InternalError(
+                "Store ID doesn't match logged in store_id".to_string()
+            ))
+        );
+
+        // The row must be unchanged.
+        let unchanged = PluginDataRowRepository::new(&connection)
+            .find_one_by_id("plugin_data")
+            .unwrap()
+            .unwrap();
+        assert_eq!(unchanged.data, "test");
     }
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12185

# 👩🏻‍💻 What does this PR do?
Closes two cross-store authorization gaps in plugin data. Previously the API authorized the *request's* `store_id` but did not check that the data being accessed actually belonged to that store, so a user authorized for store A could reach store B's plugin data:

- **Update** (`service/src/plugin_data/update.rs`): `validate()` enforced the global/central-only rule but never compared `ctx.store_id` against the row's `store_id`. A store could overwrite the `data`/`datetime` of another store's row (ownership couldn't be changed, but the payload could). Added the same `ctx.store_id == row.store_id` check that `delete` already has, and moved the ownership checks ahead of the field-integrity checks so we don't leak field info about a row the caller doesn't own.

- **Read** (`graphql/plugin/src/plugin_data/query.rs`): `get_plugin_data` built a non-store-scoped context and only forced `plugin_code`, so it returned every store's rows for that plugin (or another store's when `store_id` was passed in the filter). Now forces `store_id` server-side to the authorized store + global (`NULL`) rows using the existing `equal_any_or_null` pattern, ignoring any caller-supplied `store_id`.

Delete was already correct and is unchanged.

<!-- Explain the changes you made -->

<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

- The read change is **API-behaviour-changing**: `get_plugin_data` now returns only the authorized store's rows plus global rows. If a central-admin use case needs to read all stores' plugin data, flag it — we may need a separate path.
- **Out of scope (left as-is):** backend JS plugins (`boajs` `use_repository` / `get_plugin_data`) still write/read plugin data without store scoping. That's trusted, centrally-managed plugin code; called out here so it's a conscious decision rather than an oversight.
- Minor footgun not changed: `UpdatePluginDataInput.store_id` is accepted but ignored on update (it's what *prevents* re-homing a row).
- The fix lives in the GraphQL resolver (next to where `plugin_code` is already forced). The plugin GraphQL crate has no test harness, so the regression test sits at the service layer and locks in the scoping filter the resolver builds.

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->
Covered by automated tests (`cargo nextest run -p service plugin_data`):

- `update_plugin_data_wrong_store` — logged into store A, updating store B's row is rejected and the row is left unchanged.
- `get_plugin_data_store_scoping` — querying as store A returns its own + global rows, never store B's.

Manual (multi-store site or central server, where >1 store's data coexists):

- [ ] As store A, attempt to **update** a plugin_data row owned by store B (by id) → rejected; store B's row is unchanged.
- [ ] As store A, **query** plugin data → see only store A's rows + global rows; store B's rows are not returned, even if `store_id: B` is passed in the filter.
- [ ] As store A, normal insert/update/delete/read of store A's own rows still works.
- [ ] Global (`store_id = NULL`) plugin data is still readable by all stores and remains editable only from the central server.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

