### PR TITLE
#12366 Custom fields: show nothing for an unresolvable option value

### DIFF
--- a/client/packages/common/src/utils/customFields/customFields.test.ts
+++ b/client/packages/common/src/utils/customFields/customFields.test.ts
@@ -31,12 +31,18 @@ describe('resolveOptionValue', () => {
     expect(resolveOptionValue(definition, 'opt_1')).toBe('Red');
   });
 
-  it('falls back to the raw value for an unknown option id', () => {
-    expect(resolveOptionValue(definition, 'opt_missing')).toBe('opt_missing');
+  it('shows nothing for an unknown option id (e.g. a category deleted in OG before migration) rather than leaking the raw id', () => {
+    expect(resolveOptionValue(definition, 'opt_missing')).toBe('');
   });
 
   it('joins an array of option ids', () => {
     expect(resolveOptionValue(definition, ['opt_1', 'opt_2'])).toBe('Red, Blue');
+  });
+
+  it('drops unresolvable ids from an array so a missing id leaves no stray comma', () => {
+    expect(resolveOptionValue(definition, ['opt_1', 'opt_missing', 'opt_2'])).toBe(
+      'Red, Blue'
+    );
   });
 });
 

--- a/client/packages/common/src/utils/customFields/customFields.ts
+++ b/client/packages/common/src/utils/customFields/customFields.ts
@@ -117,17 +117,26 @@ export const getOptionAndDescendantIds = (
 };
 
 /**
- * Resolve an OPTION value (an option id, or array of ids) to its display name,
- * falling back to the raw value when the id isn't a known option.
+ * Resolve an OPTION value (an option id, or array of ids) to its display name.
+ * An id with no matching option resolves to '' — we show nothing rather than
+ * leaking the raw internal id (#12366). This happens for legacy categories
+ * deleted in mSupply before the OG→OMS migration: the `transaction_category`
+ * record is gone, so no `custom_field_option` ever syncs and the invoice's
+ * stored id references nothing. Mirrors OG, which falls back to "None" for an
+ * orphaned `category_ID`. (OMS-authored options are only ever soft-deleted, so
+ * their row — and label — survives and keeps resolving here.) Array entries
+ * that don't resolve are dropped so a missing id doesn't leave a stray comma.
  */
 export const resolveOptionValue = (
   definition: CustomFieldDefinitionLike,
   value: unknown
 ): string => {
-  const lookup = (v: unknown) =>
-    definition.options.find(o => o.id === v)?.name ?? String(v);
+  const lookup = (v: unknown): string =>
+    definition.options.find(o => o.id === v)?.name ?? '';
 
-  return Array.isArray(value) ? value.map(lookup).join(', ') : lookup(value);
+  return Array.isArray(value)
+    ? value.map(lookup).filter(Boolean).join(', ')
+    : lookup(value);
 };
 
 /**


### PR DESCRIPTION
Fixes #12366

# 👩🏻‍💻 What does this PR do?

Invoice OPTION custom fields whose stored id has no matching option were rendering the raw internal id in read-only display (the Custom fields tab). This happens for legacy transaction categories deleted in mSupply before the OG→OMS migration — the `transaction_category` is gone, so no `custom_field_option` syncs and the stored id resolves to nothing.

`resolveOptionValue` now resolves an unresolvable id to `''` (show nothing) instead of the raw id, mirroring OG which shows "None" for an orphaned `category_ID`.

## 💌 Any notes for the reviewer?

Single-file change in the shared `customFields` helper, so it covers every record kind. The editable dropdown already blanked unresolved values; this closes the read-only gap.
