### PR TITLE
12407 Fix line edit modal input hidden by soft keyboard on Android tablets

### DIFF
--- a/client/packages/common/src/hooks/useDialog/useDialog.tsx
+++ b/client/packages/common/src/hooks/useDialog/useDialog.tsx
@@ -173,7 +173,7 @@ export const useDialog = (dialogProps?: DialogProps): DialogState => {
       isRtl,
       animationTimeout
     );
-    const { keyboardIsOpen } = useKeyboard();
+    const { keyboardIsOpen, keyboardHeight } = useKeyboard();
     const isAndroid = EnvUtils.platform === Platform.Android;
 
     const defaultPreventedOnClick =
@@ -224,6 +224,73 @@ export const useDialog = (dialogProps?: DialogProps): DialogState => {
 
     const formProps = enableAutocomplete ? { autoComplete: 'on' } : {};
     const { sx: contentSX, ...restOfContentProps } = contentProps ?? {};
+
+    // The Android soft keyboard shrinks the fullscreen modal's viewport. The
+    // rigid flex layout (#11891) has only the inner table scroll, so the focused
+    // input gets trapped under the keyboard. While the keyboard is open, fall
+    // back to a scrollable body so the input can scroll into view. Gated on
+    // isAndroid && keyboardIsOpen (never true off-device), so desktop/web keep
+    // the #11891 layout untouched.
+    const scrollBodyForKeyboard = isAndroid && keyboardIsOpen;
+
+    // Center the focused input in the scroll area so its row and neighbors stay
+    // visible above the keyboard (native-app "scroll on focus" behavior).
+    // scrollIntoView is unreliable in the Android WebView (smooth scroll gets
+    // cancelled by the tap, wrong scroll ancestor picked), so we find the real
+    // scroll container and set scrollTop ourselves.
+    const centerFocusedInScroll = () => {
+      // rAF: measure after layout/paint has settled.
+      requestAnimationFrame(() => {
+        const el = document.activeElement;
+        if (!(el instanceof HTMLElement)) return;
+
+        // Nearest vertically scrollable ancestor.
+        let node = el.parentElement;
+        let scroller: HTMLElement | null = null;
+        while (node) {
+          const { overflowY } = window.getComputedStyle(node);
+          if (
+            /(auto|scroll)/.test(overflowY) &&
+            node.scrollHeight > node.clientHeight
+          ) {
+            scroller = node;
+            break;
+          }
+          node = node.parentElement;
+        }
+        if (!scroller) return;
+
+        const elRect = el.getBoundingClientRect();
+        const scRect = scroller.getBoundingClientRect();
+        const delta =
+          elRect.top -
+          scRect.top -
+          (scroller.clientHeight / 2 - elRect.height / 2);
+        scroller.scrollBy({ top: delta, behavior: 'smooth' });
+      });
+    };
+
+    // Keyboard opening: the focus event fires before scrollBodyForKeyboard
+    // flips, so this handles the first focus (delay = keyboard animation).
+    React.useEffect(() => {
+      if (!scrollBodyForKeyboard) return;
+      const id = setTimeout(centerFocusedInScroll, 150);
+      return () => clearTimeout(id);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [scrollBodyForKeyboard, keyboardHeight]);
+
+    // Moving between rows with the keyboard already open: no resize fires, so
+    // re-center on each focus.
+    const handleFormFocus = () => {
+      if (scrollBodyForKeyboard) centerFocusedInScroll();
+    };
+
+    // Children wrapper. Default: fill the modal so the inner table scrolls
+    // internally (#11891). Keyboard open: plain block that flows to its natural
+    // height, padded by the keyboard height so the last rows can scroll clear.
+    const keyboardScrollWrapperStyle: React.CSSProperties = scrollBodyForKeyboard
+      ? { display: 'block', paddingBottom: keyboardHeight }
+      : { flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' };
     const dimensions = {
       height: height ? Math.min(window.innerHeight - 50, height) : undefined,
       width: width ? Math.min(window.innerWidth - 50, width) : undefined,
@@ -269,40 +336,33 @@ export const useDialog = (dialogProps?: DialogProps): DialogState => {
             display: 'flex',
             flexDirection: 'column',
             flex: '1 1 auto',
-            overflow: 'hidden',
+            overflow: scrollBodyForKeyboard ? 'auto' : 'hidden',
             width: defaultFullscreen ? '100%' : dimensions.width,
             margin: '0 auto',
           }}
+          onFocus={handleFormFocus}
           {...formProps}
         >
           <DialogContent
             {...restOfContentProps}
-            sx={{ overflowX: 'hidden', ...contentSX }}
+            sx={{
+              overflowX: 'hidden',
+              ...contentSX,
+              // Override the per-modal overflowY:hidden / display:flex lock so
+              // the body can scroll the focused input above the keyboard.
+              ...(scrollBodyForKeyboard
+                ? { overflowY: 'auto', display: 'block' }
+                : {}),
+            }}
           >
             {slideAnimation ? (
               <Slide in={slideConfig.in} direction={slideConfig.direction}>
-                <div
-                  style={{
-                    flex: 1,
-                    minHeight: 0,
-                    display: 'flex',
-                    flexDirection: 'column',
-                  }}
-                >
+                <div style={keyboardScrollWrapperStyle}>
                   {slideConfig.in && children}
                 </div>
               </Slide>
             ) : (
-              <div
-                style={{
-                  flex: 1,
-                  minHeight: 0,
-                  display: 'flex',
-                  flexDirection: 'column',
-                }}
-              >
-                {children}
-              </div>
+              <div style={keyboardScrollWrapperStyle}>{children}</div>
             )}
           </DialogContent>
           <DialogActions

--- a/client/packages/common/src/hooks/useKeyboard/Keyboard.tsx
+++ b/client/packages/common/src/hooks/useKeyboard/Keyboard.tsx
@@ -5,23 +5,31 @@ import { create } from 'zustand';
 interface KeyboardControl {
   keyboardIsOpen: boolean;
   keyboardIsEnabled: boolean;
+  // Soft keyboard height in px (0 when closed); used to reserve scroll space
+  // below the focused input so it can be lifted above the keyboard.
+  keyboardHeight: number;
 }
 
 export const useKeyboard = create<KeyboardControl>(set => {
   const keyboardIsEnabled = Capacitor.isPluginAvailable('Keyboard');
 
   if (keyboardIsEnabled) {
-    Keyboard.addListener('keyboardDidShow', () =>
-      set({ keyboardIsEnabled, keyboardIsOpen: true })
+    Keyboard.addListener('keyboardDidShow', info =>
+      set({
+        keyboardIsEnabled,
+        keyboardIsOpen: true,
+        keyboardHeight: info.keyboardHeight,
+      })
     );
 
     Keyboard.addListener('keyboardDidHide', () =>
-      set({ keyboardIsEnabled, keyboardIsOpen: false })
+      set({ keyboardIsEnabled, keyboardIsOpen: false, keyboardHeight: 0 })
     );
   }
 
   return {
     keyboardIsEnabled,
     keyboardIsOpen: false,
+    keyboardHeight: 0,
   };
 });


### PR DESCRIPTION
Fixes #12407

# 👩🏻‍💻 What does this PR do?
Fixes a regression from #11891 where, on Android tablets, editing a line in the line-edit modal tables (Outbound shipment, Customer return, Stocktake, Supplier return) was broken: opening the soft keyboard pushed the table up and hid the focused batch/line input, making it hard to see or keep focus on the row you were editing.

**Cause:** #11891 converted these modals from a single scrollable body to a rigid, height-locked flex layout (`form` content `overflow: hidden`, only the innermost table scrolls). This was needed to show multiple line rows on the Windows/Electron desktop app at 150% scale / 1920×1080. But on Android the soft keyboard shrinks the fullscreen modal's viewport, and because nothing outside the table can scroll, the focused input gets trapped under the keyboard and the table collapses.

**Fix (Android only):** the shared modal shell (`useDialog`) now detects when the Android soft keyboard is open and, only then:
- falls back to a scrollable modal body (the pre-#11891 behaviour) so the focused input can move above the keyboard;
- reserves the keyboard's height as bottom padding so even the last rows can scroll fully clear of the keyboard;
- centers the focused input within the scroll area on focus — including when jumping between rows with the keyboard already open — so the edited row and its neighbours stay visible (the "scroll on focus" feel of native apps).

Because the shell is shared, all four modal families are fixed from one place.

The behaviour is gated on `isAndroid && keyboardIsOpen`. `keyboardIsOpen` comes from the Capacitor Keyboard plugin and is only ever true inside the Android app, so Electron/desktop and the web app never enter this branch and keep the #11891 layout unchanged.

Files changed:
- `common/src/hooks/useKeyboard/Keyboard.tsx` — also track `keyboardHeight`.
- `common/src/hooks/useDialog/useDialog.tsx` — keyboard-aware scrollable body, bottom padding, and center-focused-input-on-focus.


<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

## 💌 Any notes for the reviewer?

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->

# 🧪 Tested

- Type-check passes for the `common` package (`tsc --noEmit`).
- On an Android tablet, for each of Outbound shipment, Customer return, Stocktake and Supplier return:
- Added a new batch/line and edited an existing one — the focused input stays visible above the keyboard instead of being pushed off-screen.
- Tapped inputs on different rows (e.g. row 1 then row 4) with the keyboard already open — the focused row recenters with neighbouring rows visible, no manual scrolling needed.
- Checked rows near the top and bottom of a 10+ row table — all scroll clear of the keyboard.
- On the Windows/Electron desktop app (150% scale, 1920×1080), confirmed the #11891 multi-row table layout and internal scrolling are unchanged.

# 📃 Documentation
- [x] **No documentation required** — bug fix restoring expected behaviour; no
  change to how the feature is used.
