### PR TITLE
12427 Allow sorting by campaign in stock view

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -9947,6 +9947,7 @@ export type StockLineResponse = NodeError | StockLineNode;
 
 export enum StockLineSortFieldInput {
   Batch = 'batch',
+  Campaign = 'campaign',
   CostPricePerPack = 'costPricePerPack',
   ExpiryDate = 'expiryDate',
   ItemCode = 'itemCode',

--- a/client/packages/system/src/Stock/ListView/ListView.tsx
+++ b/client/packages/system/src/Stock/ListView/ListView.tsx
@@ -282,6 +282,7 @@ export const StockListView = () => {
         Cell: TextWithTooltipCell,
         size: 150,
         defaultHideOnMobile: true,
+        enableSorting: !isGrouped,
       },
       {
         id: 'supplierName',

--- a/client/packages/system/src/Stock/api/hooks/useStockList.ts
+++ b/client/packages/system/src/Stock/api/hooks/useStockList.ts
@@ -79,6 +79,7 @@ const toSortField = (
     sellPricePerPack: StockLineSortFieldInput.SellPricePerPack,
     expiryDate: StockLineSortFieldInput.ExpiryDate,
     manufactureDate: StockLineSortFieldInput.ManufactureDate,
+    campaign: StockLineSortFieldInput.Campaign,
   };
 
   return sortFieldMap[sortBy.key] ?? StockLineSortFieldInput.ItemName;

--- a/server/graphql/location/src/mutations/delete.rs
+++ b/server/graphql/location/src/mutations/delete.rs
@@ -265,6 +265,7 @@ mod test {
                     barcode_row: None,
                     item_variant_row: None,
                     vvm_status_row: None,
+                    campaign_row: None,
                 }],
                 invoice_lines: vec![successful_invoice_line()],
             }))

--- a/server/graphql/stock_line/src/lib.rs
+++ b/server/graphql/stock_line/src/lib.rs
@@ -34,6 +34,7 @@ pub enum StockLineSortFieldInput {
     CostPricePerPack,
     SellPricePerPack,
     VvmStatusThenExpiry,
+    Campaign,
 }
 #[derive(InputObject)]
 pub struct StockLineSortInput {

--- a/server/graphql/stock_line/src/mutations/insert.rs
+++ b/server/graphql/stock_line/src/mutations/insert.rs
@@ -296,6 +296,7 @@ mod test {
                 barcode_row: None,
                 item_variant_row: None,
                 vvm_status_row: None,
+                campaign_row: None,
             })
         }));
 

--- a/server/graphql/stock_line/src/mutations/update.rs
+++ b/server/graphql/stock_line/src/mutations/update.rs
@@ -325,6 +325,7 @@ mod test {
                 barcode_row: None,
                 item_variant_row: None,
                 vvm_status_row: None,
+                campaign_row: None,
             })
         }));
 

--- a/server/repository/src/db_diesel/campaign/campaign_row.rs
+++ b/server/repository/src/db_diesel/campaign/campaign_row.rs
@@ -1,3 +1,8 @@
+use crate::db_diesel::{
+    barcode_row::barcode, item_row::item, item_variant::item_variant_row::item_variant,
+    location_row::location, name_row::name, stock_line_row::stock_line,
+    vvm_status::vvm_status_row::vvm_status,
+};
 use crate::{
     ChangeLogInsertRow, ChangelogRepository, ChangelogTableName, RepositoryError, RowActionType,
     StorageConnection, Upsert,
@@ -15,6 +20,14 @@ table! {
         deleted_datetime -> Nullable<Timestamp>,
     }
 }
+
+allow_tables_to_appear_in_same_query!(campaign, stock_line);
+allow_tables_to_appear_in_same_query!(campaign, item);
+allow_tables_to_appear_in_same_query!(campaign, item_variant);
+allow_tables_to_appear_in_same_query!(campaign, location);
+allow_tables_to_appear_in_same_query!(campaign, name);
+allow_tables_to_appear_in_same_query!(campaign, barcode);
+allow_tables_to_appear_in_same_query!(campaign, vvm_status);
 
 #[derive(
     Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq, Default, Serialize, Deserialize,

--- a/server/repository/src/db_diesel/stock_line.rs
+++ b/server/repository/src/db_diesel/stock_line.rs
@@ -1,5 +1,6 @@
 use super::{
     barcode_row::barcode,
+    campaign_row::campaign,
     item_row::item,
     item_variant::item_variant_row::{item_variant, ItemVariantRow},
     location_row::location,
@@ -11,6 +12,7 @@ use super::{
 };
 
 use crate::{
+    campaign_row::CampaignRow,
     diesel_extensions::OrderByExtensions,
     diesel_macros::{
         apply_date_filter, apply_equal_filter, apply_sort, apply_sort_asc_nulls_last,
@@ -33,6 +35,7 @@ pub struct StockLine {
     pub barcode_row: Option<BarcodeRow>,
     pub item_variant_row: Option<ItemVariantRow>,
     pub vvm_status_row: Option<VVMStatusRow>,
+    pub campaign_row: Option<CampaignRow>,
 }
 
 pub enum StockLineSortField {
@@ -48,6 +51,7 @@ pub enum StockLineSortField {
     CostPricePerPack,
     SellPricePerPack,
     VvmStatusThenExpiry,
+    Campaign,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -81,6 +85,7 @@ type StockLineJoin = (
     Option<NameRow>,
     Option<BarcodeRow>,
     Option<VVMStatusRow>,
+    Option<CampaignRow>,
 );
 pub struct StockLineRepository<'a> {
     connection: &'a StorageConnection,
@@ -155,6 +160,9 @@ impl<'a> StockLineRepository<'a> {
                 }
                 StockLineSortField::SellPricePerPack => {
                     apply_sort!(query, sort, stock_line::sell_price_per_pack);
+                }
+                StockLineSortField::Campaign => {
+                    apply_sort_no_case!(query, sort, campaign::name);
                 }
                 StockLineSortField::VvmStatusThenExpiry => {
                     // Complex sort, not using apply_sort
@@ -373,6 +381,7 @@ fn query() -> _ {
         .left_join(name::table)
         .left_join(barcode::table)
         .left_join(vvm_status::table)
+        .left_join(campaign::table)
 }
 
 type BoxedStockLineQuery = IntoBoxed<'static, query, DBType>;
@@ -386,6 +395,7 @@ fn to_domain(
         supplier_name_row,
         barcode_row,
         vvm_status_row,
+        campaign_row,
     ): StockLineJoin,
 ) -> StockLine {
     StockLine {
@@ -396,6 +406,7 @@ fn to_domain(
         barcode_row,
         item_variant_row,
         vvm_status_row,
+        campaign_row,
     }
 }
 

--- a/server/service/src/stocktake/insert/generate.rs
+++ b/server/service/src/stocktake/insert/generate.rs
@@ -163,6 +163,7 @@ fn generate_stocktake_lines(
                  barcode_row: _,
                  item_variant_row: _,
                  vvm_status_row: _,
+                 campaign_row: _,
              }| {
                 StocktakeLineRow {
                     id: uuid(),


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12427

<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

The Stock list is server-paginated, so a sortable column needs its sort key wired through to the backend — enabling sorting on the column alone isn't enough.

Client: enabled sorting on the Campaign column and mapped it to the new sort field; regenerated GraphQL types.
Server: added Campaign to StockLineSortField (repository + GraphQL enum) and joined the campaign table in the stock line query so it can ORDER BY campaign.name.

## 💌 Any notes for the reviewer?

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- [ ]  Create campaigns in Manage → Campaigns on a central server.
- [ ]  In stock view, assign some campaigns to stock lines (campaign/program field)
- [ ] Sort the campaign by asc/desc 
- [ ] Sort by something else (name) then re-sort campaigns -> works

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
