### PR TITLE
xxxx use sync clients app name

### DIFF
--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -220,7 +220,7 @@ fn build_v5_api_for_request(
         password_sha256: input.password_sha256.clone(),
         site_uuid: input.hardware_id.clone(),
         app_version: input.version.to_string(),
-        app_name: "Open mSupply Central".to_string(),
+        app_name: input.app_name.to_string(),
         sync_version: SYNC_V5_VERSION.to_string(),
     };
 
@@ -958,11 +958,8 @@ mod tests {
             connection,
             service_provider,
             ..
-        } = setup_all_and_service_provider(
-            "ensure_site_is_v7_already_v7",
-            MockDataInserts::none(),
-        )
-        .await;
+        } = setup_all_and_service_provider("ensure_site_is_v7_already_v7", MockDataInserts::none())
+            .await;
         test_util_set_is_central_server(true);
 
         // test_site inserts a v7 site. No legacy sync URL is set, so any attempt

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -220,7 +220,7 @@ fn build_v5_api_for_request(
         password_sha256: input.password_sha256.clone(),
         site_uuid: input.hardware_id.clone(),
         app_version: input.version.to_string(),
-        app_name: input.app_name.to_string(),
+        app_name: input.app_name.clone(),
         sync_version: SYNC_V5_VERSION.to_string(),
     };
 


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

<img width="1071" height="253" alt="image" src="https://github.com/user-attachments/assets/7e0a25ab-f400-46dc-956f-16a695bd897e" />

In OG I've been observing this weird app naming being shown when helping QA over the last couple weeks. OG already knows what the OMS central server site is, so automatically renames it `Open mSupply Central Server`. However, people frequently have other sites with app name `Open mSupply Central`. This leads to confusion, why the heck are these 3.0.0 remote sites being dubbed "Central" when they're Remote???

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

1. COGS/COMS sync v7
2. ROMS OMS3.0 installed
3. Initialise, it goes into state where where it's waiting for COMS to sync msupply-foundation/open-msupply-frontend#504
4. Check COGS, the site you just tried to initialise is now "Open mSupply Desktop"
5. Finish initialising, it is still "Open mSupply Desktop"

On android the last two would be "Open mSupply Android"
