### PR TITLE
12439 Move stock movement report context migration to v2.21

### DIFF
--- a/server/repository/src/migrations/v2_20_00/mod.rs
+++ b/server/repository/src/migrations/v2_20_00/mod.rs
@@ -10,7 +10,6 @@ mod add_plugin_data_datetime_field;
 mod add_plugin_data_indexes;
 mod add_received_number_of_packs_to_invoice_line;
 mod add_shipment_variance_reason_option_type;
-mod add_stock_movement_report_context;
 mod add_stock_relocation_table;
 mod add_stocktake_edited_activity_log_type;
 mod add_support_upload_files_processor_cursor_key_value_store;
@@ -39,7 +38,6 @@ impl Migration for V2_20_00 {
             Box::new(add_shipment_variance_reason_option_type::Migrate),
             Box::new(add_invoice_received_qty_updated_activity_log_type::Migrate),
             Box::new(add_stock_relocation_table::Migrate),
-            Box::new(add_stock_movement_report_context::Migrate),
             Box::new(add_item_store_join_indexes::Migrate),
             Box::new(add_assign_prescription_number_processor_cursor_key_value_store::Migrate),
         ]

--- a/server/repository/src/migrations/v2_21_00/add_stock_movement_report_context.rs
+++ b/server/repository/src/migrations/v2_21_00/add_stock_movement_report_context.rs
@@ -12,7 +12,7 @@ impl MigrationFragment for Migrate {
             sql!(
                 connection,
                 r#"
-                    ALTER TYPE context_type ADD VALUE 'STOCK_MOVEMENT';
+                    ALTER TYPE context_type ADD VALUE IF NOT EXISTS 'STOCK_MOVEMENT';
                 "#
             )?;
         }

--- a/server/repository/src/migrations/v2_21_00/mod.rs
+++ b/server/repository/src/migrations/v2_21_00/mod.rs
@@ -2,6 +2,7 @@ use super::{version::Version, Migration, MigrationFragment};
 use crate::StorageConnection;
 
 mod add_help_document_table;
+mod add_stock_movement_report_context;
 mod add_stock_relocation_line_table;
 mod recreate_stock_relocation_table;
 
@@ -20,6 +21,7 @@ impl Migration for V2_21_00 {
             Box::new(recreate_stock_relocation_table::Migrate),
             Box::new(add_stock_relocation_line_table::Migrate),
             Box::new(add_help_document_table::Migrate),
+            Box::new(add_stock_movement_report_context::Migrate),
         ]
     }
 }


### PR DESCRIPTION
Fixes #12439 

# 👩🏻‍💻 What does this PR do?
Fixes a startup panic on Postgres where the server crashes with:

```
invalid input value for enum context_type: "STOCK_MOVEMENT"
```

at `StandardReports::load_reports` (`server/src/lib.rs:363`).

The migration that adds `STOCK_MOVEMENT` to the `context_type` enum was filed under **v2_20_00**. The migration runner only runs a version's fragments when `migration_version >= database_version` (`repository/src/migrations/mod.rs:259`), so any database already on **2.21.0** (bumped by an earlier 2.21.0-RC build before this fragment existed) skips the whole v2_20_00 fragment set and never gets the enum value. The next startup then panics loading the stock-movement standard report.

Changes:

- **Moved** `add_stock_movement_report_context` from `v2_20_00/` to `v2_21_00/` so databases already at 2.21.0 run it.
- **Made it idempotent** — `ALTER TYPE context_type ADD VALUE IF NOT EXISTS 'STOCK_MOVEMENT'` — so databases that already applied it under 2.20.0 don't error when the re-keyed fragment runs again (the migration fragment log is keyed on version + identifier, so moving it re-runs it).
- Updated the `mod.rs` registrations in both `v2_20_00` and `v2_21_00`.

<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

## 💌 Any notes for the reviewer?

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- Should be on the Postgres OMS setup
- Should be the OMS server already updated to the earlier 2.21.0-RC build. Before this fix applied version i.e 2 or 3 2.21.0-RC build eariler than this fix applied version.
- Start the OMS server/app (Windows - start service)
- The app wouldn't start. Open the server log and you should see `invalid input value for enum context_type: "STOCK_MOVEMENT"` error.
- Now upgrade the OMS server with this fix applied version and start the app.
- The app should run smoothly without any issues.
- To check further more, you can open server log and check - the above error wouldn't be there.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (bug fix that restores intended startup behaviour; no behaviour change)
