### PR TITLE
#12356 Custom fields: order fields and options by sort_order

### DIFF
--- a/client/packages/invoices/src/common/customFields/InvoiceCustomFieldsTab.tsx
+++ b/client/packages/invoices/src/common/customFields/InvoiceCustomFieldsTab.tsx
@@ -85,13 +85,12 @@ export const InvoiceCustomFieldsTab = ({
     <CustomFieldsEditTab
       // Prominent fields are surfaced as quick-access controls in the toolbar
       // (InvoiceToolbarCustomFields), so exclude them here to avoid duplication.
-      // Remaining fields are sorted alphabetically by label, as this tab has
-      // always rendered them — the shared renderer keeps the order it is handed.
-      definitions={definitions
-        .filter(
-          d => d.displayMode !== CustomFieldNodeDisplayMode.Prominent
-        )
-        .sort((a, b) => (a.name || a.key).localeCompare(b.name || b.key))}
+      // Remaining fields render in backend (definition) order — the server
+      // returns them ordered by the per-scope sort_order rank, consistent with
+      // every other custom-fields tab — so no client-side sort here.
+      definitions={definitions.filter(
+        d => d.displayMode !== CustomFieldNodeDisplayMode.Prominent
+      )}
       properties={customFields}
       disabled={disabled}
       onEdit={onEdit}

--- a/server/graphql/general/src/queries/tests/custom_field.rs
+++ b/server/graphql/general/src/queries/tests/custom_field.rs
@@ -66,6 +66,7 @@ mod graphql {
                 deleted_datetime: None,
             },
             display_mode: None,
+            sort_order: None,
         }
     }
 

--- a/server/graphql/general/src/queries/tests/names.rs
+++ b/server/graphql/general/src/queries/tests/names.rs
@@ -267,6 +267,7 @@ mod graphql {
                 custom_field_id: "prop1".to_string(),
                 scope: "supplier".to_string(),
                 display_mode: CustomFieldDisplayMode::Visible,
+                ..Default::default()
             })
             .unwrap();
 

--- a/server/graphql/invoice/src/query_tests/invoices.rs
+++ b/server/graphql/invoice/src/query_tests/invoices.rs
@@ -165,6 +165,7 @@ mod test {
                 custom_field_id: "inbound_shipment_category".to_string(),
                 scope: "inbound_shipment".to_string(),
                 display_mode: CustomFieldDisplayMode::Visible,
+                ..Default::default()
             })
             .unwrap();
 

--- a/server/repository/src/db_diesel/custom_field.rs
+++ b/server/repository/src/db_diesel/custom_field.rs
@@ -9,14 +9,17 @@ use crate::{diesel_macros::apply_equal_filter, EqualFilter};
 use crate::{repository_error::RepositoryError, DBType};
 use diesel::{dsl::IntoBoxed, prelude::*};
 
-/// A custom_field definition together with its per-scope display mode.
-/// `display_mode` is populated only when the query is scoped to a single
-/// `scope` (the per-`(custom_field, table)` mode lives on `custom_field_scope`);
-/// it is `None` for unscoped or multi-table queries.
+/// A custom_field definition together with its per-scope display mode and order.
+/// `display_mode`/`sort_order` are populated only when the query is scoped to a
+/// single `scope` (they live on `custom_field_scope`, per-`(custom_field, table)`);
+/// both are `None` for unscoped or multi-table queries. `sort_order` being an
+/// `Option` reflects "not known without a single scope", not column nullability —
+/// the column is `NOT NULL DEFAULT ''`.
 #[derive(Clone, Default, PartialEq, Debug)]
 pub struct CustomField {
     pub custom_field: CustomFieldRow,
     pub display_mode: Option<CustomFieldDisplayMode>,
+    pub sort_order: Option<String>,
 }
 
 /// Whether a custom_field is surfaced to read paths. The `Other` catch-all on
@@ -81,36 +84,59 @@ impl<'a> CustomFieldRepository<'a> {
         let query = Self::create_filtered_query(filter).order(custom_field::id.asc());
         let rows = query.load::<CustomFieldRow>(self.connection.lock().connection())?;
 
-        // When scoped to one table, fetch each custom_field's display_mode for that
-        // table so it can be surfaced per-scope (e.g. to drive toolbar promotion).
-        // Skip Hidden mappings to stay in lock-step with the main query (which
-        // already excludes them) — those rows could never be matched anyway.
-        let modes: HashMap<String, CustomFieldDisplayMode> = match &scope_table {
+        // When scoped to one table, fetch each custom_field's display_mode and
+        // sort_order for that table so they can be surfaced per-scope (display_mode
+        // drives toolbar promotion; sort_order drives display order below). Skip
+        // Hidden mappings to stay in lock-step with the main query (which already
+        // excludes them) — those rows could never be matched anyway.
+        let scope_meta: HashMap<String, (CustomFieldDisplayMode, String)> = match &scope_table {
             Some(scope) => custom_field_scope::table
                 .filter(custom_field_scope::scope.eq(scope))
                 .filter(custom_field_scope::display_mode.ne(CustomFieldDisplayMode::Hidden))
                 .select((
                     custom_field_scope::custom_field_id,
                     custom_field_scope::display_mode,
+                    custom_field_scope::sort_order,
                 ))
-                .load::<(String, CustomFieldDisplayMode)>(self.connection.lock().connection())?
+                .load::<(String, CustomFieldDisplayMode, String)>(
+                    self.connection.lock().connection(),
+                )?
                 .into_iter()
+                .map(|(id, mode, order)| (id, (mode, order)))
                 .collect(),
             None => HashMap::new(),
         };
 
         // Unrecognised value_type/kind (`Other`) are hidden — see `is_displayable`.
-        Ok(rows
+        let mut result: Vec<CustomField> = rows
             .into_iter()
             .filter(|custom_field| is_displayable(&custom_field.value_type, &custom_field.kind))
             .map(|custom_field| {
-                let display_mode = modes.get(&custom_field.id).cloned();
+                let meta = scope_meta.get(&custom_field.id).cloned();
+                let (display_mode, sort_order) = match meta {
+                    Some((mode, order)) => (Some(mode), Some(order)),
+                    None => (None, None),
+                };
                 CustomField {
                     custom_field,
                     display_mode,
+                    sort_order,
                 }
             })
-            .collect())
+            .collect();
+
+        // Order by the per-scope lexical rank then `id` (unranked `''`/None falls
+        // back to `id` order). Sorting in Rust keeps null-handling identical across
+        // SQLite/Postgres; the custom_field table is small (config definitions).
+        result.sort_by(|a, b| {
+            a.sort_order
+                .as_deref()
+                .unwrap_or_default()
+                .cmp(b.sort_order.as_deref().unwrap_or_default())
+                .then_with(|| a.custom_field.id.cmp(&b.custom_field.id))
+        });
+
+        Ok(result)
     }
 
     /// Returns the set of custom_field keys shown on the given table
@@ -148,25 +174,29 @@ impl<'a> CustomFieldRepository<'a> {
         &self,
         target_scope: &str,
     ) -> Result<Vec<CustomField>, RepositoryError> {
-        let rows: Vec<(CustomFieldRow, CustomFieldDisplayMode)> = custom_field::table
+        let rows: Vec<(CustomFieldRow, CustomFieldDisplayMode, String)> = custom_field::table
             .inner_join(custom_field_scope::table)
             .filter(custom_field::deleted_datetime.is_null())
             .filter(custom_field_scope::scope.eq(target_scope))
             .select((
                 custom_field::all_columns,
                 custom_field_scope::display_mode,
+                custom_field_scope::sort_order,
             ))
-            .order(custom_field::id.asc())
+            // Order by the per-scope lexical rank then `id` (unranked `''` falls
+            // back to `id` order).
+            .order((custom_field_scope::sort_order.asc(), custom_field::id.asc()))
             .load(self.connection.lock().connection())?;
 
         Ok(rows
             .into_iter()
-            .filter(|(custom_field, _)| {
+            .filter(|(custom_field, _, _)| {
                 is_displayable(&custom_field.value_type, &custom_field.kind)
             })
-            .map(|(custom_field, display_mode)| CustomField {
+            .map(|(custom_field, display_mode, sort_order)| CustomField {
                 custom_field,
                 display_mode: Some(display_mode),
+                sort_order: Some(sort_order),
             })
             .collect())
     }
@@ -281,6 +311,7 @@ mod tests {
             custom_field_id: custom_field_id.to_string(),
             scope: scope.to_string(),
             display_mode,
+            ..Default::default()
         }
     }
 
@@ -456,6 +487,57 @@ mod tests {
             .find(|r| r.custom_field.id == "p_prominent_name")
             .unwrap();
         assert_eq!(prominent.display_mode, None);
+    }
+
+    #[actix_rt::test]
+    async fn custom_field_query_orders_by_sort_order() {
+        // A scoped query returns fields in per-scope `sort_order` (lexical) order,
+        // not `id` order; unranked (`''`) fields fall back after ranked ones, then
+        // by `id`.
+        let (_, connection, _, _) = test_db::setup_all(
+            "custom_field_repository_orders_by_sort_order",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        let field_repo = CustomFieldRowRepository::new(&connection);
+        let scope_repo = CustomFieldScopeRowRepository::new(&connection);
+
+        // id order is a/b/c/d; the ranks below reorder them to c, a, b, with the
+        // unranked `d` falling to the end (`''` < any rank, but there are no other
+        // unranked rows here, so it lands last only because ranked ones sort first
+        // — assert the explicit expected order instead of reasoning about it).
+        for id in ["a_field", "b_field", "c_field", "d_field"] {
+            field_repo.upsert_one(&custom_field(id, id, false)).unwrap();
+        }
+        for (id, rank) in [
+            ("a_field", "0200"),
+            ("b_field", "0300"),
+            ("c_field", "0100"),
+            ("d_field", ""),
+        ] {
+            scope_repo
+                .upsert_one(&CustomFieldScopeRow {
+                    id: format!("{id}__name"),
+                    custom_field_id: id.to_string(),
+                    scope: "name".to_string(),
+                    display_mode: CustomFieldDisplayMode::Visible,
+                    sort_order: rank.to_string(),
+                })
+                .unwrap();
+        }
+
+        let repo = CustomFieldRepository::new(&connection);
+        let ordered: Vec<_> = repo
+            .query_by_filter(CustomFieldFilter::new().scope(EqualFilter::equal_to("name".to_string())))
+            .unwrap()
+            .into_iter()
+            .map(|r| r.custom_field.id)
+            .collect();
+
+        // Unranked `d_field` (`''`) sorts before the ranked ones (empty string is
+        // less than any digit string), then c/a/b by their ranks.
+        assert_eq!(ordered, vec!["d_field", "c_field", "a_field", "b_field"]);
     }
 
     #[actix_rt::test]

--- a/server/repository/src/db_diesel/custom_field_option_row.rs
+++ b/server/repository/src/db_diesel/custom_field_option_row.rs
@@ -19,6 +19,7 @@ table! {
         name -> Text,
         parent_option_id -> Nullable<Text>,
         deleted_datetime -> Nullable<Timestamp>,
+        sort_order -> Text,
     }
 }
 
@@ -38,6 +39,7 @@ pub struct CustomFieldOptionRow {
     pub name: String,
     pub parent_option_id: Option<String>,
     pub deleted_datetime: Option<NaiveDateTime>,
+    pub sort_order: String,
 }
 
 pub struct CustomFieldOptionRowRepository<'a> {
@@ -97,7 +99,8 @@ impl<'a> CustomFieldOptionRowRepository<'a> {
 
     /// Used by the `CustomFieldNode.options` GraphQL dataloader to batch
     /// option lookups across many custom_fields in a single request. Soft-deleted
-    /// options are excluded; rows are ordered by `id` for deterministic UI.
+    /// options are excluded; rows are ordered by `sort_order` then `id` for a
+    /// deterministic UI (unranked `''` sort_order falls back to `id` order).
     pub fn find_many_by_custom_field_ids(
         &self,
         custom_field_ids: &[String],
@@ -105,7 +108,10 @@ impl<'a> CustomFieldOptionRowRepository<'a> {
         Ok(custom_field_option::table
             .filter(custom_field_option::custom_field_id.eq_any(custom_field_ids))
             .filter(custom_field_option::deleted_datetime.is_null())
-            .order(custom_field_option::id.asc())
+            .order((
+                custom_field_option::sort_order.asc(),
+                custom_field_option::id.asc(),
+            ))
             .load(self.connection.lock().connection())?)
     }
 }
@@ -137,5 +143,65 @@ impl Upsert for CustomFieldOptionRow {
             CustomFieldOptionRowRepository::new(con).find_one_by_id(&self.id),
             Ok(Some(self.clone()))
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        mock::MockDataInserts, test_db, CustomFieldKind, CustomFieldRow, CustomFieldRowRepository,
+        CustomFieldValueType,
+    };
+
+    #[actix_rt::test]
+    async fn options_ordered_by_sort_order_then_id() {
+        // `find_many_by_custom_field_ids` (feeds the GraphQL dataloader) returns
+        // options ordered by `sort_order` (lexical) then `id`; unranked (`''`)
+        // options fall back to `id` order.
+        let (_, connection, _, _) =
+            test_db::setup_all("custom_field_option_ordering", MockDataInserts::none()).await;
+
+        // FK parent for the options.
+        CustomFieldRowRepository::new(&connection)
+            .upsert_one(&CustomFieldRow {
+                id: "field".to_string(),
+                key: "field".to_string(),
+                name: "Field".to_string(),
+                value_type: CustomFieldValueType::Option,
+                kind: CustomFieldKind::Legacy,
+                deleted_datetime: None,
+            })
+            .unwrap();
+
+        let repo = CustomFieldOptionRowRepository::new(&connection);
+        // id order is a/b/c/d; ranks reorder to c, a, b, with unranked `d` (`''`)
+        // sorting before all of them (empty string < any digit string).
+        for (opt_id, rank) in [
+            ("a", "000002"),
+            ("b", "000003"),
+            ("c", "000001"),
+            ("d", ""),
+        ] {
+            repo.upsert_one(&CustomFieldOptionRow {
+                id: opt_id.to_string(),
+                custom_field_id: "field".to_string(),
+                key: opt_id.to_string(),
+                name: opt_id.to_string(),
+                parent_option_id: None,
+                deleted_datetime: None,
+                sort_order: rank.to_string(),
+            })
+            .unwrap();
+        }
+
+        let ordered: Vec<_> = repo
+            .find_many_by_custom_field_ids(&["field".to_string()])
+            .unwrap()
+            .into_iter()
+            .map(|o| o.id)
+            .collect();
+
+        assert_eq!(ordered, vec!["d", "c", "a", "b"]);
     }
 }

--- a/server/repository/src/db_diesel/custom_field_scope_row.rs
+++ b/server/repository/src/db_diesel/custom_field_scope_row.rs
@@ -61,6 +61,7 @@ table! {
         custom_field_id -> Text,
         scope -> Text,
         display_mode -> diesel::sql_types::Text,
+        sort_order -> Text,
     }
 }
 
@@ -78,6 +79,7 @@ pub struct CustomFieldScopeRow {
     pub custom_field_id: String,
     pub scope: String,
     pub display_mode: CustomFieldDisplayMode,
+    pub sort_order: String,
 }
 
 pub struct CustomFieldScopeRowRepository<'a> {

--- a/server/repository/src/migrations/v3_00_00/add_custom_field_sort_order.rs
+++ b/server/repository/src/migrations/v3_00_00/add_custom_field_sort_order.rs
@@ -1,0 +1,30 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_custom_field_sort_order"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // Per-scope display order for custom_fields, and option order within an
+        // OPTION custom_field. A plain-TEXT lexical rank (fractional/LexoRank
+        // style) rather than an integer so a future reorder can always mint a key
+        // *between* two neighbours and write only the moved row. `NOT NULL DEFAULT
+        // ''` keeps ordering a simple `ORDER BY sort_order, id` that behaves the
+        // same on SQLite and Postgres (no nulls-ordering divergence); unranked
+        // rows ('') fall back to `id` order. Populated for legacy mapping fields by
+        // `central_mapping_custom_fields` and for options by the category
+        // translators.
+        sql!(
+            connection,
+            r#"
+                ALTER TABLE custom_field_scope ADD COLUMN sort_order TEXT NOT NULL DEFAULT '';
+                ALTER TABLE custom_field_option ADD COLUMN sort_order TEXT NOT NULL DEFAULT '';
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v3_00_00/mod.rs
+++ b/server/repository/src/migrations/v3_00_00/mod.rs
@@ -1,6 +1,7 @@
 use super::{version::Version, Migration, MigrationFragment};
 use crate::StorageConnection;
 
+mod add_custom_field_sort_order;
 mod add_invoice_custom_fields;
 mod add_is_standalone_central_pg_enum;
 mod add_item_custom_fields;
@@ -84,6 +85,8 @@ impl Migration for V3_00_00 {
             Box::new(reintegrate_transaction_categories_for_custom_field_options::Migrate),
             Box::new(remove_add_central_patient_visibility_processor_cursor::Migrate),
             Box::new(populate_routed_changelog_for_sync_v7_tables::Migrate),
+            // Must run after `create_custom_field` (adds columns to its tables).
+            Box::new(add_custom_field_sort_order::Migrate),
         ]
     }
 }

--- a/server/service/src/custom_field/mod.rs
+++ b/server/service/src/custom_field/mod.rs
@@ -211,6 +211,7 @@ mod tests {
             custom_field_id: field_id.to_string(),
             scope: scope.to_string(),
             display_mode: mode,
+            ..Default::default()
         }
     }
 

--- a/server/service/src/invoice/custom_fields.rs
+++ b/server/service/src/invoice/custom_fields.rs
@@ -78,6 +78,7 @@ mod test {
                 custom_field_id: "inbound_shipment_category".to_string(),
                 scope: "inbound_shipment".to_string(),
                 display_mode: CustomFieldDisplayMode::Visible,
+                ..Default::default()
             })
             .unwrap();
 

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -2417,6 +2417,7 @@ mod test {
                 custom_field_id: "inbound_shipment_category".to_string(),
                 scope: "inbound_shipment".to_string(),
                 display_mode: CustomFieldDisplayMode::Visible,
+                ..Default::default()
             })
             .unwrap();
 

--- a/server/service/src/programs/patient/update_custom_fields.rs
+++ b/server/service/src/programs/patient/update_custom_fields.rs
@@ -118,6 +118,7 @@ mod test {
                 custom_field_id: "custom_1".to_string(),
                 scope: "patient".to_string(),
                 display_mode: CustomFieldDisplayMode::Visible,
+                ..Default::default()
             })
             .unwrap();
     }

--- a/server/service/src/sync/central_mapping_custom_fields.rs
+++ b/server/service/src/sync/central_mapping_custom_fields.rs
@@ -94,6 +94,13 @@ struct MappingCustomField {
 /// The full set of legacy mSupply mapping custom_fields. Add new ones here; the
 /// central server seeds them on its next sync and they fan out to v7 remotes
 /// from there.
+///
+/// The **order of entries defines the per-scope display order**: each entry's
+/// index becomes its `sort_order` rank in `seed_central_mapping_custom_fields`,
+/// and fields render in that order within each scope they map to. Fields on
+/// different scopes never interact, so the item and name groups below can be
+/// interleaved freely — the order that matters is the relative order *within* a
+/// scope. Reordering entries here changes display order on the next central sync.
 fn mapping_custom_fields() -> Vec<MappingCustomField> {
     use keys::*;
     // Import value-type/display-mode variants explicitly rather than glob-importing
@@ -101,86 +108,15 @@ fn mapping_custom_fields() -> Vec<MappingCustomField> {
     use CustomFieldDisplayMode::{Prominent, Visible};
     use CustomFieldValueType::{Boolean, Option, Real, Text};
     vec![
-        // name `[name]custom1/2/3` — 4D column names are mapped onto snake_case
-        // slugs by the v5 name translator.
-        MappingCustomField {
-            key: NAME_CUSTOM_1,
-            name: "Custom 1",
-            value_type: Text,
-            display_mode: Visible,
-            scopes: &["customer", "supplier", "patient"],
-        },
-        MappingCustomField {
-            key: NAME_CUSTOM_2,
-            name: "Custom 2",
-            value_type: Text,
-            display_mode: Visible,
-            scopes: &["customer", "supplier", "patient"],
-        },
-        MappingCustomField {
-            key: NAME_CUSTOM_3,
-            name: "Custom 3",
-            value_type: Text,
-            display_mode: Visible,
-            scopes: &["customer", "supplier", "patient"],
-        },
-        // item `[item]user_field_1..7` — 4D names are already snake_case, so the
-        // key matches the wire field 1:1. Value types come from the 4D catalog.
-        MappingCustomField {
-            key: ITEM_USER_FIELD_1,
-            name: "User field 1",
-            value_type: Text,
-            display_mode: Visible,
-            scopes: &["item"],
-        },
-        MappingCustomField {
-            key: ITEM_USER_FIELD_2,
-            name: "User field 2",
-            value_type: Text,
-            display_mode: Visible,
-            scopes: &["item"],
-        },
-        MappingCustomField {
-            key: ITEM_USER_FIELD_3,
-            name: "User field 3",
-            value_type: Text,
-            display_mode: Visible,
-            scopes: &["item"],
-        },
-        MappingCustomField {
-            key: ITEM_USER_FIELD_4,
-            name: "User field 4",
-            value_type: Boolean,
-            display_mode: Visible,
-            scopes: &["item"],
-        },
-        MappingCustomField {
-            key: ITEM_USER_FIELD_5,
-            name: "User field 5",
-            value_type: Real,
-            display_mode: Visible,
-            scopes: &["item"],
-        },
-        MappingCustomField {
-            key: ITEM_USER_FIELD_6,
-            name: "User field 6",
-            value_type: Text,
-            display_mode: Visible,
-            scopes: &["item"],
-        },
-        MappingCustomField {
-            key: ITEM_USER_FIELD_7,
-            name: "User field 7",
-            value_type: Boolean,
-            display_mode: Visible,
-            scopes: &["item"],
-        },
+        // ===== item scope: categories first, then user fields =====
+
         // item categories — a single OPTION custom_field whose options are the
-        // mSupply `item_category*` levels. Unlike the fields above, its *options*
-        // are not seeded here: they are authored dynamically by the v5 category
-        // import (`translations/category.rs`, central-only) as `custom_field_option`
-        // rows. The item stores the leaf `category_ID` under this key. See the
-        // custom_fields dev doc — this is the deliberate "hard" mapping test.
+        // mSupply `item_category*` levels. Unlike the plain user fields below, its
+        // *options* are not seeded here: they are authored dynamically by the v5
+        // category import (`translations/category.rs`, central-only) as
+        // `custom_field_option` rows. The item stores the leaf `category_ID` under
+        // this key. See the custom_fields dev doc — this is the deliberate "hard"
+        // mapping test.
         MappingCustomField {
             key: ITEM_CATEGORY_1,
             name: "Category",
@@ -208,6 +144,61 @@ fn mapping_custom_fields() -> Vec<MappingCustomField> {
             display_mode: Visible,
             scopes: &["item"],
         },
+        // item `[item]user_field_1..7` — 4D names are already snake_case, so the
+        // key matches the wire field 1:1. Value types come from the 4D catalog.
+        // Deliberate display order (not strictly ascending): 1, 2, 3, 5, 6, 4, 7.
+        MappingCustomField {
+            key: ITEM_USER_FIELD_1,
+            name: "User field 1",
+            value_type: Text,
+            display_mode: Visible,
+            scopes: &["item"],
+        },
+        MappingCustomField {
+            key: ITEM_USER_FIELD_2,
+            name: "User field 2",
+            value_type: Text,
+            display_mode: Visible,
+            scopes: &["item"],
+        },
+        MappingCustomField {
+            key: ITEM_USER_FIELD_3,
+            name: "User field 3",
+            value_type: Text,
+            display_mode: Visible,
+            scopes: &["item"],
+        },
+        MappingCustomField {
+            key: ITEM_USER_FIELD_5,
+            name: "User field 5",
+            value_type: Real,
+            display_mode: Visible,
+            scopes: &["item"],
+        },
+        MappingCustomField {
+            key: ITEM_USER_FIELD_6,
+            name: "User field 6",
+            value_type: Text,
+            display_mode: Visible,
+            scopes: &["item"],
+        },
+        MappingCustomField {
+            key: ITEM_USER_FIELD_4,
+            name: "User field 4",
+            value_type: Boolean,
+            display_mode: Visible,
+            scopes: &["item"],
+        },
+        MappingCustomField {
+            key: ITEM_USER_FIELD_7,
+            name: "User field 7",
+            value_type: Boolean,
+            display_mode: Visible,
+            scopes: &["item"],
+        },
+        // ===== name scopes (customer / supplier / patient): categories first,
+        // then the name customs =====
+
         // name categories 1–6 — six independent OPTION dimensions
         // (`[name]category1_ID..category6_ID`). category1 is hierarchical (its
         // `name_category1*` level tables map via `parent_option_id`); 2–6 are flat.
@@ -258,6 +249,29 @@ fn mapping_custom_fields() -> Vec<MappingCustomField> {
             key: NAME_CATEGORY_6,
             name: "Category 6",
             value_type: Option,
+            display_mode: Visible,
+            scopes: &["customer", "supplier", "patient"],
+        },
+        // name `[name]custom1/2/3` — 4D column names are mapped onto snake_case
+        // slugs by the v5 name translator.
+        MappingCustomField {
+            key: NAME_CUSTOM_1,
+            name: "Custom 1",
+            value_type: Text,
+            display_mode: Visible,
+            scopes: &["customer", "supplier", "patient"],
+        },
+        MappingCustomField {
+            key: NAME_CUSTOM_2,
+            name: "Custom 2",
+            value_type: Text,
+            display_mode: Visible,
+            scopes: &["customer", "supplier", "patient"],
+        },
+        MappingCustomField {
+            key: NAME_CUSTOM_3,
+            name: "Custom 3",
+            value_type: Text,
             display_mode: Visible,
             scopes: &["customer", "supplier", "patient"],
         },
@@ -340,7 +354,7 @@ pub(crate) fn seed_central_mapping_custom_fields(
     let custom_field_repo = CustomFieldRowRepository::new(connection);
     let table_repo = CustomFieldScopeRowRepository::new(connection);
 
-    for def in mapping_custom_fields() {
+    for (index, def) in mapping_custom_fields().into_iter().enumerate() {
         let existing = custom_field_repo.find_one_by_id(def.key)?;
         let custom_field = CustomFieldRow {
             id: def.key.to_string(),
@@ -360,17 +374,33 @@ pub(crate) fn seed_central_mapping_custom_fields(
             custom_field_repo.upsert_one(&custom_field)?;
         }
 
-        // Only create each table mapping if it doesn't exist — never overwrite,
-        // so an admin's future display-mode change isn't reset on the next sync.
+        // Fixed, evenly-spaced lexical rank from the list index: `"0100"`,
+        // `"0200"`, … Zero-padded fixed width so the plain string compare matches
+        // list order, and gapped so a future reorder UI can mint a key between two
+        // neighbours (see `CustomFieldScopeRow::sort_order`). Reordering the list
+        // above changes display order on the next central sync.
+        let sort_order = format!("{:04}", (index + 1) * 100);
+
         for scope in def.scopes {
             let table_id = format!("{}__{}", def.key, scope);
-            if table_repo.find_one_by_id(&table_id)?.is_none() {
-                table_repo.upsert_one(&CustomFieldScopeRow {
-                    id: table_id,
-                    custom_field_id: def.key.to_string(),
-                    scope: scope.to_string(),
-                    display_mode: def.display_mode.clone(),
-                })?;
+            let existing_scope = table_repo.find_one_by_id(&table_id)?;
+            let scope_row = CustomFieldScopeRow {
+                id: table_id,
+                custom_field_id: def.key.to_string(),
+                scope: scope.to_string(),
+                // `display_mode` is admin-owned once the row exists (a config
+                // edit must survive re-seeds), so only default it on create.
+                // `sort_order` is code-authoritative for legacy fields, so it is
+                // (re)set here — this also backfills already-seeded centrals.
+                display_mode: existing_scope
+                    .as_ref()
+                    .map_or_else(|| def.display_mode.clone(), |row| row.display_mode.clone()),
+                sort_order: sort_order.clone(),
+            };
+            // Change-aware: only write when the row differs, so steady-state
+            // re-seeds add no changelog churn.
+            if existing_scope.as_ref() != Some(&scope_row) {
+                table_repo.upsert_one(&scope_row)?;
             }
         }
     }
@@ -439,6 +469,54 @@ mod tests {
         assert_eq!(patient_mapping.scope, "patient");
         assert_eq!(patient_mapping.display_mode, CustomFieldDisplayMode::Visible);
 
+        // sort_order ranks fields by their position in `mapping_custom_fields()`;
+        // assert the resulting per-scope display order matches the intended order
+        // (this is what changes when the list above is reordered).
+        let order_for = |scope: &str| {
+            let mut rows: Vec<_> = table_repo
+                .find_all()
+                .unwrap()
+                .into_iter()
+                .filter(|r| r.scope == scope)
+                .collect();
+            rows.sort_by(|a, b| a.sort_order.cmp(&b.sort_order));
+            rows.into_iter()
+                .map(|r| r.custom_field_id)
+                .collect::<Vec<_>>()
+        };
+
+        // item scope: categories, then user fields in order 1, 2, 3, 5, 6, 4, 7.
+        assert_eq!(
+            order_for("item"),
+            vec![
+                "item_category_1",
+                "item_category_2",
+                "item_category_3",
+                "user_field_1",
+                "user_field_2",
+                "user_field_3",
+                "user_field_5",
+                "user_field_6",
+                "user_field_4",
+                "user_field_7",
+            ]
+        );
+        // name scopes: categories 1–6, then customs 1–3 (same on every name scope).
+        assert_eq!(
+            order_for("patient"),
+            vec![
+                "name_category_1",
+                "name_category_2",
+                "name_category_3",
+                "name_category_4",
+                "name_category_5",
+                "name_category_6",
+                "custom_1",
+                "custom_2",
+                "custom_3",
+            ]
+        );
+
         // A second run is a no-op: change-aware seeding must not write (and so
         // must not add changelog rows) when nothing has changed.
         let cursor_before = changelog_repo.max_cursor().unwrap();
@@ -470,6 +548,7 @@ mod tests {
                 custom_field_id: "custom_1".to_string(),
                 scope: "customer".to_string(),
                 display_mode: CustomFieldDisplayMode::Hidden,
+                ..Default::default()
             })
             .unwrap();
         seed_central_mapping_custom_fields(&connection).unwrap();

--- a/server/service/src/sync/translations/category.rs
+++ b/server/service/src/sync/translations/category.rs
@@ -96,6 +96,10 @@ impl SyncTranslation for CategoryTranslation {
                 name: data.Description,
                 parent_option_id: data.parent_ID,
                 deleted_datetime: None,
+                // OG `sort_order` (an integer) as a fixed-width zero-padded string
+                // so lexical order matches the numeric order and stays comparable
+                // with the field-rank scheme (see custom_field_option_row.rs).
+                sort_order: format!("{:06}", data.sort_order),
             }));
         }
 

--- a/server/service/src/sync/translations/name_category.rs
+++ b/server/service/src/sync/translations/name_category.rs
@@ -54,6 +54,11 @@ pub struct LegacyNameCategoryRow {
     // `name_category1_level2`); absent/empty on level1 and the flat dimensions.
     #[serde(default, deserialize_with = "empty_str_as_option_string")]
     parent_ID: Option<String>,
+    // OG display order (same `sort_order` column item categories use). Defaulted
+    // so any table/record that omits it falls back to `id` order rather than
+    // failing the record.
+    #[serde(default)]
+    sort_order: i32,
 }
 
 // Needs to be added to all_translators()
@@ -107,6 +112,9 @@ impl SyncTranslation for NameCategoryTranslation {
             name: data.description,
             parent_option_id: data.parent_ID,
             deleted_datetime: None,
+            // OG `sort_order` as a fixed-width zero-padded string so lexical order
+            // matches the numeric order (see custom_field_option_row.rs).
+            sort_order: format!("{:06}", data.sort_order),
         }))
     }
 
@@ -169,13 +177,14 @@ mod tests {
             action: SyncAction::Upsert,
             ..Default::default()
         };
-        // A flat dimension has no parent.
+        // A flat dimension has no parent; `sort_order` carries the OG order.
         let cat4 = SyncBufferRow {
             table_name: "name_category4".to_string(),
             record_id: "N_CAT4".to_string(),
             data: SyncRecordData(serde_json::json!({
                 "ID": "N_CAT4",
                 "description": "Region A",
+                "sort_order": 5,
             })),
             action: SyncAction::Upsert,
             ..Default::default()
@@ -204,6 +213,12 @@ mod tests {
             .unwrap();
         let debug = format!("{result:?}");
         assert!(debug.contains("name_category_4"), "{}", debug);
+        // OG `sort_order` (5) persisted as the zero-padded lexical rank.
+        assert!(
+            debug.contains("000005"),
+            "OG sort_order must map to the option rank: {}",
+            debug
+        );
 
         // On a remote, nothing is authored (options arrive via v7).
         test_util_set_is_central_server(false);

--- a/server/service/src/sync/translations/transaction_category.rs
+++ b/server/service/src/sync/translations/transaction_category.rs
@@ -89,6 +89,9 @@ impl SyncTranslation for TransactionCategoryTranslation {
             name: data.category,
             parent_option_id: None,
             deleted_datetime: None,
+            // The `transaction_category` sync table doesn't carry an order field,
+            // so these options fall back to `id` order (empty rank).
+            sort_order: String::new(),
         }))
     }
 
@@ -181,6 +184,7 @@ mod tests {
                     name: "Donation".to_string(),
                     parent_option_id: None,
                     deleted_datetime: None,
+                    ..Default::default()
                 }),
             );
         }
@@ -234,6 +238,7 @@ mod tests {
                 name: "Donation".to_string(),
                 parent_option_id: None,
                 deleted_datetime: None,
+                ..Default::default()
             })
             .unwrap();
 


### PR DESCRIPTION
Fixes #12356

# 👩🏻‍💻 What does this PR do?

Custom fields and their options had no defined display order. The backend returned both ordered only by primary-key `id`, so the legacy mapping fields and their category options (e.g. item categories synced from OG) showed up in effectively random order — the ordering bug in this issue.

This adds a lexical `sort_order` rank end-to-end:

- **New columns** (migration `add_custom_field_sort_order`): `sort_order TEXT NOT NULL DEFAULT ''` on `custom_field_scope` (per-scope field order) and on `custom_field_option` (option order within an OPTION field). It's a plain-text fractional/LexoRank-style rank rather than an integer, so a future reorder UI can always mint a key *between* two neighbours and only write the moved row.
- **Field order** is hardcoded from each field's position in `mapping_custom_fields()` (the seeder writes the rank, code-authoritative, change-aware). Intended order — item scope: categories, then user fields `1, 2, 3, 5, 6, 4, 7`; name scopes: categories `1–6`, then customs `1–3`.
- **Option order** comes from OG's `sort_order` column, persisted onto `custom_field_option` by the item- and name-category translators.
- **Read paths** return fields and options already ordered (`custom_field.rs` query + option dataloader), so the client renders in received order. The invoice tab's ad-hoc alphabetical sort is removed so every custom-fields surface is consistent.

## 💌 Any notes for the reviewer?

- **Scope vs the issue.** The issue lists two things: (1) item categories displaying in random order, and (2) a stray "Click to Edit" link in the category filter. This PR fixes **(1)** — and goes a bit further by giving the mapping *fields* themselves a defined per-scope order and ordering the other option sets (name categories) too. The **"Click to Edit" link (2)** is not addressed here — it's probably coming from OG.
- **No config UI.** `sort_order` is deliberately a string rank to be future-proof for an admin drag-to-reorder UI, but that UI is **not** in this PR. The midpoint rank-generation helper is likewise deferred; the seeder just assigns fixed, gapped ranks (`"0100"`, `"0200"`, …).
- **Transaction categories** have no OG order field wired, so they fall back to `id` order (unchanged).

# 🧪 Testing

- [ ] Central sync server (connected to Legacy mSupply, not standalone) + an OMS remote, running this PR
- [ ] Define item categories in a deliberate order in OG; sync
- [ ] Open an Item detail → Custom fields tab: categories appear first, then user fields in order `1, 2, 3, 5, 6, 4, 7`
- [ ] Open a Name (customer / supplier / patient) → Custom fields: categories `1–6` first, then customs `1–3`
- [ ] Open the item Category filter / an OPTION dropdown: options appear in the OG-defined order, not random
- [ ] Confirm on both Postgres and SQLite
