### PR TITLE
Custom fields: fix Returns quick-edit clobber and DATE display offset

### DIFF
--- a/client/packages/common/src/utils/customFields/customFields.test.ts
+++ b/client/packages/common/src/utils/customFields/customFields.test.ts
@@ -190,9 +190,17 @@ describe('getOptionAndDescendantIds', () => {
   });
 });
 
-describe('formatCustomFieldValue', () => {
-  const localisedDate = (d: Date) => d.toISOString().slice(0, 10);
+// Mirrors the real localisedDate (date-fns format), which renders the Date's
+// *local* date parts — a toISOString-based stub reads UTC parts instead and
+// would mask local-midnight vs UTC-midnight off-by-one-day bugs.
+const localisedDate = (d: Date) =>
+  [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, '0'),
+    String(d.getDate()).padStart(2, '0'),
+  ].join('-');
 
+describe('formatCustomFieldValue', () => {
   it('stringifies text/number/real values', () => {
     expect(formatCustomFieldValue(def({}), 'hello', localisedDate)).toBe('hello');
     expect(
@@ -225,6 +233,41 @@ describe('formatCustomFieldValue', () => {
       options: [option('opt_1', 'Red')],
     });
     expect(formatCustomFieldValue(optDef, 'opt_1', localisedDate)).toBe('Red');
+  });
+});
+
+describe('formatCustomFieldValue DATE values west of GMT', () => {
+  // Emulate a machine in a negative-offset zone — jest workers copy
+  // process.env, so setting TZ at runtime never reaches V8. getNaiveDate
+  // resolves the machine zone via Intl.DateTimeFormat().resolvedOptions()
+  // .timeZone, so mock that, and render via the same zone as the real
+  // localisedDate would on such a machine.
+  const timeZone = 'America/Chicago';
+
+  beforeAll(() => {
+    const defaults = new Intl.DateTimeFormat().resolvedOptions();
+    jest
+      .spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions')
+      .mockImplementation(() => ({ ...defaults, timeZone }));
+  });
+  afterAll(() => jest.restoreAllMocks());
+
+  const chicagoLocalisedDate = (d: Date) =>
+    new Intl.DateTimeFormat('en-CA', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(d);
+
+  it('renders the stored calendar date, not the previous day', () => {
+    // `new Date('2024-03-15')` is UTC midnight — still 2024-03-14 in Chicago —
+    // so the parse must yield local midnight to keep the calendar date the
+    // user entered.
+    const dateDef = def({ valueType: CustomFieldNodeValueType.Date });
+    expect(
+      formatCustomFieldValue(dateDef, '2024-03-15', chicagoLocalisedDate)
+    ).toBe('2024-03-15');
   });
 });
 

--- a/client/packages/common/src/utils/customFields/customFields.ts
+++ b/client/packages/common/src/utils/customFields/customFields.ts
@@ -1,3 +1,4 @@
+import { DateUtils } from '@common/intl';
 import { CustomFieldNodeValueType } from '@common/types';
 
 /**
@@ -156,8 +157,11 @@ export const formatCustomFieldValue = (
     case CustomFieldNodeValueType.Option:
       return resolveOptionValue(definition, value);
     case CustomFieldNodeValueType.Date: {
-      const date = new Date(String(value));
-      return isNaN(date.getTime()) ? String(value) : localisedDate(date);
+      // DATE values are date-only strings (stored via Formatter.naiveDate), so
+      // parse as local midnight — `new Date('2024-03-15')` is UTC midnight,
+      // which renders as the previous day in negative-offset timezones.
+      const date = DateUtils.getNaiveDate(String(value));
+      return date ? localisedDate(date) : String(value);
     }
     default:
       return String(value);

--- a/client/packages/invoices/src/Returns/CustomerDetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Returns/CustomerDetailView/Toolbar.tsx
@@ -13,7 +13,10 @@ import {
 } from '@openmsupply-client/common';
 import { CustomerReturnFragment, useReturns } from '../api';
 import { CustomerSearchInput } from '@openmsupply-client/system';
-import { InvoiceToolbarCustomFields } from '../../common';
+import {
+  InvoiceToolbarCustomFields,
+  useCustomFieldsQuickEdit,
+} from '../../common';
 
 export const Toolbar: FC = () => {
   const t = useTranslation();
@@ -35,6 +38,18 @@ export const Toolbar: FC = () => {
     setDraft({ ...data });
     debouncedMutateAsync({ id, ...data });
   };
+
+  // Quick-edits need different shapes locally vs on the wire — the whole
+  // merged blob for setDraft (which replaces top-level keys), the accumulated
+  // patch for the server (which merge-patches customFields) — see the hook.
+  const updateCustomFields = useCustomFieldsQuickEdit(
+    customFields,
+    ({ customFields, patch }) => {
+      if (!id) return;
+      setDraft({ customFields });
+      debouncedMutateAsync({ id, customFields: patch });
+    }
+  );
 
   return (
     <AppBarContentPortal sx={{ display: 'flex', flex: 1, marginBottom: 1 }}>
@@ -76,7 +91,7 @@ export const Toolbar: FC = () => {
             <InvoiceToolbarCustomFields
               invoiceType={InvoiceNodeType.CustomerReturn}
               customFields={customFields}
-              onUpdate={patch => update({ customFields: patch })}
+              onUpdate={updateCustomFields}
               disabled={isDisabled}
             />
           </Box>

--- a/client/packages/invoices/src/Returns/SupplierDetailView/Toolbar.tsx
+++ b/client/packages/invoices/src/Returns/SupplierDetailView/Toolbar.tsx
@@ -13,7 +13,10 @@ import {
 } from '@openmsupply-client/common';
 import { SupplierReturnFragment, useReturns } from '../api';
 import { SupplierSearchInput } from '@openmsupply-client/system';
-import { InvoiceToolbarCustomFields } from '../../common';
+import {
+  InvoiceToolbarCustomFields,
+  useCustomFieldsQuickEdit,
+} from '../../common';
 import { AppRoute } from '@openmsupply-client/config';
 
 export const Toolbar: FC = () => {
@@ -33,6 +36,19 @@ export const Toolbar: FC = () => {
     setBufferedState({ ...data });
     debouncedMutateAsync({ id, ...data });
   };
+
+  // Quick-edits need different shapes locally vs on the wire — the whole
+  // merged blob for setBufferedState (which replaces top-level keys), the
+  // accumulated patch for the server (which merge-patches customFields) — see
+  // the hook.
+  const updateCustomFields = useCustomFieldsQuickEdit(
+    customFields,
+    ({ customFields, patch }) => {
+      if (!id) return;
+      setBufferedState({ customFields });
+      debouncedMutateAsync({ id, customFields: patch });
+    }
+  );
 
   const isDisabled = useReturns.utils.supplierIsDisabled();
 
@@ -90,7 +106,7 @@ export const Toolbar: FC = () => {
             <InvoiceToolbarCustomFields
               invoiceType={InvoiceNodeType.SupplierReturn}
               customFields={customFields}
-              onUpdate={patch => update({ customFields: patch })}
+              onUpdate={updateCustomFields}
               disabled={isDisabled}
             />
           </Box>

--- a/client/packages/invoices/src/common/customFields/InvoiceToolbarCustomFields.tsx
+++ b/client/packages/invoices/src/common/customFields/InvoiceToolbarCustomFields.tsx
@@ -20,7 +20,10 @@ interface InvoiceToolbarCustomFieldsProps {
   /**
    * Saves a single-key patch through the view's own update mutation. The server
    * patch-merges into the existing blob, so a partial patch never clobbers the
-   * other property values — no need to merge the current blob here.
+   * other property values — no need to merge the current blob here. Callers
+   * whose local draft state replaces top-level keys (the Returns toolbars) must
+   * still merge the patch into their local blob, or the other prominent fields
+   * blank out until the next refetch.
    */
   onUpdate: (patch: DraftProperties) => void;
   /** Status-based editability, matching the other toolbar fields. */

--- a/client/packages/invoices/src/common/customFields/index.ts
+++ b/client/packages/invoices/src/common/customFields/index.ts
@@ -1,4 +1,5 @@
 export * from './hooks';
 export * from './InvoiceCustomFieldsTab';
 export * from './InvoiceToolbarCustomFields';
+export * from './useCustomFieldsQuickEdit';
 export type { InvoiceCustomFieldFragment } from './operations.generated';

--- a/client/packages/invoices/src/common/customFields/useCustomFieldsQuickEdit.test.ts
+++ b/client/packages/invoices/src/common/customFields/useCustomFieldsQuickEdit.test.ts
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react';
+import { useCustomFieldsQuickEdit } from './useCustomFieldsQuickEdit';
+
+describe('useCustomFieldsQuickEdit', () => {
+  it('keeps the local blob whole and sends only the edited key', () => {
+    const update = jest.fn();
+    const { result } = renderHook(() =>
+      useCustomFieldsQuickEdit({ category: 'a', other: 'keep' }, update)
+    );
+
+    result.current({ category: 'b' });
+
+    expect(update).toHaveBeenCalledWith({
+      customFields: { category: 'b', other: 'keep' },
+      patch: { category: 'b' },
+    });
+  });
+
+  it('accumulates rapid edits to different fields so the last (debounce-surviving) mutation carries both', () => {
+    const update = jest.fn();
+    const { result, rerender } = renderHook(
+      ({ customFields }) => useCustomFieldsQuickEdit(customFields, update),
+      { initialProps: { customFields: { a: '1' } as Record<string, unknown> } }
+    );
+
+    result.current({ b: '2' });
+    // The view writes the merged blob back to its draft state, re-rendering
+    // the toolbar with the updated blob before the next edit.
+    rerender({ customFields: { a: '1', b: '2' } });
+    result.current({ c: '3' });
+
+    expect(update).toHaveBeenLastCalledWith({
+      customFields: { a: '1', b: '2', c: '3' },
+      patch: { b: '2', c: '3' },
+    });
+  });
+
+  it('keeps the latest value when the same field is edited twice', () => {
+    const update = jest.fn();
+    const { result } = renderHook(() => useCustomFieldsQuickEdit({}, update));
+
+    result.current({ a: 'first' });
+    result.current({ a: 'second' });
+
+    expect(update).toHaveBeenLastCalledWith(
+      expect.objectContaining({ patch: { a: 'second' } })
+    );
+  });
+
+  it('treats a missing blob as empty', () => {
+    const update = jest.fn();
+    const { result } = renderHook(() => useCustomFieldsQuickEdit(null, update));
+
+    result.current({ a: '1' });
+
+    expect(update).toHaveBeenCalledWith({
+      customFields: { a: '1' },
+      patch: { a: '1' },
+    });
+  });
+});

--- a/client/packages/invoices/src/common/customFields/useCustomFieldsQuickEdit.ts
+++ b/client/packages/invoices/src/common/customFields/useCustomFieldsQuickEdit.ts
@@ -1,0 +1,35 @@
+import { useRef } from 'react';
+import { DraftProperties } from '@openmsupply-client/common';
+
+/**
+ * Builds the `onUpdate` handler for {@link InvoiceToolbarCustomFields} in views
+ * whose local draft/buffered state replaces top-level keys wholesale (the
+ * Returns toolbars). Each quick-edit patch is a single key, so it needs two
+ * different shapes on the way out:
+ *
+ * - `customFields`: the whole current blob with the patch merged in, for the
+ *   view's local state — writing the bare patch there would blank every other
+ *   prominent field in the toolbar.
+ * - `patch`: only the keys quick-edited so far, for the update mutation — the
+ *   server merge-patches `customFields`, matching the other invoice toolbars.
+ *   Patches accumulate across calls because the views' trailing debounce only
+ *   fires the last mutation, which would otherwise drop the first of two rapid
+ *   edits to different fields.
+ */
+export const useCustomFieldsQuickEdit = (
+  customFields: Record<string, unknown> | null | undefined,
+  update: (data: {
+    customFields: Record<string, unknown>;
+    patch: DraftProperties;
+  }) => void
+) => {
+  const accumulated = useRef<DraftProperties>({});
+
+  return (patch: DraftProperties) => {
+    accumulated.current = { ...accumulated.current, ...patch };
+    update({
+      customFields: { ...customFields, ...patch },
+      patch: accumulated.current,
+    });
+  };
+};


### PR DESCRIPTION
Part of #11827 (no linked sub-issue — fixes findings #2 and #3 from the pre-merge review of the custom-fields feature branch, ahead of #12410).

# 👩🏻‍💻 What does this PR do?

Fixes two user-visible bugs in the custom fields feature.

**1. Returns toolbars clobbered the local `customFields` blob on quick-edit**

The Customer/Supplier Return toolbars fed a single-key patch (`{ editedKey: value }`) into draft state that merges only *top-level* keys, so with two prominent fields configured, editing field A blanked field B in the toolbar — permanently on supplier returns, since `bufferedState` only re-syncs from the query once. The shared 500 ms trailing debounce also collapsed rapid edits to two different fields into just the last one, so the first edit was never sent to the server at all.

Fix: a small shared hook, `useCustomFieldsQuickEdit`, now used by both Returns toolbars:

- **local state** receives the whole merged blob (`{ ...customFields, ...patch }`), so the other prominent fields survive the top-level-replacing draft merge;
- **the server** still receives only the accumulated quick-edit keys (it merge-patches `customFields`), matching the Inbound/Outbound/Prescription toolbars. Deliberately *not* the full local blob — the Returns views' local blob can go stale, and sending it whole would resurrect old values of tab-managed keys;
- **patches accumulate in a ref across the debounce window**, so two rapid edits to different fields both survive the collapsed mutation.

**2. DATE custom fields rendered one day off west of GMT**

`formatCustomFieldValue` parsed date-only strings (`"2024-03-15"`) with `new Date(...)` — UTC midnight — then formatted in local time, so a 15 March value rendered as **14 March** anywhere in a UTC-negative timezone, in every list column and read-only detail row. It now parses with the existing `DateUtils.getNaiveDate` (local midnight), which documents this exact trap. Unparseable values still pass through unchanged.

## 💌 Any notes for the reviewer?

- The old date test stubbed `localisedDate` via `toISOString` (UTC parts), which masked the bug — and would have failed the *fixed* code east of GMT. It's replaced with a local-date-parts stub, plus a regression test that emulates a UTC-negative machine by mocking `Intl.DateTimeFormat.prototype.resolvedOptions` (the default-zone lookup `getNaiveDate` uses). Setting `process.env.TZ` inside a jest worker doesn't work — verified empirically.
- The chosen server-send semantics for quick-edit is the partial patch (matching the other three invoice toolbars), not the merged blob — reasoning above.
- Pre-existing and out of scope: the shared toolbar debounce still collapses a `theirReference` edit followed quickly by a custom-field edit (mixed top-level keys). This predates the custom-fields feature.

# 🧪 Testing

Already done on this branch:

- `packages/common/src/utils/customFields/` — 3 suites / 34 tests pass. With the fix stashed, the new date regression test fails with `Received: "2024-03-14"` (verified in both directions).
- New `useCustomFieldsQuickEdit.test.ts` — 4 tests: whole-blob local write, patch accumulation across the debounce, same-key overwrite, null starting blob.
- Full `packages/invoices/` (11 suites / 96 tests) and `packages/common/` (58 suites / 340 tests) pass; `yarn re-compile` (tsc) clean; eslint clean on touched files.

Manual steps:

- [ ] On a central server, configure two custom fields as **Prominent** on the Supplier Return scope (Manage → Custom fields)
- [ ] Open a supplier return; set field A from the toolbar, then field B — field A must keep its value (previously it blanked)
- [ ] Edit field A then field B within ~half a second — both values persist after a refresh
- [ ] Set the machine timezone to e.g. America/Chicago; a DATE custom field saved as 15 March must display as 15 March in list columns and the Custom fields tab (previously 14 March)

# 📃 Documentation

- [x] **No documentation required**: bug fixes, no change in intended behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
