### PR TITLE
diesel_string_enum: heal wire-cased stored values on parse

### DIFF
--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -726,5 +726,17 @@ mod print_query_tests {
             ChangelogTableName::Other("table_from_the_future".to_string())
         );
         assert_eq!(from_db.to_string(), "table_from_the_future");
+
+        // Stored-string healing: a wire-cased name captured by the fallback while the
+        // table was unknown must parse into the real variant once it exists, while a
+        // still-unknown name keeps falling back.
+        assert_eq!(
+            ChangelogTableName::from_stored_str("StockLine").unwrap(),
+            ChangelogTableName::StockLine
+        );
+        assert_eq!(
+            ChangelogTableName::from_stored_str("TableFromTheFuture").unwrap(),
+            ChangelogTableName::Other("TableFromTheFuture".to_string())
+        );
     }
 }

--- a/server/repository/src/db_diesel/custom_field_row.rs
+++ b/server/repository/src/db_diesel/custom_field_row.rs
@@ -199,6 +199,18 @@ mod tests {
                 .unwrap(),
             CustomFieldValueType::Other("FUTURE_TYPE".to_string())
         );
+
+        // Stored-string healing: a wire-cased value captured into `Other` (and thus
+        // stored verbatim) by a build that predated the variant must parse into the
+        // real variant on a build that knows it. DB casing still parses too.
+        assert_eq!(
+            CustomFieldValueType::from_stored_str("Integer").unwrap(),
+            CustomFieldValueType::Integer
+        );
+        assert_eq!(
+            CustomFieldValueType::from_stored_str("INTEGER").unwrap(),
+            CustomFieldValueType::Integer
+        );
     }
 
     #[test]

--- a/server/repository/src/db_diesel/custom_field_scope_row.rs
+++ b/server/repository/src/db_diesel/custom_field_scope_row.rs
@@ -208,5 +208,17 @@ mod tests {
                 .unwrap(),
             CustomFieldDisplayMode::Other("FUTURE_MODE".to_string())
         );
+
+        // Stored-string healing: a wire-cased mode captured into `Other` (and thus
+        // stored verbatim) by a build that predated the variant must parse into the
+        // real variant on a build that knows it. DB casing still parses too.
+        assert_eq!(
+            CustomFieldDisplayMode::from_stored_str("Prominent").unwrap(),
+            CustomFieldDisplayMode::Prominent
+        );
+        assert_eq!(
+            CustomFieldDisplayMode::from_stored_str("PROMINENT").unwrap(),
+            CustomFieldDisplayMode::Prominent
+        );
     }
 }

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -664,6 +664,20 @@ macro_rules! define_linked_tables {
 /// `as_ref()`/`Display`/serde emit the inner string). Enums with no fallback variant keep
 /// the strict behaviour — an unknown value is an error.
 ///
+/// # Stored-string healing (`from_stored_str`)
+///
+/// The fallback creates a casing asymmetry over time: when an older build receives a
+/// wire value it doesn't know, the `transparent` fallback writes the *wire* string
+/// (PascalCase identifier) verbatim into the DB column, whose known values use the
+/// `strum` casing. After that build upgrades to one that knows the variant, a plain
+/// `from_str` (strum) would keep reading the stored wire form as the fallback forever
+/// (until the record happens to re-sync). `from_stored_str` heals this: it parses with
+/// the `strum` casing first, and only if that lands in the fallback does it retry the
+/// value against the wire identifiers. The generated `FromSql` and `From<String>` go
+/// through it, so DB reads self-heal on upgrade; call it directly for enum strings
+/// persisted outside an enum-typed column (e.g. `sync_buffer.table_name`). Enums
+/// without a fallback variant are unaffected.
+///
 /// Usage:
 /// ```
 /// diesel_string_enum! {
@@ -706,10 +720,41 @@ macro_rules! diesel_string_enum {
             ),*
         }
 
+        impl $name {
+            /// Parse a *stored* string form of this enum (a DB TEXT column, or an
+            /// enum string persisted elsewhere, e.g. `sync_buffer.table_name`).
+            ///
+            /// Tries the `strum` (database) casing first. If that lands in the
+            /// `#[strum(default)]` fallback variant, the serde *wire* identifiers get
+            /// a second chance: an older build stores a then-unknown wire value
+            /// verbatim via the transparent fallback, so once this build knows the
+            /// variant the stored wire form must parse into it rather than staying
+            /// opaque. See the `diesel_string_enum!` docs ("Stored-string healing").
+            ///
+            /// The error type follows `FromStr`: `Infallible` when the enum has a
+            /// `#[strum(default)]` fallback, `strum::ParseError` when it is strict.
+            // The `false || …` chain is one `||` operand per variant (macros can't
+            // emit a partial `match`), which clippy would flag as non-minimal.
+            #[allow(clippy::nonminimal_bool)]
+            $vis fn from_stored_str(
+                value: &str,
+            ) -> Result<Self, <Self as std::str::FromStr>::Err> {
+                use std::str::FromStr;
+                let parsed = Self::from_str(value)?;
+                let is_fallback = false
+                    $(|| diesel_string_enum!(@is_fallback_variant parsed $name $variant $(( $($variant_payload)* ))?))*;
+                if is_fallback {
+                    $(
+                        diesel_string_enum!(@match_wire_identifier value $name $variant $(( $($variant_payload)* ))?);
+                    )*
+                }
+                Ok(parsed)
+            }
+        }
+
         impl From<String> for $name {
             fn from(value: String) -> Self {
-                use std::str::FromStr;
-                Self::from_str(&value).unwrap()
+                Self::from_stored_str(&value).unwrap()
             }
         }
 
@@ -736,9 +781,8 @@ macro_rules! diesel_string_enum {
             fn from_sql(
                 bytes: <crate::DBType as diesel::backend::Backend>::RawValue<'_>,
             ) -> diesel::deserialize::Result<Self> {
-                use std::str::FromStr;
                 let s = <String as diesel::deserialize::FromSql<diesel::sql_types::Text, crate::DBType>>::from_sql(bytes)?;
-                Self::from_str(&s).map_err(|e| e.into())
+                Self::from_stored_str(&s).map_err(|e| e.into())
             }
         }
 
@@ -806,6 +850,23 @@ macro_rules! diesel_string_enum {
     (@deserialize_variant $value:ident $name:ident $variant:ident ( $($variant_payload:tt)* )) => {
         return Ok($name::$variant($value));
     };
+
+    // --- from_stored_str helpers ---
+    // Is `parsed` the payload-carrying fallback variant? One `||` operand per variant.
+    (@is_fallback_variant $parsed:ident $name:ident $variant:ident) => {
+        false
+    };
+    (@is_fallback_variant $parsed:ident $name:ident $variant:ident ( $($variant_payload:tt)* )) => {
+        matches!(&$parsed, $name::$variant(_))
+    };
+    // Second-chance match of a stored string against the wire identifiers. The fallback
+    // variant expands to nothing — it must not re-capture here.
+    (@match_wire_identifier $value:ident $name:ident $variant:ident) => {
+        if $value == stringify!($variant) {
+            return Ok($name::$variant);
+        }
+    };
+    (@match_wire_identifier $value:ident $name:ident $variant:ident ( $($variant_payload:tt)* )) => {};
 }
 
 macro_rules! diesel_json_type {
@@ -861,3 +922,71 @@ pub(crate) use apply_string_or_filter;
 pub(crate) use define_linked_tables;
 pub(crate) use diesel_json_type;
 pub(crate) use diesel_string_enum;
+
+#[cfg(test)]
+mod diesel_string_enum_test {
+    diesel_string_enum! {
+        #[derive(Clone, Eq)]
+        #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+        pub enum WithFallback {
+            #[default]
+            VariantA,
+            VariantB,
+            #[strum(default, transparent)]
+            Other(String),
+        }
+    }
+
+    diesel_string_enum! {
+        #[derive(Clone, Eq)]
+        #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+        pub enum Strict {
+            #[default]
+            VariantA,
+            VariantB,
+        }
+    }
+
+    #[test]
+    fn from_stored_str_parses_db_casing() {
+        assert_eq!(
+            WithFallback::from_stored_str("VARIANT_B").unwrap(),
+            WithFallback::VariantB
+        );
+    }
+
+    #[test]
+    fn from_stored_str_heals_wire_cased_fallback_values() {
+        // An older build that didn't know VariantB captured the wire identifier in
+        // `Other` and stored it verbatim; once this build knows the variant, the
+        // stored wire form must parse into it instead of staying opaque.
+        assert_eq!(
+            WithFallback::from_stored_str("VariantB").unwrap(),
+            WithFallback::VariantB
+        );
+        // `From<String>` (and therefore the generated `FromSql`) heals the same way.
+        assert_eq!(
+            WithFallback::from("VariantB".to_string()),
+            WithFallback::VariantB
+        );
+    }
+
+    #[test]
+    fn from_stored_str_keeps_unknown_values_in_fallback() {
+        assert_eq!(
+            WithFallback::from_stored_str("NeverHeardOfIt").unwrap(),
+            WithFallback::Other("NeverHeardOfIt".to_string())
+        );
+    }
+
+    #[test]
+    fn from_stored_str_strict_enum_is_unaffected() {
+        assert_eq!(
+            Strict::from_stored_str("VARIANT_B").unwrap(),
+            Strict::VariantB
+        );
+        // No fallback ever wrote wire-cased values, so there is nothing to heal —
+        // an unknown (or wire-cased) value stays an error.
+        assert!(Strict::from_stored_str("VariantB").is_err());
+    }
+}

--- a/server/service/src/sync_v7/validate_translate_integrate.rs
+++ b/server/service/src/sync_v7/validate_translate_integrate.rs
@@ -68,8 +68,11 @@ pub(crate) fn create_changelog(
 }
 
 fn parse_table_name(table_name: &str) -> Result<ChangelogTableName, Error> {
-    table_name
-        .parse::<ChangelogTableName>()
+    // `from_stored_str` (not plain `parse`) so buffer rows stored under the *wire*
+    // name — written while this site didn't know the table (see issue #12361) —
+    // parse into the real variant after an upgrade and become integrable, instead
+    // of staying `Other(..)` forever.
+    ChangelogTableName::from_stored_str(table_name)
         .map_err(|_| Error::UnknownTableName(table_name.to_string()))
 }
 


### PR DESCRIPTION
Follow-up from the #12410 review discussion (no linked sub-issue). Hardens the `diesel_string_enum!` unknown-value fallback introduced with #12361.

# 👩🏻‍💻 What does this PR do?

`diesel_string_enum!` pins two casings per enum: the DB column uses the strum casing (e.g. `SCREAMING_SNAKE_CASE`, or `snake_case` for `ChangelogTableName`), while the serde wire form uses the PascalCase variant identifier. The `#[strum(default, transparent)]` fallback captures an unknown wire value verbatim — and, because `ToSql` writes `as_ref()`, stores that *wire-cased* string into a column whose known values are *strum-cased*.

That created a permanent asymmetry: after a site upgrades to a build that knows the variant, a plain `from_str` kept reading the stored wire form as `Other("Barcode")` forever (or a v7 sync-buffer row stored under `"CustomField"` while the table was unknown stayed unintegrable), until the record happened to re-flow from central.

The fix is generic, in the macro:

- New generated method **`from_stored_str(value)`**: parses with the strum casing first (authoritative DB form, including the `default` fallback); only when that lands in the fallback variant does it retry the value against the wire identifiers; if none match it keeps `Other(value)`.
- The generated **`FromSql`** and **`From<String>`** impls route through it, so DB reads self-heal on upgrade for every enum the macro defines.
- **`parse_table_name`** in the v7 integrate path uses it too, so a buffer row's wire-cased table name parses into the real variant. Note (see the analysis comment below): this alone does **not** rescue historical stuck buffer rows — the per-table pending query selects by the strum-cased name, so those rows are never handed to `parse_table_name` in the first place. Normalising them is deliberately deferred and tracked in #12417.

Not changed: the wire format (serde serialize/deserialize are untouched — released enums' wire bytes stay identical), `FromStr` itself (strum-derived; existing direct callers keep exact behaviour), and strict enums without a fallback (the strum error propagates before the retry, so an unknown value is still an error).

## 💌 Any notes for the reviewer?

- The method's error type follows `FromStr`: this repo's strum generates `Err = Infallible` for enums with a `#[strum(default)]` fallback and `strum::ParseError` for strict ones, so the signature is `Result<Self, <Self as FromStr>::Err>`.
- The `false || matches!(…)` chain in the generated body is one `||` operand per variant (macros can't emit partial `match` arms — same technique as the macro's serde impls); a targeted `#[allow(clippy::nonminimal_bool)]` covers it.
- Healing is read-side only: a healed value normalises to the strum casing on its next write. Raw-SQL comparisons against strum-cased literals still won't match not-yet-rewritten rows — same as before this PR; only the Rust-side parse improves.
- The heal deliberately runs *after* the strum parse, so it can never change the result for any string that parsed to a known variant before.

# 🧪 Testing

Already done on this branch:

- 4 new macro-level tests (`diesel_macros.rs`): DB casing parses, wire-cased value heals (via `from_stored_str` and `From<String>`), unknown-in-both-casings stays `Other`, strict enums still error.
- Heal assertions added to the existing wire-form pinning tests for `CustomFieldValueType` / `CustomFieldDisplayMode`, and to the #12361 `ChangelogTableName` regression test (`"StockLine"` heals; `"TableFromTheFuture"` stays `Other`).
- `cargo check --workspace --all-targets` clean; targeted `cargo nextest run -p repository -p service diesel_string_enum custom_field changelog sync_v7` — **115/115 passed**.

Manual steps (optional — behaviour is unit-covered):

- [ ] On a v7 remote running an older build, sync a record carrying an enum value only the central knows (it lands as the raw wire string in the DB / sync buffer); upgrade the remote; confirm the value now reads as the real variant and a stuck buffer row integrates on the next sync cycle.

# 📃 Documentation

- [x] **No documentation required**: internal robustness fix; the `diesel_string_enum!` doc comment gained a "Stored-string healing" section covering the new behaviour.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend

