### PR TITLE
Enable Corepack in build-standard-reports workflow

### DIFF
--- a/.github/workflows/build-standard-reports.yaml
+++ b/.github/workflows/build-standard-reports.yaml
@@ -43,6 +43,9 @@ jobs:
         with:
           node-version: 20
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install JS dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Adds an `Enable Corepack` step to the `Build standard reports` workflow so that Yarn 4 is activated before dependencies are installed.

The `build-reports` job runs `yarn install --immutable` but never enabled Corepack, so it fell back to the runner's global Yarn 1.22.22 and failed against the repo's `"packageManager": "yarn@4.13.0"`:

```
error This project's package.json defines "packageManager": "yarn@4.13.0".
However the current global version of Yarn is 1.22.22.
```

This surfaced after the yarn workspace root was moved to the repo root (#11112), which put the `packageManager` declaration at the path this job installs from. The fix mirrors what every other workflow in `.github/workflows/` already does (`client-code-checks`, `client-tests`, `generate-schema`, `dockerise`, `build-android-apk`) — a dedicated `corepack enable` step right after `actions/setup-node`.

## 💌 Any notes for the reviewer?

- No linked issue — this is a CI fix.
- **This fixes two observed failures with the same root cause.** Without Corepack, `yarn install` runs as the runner's global Yarn 1.22.22:
  - When it errors on the `packageManager` mismatch, the `Install JS dependencies` step fails outright ([run 28561910782](https://github.com/msupply-foundation/open-msupply/actions/runs/28561910782)).
  - When it silently no-ops (0.55s "Done", installs nothing), the step "passes" but the later `Build reports` step fails because the per-report webpack build can't resolve `lodash` — `standard_reports`'s dependency, which under Yarn 4 hoists to the root `node_modules` ([run 28625903995](https://github.com/msupply-foundation/open-msupply/actions/runs/28625903995)). With Corepack, Yarn 4 runs the real workspace install and hoists `lodash` to root where webpack finds it.
- This workflow is a post-merge job (`pull_request_target: [closed]`, gated on `merged == true`) that checks out `develop`, regenerates the standard reports/forms, and auto-commits them. It is not a PR check, so it will not run against this branch. It can be verified after merge via the next report-touching merge or manually through the `workflow_dispatch` input (`branch: develop`).
- Single-line addition; verified locally by running `remote_server_cli build-reports` with Corepack enabled.

# 🧪 Testing

- [ ] After merge, run the workflow manually via **Actions → Build standard reports → Run workflow** with `branch: develop`.
- [ ] Confirm the `Install JS dependencies` step now succeeds (Corepack shims Yarn 4).
- [ ] Confirm the job proceeds to `Build reports` and completes.

# 📃 Documentation

- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
