### PR TITLE
#12371 Hide standalone tab for production builds

### DIFF
--- a/client/packages/host/src/components/Initialise/Initialise.tsx
+++ b/client/packages/host/src/components/Initialise/Initialise.tsx
@@ -44,6 +44,9 @@ export const Initialise = () => {
 
   const isCentralServer = useIsCentralServerApi();
   const isAndroid = EnvUtils.platform === Platform.Android;
+  // Only offer the standalone-central setup in dev (`yarn start`), not in
+  // production builds.
+  const showCentralTab = !isAndroid && isCentralServer && !EnvUtils.isProduction();
   const isInputDisabled = formState.isInitialising || formState.isLoading;
   const isExtraSmallScreen = useIsExtraSmallScreen();
   const nativeClient = useNativeClient();
@@ -104,7 +107,7 @@ export const Initialise = () => {
             <Stack direction="row" sx={{ justifyContent: 'center' }}>
               <LoginIcon small />
             </Stack>
-            {!isAndroid && isCentralServer && (
+            {showCentralTab && (
               <TabList
                 value={mode}
                 onChange={(_, v) => !isInputDisabled && setMode(v as InitMode)}
@@ -128,7 +131,7 @@ export const Initialise = () => {
                 isCentralServer={isCentralServer}
               />
             )}
-            {mode === 'central' && isCentralServer && <StandaloneCentralTab />}
+            {mode === 'central' && showCentralTab && <StandaloneCentralTab />}
           </Stack>
         </Stack>
         {isAndroid && (


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Fixes #12371

# 👩🏻‍💻 What does this PR do?

Hides standalone tab on production builds

Prod:
<img width="992" height="1168" alt="image" src="https://github.com/user-attachments/assets/a0cfeed0-2a6f-42c3-9199-237f765356ca" />

Dev: 
<img width="1152" height="1310" alt="image" src="https://github.com/user-attachments/assets/09df3749-b66b-4822-a418-9607f7b2b8a7" />


<!-- why are the changes needed -->

<!-- Add a screenshot if there are UI changes  -->

## 💌 Any notes for the reviewer?

<!-- Do you have any specific questions for the reviewer? -->

<!-- Is there a high risk/complicated change they should focus on? -->

<!-- any general areas of the codebase touched? any side effects caused? -->

<!-- Anything half cooked but going to be finished off in a different PR? -->

# 🧪 Testing

<!-- Explain the steps you'd take to test the changes of this PR manually -->

- [ ] tested production using `yarn build --env production` and then accessing frontend using server port
- [ ] tested dev using `yarn start`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**: <!-- _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
  1.
  2.
