### PR TITLE
12333 Add inbound shipment status validation plugin

### DIFF
--- a/client/packages/common/src/plugins/types.ts
+++ b/client/packages/common/src/plugins/types.ts
@@ -16,7 +16,7 @@ import {
 import { PrescriptionPaymentComponentProps } from './prescriptionTypes';
 import { DraftRequestLine } from 'packages/requisitions/src/RequestRequisition/DetailView/RequestLineEdit';
 import { StocktakeLineFragment } from '@openmsupply-client/inventory';
-import { UserPermission } from '../types/schema';
+import { InvoiceNodeStatus, UserPermission } from '../types/schema';
 
 // Plugins import any icon they want from `@openmsupply-client/common` (e.g.
 // `StockIcon`) and pass it directly. The host renders it themed to match the
@@ -57,6 +57,14 @@ export type ShipmentLinePluginState = {
 export type Plugins = {
   prescriptionPaymentForm?: React.ComponentType<PrescriptionPaymentComponentProps>[];
   inboundShipmentAppBar?: React.ComponentType<{ shipment: InboundFragment }>[];
+  inboundShipment?: {
+    // Runs before an inbound shipment status change. Each validator returns a
+    // user-facing message to BLOCK the transition, or null to allow it.
+    validateStatusChange?: ((
+      shipment: InboundFragment,
+      targetStatus: InvoiceNodeStatus
+    ) => string | null)[];
+  };
   inboundShipmentLine?: {
     editViewField: {
       header: string;

--- a/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx
@@ -10,6 +10,7 @@ import {
   useConfirmationModal,
   useDisabledNotificationToast,
   usePreferences,
+  usePluginProvider,
 } from '@openmsupply-client/common';
 import {
   isInboundPlaceholderRow,
@@ -37,6 +38,7 @@ const StatusChangeButtonContent = ({
 }) => {
   const t = useTranslation();
   const { invoiceStatusOptions } = usePreferences();
+  const { plugins } = usePluginProvider();
   const { success, error } = useNotification();
   const { status, onHold, lines } = data;
   const shipmentType = getInboundShipmentType(data);
@@ -138,6 +140,11 @@ const StatusChangeButtonContent = ({
       if (!validateNoPendingLines(lines)) {
         return pendingLinesNotification();
       }
+    }
+    // Let plugins block the transition (e.g. require a discrepancy reason).
+    for (const validate of plugins.inboundShipment?.validateStatusChange ?? []) {
+      const message = validate(data, selectedOption.value);
+      if (message) return error(message)();
     }
     if (selectedOption?.value === InvoiceNodeStatus.Verified) return onVerify();
     return getConfirmation();

--- a/docs/content/client/packages/plugins/_index.md
+++ b/docs/content/client/packages/plugins/_index.md
@@ -73,6 +73,10 @@ Register a complete page with its own route and menu item. The plugin chooses wh
 
 Array of components rendered in the app bar of the inbound-shipment detail view. Each receives the current `shipment: InboundFragment` as a prop.
 
+### Inbound shipment status change — `inboundShipment.validateStatusChange`
+
+Array of **pure validator functions** run before an inbound-shipment status change (from the detail-view footer). Each receives `(shipment: InboundFragment, targetStatus: InvoiceNodeStatus)` and returns a user-facing message to **block** the transition, or `null` to allow it. The host runs them after its own checks (permission, empty invoice, on-hold, pending lines) and shows the first returned message as an error. Use this to enforce a rule across all lines at receive/verify time — e.g. requiring a discrepancy reason — that a per-line `editViewField` alone can't guarantee (bulk actions like "set quantities to 0" never open the line modal). Functions must be pure (no React hooks); they run against the shipment data already loaded by the host.
+
 ### Prescription — `prescriptionPaymentForm`
 
 Array of components rendered inside the prescription payment dialog. Receives props described by `PrescriptionPaymentComponentProps`.


### PR DESCRIPTION
Fixes #12333 

# 👩🏻‍💻 What does this PR do?
Adds a **generic plugin extension point** to the frontend plugin framework: `inboundShipment.validateStatusChange`. Registered validators run **before an inbound shipment status change** (from the detail-view footer's status button); if any validator returns a message, the transition is blocked and that message is shown to the user.

Core carries **no business logic** — it's a neutral capability ("a plugin may veto an inbound status change with a message") and is a complete **no-op when no plugin registers a validator**, exactly like the existing empty slots (`inboundShipmentAppBar`, `inboundShipmentLine`, …).

**Why:** plugins that add per-line rules (e.g. the delivery-discrepancy "reason" plugin) could previously only enforce them inside the line-edit modal. Bulk/list actions such as "Set quantities to 0", and simply clicking Verify, bypassed that enforcement. This slot lets a plugin apply its rule from a single place at status-change time, closing those gaps — without baking plugin-specific rules into core.

Changes:
- `client/packages/common/src/plugins/types.ts` — new `inboundShipment.validateStatusChange` slot on the `Plugins` type.
- `client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx` — runs the registered validators in `onStatusClick` (after the existing permission / empty / on-hold / pending-line checks, before confirm/verify) and blocks with the returned message.
- `docs/content/client/packages/plugins/_index.md` — documents the new injection point in the "Available injection points" list.

<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

## 💌 Any notes for the reviewer?

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->

# 🧪 Tested
- `yarn re-compile` (host typecheck) passes.
- Manual, with a plugin registering a `validateStatusChange` validator (the [haiti-plugins](https://github.com/msupply-foundation/haiti-plugins/pull/11)):
- Created an inbound discrepancy via manual quantity entry, via a pack-size change (same packs, different pack size), and via "Set quantities to 0" from the list view — in each case attempting to Receive/Verify was blocked with the plugin's message until a reason was selected; selecting a reason unblocked the transition.
- Confirmed that with **no** plugin contributing a validator, the status-change flow behaves exactly as before (slot is a no-op).

# 📃 Documentation

- [x] **Developer docs needed** (`docs: internal`) — new plugin injection point:
  - Added `inboundShipment.validateStatusChange` to the "Available injection points" list in `docs/content/client packages/plugins/_index.md`: a validator array run before an inbound status change; return a message to block the transition, or `null` to allow it. No-op when unused.
