### PR TITLE
11473 - Add additional multi device site tests

### DIFF
--- a/server/repository/src/db_diesel/changelog/test.rs
+++ b/server/repository/src/db_diesel/changelog/test.rs
@@ -12,10 +12,12 @@ use crate::{
     test_db::{self, setup_all, setup_all_with_data},
     ChangelogCondition, ChangelogFilter, ChangelogRepository, ChangelogRow, ChangelogSyncType,
     ChangelogTableName, CurrencyRow, CursorAndLimit, FilterBuilder, InvoiceLineRow,
-    InvoiceLineRowRepository, InvoiceRow, InvoiceRowRepository, KeyType, KeyValueStoreRepository,
-    LocationRowRepository, NameRow, RequisitionLineRow, RequisitionLineRowRepository,
-    RequisitionRow, RequisitionRowRepository, RowActionType, StorageConnection, StoreRow,
-    StoreRowRepository, Upsert, VaccinationRow, VaccinationRowRepository,
+    InvoiceLineRowRepository, InvoiceRow, InvoiceRowRepository, KeyType,
+    KeyValueStoreRepository, LocationRowRepository, NameRow, RequisitionLineRow,
+    RequisitionLineRowRepository, RequisitionRow, RequisitionRowRepository, RowActionType,
+    ShippingMethodRow, ShippingMethodRowRepository, StocktakeRow, StorageConnection, StoreRow,
+    StoreRowRepository, Upsert, VaccinationRow,
+    VaccinationRowRepository,
 };
 
 fn delete_all_changelog(connection: &StorageConnection) {
@@ -852,6 +854,188 @@ async fn test_changelog_outgoing_sync_records() {
         .rows;
     assert_eq!(outgoing_results.len(), 2);
     assert_eq!(outgoing_results[1].record_id, central_asset_id);
+}
+
+#[actix_rt::test]
+async fn test_changelog_outgoing_multi_device_sync_records() {
+    let (_, connection, _, _) = test_db::setup_all(
+        "test_changelog_outgoing_multi_device_sync_records",
+        MockDataInserts::none().names().stores(),
+    )
+    .await;
+
+    let site1_id = mock_store_a().site_id;
+    let site1_store_id = mock_store_a().id;
+
+    // Simulate the central server: current site id distinct from site1 so that
+    // locally-upserted rows (SourceSiteId::CurrentSiteId) get central's id.
+    let central_site_id = 999;
+    assert_ne!(central_site_id, site1_id);
+    KeyValueStoreRepository::new(&connection)
+        .set_i32(KeyType::SettingsSyncSiteId, Some(central_site_id))
+        .unwrap();
+
+    let cursor_before = ChangelogRepository::new(&connection).max_cursor().unwrap() as i64;
+
+    // Central, multi-device → reaches a multi-device site.
+    let md_central_id = "md_asset_class".to_string();
+    AssetClassRowRepository::new(&connection)
+        .upsert_one(&AssetClassRow {
+            id: md_central_id.clone(),
+            ..Default::default()
+        })
+        .unwrap();
+
+    // Central, NOT multi-device → dropped by the flag, kept by the ordinary filter.
+    // (Central-distributed so it survives a post-init pull, unlike RemoteOwned.)
+    let non_md_central_id = "non_md_shipping_method".to_string();
+    ShippingMethodRowRepository::new(&connection)
+        .upsert_one(&ShippingMethodRow {
+            id: non_md_central_id.clone(),
+            ..Default::default()
+        })
+        .unwrap();
+
+    // Remote, multi-device, authored by site1 itself. Post-initialisation the
+    // ordinary filter's echo guard drops this; the multi-device filter keeps it.
+    let md_self_sourced_id = "md_asset".to_string();
+    AssetRow {
+        id: md_self_sourced_id.clone(),
+        store_id: Some(site1_store_id.clone()),
+        ..Default::default()
+    }
+    .upsert_sync(
+        &connection,
+        ChangelogSyncType::SyncTypeV5V6 {
+            source_site_id: Some(site1_id),
+        },
+    )
+    .unwrap();
+
+    // Ordinary post-init pull: both central rows (in cursor order); the
+    // self-sourced Asset is excluded by the echo guard.
+    let outgoing_results = ChangelogRepository::new(&connection)
+        .query(
+            ChangelogFilter::all_data_for_site(site1_id, false, None),
+            CursorAndLimit {
+                cursor: cursor_before,
+                limit: 1000,
+            },
+        )
+        .unwrap()
+        .rows;
+    assert_eq!(outgoing_results.len(), 2);
+    assert_eq!(outgoing_results[0].record_id, md_central_id);
+    assert_eq!(outgoing_results[1].record_id, non_md_central_id);
+
+    // Multi-device post-init pull: the non-multi-device ShippingMethod is dropped
+    // by the flag intersection, while the self-sourced Asset is kept (guard dropped).
+    let outgoing_results = ChangelogRepository::new(&connection)
+        .query(
+            ChangelogFilter::multi_device_all_data_for_site(site1_id, false, None),
+            CursorAndLimit {
+                cursor: cursor_before,
+                limit: 1000,
+            },
+        )
+        .unwrap()
+        .rows;
+    assert_eq!(outgoing_results.len(), 2);
+    assert_eq!(outgoing_results[0].record_id, md_central_id);
+    assert_eq!(outgoing_results[1].record_id, md_self_sourced_id);
+}
+
+#[actix_rt::test]
+async fn test_changelog_edited_on_multi_device_site_push_records() {
+    let (_, connection, _, _) = test_db::setup_all(
+        "test_changelog_edited_on_multi_device_site_push_records",
+        MockDataInserts::none().names().stores(),
+    )
+    .await;
+
+    let site1_id = mock_store_a().site_id;
+    let site1_store_id = mock_store_a().id;
+
+    let cursor_before = ChangelogRepository::new(&connection).max_cursor().unwrap() as i64;
+
+    // Multi-device table, authored by this site → pushed by both filters.
+    let md_edited_id = "md_asset".to_string();
+    AssetRow {
+        id: md_edited_id.clone(),
+        store_id: Some(site1_store_id.clone()),
+        ..Default::default()
+    }
+    .upsert_sync(
+        &connection,
+        ChangelogSyncType::SyncTypeV5V6 {
+            source_site_id: Some(site1_id),
+        },
+    )
+    .unwrap();
+
+    // NOT a multi-device table, authored by this site → pushed by the ordinary
+    // filter, dropped by the multi-device filter's flag intersection.
+    let non_md_edited_id = "non_md_stocktake".to_string();
+    StocktakeRow {
+        id: non_md_edited_id.clone(),
+        store_id: site1_store_id.clone(),
+        ..Default::default()
+    }
+    .upsert_sync(
+        &connection,
+        ChangelogSyncType::SyncTypeV5V6 {
+            source_site_id: Some(site1_id),
+        },
+    )
+    .unwrap();
+
+    // Multi-device table, but authored by a *different* site → excluded by the
+    // `source_site_id` match in both filters (nothing to push back out).
+    let other_site_id = 999;
+    assert_ne!(other_site_id, site1_id);
+    AssetRow {
+        id: "md_asset_other_site".to_string(),
+        store_id: Some(site1_store_id.clone()),
+        ..Default::default()
+    }
+    .upsert_sync(
+        &connection,
+        ChangelogSyncType::SyncTypeV5V6 {
+            source_site_id: Some(other_site_id),
+        },
+    )
+    .unwrap();
+
+    // Ordinary push: both rows this site authored (in cursor order); the
+    // other-site row is excluded.
+    let outgoing_results = ChangelogRepository::new(&connection)
+        .query(
+            ChangelogFilter::all_data_edited_on_site(site1_id),
+            CursorAndLimit {
+                cursor: cursor_before,
+                limit: 1000,
+            },
+        )
+        .unwrap()
+        .rows;
+    assert_eq!(outgoing_results.len(), 2);
+    assert_eq!(outgoing_results[0].record_id, md_edited_id);
+    assert_eq!(outgoing_results[1].record_id, non_md_edited_id);
+
+    // Multi-device push: the non-multi-device Stocktake is additionally dropped by
+    // the flag intersection, leaving only the tagged Asset this site authored.
+    let outgoing_results = ChangelogRepository::new(&connection)
+        .query(
+            ChangelogFilter::all_data_edited_on_multi_device_site(site1_id),
+            CursorAndLimit {
+                cursor: cursor_before,
+                limit: 1000,
+            },
+        )
+        .unwrap()
+        .rows;
+    assert_eq!(outgoing_results.len(), 1);
+    assert_eq!(outgoing_results[0].record_id, md_edited_id);
 }
 
 #[actix_rt::test]

--- a/server/repository/src/syncv7/integration_order.rs
+++ b/server/repository/src/syncv7/integration_order.rs
@@ -334,15 +334,17 @@ mod tests {
         panic!("{}", msg);
     }
 
-    /// The multi-device-tagged set must be FK-closed: every changelog table
-    /// reachable via a tagged table's FKs (through non-changelog intermediates
-    /// like `*_link`) must also be tagged, else a child syncs without its parent.
+    /// Every table synced to multi-device sites must have all its FK parents
+    /// synced too. Check that no FK dependencies are violated.
     #[actix_rt::test]
-    async fn multi_device_set_is_fk_closed() {
-        let (_, connection, _, _) =
-            setup_all("test_sync_v7_multi_device_fk_closure", MockDataInserts::none()).await;
+    async fn multi_device_synced_tables_include_fk_parents() {
+        let (_, connection, _, _) = setup_all(
+            "test_sync_v7_multi_device_fk_dependencies",
+            MockDataInserts::none(),
+        )
+        .await;
 
-        let multi_device: HashSet<String> = ChangelogTableName::iter()
+        let multi_device_tables: HashSet<String> = ChangelogTableName::iter()
             .filter(|t| t.sync_style().multi_device_site)
             .map(|t| t.to_string())
             .collect();
@@ -374,15 +376,14 @@ mod tests {
                 .push(fk.parent_table.clone());
         }
 
-        // BFS each tagged table's FK parents. A changelog-table parent is a
-        // boundary (it's integrated as its own unit and must be tagged); a
-        // non-changelog parent is a pass-through we keep traversing.
+        // BFS from each listed table, hopping through non-listed intermediates
+        // to find transitive listed-table parents.
         let mut violations: Vec<(String, String)> = Vec::new();
-        for root in &multi_device {
+        for child in &multi_device_tables {
             let mut queue: VecDeque<String> = VecDeque::new();
             let mut visited: HashSet<String> = HashSet::new();
-            queue.push_back(root.clone());
-            visited.insert(root.clone());
+            queue.push_back(child.clone());
+            visited.insert(child.clone());
 
             while let Some(current) = queue.pop_front() {
                 let Some(parents) = parents_of.get(&current) else {
@@ -393,8 +394,8 @@ mod tests {
                         continue;
                     }
                     if changelog_tables.contains(parent) {
-                        if !multi_device.contains(parent) {
-                            violations.push((root.clone(), parent.clone()));
+                        if !multi_device_tables.contains(parent) {
+                            violations.push((child.clone(), parent.clone()));
                         }
                     } else {
                         queue.push_back(parent.clone());
@@ -407,11 +408,11 @@ mod tests {
 
         assert!(
             violations.is_empty(),
-            "multi-device table set is not FK-closed — these tagged tables depend on \
-             untagged changelog tables that would never sync to a multi-device site:\n{}",
+            "FK violation:  FK parent doesn't sync to multi-device sites, so the child \
+             fails to integrate. Set multi_device_site: true on each parent (or false on the child):\n{}",
             violations
                 .iter()
-                .map(|(c, p)| format!("  - {c} -> {p}"))
+                .map(|(c, p)| format!("  - {c} depends on {p}"))
                 .collect::<Vec<_>>()
                 .join("\n"),
         );

--- a/server/repository/src/syncv7/integration_order.rs
+++ b/server/repository/src/syncv7/integration_order.rs
@@ -334,6 +334,89 @@ mod tests {
         panic!("{}", msg);
     }
 
+    /// The multi-device-tagged set must be FK-closed: every changelog table
+    /// reachable via a tagged table's FKs (through non-changelog intermediates
+    /// like `*_link`) must also be tagged, else a child syncs without its parent.
+    #[actix_rt::test]
+    async fn multi_device_set_is_fk_closed() {
+        let (_, connection, _, _) =
+            setup_all("test_sync_v7_multi_device_fk_closure", MockDataInserts::none()).await;
+
+        let multi_device: HashSet<String> = ChangelogTableName::iter()
+            .filter(|t| t.sync_style().multi_device_site)
+            .map(|t| t.to_string())
+            .collect();
+        let changelog_tables: HashSet<String> =
+            ChangelogTableName::iter().map(|t| t.to_string()).collect();
+
+        // Same FK source as check_integration_order: child -> parent across `public`.
+        let fk_query = r#"
+            SELECT DISTINCT
+                tc.table_name   AS child_table,
+                ccu.table_name  AS parent_table
+            FROM information_schema.table_constraints  tc
+            JOIN information_schema.constraint_column_usage ccu
+              ON tc.constraint_name = ccu.constraint_name
+             AND tc.table_schema    = ccu.table_schema
+            WHERE tc.constraint_type = 'FOREIGN KEY'
+              AND tc.table_schema    = 'public'
+              AND tc.table_name     <> ccu.table_name
+        "#;
+        let all_fks: Vec<FkRow> = diesel::sql_query(fk_query)
+            .load(connection.lock().connection())
+            .expect("failed to query information_schema for FK constraints");
+
+        let mut parents_of: HashMap<String, Vec<String>> = HashMap::new();
+        for fk in &all_fks {
+            parents_of
+                .entry(fk.child_table.clone())
+                .or_default()
+                .push(fk.parent_table.clone());
+        }
+
+        // BFS each tagged table's FK parents. A changelog-table parent is a
+        // boundary (it's integrated as its own unit and must be tagged); a
+        // non-changelog parent is a pass-through we keep traversing.
+        let mut violations: Vec<(String, String)> = Vec::new();
+        for root in &multi_device {
+            let mut queue: VecDeque<String> = VecDeque::new();
+            let mut visited: HashSet<String> = HashSet::new();
+            queue.push_back(root.clone());
+            visited.insert(root.clone());
+
+            while let Some(current) = queue.pop_front() {
+                let Some(parents) = parents_of.get(&current) else {
+                    continue;
+                };
+                for parent in parents {
+                    if !visited.insert(parent.clone()) {
+                        continue;
+                    }
+                    if changelog_tables.contains(parent) {
+                        if !multi_device.contains(parent) {
+                            violations.push((root.clone(), parent.clone()));
+                        }
+                    } else {
+                        queue.push_back(parent.clone());
+                    }
+                }
+            }
+        }
+        violations.sort();
+        violations.dedup();
+
+        assert!(
+            violations.is_empty(),
+            "multi-device table set is not FK-closed — these tagged tables depend on \
+             untagged changelog tables that would never sync to a multi-device site:\n{}",
+            violations
+                .iter()
+                .map(|(c, p)| format!("  - {c} -> {p}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+    }
+
     // ---- Shared meta-test setup ----
 
     /// Creates a fresh test DB and builds the FK chain used by every


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #11473 part 3

# 👩🏻‍💻 What does this PR do?

Adds some additional tests for multi site devices 

Had identified the gap as part of a self/claude review, but the PR was reviewed before I got them ready. I think these are worth getting in still

- FK integration order test, for the multi sites subset. Primarily for if a table is missing from the multi device table set, as the order would still be correct from the full table set
- Changelog filter tests

Example of failed FK integration test - specific about what has failed and why
<img width="1241" height="245" alt="Screenshot 2026-07-06 at 10 49 06 AM" src="https://github.com/user-attachments/assets/3e405960-b4c5-4453-b578-9d09a6f11a84" />


## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] Tests pass

# 📃 Documentation

- [x] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
