### PR TITLE
12307 12308 Persist outbound variance fields on first save

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1879,6 +1879,7 @@
   "log.invoice-date-backdated": "Received date backdated",
   "log.invoice-deleted": "Deleted",
   "log.invoice-number-allocated": "Number allocated",
+  "log.invoice-received-qty-updated": "Received quantity updated",
   "log.invoice-status-allocated": "Status changed to Allocated",
   "log.invoice-status-delivered": "Status changed to Delivered",
   "log.invoice-status-picked": "Status changed to Picked",

--- a/client/packages/common/src/plugins/types.ts
+++ b/client/packages/common/src/plugins/types.ts
@@ -81,6 +81,7 @@ export type Plugins = {
       header: string;
       Component: React.ComponentType<{
         line: StockOutLineFragment;
+        update: (patch: Partial<StockOutLineFragment>) => void;
         events: UsePluginEvents<ShipmentLinePluginState>;
         isExternal: boolean;
       }>;

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -72,6 +72,7 @@ export const OutboundLineEditTable = ({
     manualAllocate,
     setVvmStatus,
     setReceivedNumberOfPacks,
+    setReasonOption,
   } = useAllocationContext(
     useShallow(state => {
       const { placeholderUnits, item, allocateIn } = state;
@@ -85,6 +86,7 @@ export const OutboundLineEditTable = ({
         manualAllocate: state.manualAllocate,
         setVvmStatus: state.setVvmStatus,
         setReceivedNumberOfPacks: state.setReceivedNumberOfPacks,
+        setReasonOption: state.setReasonOption,
         // In packs & units: we show totals in units
         // In doses: we show totals in doses
         allocatedQuantity: getAllocatedQuantity({
@@ -147,6 +149,7 @@ export const OutboundLineEditTable = ({
     allocateIn: allocateIn,
     setVvmStatus,
     setReceivedNumberOfPacks,
+    setReasonOption,
     pluginEvents,
     getIsDisabled,
   });

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/OutboundLineEditTable.tsx
@@ -72,7 +72,7 @@ export const OutboundLineEditTable = ({
     manualAllocate,
     setVvmStatus,
     setReceivedNumberOfPacks,
-    setReasonOption,
+    updateLine,
   } = useAllocationContext(
     useShallow(state => {
       const { placeholderUnits, item, allocateIn } = state;
@@ -86,7 +86,7 @@ export const OutboundLineEditTable = ({
         manualAllocate: state.manualAllocate,
         setVvmStatus: state.setVvmStatus,
         setReceivedNumberOfPacks: state.setReceivedNumberOfPacks,
-        setReasonOption: state.setReasonOption,
+        updateLine: state.updateLine,
         // In packs & units: we show totals in units
         // In doses: we show totals in doses
         allocatedQuantity: getAllocatedQuantity({
@@ -149,7 +149,7 @@ export const OutboundLineEditTable = ({
     allocateIn: allocateIn,
     setVvmStatus,
     setReceivedNumberOfPacks,
-    setReasonOption,
+    updateLine,
     pluginEvents,
     getIsDisabled,
   });

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.tsx
@@ -56,7 +56,7 @@ export const useOutboundLineEditColumns = ({
   allocateIn,
   setVvmStatus,
   setReceivedNumberOfPacks,
-  setReasonOption,
+  updateLine,
   pluginEvents,
   getIsDisabled,
 }: {
@@ -68,10 +68,7 @@ export const useOutboundLineEditColumns = ({
   allocateIn: AllocateInOption;
   setVvmStatus: (id: string, vvmStatus?: VvmStatusFragment | null) => void;
   setReceivedNumberOfPacks: (id: string, value: number | null) => void;
-  setReasonOption: (
-    id: string,
-    reasonOption: DraftStockOutLineFragment['reasonOption']
-  ) => void;
+  updateLine: (id: string, patch: Partial<DraftStockOutLineFragment>) => void;
   pluginEvents: UsePluginEvents<ShipmentLinePluginState>;
 }) => {
   const { store } = useAuthContext();
@@ -199,7 +196,10 @@ export const useOutboundLineEditColumns = ({
         includeColumn:
           isExternalSupplier && !!store?.preferences.issueInForeignCurrency,
         Cell: props => (
-          <CurrencyValueCell {...props} currencyCode={currency?.code as Currencies} />
+          <CurrencyValueCell
+            {...props}
+            currencyCode={currency?.code as Currencies}
+          />
         ),
         accessorFn: rowData =>
           currency ? rowData.sellPricePerPack / currency.rate : undefined,
@@ -269,9 +269,9 @@ export const useOutboundLineEditColumns = ({
             max={
               dosesView
                 ? QuantityUtils.packsToDoses(
-                  row.original.availablePacks,
-                  row.original
-                )
+                    row.original.availablePacks,
+                    row.original
+                  )
                 : row.original.availablePacks
             }
             disabled={getIsDisabled(row.original)}
@@ -329,7 +329,10 @@ export const useOutboundLineEditColumns = ({
         includeColumn: isExternalSupplier,
       },
       ...(plugins.outboundShipmentLine?.editViewField ?? []).map(
-        ({ header, Component }, index): ColumnDef<DraftStockOutLineFragment> => ({
+        (
+          { header, Component },
+          index
+        ): ColumnDef<DraftStockOutLineFragment> => ({
           id: `plugin-field-${index}`,
           header,
           size: 180,
@@ -339,7 +342,10 @@ export const useOutboundLineEditColumns = ({
             <Component
               line={row.original as unknown as StockOutLineFragment}
               update={patch =>
-                setReasonOption(row.original.id, patch.reasonOption ?? null)
+                updateLine(
+                  row.original.id,
+                  patch as Partial<DraftStockOutLineFragment>
+                )
               }
               events={pluginEvents}
               isExternal={isExternalSupplier}

--- a/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/OutboundLineEdit/columns.tsx
@@ -56,6 +56,7 @@ export const useOutboundLineEditColumns = ({
   allocateIn,
   setVvmStatus,
   setReceivedNumberOfPacks,
+  setReasonOption,
   pluginEvents,
   getIsDisabled,
 }: {
@@ -67,6 +68,10 @@ export const useOutboundLineEditColumns = ({
   allocateIn: AllocateInOption;
   setVvmStatus: (id: string, vvmStatus?: VvmStatusFragment | null) => void;
   setReceivedNumberOfPacks: (id: string, value: number | null) => void;
+  setReasonOption: (
+    id: string,
+    reasonOption: DraftStockOutLineFragment['reasonOption']
+  ) => void;
   pluginEvents: UsePluginEvents<ShipmentLinePluginState>;
 }) => {
   const { store } = useAuthContext();
@@ -290,8 +295,9 @@ export const useOutboundLineEditColumns = ({
       },
       {
         id: 'receivedNumberOfPacks',
-        // Pre-populate with issued packs; user can edit to record a variance.
-        accessorFn: row => row.receivedNumberOfPacks ?? row.numberOfPacks,
+        // Empty until the destination reports what it received; the user enters
+        // the received quantity to record a variance.
+        accessorFn: row => row.receivedNumberOfPacks,
         header: t('label.packs-received'),
         description: t('description.packs-received'),
         columnType: ColumnType.Number,
@@ -332,6 +338,9 @@ export const useOutboundLineEditColumns = ({
           Cell: ({ row }) => (
             <Component
               line={row.original as unknown as StockOutLineFragment}
+              update={patch =>
+                setReasonOption(row.original.id, patch.reasonOption ?? null)
+              }
               events={pluginEvents}
               isExternal={isExternalSupplier}
             />

--- a/client/packages/invoices/src/OutboundShipment/DetailView/columns.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/columns.tsx
@@ -110,7 +110,8 @@ export const useOutboundColumns = () => {
       },
       {
         id: 'receivedNumberOfPacks',
-        accessorFn: row => row.receivedNumberOfPacks ?? row.numberOfPacks,
+        // Null until the destination reports what it received — shown as a dash.
+        accessorFn: row => row.receivedNumberOfPacks,
         header: t('label.packs-received'),
         description: t('description.packs-received'),
         columnType: ColumnType.Number,

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/useSaveOutboundLines.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/useSaveOutboundLines.ts
@@ -28,10 +28,12 @@ export const useSaveOutboundLines = (outboundId: string) => {
             campaignId: line.campaign?.id,
             programId: line.program?.id,
             vvmStatusId: 'vvmStatus' in line ? line.vvmStatus?.id : null,
-            // Default received to issued when unset, so only an explicit
-            // edit creates a variance.
-            receivedNumberOfPacks:
-              line.receivedNumberOfPacks ?? line.numberOfPacks,
+            // Persist received as-is (null until the destination reports it), so
+            // it isn't faked as the issued quantity before receipt.
+            receivedNumberOfPacks: line.receivedNumberOfPacks,
+            // Carry the discrepancy reason on the same save path so it isn't
+            // cleared by this batch update.
+            reasonOptionId: line.reasonOption?.id ?? null,
           })),
           placeholderQuantity,
         },

--- a/client/packages/invoices/src/StockOut/useAllocationContext.ts
+++ b/client/packages/invoices/src/StockOut/useAllocationContext.ts
@@ -85,6 +85,10 @@ interface AllocationContext {
   setNote: (note: string | null) => void;
   setVvmStatus: (id: string, vvmStatus?: VvmStatusFragment | null) => void;
   setReceivedNumberOfPacks: (id: string, value: number | null) => void;
+  setReasonOption: (
+    id: string,
+    reasonOption: DraftStockOutLineFragment['reasonOption']
+  ) => void;
   setAllocateIn: (
     allocateIn: AllocateInOption,
     // TODO: these are passed into a few functions, can we intialise with them instead?
@@ -309,6 +313,14 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
     const { draftLines } = get();
     const updatedLines = draftLines.map(line =>
       line.id === id ? { ...line, receivedNumberOfPacks: value } : line
+    );
+    set(state => ({ ...state, draftLines: updatedLines, isDirty: true }));
+  },
+
+  setReasonOption: (id, reasonOption) => {
+    const { draftLines } = get();
+    const updatedLines = draftLines.map(line =>
+      line.id === id ? { ...line, reasonOption } : line
     );
     set(state => ({ ...state, draftLines: updatedLines, isDirty: true }));
   },

--- a/client/packages/invoices/src/StockOut/useAllocationContext.ts
+++ b/client/packages/invoices/src/StockOut/useAllocationContext.ts
@@ -85,10 +85,7 @@ interface AllocationContext {
   setNote: (note: string | null) => void;
   setVvmStatus: (id: string, vvmStatus?: VvmStatusFragment | null) => void;
   setReceivedNumberOfPacks: (id: string, value: number | null) => void;
-  setReasonOption: (
-    id: string,
-    reasonOption: DraftStockOutLineFragment['reasonOption']
-  ) => void;
+  updateLine: (id: string, patch: Partial<DraftStockOutLineFragment>) => void;
   setAllocateIn: (
     allocateIn: AllocateInOption,
     // TODO: these are passed into a few functions, can we intialise with them instead?
@@ -317,10 +314,10 @@ export const useAllocationContext = create<AllocationContext>((set, get) => ({
     set(state => ({ ...state, draftLines: updatedLines, isDirty: true }));
   },
 
-  setReasonOption: (id, reasonOption) => {
+  updateLine: (id, patch) => {
     const { draftLines } = get();
     const updatedLines = draftLines.map(line =>
-      line.id === id ? { ...line, reasonOption } : line
+      line.id === id ? { ...line, ...patch } : line
     );
     set(state => ({ ...state, draftLines: updatedLines, isDirty: true }));
   },

--- a/server/service/src/invoice_line/save_stock_out_item_lines/generate.rs
+++ b/server/service/src/invoice_line/save_stock_out_item_lines/generate.rs
@@ -118,7 +118,15 @@ pub fn generate(
     let lines_to_update = lines
         .clone()
         .into_iter()
-        .filter(|line| line.number_of_packs > 0.0 && check_already_exists(&line.id))
+        .filter(|line| {
+            line.number_of_packs > 0.0
+                && (check_already_exists(&line.id)
+                    // A newly-allocated line carrying a received qty or a
+                    // discrepancy reason is inserted above, then also updated
+                    // here to persist those fields (the insert path drops them).
+                    || line.received_number_of_packs.is_some()
+                    || line.reason_option_id.is_some())
+        })
         .map(
             |SaveStockOutInvoiceLine {
                  id,

--- a/server/service/src/invoice_line/save_stock_out_item_lines/mod.rs
+++ b/server/service/src/invoice_line/save_stock_out_item_lines/mod.rs
@@ -199,7 +199,8 @@ mod test {
     use repository::{
         mock::{
             mock_item_a, mock_name_store_b, mock_outbound_shipment_a, mock_stock_line_a,
-            mock_stock_line_b, mock_stock_line_vaccine_item_a, mock_store_a, mock_store_b,
+            mock_shipment_variance_reason_option, mock_stock_line_b,
+            mock_stock_line_vaccine_item_a, mock_store_a, mock_store_b,
             mock_transferred_inbound_shipment_a, mock_user_account_a, MockData, MockDataInserts,
         },
         test_db::setup_all_with_data,
@@ -455,5 +456,71 @@ mod test {
         assert!(!updated_lines
             .iter()
             .any(|line| line.id == line_to_delete().id));
+    }
+
+    #[actix_rt::test]
+    async fn test_save_outbound_new_line_persists_received_and_reason() {
+        fn outbound() -> InvoiceRow {
+            InvoiceRow {
+                id: "outbound_variance".to_string(),
+                store_id: mock_store_b().id,
+                name_id: mock_name_store_b().id,
+                r#type: InvoiceType::OutboundShipment,
+                status: InvoiceStatus::New,
+                ..Default::default()
+            }
+        }
+
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "test_save_outbound_new_line_persists_received_and_reason",
+            MockDataInserts::all(),
+            MockData {
+                invoices: vec![outbound()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_b().id, mock_user_account_a().id)
+            .unwrap();
+
+        // First save of a brand-new line that carries a received qty and a
+        // discrepancy reason. The insert path drops these, so they must be
+        // applied via the follow-up update — otherwise they'd only persist on a
+        // second save.
+        service_provider
+            .invoice_line_service
+            .save_stock_out_item_lines(
+                &context,
+                SaveStockOutItemLines {
+                    invoice_id: outbound().id,
+                    item_id: mock_item_a().id,
+                    lines: vec![SaveStockOutInvoiceLine {
+                        id: "new_variance_line".to_string(),
+                        number_of_packs: 5.0,
+                        stock_line_id: mock_stock_line_a().id,
+                        received_number_of_packs: Some(3.0),
+                        reason_option_id: Some(mock_shipment_variance_reason_option().id),
+                        ..Default::default()
+                    }],
+                    placeholder_quantity: None,
+                    prescribed_quantity: None,
+                    note: None,
+                },
+            )
+            .unwrap();
+
+        let line = InvoiceLineRowRepository::new(&connection)
+            .find_one_by_id("new_variance_line")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(line.received_number_of_packs, Some(3.0));
+        assert_eq!(
+            line.reason_option_id,
+            Some(mock_shipment_variance_reason_option().id)
+        );
     }
 }


### PR DESCRIPTION
Fixes #12307 #12308 #12310

# 👩🏻‍💻 What does this PR do?
Fixes three related bugs on outbound shipment lines — the received packs and the delivery-discrepancy reason (the reason field is provided by the haiti plugin):

1. **"Packs Received" showed / persisted the issued quantity before receipt.**
Display and save fell back to `receivedNumberOfPacks ?? numberOfPacks`, so an unreceived line showed the issued qty and any save wrote `received = issued` (making it non-null forever, before the customer had received anything).
2. **Received packs and the reason weren't saved on the first save — only the second.** A newly-allocated line goes through the server **insert** path, which doesn't carry `received_number_of_packs` / `reason_option_id`; only the **update** path applies them. So the first save (insert) dropped both, and they only stuck on a later save (update, once the line already existed).
3. **The reason could be cleared by the batch save**, because the client didn't send `reasonOptionId` and the server batch generate wraps it in a `NullableUpdate` (a null value clears the field).

**Client**
- `common/src/plugins/types.ts` — add an `update: (patch) => void` prop to the outbound `editViewField` slot (mirrors inbound) so the plugin writes the reason into the draft instead of via its own mutation.
- `StockOut/useAllocationContext.ts` — add a `setReasonOption` draft setter (mirrors `setReceivedNumberOfPacks`).
- `OutboundLineEdit/columns.tsx` + `OutboundLineEditTable.tsx` — thread `setReasonOption` through and pass `update` to the plugin component.
- `useSaveOutboundLines.ts` — send `reasonOptionId` from the draft (so it isn't cleared) and send `receivedNumberOfPacks` as-is (drop `?? numberOfPacks`).
- `OutboundShipment/DetailView/columns.tsx` + `OutboundLineEdit/columns.tsx` — drop the `?? numberOfPacks` fallback so an unreceived line renders as a dash.

**Server**
- `invoice_line/save_stock_out_item_lines/generate.rs` — widen the `lines_to_update` filter so a **new** line that carries a received qty or a reason is also updated after it's inserted. The insert creates the line; the follow-up update (same transaction) persists the received/reason fields the insert path drops — fixing the "only saves on the second attempt" bug.

**Note: Referenced [haiti-plugins](https://github.com/msupply-foundation/haiti-plugins/pull/15) changes to test**
<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

## 💌 Any notes for the reviewer?

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->

# 🧪 Tested
- Added `test_save_outbound_new_line_persists_received_and_reason` (`cargo nextest run -p service`): a first-save **new** line carrying `receivedNumberOfPacks` and a `reasonOptionId` now persists **both**. Existing batch-save tests (`_success`, `_errors`, `remap_ids`) still pass.
- `cargo check -p service` clean; client `yarn re-compile` clean.
- Manual (external-supplier outbound, plugin loaded): allocated a vaccine line — "Packs Received" showed a dash (not the issued qty); edited received to differ from issued → reason enabled; picked a reason → OK → reopened the line: received, difference, and reason all persisted on the **first** save (and survived a reopen). With the preference/plugin absent, status changes behave as before.


# 📃 Documentation

- [x] **No documentation required** — bug fix restoring correct behaviour (received shows a dash until reported, and received/reason persist on save; the previous "received = issued before receipt" was a defect, not a documented feature). The outbound `editViewField` slot gaining an `update` prop simply mirrors the already-documented inbound slot.
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
