### PR TITLE
diesel_string_enum: normalize unknown fallback values to DB casing

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -8889,6 +8889,7 @@ dependencies = [
  "diesel-derive-enum",
  "futures-util",
  "glob",
+ "heck 0.5.0",
  "libsqlite3-sys",
  "log",
  "pretty_assertions",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -34,6 +34,9 @@ reqwest = { version = "0.13.3", features = [
 # `util::tls::tests::https_client_builds`). Bump together with reqwest.
 rustls = "0.23.4"
 webpki-roots = "1.0"
+# The same crate/version strum_macros uses for `serialize_all` casings — the
+# diesel_string_enum! fallback normalization relies on identical conversions.
+heck = "0.5.0"
 serde = { version = "^1.0.219", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml = "0.9.34"

--- a/server/repository/Cargo.toml
+++ b/server/repository/Cargo.toml
@@ -23,6 +23,7 @@ diesel = { version = "2.3.7", default-features = false, features = [
 ] }
 diesel-derive-enum = { version = "2.1.0", default-features = false }
 futures-util = { workspace = true }
+heck = { workspace = true }
 libsqlite3-sys = { version = "0.36.0", features = ["bundled"], optional = true }
 rusqlite = "0.38.0"
 regex = { workspace = true }

--- a/server/repository/src/db_diesel/changelog/changelog.rs
+++ b/server/repository/src/db_diesel/changelog/changelog.rs
@@ -53,6 +53,7 @@ diesel_string_enum! {
 }
 
 diesel_string_enum! {
+    db_case = snake_case;
     #[derive(Clone, Eq, Hash, strum::EnumIter, TS)]
     #[strum(serialize_all = "snake_case")]
     // The set of tables tracked by the changelog. How each one syncs is
@@ -698,23 +699,24 @@ mod print_query_tests {
     }
 
     /// Regression for issue #12361: a table name a newer central knows but this site
-    /// doesn't must deserialize to `Other(..)` instead of failing the whole batch parse,
-    /// and must round-trip back out unchanged so it reaches the sync buffer under its
-    /// real name.
+    /// doesn't must deserialize to `Other(..)` instead of failing the whole batch parse.
+    /// The captured name is normalized to the DB casing (`db_case = snake_case`), so the
+    /// sync buffer stores it under exactly the name the per-table pending query selects
+    /// once an upgrade makes the table known — stranded rows self-heal.
     #[test]
     fn changelog_table_name_unknown_falls_back_to_other() {
-        // serde (v7 wire) — unknown PascalCase name is captured verbatim.
+        // serde (v7 wire) — unknown PascalCase name is captured normalized to snake_case.
         // (The original example, "CustomField", became a real variant when the
         // custom-fields feature landed, so a fabricated name is used instead.)
         let parsed: ChangelogTableName = serde_json::from_str("\"TableFromTheFuture\"").unwrap();
         assert_eq!(
             parsed,
-            ChangelogTableName::Other("TableFromTheFuture".to_string())
+            ChangelogTableName::Other("table_from_the_future".to_string())
         );
         assert_eq!(
             serde_json::to_string(&parsed).unwrap(),
-            "\"TableFromTheFuture\"",
-            "Other round-trips back to its raw wire name"
+            "\"table_from_the_future\"",
+            "Other re-serialises in its normalized (DB-cased) form; re-capture is idempotent"
         );
 
         // strum (DB column / sync buffer `to_string()`) — same fallback, inner string

--- a/server/repository/src/db_diesel/custom_field_row.rs
+++ b/server/repository/src/db_diesel/custom_field_row.rs
@@ -11,6 +11,7 @@ use crate::StorageConnection;
 use crate::{ChangelogSyncType, Upsert};
 
 diesel_string_enum! {
+    db_case = SCREAMING_SNAKE_CASE;
     #[derive(Clone, Eq)]
     #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
     // Stored as plain TEXT (not a native DB enum) for v7 forwards-compatibility:
@@ -31,6 +32,7 @@ diesel_string_enum! {
 }
 
 diesel_string_enum! {
+    db_case = SCREAMING_SNAKE_CASE;
     #[derive(Clone, Eq)]
     #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
     // Stored as plain TEXT (not a native DB enum) for v7 forwards-compatibility:
@@ -199,6 +201,16 @@ mod tests {
                 .unwrap(),
             CustomFieldValueType::Other("FUTURE_TYPE".to_string())
         );
+
+        // A wire-cased unknown (how a newer central actually sends a variant this build
+        // doesn't know) is captured normalized to the DB casing (`db_case` in
+        // diesel_string_enum!), so the stored value parses into the real variant once an
+        // upgrade adds it.
+        assert_eq!(
+            serde_json::from_value::<CustomFieldValueType>(serde_json::json!("FutureType"))
+                .unwrap(),
+            CustomFieldValueType::Other("FUTURE_TYPE".to_string())
+        );
     }
 
     #[test]
@@ -230,6 +242,12 @@ mod tests {
         );
         assert_eq!(
             serde_json::from_value::<CustomFieldKind>(serde_json::json!("FUTURE_KIND")).unwrap(),
+            CustomFieldKind::Other("FUTURE_KIND".to_string())
+        );
+
+        // Wire-cased unknown captures normalized to the DB casing (`db_case`).
+        assert_eq!(
+            serde_json::from_value::<CustomFieldKind>(serde_json::json!("FutureKind")).unwrap(),
             CustomFieldKind::Other("FUTURE_KIND".to_string())
         );
     }

--- a/server/repository/src/db_diesel/custom_field_scope_row.rs
+++ b/server/repository/src/db_diesel/custom_field_scope_row.rs
@@ -12,6 +12,7 @@ use crate::StorageConnection;
 use crate::{ChangelogSyncType, Upsert};
 
 diesel_string_enum! {
+    db_case = SCREAMING_SNAKE_CASE;
     #[derive(Clone, Eq)]
     #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
     // How much UI presence a custom_field gets on this table scope — a single
@@ -205,6 +206,13 @@ mod tests {
         );
         assert_eq!(
             serde_json::from_value::<CustomFieldDisplayMode>(serde_json::json!("FUTURE_MODE"))
+                .unwrap(),
+            CustomFieldDisplayMode::Other("FUTURE_MODE".to_string())
+        );
+
+        // Wire-cased unknown captures normalized to the DB casing (`db_case`).
+        assert_eq!(
+            serde_json::from_value::<CustomFieldDisplayMode>(serde_json::json!("FutureMode"))
                 .unwrap(),
             CustomFieldDisplayMode::Other("FUTURE_MODE".to_string())
         );

--- a/server/repository/src/db_diesel/user_permission_row.rs
+++ b/server/repository/src/db_diesel/user_permission_row.rs
@@ -19,6 +19,7 @@ table! {
 }
 
 diesel_string_enum! {
+    db_case = SCREAMING_SNAKE_CASE;
     #[derive(Clone, Eq, Hash, EnumIter)]
     #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
     pub enum PermissionType {

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -684,6 +684,15 @@ macro_rules! define_linked_tables {
 /// and simply stays in the fallback after upgrade — the same as before this existed.
 /// Enums without a fallback variant don't need (or use) a declaration.
 ///
+/// **An enum with a `#[strum(default, transparent)]` fallback variant must declare
+/// `db_case` — this is enforced at compile time.** The declaration-less form of the macro
+/// only accepts enums whose variants are all unit (no `String` payload); a fallback enum
+/// that omits `db_case` matches no arm and fails to build with a `compile_error!` pointing
+/// here, rather than silently capturing unknowns in wire casing (the stranded-value bug
+/// this section prevents). Choose the `db_case` that matches the enum's
+/// `#[strum(serialize_all = ...)]`. If you deliberately want unknowns captured as-is with
+/// no normalization, opt in explicitly with `db_case = verbatim;`.
+///
 /// Usage:
 /// ```
 /// diesel_string_enum! {
@@ -700,19 +709,28 @@ macro_rules! define_linked_tables {
 /// }
 /// ```
 macro_rules! diesel_string_enum {
-    // Without a `db_case` declaration: unknown values are captured verbatim
-    // (only correct for enums without a fallback variant — see the macro docs).
+    // Declaration-less form: accepted ONLY for enums whose variants are all unit (no
+    // `String`-payload fallback). Such enums capture nothing, so `db_case` is inert and
+    // defaults to `verbatim`. An enum with a fallback variant does NOT match this arm
+    // (the variant matcher below rejects payloads) — it must declare `db_case` explicitly,
+    // otherwise it falls through to the `compile_error!` arm below the main expansion.
     (
         $(#[$meta:meta])*
         $vis:vis enum $name:ident {
-            $($body:tt)*
+            $(
+                $(#[$variant_meta:meta])*
+                $variant:ident
+            ),* $(,)?
         }
     ) => {
         diesel_string_enum! {
             db_case = verbatim;
             $(#[$meta])*
             $vis enum $name {
-                $($body)*
+                $(
+                    $(#[$variant_meta])*
+                    $variant
+                ),*
             }
         }
     };
@@ -818,6 +836,28 @@ macro_rules! diesel_string_enum {
                 )))
             }
         }
+    };
+
+    // Fallback-without-`db_case` guard. Only reached when the unit-only declaration-less
+    // arm rejected the enum (so it has a `String`-payload fallback variant) AND no
+    // `db_case = ...;` was supplied. Turn that into a clear error rather than silently
+    // capturing unknowns in wire casing. (`@`-prefixed internal calls never reach here —
+    // they don't match the `enum` shape — and explicit-`db_case` invocations matched above.)
+    (
+        $(#[$meta:meta])*
+        $vis:vis enum $name:ident {
+            $($body:tt)*
+        }
+    ) => {
+        compile_error!(concat!(
+            "diesel_string_enum!: `",
+            stringify!($name),
+            "` has a fallback (`String`-payload) variant, so it must declare a `db_case` as \
+             its first line, matching `#[strum(serialize_all = ...)]` — e.g. \
+             `db_case = SCREAMING_SNAKE_CASE;` or `db_case = snake_case;`. Use \
+             `db_case = verbatim;` only to deliberately capture unknowns in wire casing \
+             (no normalization)."
+        ));
     };
 
     // --- serde serialize: one `if let` per variant (macros can't emit partial match arms) ---
@@ -935,9 +975,11 @@ mod diesel_string_enum_test {
         }
     }
 
-    // No db_case declaration: fallback capture stays verbatim (legacy behaviour,
-    // exercised to pin that the declaration-less arm still works).
+    // Explicit `db_case = verbatim;`: the opt-out that keeps unknowns captured as-is (no
+    // normalization). A fallback enum can no longer omit `db_case` — it's a compile error —
+    // so this pins that `verbatim` remains available when a caller genuinely wants it.
     diesel_string_enum! {
+        db_case = verbatim;
         #[derive(Clone, Eq)]
         #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
         pub enum VerbatimFallback {
@@ -1001,8 +1043,11 @@ mod diesel_string_enum_test {
         );
     }
 
+    // `db_case = verbatim;` opts out of normalization: the unknown is captured exactly as
+    // it arrived on the wire. (A fallback enum can no longer omit `db_case` at all — that
+    // is now a compile error — so verbatim capture is only reachable by asking for it.)
     #[test]
-    fn without_db_case_capture_is_verbatim() {
+    fn verbatim_db_case_captures_unknown_as_is() {
         assert_eq!(
             serde_json::from_value::<VerbatimFallback>(serde_json::json!("FutureVariant"))
                 .unwrap(),

--- a/server/repository/src/diesel_macros.rs
+++ b/server/repository/src/diesel_macros.rs
@@ -660,14 +660,36 @@ macro_rules! define_linked_tables {
 /// for any value the enum doesn't recognise — both from the database and from serde. This
 /// lets a newer peer send a value an older peer has never heard of (e.g. a table added on
 /// central but not yet on a remote) without failing the whole parse: the unknown string is
-/// captured in the fallback variant and round-trips back out unchanged (`transparent` makes
-/// `as_ref()`/`Display`/serde emit the inner string). Enums with no fallback variant keep
+/// captured in the fallback variant and emitted back out via `transparent` (`as_ref()`/
+/// `Display`/serde all yield the inner string). Enums with no fallback variant keep
 /// the strict behaviour — an unknown value is an error.
+///
+/// # `db_case` — unknown values are normalized to the DB casing at capture
+///
+/// A serde-captured unknown arrives in the *wire* casing (the newer peer's variant
+/// identifier, PascalCase) but is subsequently written to a DB column whose known values
+/// use the *strum* casing — and would then never parse into the real variant once an
+/// upgrade adds it (`from_str` only knows the strum casing). To make stored values
+/// self-heal, an enum with a fallback variant declares its strum rule up front:
+///
+/// `db_case = SCREAMING_SNAKE_CASE;` (or `snake_case`)
+///
+/// and the serde deserialize fallback converts the captured string with the matching
+/// [`heck`] function — the same crate and version `strum_macros` uses for
+/// `serialize_all`, so the conversion is byte-identical to what strum derives for the
+/// variant on the build that knows it. The wire format for *known* values is unchanged
+/// in both directions; a pass-through unknown re-serialises in its normalized form and
+/// is re-captured idempotently at every hop. Caveat: a future variant carrying a
+/// per-variant `#[strum(serialize = "…")]` override won't match its heck-derived form
+/// and simply stays in the fallback after upgrade — the same as before this existed.
+/// Enums without a fallback variant don't need (or use) a declaration.
 ///
 /// Usage:
 /// ```
 /// diesel_string_enum! {
+///     db_case = SCREAMING_SNAKE_CASE;
 ///     #[derive(Clone)]
+///     #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 ///     pub enum MyEnum {
 ///         #[default]
 ///         VariantA,
@@ -678,7 +700,25 @@ macro_rules! define_linked_tables {
 /// }
 /// ```
 macro_rules! diesel_string_enum {
+    // Without a `db_case` declaration: unknown values are captured verbatim
+    // (only correct for enums without a fallback variant — see the macro docs).
     (
+        $(#[$meta:meta])*
+        $vis:vis enum $name:ident {
+            $($body:tt)*
+        }
+    ) => {
+        diesel_string_enum! {
+            db_case = verbatim;
+            $(#[$meta])*
+            $vis enum $name {
+                $($body)*
+            }
+        }
+    };
+
+    (
+        db_case = $db_case:ident;
         $(#[$meta:meta])*
         $vis:vis enum $name:ident {
             $(
@@ -769,7 +809,7 @@ macro_rules! diesel_string_enum {
             ) -> Result<Self, D::Error> {
                 let value = <String as serde::Deserialize>::deserialize(deserializer)?;
                 $(
-                    diesel_string_enum!(@deserialize_variant value $name $variant $(( $($variant_payload)* ))?);
+                    diesel_string_enum!(@deserialize_variant $db_case value $name $variant $(( $($variant_payload)* ))?);
                 )*
                 // No known variant matched and there was no fallback variant.
                 Err(serde::de::Error::custom(format!(
@@ -796,15 +836,33 @@ macro_rules! diesel_string_enum {
 
     // --- serde deserialize: compare against each known name; fallback catches the rest ---
     // Unit variant: match on its PascalCase identifier.
-    (@deserialize_variant $value:ident $name:ident $variant:ident) => {
+    (@deserialize_variant $db_case:ident $value:ident $name:ident $variant:ident) => {
         if $value == stringify!($variant) {
             return Ok($name::$variant);
         }
     };
-    // Fallback variant with a payload: capture whatever value is left. Declared last in the
-    // enum, so it only runs once every known variant has been ruled out above.
-    (@deserialize_variant $value:ident $name:ident $variant:ident ( $($variant_payload:tt)* )) => {
-        return Ok($name::$variant($value));
+    // Fallback variant with a payload: capture whatever value is left, normalized to the
+    // enum's DB casing (see the `db_case` macro docs) so anything subsequently written to
+    // the database — a column via ToSql, or `sync_buffer.table_name` via `to_string()` —
+    // parses into the real variant once an upgrade adds it. Declared last in the enum, so
+    // it only runs once every known variant has been ruled out above.
+    (@deserialize_variant $db_case:ident $value:ident $name:ident $variant:ident ( $($variant_payload:tt)* )) => {
+        return Ok($name::$variant(diesel_string_enum!(@to_db_case $db_case $value)));
+    };
+
+    // --- db_case dispatch: expansion-time mapping to the heck conversion strum_macros
+    // uses for the matching `serialize_all` rule (same crate + version → byte-identical
+    // output for any variant identifier).
+    (@to_db_case SCREAMING_SNAKE_CASE $value:ident) => {{
+        use heck::ToShoutySnakeCase;
+        $value.to_shouty_snake_case()
+    }};
+    (@to_db_case snake_case $value:ident) => {{
+        use heck::ToSnakeCase;
+        $value.to_snake_case()
+    }};
+    (@to_db_case verbatim $value:ident) => {
+        $value
     };
 }
 
@@ -861,3 +919,103 @@ pub(crate) use apply_string_or_filter;
 pub(crate) use define_linked_tables;
 pub(crate) use diesel_json_type;
 pub(crate) use diesel_string_enum;
+
+#[cfg(test)]
+mod diesel_string_enum_test {
+    diesel_string_enum! {
+        db_case = SCREAMING_SNAKE_CASE;
+        #[derive(Clone, Eq)]
+        #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+        pub enum WithFallback {
+            #[default]
+            VariantA,
+            VariantB,
+            #[strum(default, transparent)]
+            Other(String),
+        }
+    }
+
+    // No db_case declaration: fallback capture stays verbatim (legacy behaviour,
+    // exercised to pin that the declaration-less arm still works).
+    diesel_string_enum! {
+        #[derive(Clone, Eq)]
+        #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+        pub enum VerbatimFallback {
+            #[default]
+            VariantA,
+            #[strum(default, transparent)]
+            Other(String),
+        }
+    }
+
+    diesel_string_enum! {
+        #[derive(Clone, Eq)]
+        #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+        pub enum Strict {
+            #[default]
+            VariantA,
+            VariantB,
+        }
+    }
+
+    #[test]
+    fn known_variants_keep_the_identifier_wire_form() {
+        assert_eq!(
+            serde_json::to_value(WithFallback::VariantB).unwrap(),
+            serde_json::json!("VariantB")
+        );
+        assert_eq!(
+            serde_json::from_value::<WithFallback>(serde_json::json!("VariantB")).unwrap(),
+            WithFallback::VariantB
+        );
+        // DB casing is strum's, unaffected by db_case.
+        assert_eq!(WithFallback::VariantB.as_ref(), "VARIANT_B");
+    }
+
+    #[test]
+    fn unknown_values_are_captured_normalized_to_the_db_casing() {
+        // A wire-cased unknown (a variant only a newer build knows) is captured in the
+        // enum's DB casing, so ToSql / `to_string()` store a value that parses into the
+        // real variant once an upgrade adds it.
+        assert_eq!(
+            serde_json::from_value::<WithFallback>(serde_json::json!("FutureVariant")).unwrap(),
+            WithFallback::Other("FUTURE_VARIANT".to_string())
+        );
+        // Re-serialises in the normalized form; re-capture is idempotent.
+        assert_eq!(
+            serde_json::to_value(WithFallback::Other("FUTURE_VARIANT".to_string())).unwrap(),
+            serde_json::json!("FUTURE_VARIANT")
+        );
+        assert_eq!(
+            serde_json::from_value::<WithFallback>(serde_json::json!("FUTURE_VARIANT")).unwrap(),
+            WithFallback::Other("FUTURE_VARIANT".to_string())
+        );
+        // The normalized form is exactly what strum derives once the variant exists:
+        // heck's ShoutySnake of "VariantB" == strum's serialize_all output.
+        use std::str::FromStr;
+        assert_eq!(
+            serde_json::from_value::<WithFallback>(serde_json::json!("VariantB"))
+                .map(|v| v.as_ref().to_string())
+                .unwrap(),
+            WithFallback::from_str("VARIANT_B").unwrap().as_ref()
+        );
+    }
+
+    #[test]
+    fn without_db_case_capture_is_verbatim() {
+        assert_eq!(
+            serde_json::from_value::<VerbatimFallback>(serde_json::json!("FutureVariant"))
+                .unwrap(),
+            VerbatimFallback::Other("FutureVariant".to_string())
+        );
+    }
+
+    #[test]
+    fn strict_enum_still_errors_on_unknown() {
+        assert!(serde_json::from_value::<Strict>(serde_json::json!("FutureVariant")).is_err());
+        assert_eq!(
+            serde_json::from_value::<Strict>(serde_json::json!("VariantB")).unwrap(),
+            Strict::VariantB
+        );
+    }
+}

--- a/server/service/src/sync_v7/test.rs
+++ b/server/service/src/sync_v7/test.rs
@@ -365,13 +365,16 @@ mod test_sync_v7_client_api {
         let buffers = SyncBufferRepository::new(&connection).get_all().unwrap();
         assert_eq!(buffers.len(), 2);
 
-        // Unknown record is buffered under its real (unchanged) table name and never
-        // integrated — no translator matches it and it isn't in INTEGRATION_ORDER.
+        // Unknown record is buffered under its table name *normalized to the DB casing*
+        // (`db_case = snake_case` on ChangelogTableName) and never integrated — it isn't
+        // in INTEGRATION_ORDER. Because the buffered name matches the strum form the
+        // per-table pending query selects by, the row integrates naturally once an
+        // upgrade makes the table known.
         let unknown = buffers
             .iter()
             .find(|b| b.record_id == "future_table_1")
             .expect("unknown record should be in the sync buffer");
-        assert_eq!(unknown.table_name, "TableFromTheFuture");
+        assert_eq!(unknown.table_name, "table_from_the_future");
         assert!(
             unknown.integration_datetime.is_none(),
             "unknown table should be left unintegrated, not errored or integrated"


### PR DESCRIPTION
Follow-up from the #12410 review discussion (no linked sub-issue). Hardens the `diesel_string_enum!` unknown-value fallback from #12361 at the root; **supersedes #12416** and makes the sync-buffer normalization item in #12417 moot for future records.

# 👩🏻‍💻 What does this PR do?

`diesel_string_enum!` enums have two string forms: the strum/DB casing (what diesel saves, e.g. `TEXT` / `stock_line`) and the serde wire form (the PascalCase variant identifier — sync v7 and the boajs plugin bridge, e.g. `Text` / `StockLine`). When a value *unknown to this build* fell into the `#[strum(default, transparent)]` fallback, it was captured verbatim in wire casing and then written to DB columns — and to `sync_buffer.table_name` via `to_string()` — where the strum-cased parse and the per-table pending query could never find it after an upgrade added the variant. Values (and buffered records for unknown tables) stayed stuck as `Other(..)` until they happened to re-sync.

This PR normalizes the captured string to the enum's DB casing at the moment serde captures it:

- Enums with a fallback variant declare their casing rule up front: `db_case = SCREAMING_SNAKE_CASE;` (or `snake_case`) — added to the five fallback enums (`ChangelogTableName`, `PermissionType`, `CustomFieldValueType`, `CustomFieldKind`, `CustomFieldDisplayMode`).
- The macro's serde deserialize fallback converts the captured string with the matching [`heck`](https://docs.rs/heck) function — **the same crate and version `strum_macros` uses for `serialize_all`**, so the normalized form is byte-identical to what strum derives for that variant on the build that knows it. (`heck 0.5.0` added as a direct workspace dep, matching the lockfile's strum_macros dependency.)
- Enums without a fallback don't declare anything and are completely unchanged (the declaration-less macro arm delegates with `verbatim`).

Self-healing consequences:

- An unknown v7 table name arriving as `"CustomField"` is buffered as `custom_field` — exactly the strum form the per-table pending query selects by — so the stranded-buffer-row scenario from #12361 integrates naturally after upgrade, with no repair pass.
- An unknown enum value like `"Barcode"` is stored as `BARCODE` and parses into the real variant on the first DB read after upgrade.

## 💌 Any notes for the reviewer?

- **The sync v7 wire format for known values is unchanged in both directions** — this was the design constraint (per discussion on #12416). A *pass-through unknown* re-serialises in its normalized (DB-cased) form via the transparent fallback; it is re-captured idempotently at every hop, and resolves to the real variant on the first build that knows it (via the DB round-trip). Plugin-facing serde is untouched for all known values.
- Pre-existing wire-cased strandees (e.g. a buffer row already stored under `"CustomField"`) are deliberately not repaired — RC sites re-initialise; there is no production v7 data.
- Caveat documented in the macro: a future variant carrying a per-variant `#[strum(serialize = "…")]` override won't match its heck-derived form and degrades softly to `Other` — same as before this change.
- This supersedes #12416 (`from_stored_str` read-side heal), which I'll close — normalizing at capture fixes the same problem at the root and also covers the pending-query selection gap that the read-side heal couldn't.

# 🧪 Testing

Already done on this branch:

- New macro-level tests (`diesel_macros.rs`): known variants keep the identifier wire form (and strum DB form); a wire-cased unknown captures normalized (`"FutureVariant"` → `Other("FUTURE_VARIANT")`), re-serialises in that form, and re-captures idempotently; the heck-derived form matches strum's `serialize_all` output; a declaration-less fallback enum keeps verbatim capture; strict enums still error on unknowns.
- Extended the wire-form pinning tests for `CustomFieldValueType` / `CustomFieldKind` / `CustomFieldDisplayMode` with wire-cased-unknown capture assertions; known-variant assertions unchanged.
- Updated the #12361 regression tests: `ChangelogTableName` serde now captures `"TableFromTheFuture"` as `Other("table_from_the_future")`; the sync v7 end-to-end unknown-table test asserts the buffer row is stored under the DB-cased name (and all known-value fixtures are untouched — evidence the wire didn't change).
- `cargo check --workspace --all-targets` clean; `cargo nextest run -p repository -p service diesel_string_enum custom_field changelog sync_v7` — **115/115 passed**.

Manual steps (optional — behaviour is unit-covered):

- [ ] Two v7 sites where central runs a build with an extra `custom_field.value_type` variant (or table): sync to the older remote, confirm the value/table lands DB-cased in the remote's DB/sync buffer; upgrade the remote; confirm the value reads as the real variant and the buffered record integrates on the next cycle.

# 📃 Documentation

- [x] **No documentation required**: internal robustness fix; the `diesel_string_enum!` doc comment gained a `db_case` section covering the behaviour and caveats.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
