### PR TITLE
#12355 Reintegrate items to backfill custom field categories

### DIFF
--- a/server/repository/src/migrations/v3_00_00/mod.rs
+++ b/server/repository/src/migrations/v3_00_00/mod.rs
@@ -29,6 +29,7 @@ mod populate_routed_changelog_for_sync_v7_tables;
 mod populate_sync_version;
 mod rebuild_sync_buffer;
 mod reintegrate_categories_for_custom_field_options;
+mod reintegrate_items_for_custom_field_options;
 mod reintegrate_label_prefs_for_custom_field_names;
 mod reintegrate_transaction_categories_for_custom_field_options;
 mod remove_add_central_patient_visibility_processor_cursor;
@@ -77,6 +78,7 @@ impl Migration for V3_00_00 {
             Box::new(add_name_custom_fields::Migrate),
             Box::new(add_item_custom_fields::Migrate),
             Box::new(reintegrate_categories_for_custom_field_options::Migrate),
+            Box::new(reintegrate_items_for_custom_field_options::Migrate),
             Box::new(reintegrate_label_prefs_for_custom_field_names::Migrate),
             Box::new(add_invoice_custom_fields::Migrate),
             Box::new(reintegrate_transaction_categories_for_custom_field_options::Migrate),

--- a/server/repository/src/migrations/v3_00_00/reintegrate_items_for_custom_field_options.rs
+++ b/server/repository/src/migrations/v3_00_00/reintegrate_items_for_custom_field_options.rs
@@ -1,0 +1,38 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "reintegrate_items_for_custom_field_options"
+    }
+
+    /// Backfill each item's *category assignment* as a `custom_field_value`.
+    ///
+    /// `ItemTranslation` now authors an item's leaf category as `custom_field_value`
+    /// OPTION rows (the value the Custom Fields UI reads), but existing items were
+    /// integrated before that mapping existed and central data only re-flows on
+    /// initialisation or change — so the assignment stays empty until the item is
+    /// edited on OG. `reintegrate_categories_for_custom_field_options` covers the
+    /// sibling *options list*; this covers the per-item *assignment*.
+    ///
+    /// Re-integrates the (append-only, still-present) `item` buffer rows by moving
+    /// them back to pending — `is_integrated = false`, since the sync-v7 buffer
+    /// partitions on it (clearing `integration_datetime` alone is the pre-v7
+    /// pattern). The next sync cycle re-runs `ItemTranslation`, authoring the values
+    /// with no re-init or edit history.
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        sql!(
+            connection,
+            r#"
+                UPDATE sync_buffer
+                    SET is_integrated = FALSE,
+                        integration_datetime = NULL,
+                        integration_error = NULL
+                    WHERE table_name = 'item';
+            "#
+        )?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Fixes #12355

# 👩🏻‍💻 What does this PR do?

Adds a `v3_00_00` migration (`reintegrate_items_for_custom_field_options`) that backfills each item's category *assignment* as a `custom_field_value`.

`ItemTranslation` now authors an item's leaf category as a `custom_field_value` OPTION row (the value the Custom Fields UI reads), but existing items were integrated before that mapping existed, and central data only re-flows from OG on initialisation or change. As a result the assignment stays empty until the item is edited on the OG side and re-synced — which is exactly the symptom reported in the issue (category linked in the DB but not shown in the Custom Fields UI).

The migration moves the (append-only, still-present) `item` rows in `sync_buffer` back to the pending partition by setting `is_integrated = false` (the sync-v7 buffer partitions on `is_integrated`; clearing `integration_datetime` alone is the pre-v7 pattern and is not enough). The next sync cycle re-runs `ItemTranslation` over them, authoring the values with no re-initialisation and no dependency on edit history.

This mirrors the sibling `reintegrate_categories_for_custom_field_options` migration, which does the same for the category *options list*; this one covers the per-item *assignment*.

## 💌 Any notes for the reviewer?

- Still needs to be validated on a large datafile that clearing/re-integrating the `item` rows in the sync buffer like this is fast enough under sync v7. On big catalogues this re-flows every item through translation on the next sync cycle, so we should confirm the timing is acceptable before relying on it.
- Based on `feature/properties` (not `develop`).

# 🧪 Testing

- [ ] Existing OMS Central site (v6) initialised from OG **before** the Custom Fields item-category mapping existed, with items that have categories assigned
- [ ] Confirm the item's category does **not** show in the Custom Fields UI beforehand (the reported bug)
- [ ] Run this migration, then trigger a sync cycle
- [ ] Confirm the category assignment now appears in the Custom Fields UI without editing the item on OG
- [ ] Validate on a large datafile that the re-integration + subsequent sync completes in acceptable time under sync v7

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
