### PR TITLE
#12359 Hide add-translation search for non-common namespaces

### DIFF
--- a/client/packages/common/src/intl/context/IntlContext.tsx
+++ b/client/packages/common/src/intl/context/IntlContext.tsx
@@ -17,6 +17,7 @@ declare const LANG_VERSION: string;
 
 export const CUSTOM_TRANSLATIONS_NAMESPACE = 'custom-translations';
 export const DEFAULT_TRANSLATIONS_NAMESPACE = 'common';
+export const DESKTOP_TRANSLATIONS_NAMESPACE = 'desktop';
 const minuteInMilliseconds = 60 * 1000;
 const isDevelopment = process.env['NODE_ENV'] === 'development';
 
@@ -64,6 +65,7 @@ export function initialiseI18n({
             languageVersion,
             endpointByNamespace: {
               [DEFAULT_TRANSLATIONS_NAMESPACE]: defaultTranslationsLoadPath,
+              [DESKTOP_TRANSLATIONS_NAMESPACE]: defaultTranslationsLoadPath,
               [CUSTOM_TRANSLATIONS_NAMESPACE]: customTranslationsLoadPath,
             },
           },

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsModal.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsModal.tsx
@@ -22,6 +22,7 @@ import {
   mapTranslationsToObject,
   mergeTranslations,
   ImportMode,
+  DEFAULT_CUSTOM_TRANSLATION_NAMESPACE,
 } from './helpers';
 import { TranslationsTable } from './TranslationsInputTable';
 
@@ -234,6 +235,8 @@ export const CustomTranslationsModal = ({
               translations={translations}
               setTranslations={setTranslations}
               showValidationErrors={showValidationErrors}
+              // Legacy v1 is the global flat map of app-wide (common) keys.
+              namespace={DEFAULT_CUSTOM_TRANSLATION_NAMESPACE}
             />
           </Box>
         </Box>

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsModal.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsModal.tsx
@@ -25,6 +25,7 @@ import {
   DEFAULT_CUSTOM_TRANSLATION_NAMESPACE,
 } from './helpers';
 import { TranslationsTable } from './TranslationsInputTable';
+import { useNamespaceTranslationOptions } from './useNamespaceTranslationOptions';
 
 export const EditCustomTranslations = ({
   value,
@@ -83,6 +84,10 @@ export const CustomTranslationsModal = ({
     mapTranslationsToArray(value, t)
   );
   const [showDeleteAllConfirm, setShowDeleteAllConfirm] = useState(false);
+
+  const { options: addOptions } = useNamespaceTranslationOptions(
+    DEFAULT_CUSTOM_TRANSLATION_NAMESPACE
+  );
 
   const downloadTranslations = () => {
     const asObject = mapTranslationsToObject(translations);
@@ -235,8 +240,7 @@ export const CustomTranslationsModal = ({
               translations={translations}
               setTranslations={setTranslations}
               showValidationErrors={showValidationErrors}
-              // Legacy v1 is the global flat map of app-wide (common) keys.
-              namespace={DEFAULT_CUSTOM_TRANSLATION_NAMESPACE}
+              addOptions={addOptions}
             />
           </Box>
         </Box>

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsV2Modal.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsV2Modal.tsx
@@ -462,6 +462,7 @@ export const CustomTranslationsV2Modal = ({
               translations={translations}
               setTranslations={setTranslations}
               showValidationErrors={showValidationErrors}
+              namespace={namespace}
             />
           </Box>
         </Box>

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsV2Modal.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/CustomTranslationsV2Modal.tsx
@@ -22,7 +22,12 @@ import {
   UploadIcon,
   CopyIcon,
 } from '@common/icons';
-import { useIntl, useIntlUtils, useTranslation } from '@common/intl';
+import {
+  DESKTOP_TRANSLATIONS_NAMESPACE,
+  useIntl,
+  useIntlUtils,
+  useTranslation,
+} from '@common/intl';
 import { useDialog, useNotification, useToggle } from '@common/hooks';
 import {
   mapTranslationsToArray,
@@ -43,6 +48,7 @@ import {
   Translation,
 } from './helpers';
 import { TranslationsTable } from './TranslationsInputTable';
+import { useNamespaceTranslationOptions } from './useNamespaceTranslationOptions';
 import { useUpsertCustomTranslationsV2 } from '../../api';
 import { useInstalledPlugins } from '../../../Plugins/api';
 
@@ -143,16 +149,24 @@ export const CustomTranslationsV2Modal = ({
   const isLegacy = namespace === LEGACY_NAMESPACE;
   const legacyHasData = !!legacyV1 && Object.keys(legacyV1).length > 0;
 
+  const { options: addOptions, getDefaultForKey } =
+    useNamespaceTranslationOptions(namespace, nested);
+
   const viewFor = (
     ns: string,
     nestedSrc: CustomTranslationsV2,
     legacySrc: Record<string, string>
   ): Translation[] =>
-    ns === LEGACY_NAMESPACE
-      ? mapTranslationsToArray(legacySrc, t, { includeUnknownKeys: true })
-      : mapTranslationsToArray(nestedSrc[editingLanguage]?.[ns] ?? {}, t, {
-          includeUnknownKeys: true,
-        });
+    mapTranslationsToArray(
+      ns === LEGACY_NAMESPACE
+        ? legacySrc
+        : (nestedSrc[editingLanguage]?.[ns] ?? {}),
+      t,
+      {
+        includeUnknownKeys: true,
+        getDefault: key => getDefaultForKey(ns, key),
+      }
+    );
 
   const [translations, setTranslations] = useState<Translation[]>(
     viewFor(DEFAULT_CUSTOM_TRANSLATION_NAMESPACE, value, {})
@@ -195,13 +209,16 @@ export const CustomTranslationsV2Modal = ({
     return options;
   }, [installedPlugins, nested, legacyHasData, t]);
 
-  const handleNamespaceChange = (newNamespace: string) => {
+  const handleNamespaceChange = async (newNamespace: string) => {
     if (newNamespace === namespace) return;
     // Save the current edits before switching namespace
     const committed = commitCurrentView();
     if (isLegacy) setLegacyDirty(true);
     setNested(committed.nested);
     setLegacyV1(committed.legacyV1);
+    if (newNamespace === DESKTOP_TRANSLATIONS_NAMESPACE) {
+      await i18n.loadNamespaces(DESKTOP_TRANSLATIONS_NAMESPACE);
+    }
     setNamespace(newNamespace);
     setTranslations(
       viewFor(newNamespace, committed.nested, committed.legacyV1)
@@ -281,7 +298,10 @@ export const CustomTranslationsV2Modal = ({
           const importedArray = mapTranslationsToArray(
             parsed as Record<string, string>,
             t,
-            { includeUnknownKeys: true }
+            {
+              includeUnknownKeys: true,
+              getDefault: key => getDefaultForKey(namespace, key),
+            }
           );
           if (isLegacy) setLegacyDirty(true);
           setTranslations(prev =>
@@ -303,6 +323,9 @@ export const CustomTranslationsV2Modal = ({
     if (!legacyV1) return;
     const importedArray = mapTranslationsToArray(legacyV1, t, {
       includeUnknownKeys: true,
+      // Legacy v1 keys are always common keys, whatever namespace is selected
+      getDefault: key =>
+        getDefaultForKey(DEFAULT_CUSTOM_TRANSLATION_NAMESPACE, key),
     });
     setTranslations(prev =>
       mergeTranslations(prev, importedArray, 'keep-existing')
@@ -414,8 +437,8 @@ export const CustomTranslationsV2Modal = ({
             {isLegacy
               ? t('messages.custom-translations-legacy-banner')
               : t('messages.custom-translations-editing-language', {
-                  language: editingLanguageLabel,
-                })}
+                language: editingLanguageLabel,
+              })}
           </Alert>
           <Box display="flex" gap={1} alignItems="center">
             <Box display="flex" gap={1} alignItems="center">
@@ -462,7 +485,7 @@ export const CustomTranslationsV2Modal = ({
               translations={translations}
               setTranslations={setTranslations}
               showValidationErrors={showValidationErrors}
-              namespace={namespace}
+              addOptions={addOptions}
             />
           </Box>
         </Box>

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/TranslationSearchInput.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/TranslationSearchInput.tsx
@@ -1,10 +1,7 @@
 import React, { useMemo } from 'react';
 import {
   Autocomplete,
-  DEFAULT_TRANSLATIONS_NAMESPACE,
-  LocaleKey,
   RegexUtils,
-  useIntl,
   useTheme,
   useTranslation,
 } from '@openmsupply-client/common';
@@ -13,6 +10,7 @@ import { findMatchingPluralisationKeys } from './helpers';
 interface TranslationSearchInputProps {
   onChange: (option: TranslationOption[]) => void;
   existingKeys: string[];
+  options: TranslationOption[];
 }
 
 export interface TranslationOption {
@@ -23,29 +21,15 @@ export interface TranslationOption {
 export const TranslationSearchInput = ({
   onChange,
   existingKeys,
+  options,
 }: TranslationSearchInputProps) => {
   const t = useTranslation();
-  const { i18n } = useIntl();
   const theme = useTheme();
 
-  const nonTranslatedOptions = useMemo(() => {
-    // English common is the base for translations, will always be available and have all keys
-    const baseOptions =
-      i18n?.store?.data['en']?.[DEFAULT_TRANSLATIONS_NAMESPACE] ?? {};
-    const keys = Object.keys(baseOptions);
-
-    return (
-      keys
-        // Autocomplete should only show keys that don't already have custom translations
-        .filter(k => !existingKeys.includes(k))
-        .map(k => ({
-          key: k,
-          // Use defaultT rather than direct from baseOption, so shows in users language
-          default: t(k as LocaleKey, { ns: DEFAULT_TRANSLATIONS_NAMESPACE }),
-        }))
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [existingKeys.length]);
+  const nonTranslatedOptions = useMemo(
+    () => options.filter(o => !existingKeys.includes(o.key)),
+    [options, existingKeys]
+  );
 
   const handleSelect = (option: TranslationOption | null) => {
     if (!option) return;
@@ -66,7 +50,7 @@ export const TranslationSearchInput = ({
       renderOption={(props, option) => (
         <li {...props} key={option.key} style={{ display: 'flex', gap: '8px' }}>
           <span style={{ color: 'grey' }}>{option.key}</span>
-          {option.default}
+          {option.default !== option.key && option.default}
         </li>
       )}
       filterOptions={(options, { inputValue }) =>

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/TranslationsInputTable.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/TranslationsInputTable.tsx
@@ -14,11 +14,7 @@ import {
   TextInputCell,
 } from '@openmsupply-client/common';
 import { useDebounceCallback } from '@common/hooks';
-import {
-  checkInvalidVariables,
-  DEFAULT_CUSTOM_TRANSLATION_NAMESPACE,
-  Translation,
-} from './helpers';
+import { checkInvalidVariables, Translation } from './helpers';
 import {
   TranslationOption,
   TranslationSearchInput,
@@ -28,12 +24,12 @@ export const TranslationsTable = ({
   translations,
   setTranslations,
   showValidationErrors,
-  namespace,
+  addOptions,
 }: {
   translations: Translation[];
   setTranslations: React.Dispatch<React.SetStateAction<Translation[]>>;
   showValidationErrors: boolean;
-  namespace: string;
+  addOptions: TranslationOption[];
 }) => {
   const t = useTranslation();
 
@@ -176,16 +172,11 @@ export const TranslationsTable = ({
   return (
     <>
       <Box display="flex" flexDirection="column" gap={1} marginBottom="8px">
-        {/* The add-translation search offers keys from the bundled `common`
-            base, so it's only meaningful for the common namespace. Other
-            namespaces (plugins, desktop, legacy) have no bundled key list, so
-            showing it there just surfaces irrelevant common keys - hide it. */}
-        {namespace === DEFAULT_CUSTOM_TRANSLATION_NAMESPACE && (
-          <TranslationSearchInput
-            onChange={onAdd}
-            existingKeys={existingKeys}
-          />
-        )}
+        <TranslationSearchInput
+          onChange={onAdd}
+          existingKeys={existingKeys}
+          options={addOptions}
+        />
         <BasicTextInput
           fullWidth
           value={filterInput}

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/TranslationsInputTable.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/TranslationsInputTable.tsx
@@ -14,7 +14,11 @@ import {
   TextInputCell,
 } from '@openmsupply-client/common';
 import { useDebounceCallback } from '@common/hooks';
-import { checkInvalidVariables, Translation } from './helpers';
+import {
+  checkInvalidVariables,
+  DEFAULT_CUSTOM_TRANSLATION_NAMESPACE,
+  Translation,
+} from './helpers';
 import {
   TranslationOption,
   TranslationSearchInput,
@@ -24,10 +28,12 @@ export const TranslationsTable = ({
   translations,
   setTranslations,
   showValidationErrors,
+  namespace,
 }: {
   translations: Translation[];
   setTranslations: React.Dispatch<React.SetStateAction<Translation[]>>;
   showValidationErrors: boolean;
+  namespace: string;
 }) => {
   const t = useTranslation();
 
@@ -170,7 +176,16 @@ export const TranslationsTable = ({
   return (
     <>
       <Box display="flex" flexDirection="column" gap={1} marginBottom="8px">
-        <TranslationSearchInput onChange={onAdd} existingKeys={existingKeys} />
+        {/* The add-translation search offers keys from the bundled `common`
+            base, so it's only meaningful for the common namespace. Other
+            namespaces (plugins, desktop, legacy) have no bundled key list, so
+            showing it there just surfaces irrelevant common keys - hide it. */}
+        {namespace === DEFAULT_CUSTOM_TRANSLATION_NAMESPACE && (
+          <TranslationSearchInput
+            onChange={onAdd}
+            existingKeys={existingKeys}
+          />
+        )}
         <BasicTextInput
           fullWidth
           value={filterInput}

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/helpers.test.ts
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/helpers.test.ts
@@ -60,6 +60,31 @@ describe('custom translations helpers', () => {
         { id: 'button.ok', key: 'button.ok', default: 'OK', custom: 'Okay' },
       ]);
     });
+    it('resolves defaults through getDefault when provided (namespaced keys)', () => {
+      const translations = { 'Daily Tally': 'دفتر روزانه' };
+      const result = mapTranslationsToArray(translations, t, {
+        includeUnknownKeys: true,
+        getDefault: key => key,
+      });
+      expect(result).toEqual([
+        {
+          id: 'Daily Tally',
+          key: 'Daily Tally',
+          default: 'Daily Tally',
+          custom: 'دفتر روزانه',
+        },
+      ]);
+    });
+    it('applies the unknown-key filter using getDefault', () => {
+      const desktopBundle: Record<string, string> = { help: 'Help' };
+      const translations = { help: 'Potions', unknown: 'Dropped' };
+      const result = mapTranslationsToArray(translations, t, {
+        getDefault: key => desktopBundle[key] ?? '',
+      });
+      expect(result).toEqual([
+        { id: 'help', key: 'help', default: 'Help', custom: 'Potions' },
+      ]);
+    });
   });
 
   describe('mapTranslationsToObject', () => {
@@ -296,7 +321,10 @@ describe('custom translations helpers', () => {
 
     describe('replace mode', () => {
       it('replaces all existing translations with imported ones', () => {
-        const imported = [tr('button.ok', 'Sure', 'OK'), tr('label.new', 'New!', 'New')];
+        const imported = [
+          tr('button.ok', 'Sure', 'OK'),
+          tr('label.new', 'New!', 'New'),
+        ];
         const result = mergeTranslations(existing, imported, 'replace');
         expect(result).toEqual(imported);
       });
@@ -316,8 +344,8 @@ describe('custom translations helpers', () => {
     describe('keep-existing mode', () => {
       it('adds new keys without modifying existing ones', () => {
         const imported = [
-          tr('button.ok', 'Sure', 'OK'),     // exists — should be skipped
-          tr('label.new', 'Nouveau', 'New'),  // new — should be added
+          tr('button.ok', 'Sure', 'OK'), // exists — should be skipped
+          tr('label.new', 'Nouveau', 'New'), // new — should be added
         ];
         const result = mergeTranslations(existing, imported, 'keep-existing');
         expect(result).toEqual([
@@ -357,15 +385,15 @@ describe('custom translations helpers', () => {
     describe('overwrite mode', () => {
       it('overwrites existing keys and adds new ones', () => {
         const imported = [
-          tr('button.ok', 'Sure', 'OK'),     // exists — should be overwritten
-          tr('label.new', 'Nouveau', 'New'),  // new — should be added
+          tr('button.ok', 'Sure', 'OK'), // exists — should be overwritten
+          tr('label.new', 'Nouveau', 'New'), // new — should be added
         ];
         const result = mergeTranslations(existing, imported, 'overwrite');
         expect(result).toEqual([
-          tr('button.ok', 'Sure', 'OK'),       // overwritten
+          tr('button.ok', 'Sure', 'OK'), // overwritten
           tr('button.cancel', 'Annuler', 'Cancel'), // untouched
-          tr('label.name', 'Nom', 'Name'),     // untouched
-          tr('label.new', 'Nouveau', 'New'),   // added
+          tr('label.name', 'Nom', 'Name'), // untouched
+          tr('label.new', 'Nouveau', 'New'), // added
         ]);
       });
 
@@ -380,10 +408,20 @@ describe('custom translations helpers', () => {
 
       it('only updates the custom field, preserving other properties', () => {
         const existingWithMeta: Translation[] = [
-          { id: 'button.ok', key: 'button.ok', default: 'OK', custom: 'Okay', isNew: true },
+          {
+            id: 'button.ok',
+            key: 'button.ok',
+            default: 'OK',
+            custom: 'Okay',
+            isNew: true,
+          },
         ];
         const imported = [tr('button.ok', 'Sure', 'OK')];
-        const result = mergeTranslations(existingWithMeta, imported, 'overwrite');
+        const result = mergeTranslations(
+          existingWithMeta,
+          imported,
+          'overwrite'
+        );
         expect(result[0]).toEqual({
           id: 'button.ok',
           key: 'button.ok',
@@ -427,7 +465,10 @@ describe('custom translations helpers', () => {
 
     describe('collectNamespaces', () => {
       it('returns the unique namespaces across all languages', () => {
-        expect(collectNamespaces(sample()).sort()).toEqual(['common', 'report']);
+        expect(collectNamespaces(sample()).sort()).toEqual([
+          'common',
+          'report',
+        ]);
       });
       it('returns empty for an empty structure', () => {
         expect(collectNamespaces({})).toEqual([]);

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/helpers.ts
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/helpers.ts
@@ -18,24 +18,24 @@ export const mapTranslationsToArray = (
   translations: Record<string, string>,
   t: TypedTFunction<LocaleKey>,
   // Keys without a default translation (e.g. report/plugin keys not in the
-  // bundle) are hidden by default. Pass true to keep them so they aren't
-  // dropped on save.
-  options?: { includeUnknownKeys?: boolean }
+  // bundle) are hidden by default. Pass `includeUnknownKeys: true` to keep
+  // them so they aren't dropped on save. Defaults come from the bundled
+  // common base unless a namespace-aware `getDefault` is supplied
+  options?: {
+    includeUnknownKeys?: boolean;
+    getDefault?: (key: string) => string;
+  }
 ): Translation[] => {
+  const getDefault =
+    options?.getDefault ??
+    ((key: string) =>
+      t(key as LocaleKey, { ns: DEFAULT_TRANSLATIONS_NAMESPACE }));
   return Object.entries(translations)
-    .filter(
-      ([key]) =>
-        options?.includeUnknownKeys ||
-        t(key as LocaleKey, {
-          ns: DEFAULT_TRANSLATIONS_NAMESPACE,
-        }) !== ''
-    )
+    .filter(([key]) => options?.includeUnknownKeys || getDefault(key) !== '')
     .map(([key, custom]) => ({
       id: key,
       key,
-      default: t(key as LocaleKey, {
-        ns: DEFAULT_TRANSLATIONS_NAMESPACE,
-      }),
+      default: getDefault(key),
       custom,
     }));
 };
@@ -161,7 +161,10 @@ const deepClone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
  * plugin_code) and any namespaces already present in the data are added on top.
  * Arbitrary namespaces are also supported via JSON upload.
  */
-export const BASE_CUSTOM_TRANSLATION_NAMESPACES = ['common', 'desktop'] as const;
+export const BASE_CUSTOM_TRANSLATION_NAMESPACES = [
+  'common',
+  'desktop',
+] as const;
 
 /**
  * Reserved pseudo-namespace used in the editor to view/edit the legacy v1 flat

--- a/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/useNamespaceTranslationOptions.ts
+++ b/client/packages/system/src/Manage/Preferences/Components/CustomTranslations/useNamespaceTranslationOptions.ts
@@ -1,0 +1,82 @@
+import { useMemo } from 'react';
+import {
+  DEFAULT_TRANSLATIONS_NAMESPACE,
+  DESKTOP_TRANSLATIONS_NAMESPACE,
+  LocaleKey,
+  useIntl,
+  useTranslation,
+} from '@common/intl';
+import {
+  CustomTranslationsV2,
+  DEFAULT_CUSTOM_TRANSLATION_NAMESPACE,
+  LEGACY_NAMESPACE,
+} from './helpers';
+import { TranslationOption } from './TranslationSearchInput';
+
+export const useNamespaceTranslationOptions = (
+  namespace: string,
+  nested?: CustomTranslationsV2
+) => {
+  const t = useTranslation();
+  const { i18n } = useIntl();
+
+  const getBundle = (
+    language: string,
+    ns: string
+  ): Record<string, string> | undefined =>
+    i18n?.store?.data?.[language]?.[ns] as Record<string, string> | undefined;
+
+  const getDefaultForKey = (ns: string, key: string): string => {
+    if (ns === DESKTOP_TRANSLATIONS_NAMESPACE) {
+      const hierarchy: string[] = i18n.services?.languageUtils
+        ? i18n.services.languageUtils.toResolveHierarchy(i18n.language)
+        : [i18n.language, 'en'];
+      for (const language of hierarchy) {
+        const value = getBundle(language, ns)?.[key];
+        if (value !== undefined) return value;
+      }
+      return getBundle('en', ns)?.[key] ?? key;
+    }
+    if (
+      ns === DEFAULT_CUSTOM_TRANSLATION_NAMESPACE ||
+      ns === LEGACY_NAMESPACE
+    ) {
+      return t(key as LocaleKey, { ns: DEFAULT_TRANSLATIONS_NAMESPACE });
+    }
+    // Label-as-key: the key is the English string
+    return key;
+  };
+
+  const options: TranslationOption[] = useMemo(() => {
+    if (namespace === DESKTOP_TRANSLATIONS_NAMESPACE) {
+      const base = getBundle('en', DESKTOP_TRANSLATIONS_NAMESPACE) ?? {};
+      return Object.keys(base).map(key => ({
+        key,
+        default: getDefaultForKey(namespace, key),
+      }));
+    }
+    if (
+      namespace === DEFAULT_CUSTOM_TRANSLATION_NAMESPACE ||
+      namespace === LEGACY_NAMESPACE
+    ) {
+      // English common is the base for translations, will always be available
+      // and have all keys. Defaults resolve via t() so they show in the
+      // user's language.
+      const base = getBundle('en', DEFAULT_TRANSLATIONS_NAMESPACE) ?? {};
+      return Object.keys(base).map(key => ({
+        key,
+        default: getDefaultForKey(namespace, key),
+      }));
+    }
+    const keys = new Set<string>();
+    Object.values(nested ?? {}).forEach(byNamespace =>
+      Object.keys(byNamespace[namespace] ?? {}).forEach(key => keys.add(key))
+    );
+    return [...keys]
+      .sort((a, b) => a.localeCompare(b))
+      .map(key => ({ key, default: key }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [namespace, nested, i18n, t]);
+
+  return { options, getDefaultForKey };
+};


### PR DESCRIPTION
Fixes #12359

# 👩🏻‍💻 What does this PR do?

The custom-translations editor has an **"add translation" autocomplete** that lets you pick a key to add an override for. It sources its key list from the bundled `common` English base — the only namespace with a key list available on the host. Under any *other* namespace (plugin codes like `afghanistan_plugins`, `desktop`, or the reserved `legacy` view) it still only offered `common` keys, so plugin strings such as "Daily Tally" appeared unsearchable and the control was misleading.

This hides that autocomplete for every namespace except `common`. The **row filter** below it (which searches the currently-selected namespace + language's rows by key / default translation / custom value) is unchanged and remains available everywhere — so looking up and editing already-loaded plugin/desktop translations still works per namespace and per language.

## 💌 Any notes for the reviewer?

- **The approach differs from the issue's literal wording.** The issue asks to make *search* work per namespace. The autocomplete can't be made namespace-aware without a host-side key list for plugin namespaces (that's #11923) — the host only has the `common` base. Rather than keep surfacing irrelevant `common` keys, we remove the confusing control and rely on the existing per-namespace / per-language **filter** for the "look up a string to edit it" workflow — the actual need called out in the issue thread for Afghanistan's uploaded Dari/Pashto strings.
- **Consequence:** for non-`common` namespaces there is no longer an in-UI way to author a brand-new key that isn't already present; those arrive via JSON import (as Afghanistan's translations do). Editing anything already uploaded works via the filter.
- The legacy v1 standalone editor keeps its autocomplete (it edits the global `common` key map).
- Frontend-only conditional render — no schema / migration / sync / API / plugin-shape changes.

# 🧪 Testing

- [ ] Central server with the Afghanistan plugin installed and its translations uploaded (or any store with custom translations saved under a plugin namespace)
- [ ] Manage → Preferences → Custom translations → **Edit**
- [ ] `common` namespace: the "Add translation" autocomplete is shown and works as before
- [ ] Switch to the `afghanistan_plugins` (or `desktop`) namespace: the "Add translation" autocomplete is **hidden**; the "Filter translations" box remains
- [ ] Type e.g. "Daily Tally" in the filter → the matching uploaded row is shown and can be edited and saved
- [ ] Reload and confirm the edited translation persisted

# 📃 Documentation

- [ ] **No documentation required**: bug fix / UI behaviour tweak, no change to documented behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
