### PR TITLE
Fix sync label workflow

### DIFF
--- a/.github/workflows/pr-issue-label-sync.yaml
+++ b/.github/workflows/pr-issue-label-sync.yaml
@@ -119,20 +119,6 @@ jobs:
                 }
                 throw new Error(`No associated issue found for this pull request. There was a match in the description, but not to an issue: ${issueNumber}`)
               }
-
-              // Explicitly link the PR to the issue using linkPullRequestToIssue mutation
-              // This ensures the PR appears in the issue's Development panel
-              core.debug(`Linking PR #${context.issue.number} to issue #${issueNumber}`)
-              await github.graphql(`
-                mutation($pullRequestId: ID!, $issueId: ID!) {
-                  linkPullRequestToIssue(input: {pullRequestId: $pullRequestId, issueId: $issueId}) {
-                    clientMutationId
-                  }
-                }
-              `, {
-                pullRequestId: pullRequest.id,
-                issueId: issue.id
-              })
             }
 
             core.debug(issue)


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #

<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

## 💌 Any notes for the reviewer?
Sync label seems to be failing a bit of digging and it seems linkPullRequestToIssue is currently only a proposed mutation? https://github.com/orgs/community/discussions/186495

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- _(e.g.)_ Added unit tests covering the issued-quantity calculation in the requisition service
- _(e.g.)_ Set up a Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR (sample datafile: _google drive link_)
- _(e.g.)_ Opened a requisition, added some lines, and made a couple of invoices supplying some of those lines
- _(e.g.)_ Confirmed the "Issued" column showed the sum of the amounts already issued in invoices for the requisition

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [ ] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
