### PR TITLE
12091 [FSM] Store name on stock data exports

### DIFF
--- a/server/service/src/report/convert_to_excel.rs
+++ b/server/service/src/report/convert_to_excel.rs
@@ -32,7 +32,10 @@ pub fn csv_to_excel(
 
     // Create Excel workbook
     let mut book = umya_spreadsheet::new_file();
-    if let Some(name) = sheet_name.map(sanitize_sheet_name).filter(|n| !n.is_empty()) {
+    if let Some(name) = sheet_name
+        .map(sanitize_sheet_name)
+        .filter(|n| !n.is_empty())
+    {
         // Failure to rename the default sheet is non-fatal — fall through with the default name.
         let _ = book.set_sheet_name(0, &name);
     }
@@ -69,9 +72,10 @@ pub fn export_html_report_to_excel(
     report: GeneratedReport,
     report_name: String,
     template_as_buffer: &Option<Vec<u8>>,
+    sheet_name: Option<&str>,
 ) -> Result<String, ReportError> {
     let reserved_file = reserve_file(base_dir, &report_name)?;
-    let mut book = get_workbook(template_as_buffer, &reserved_file.path)?;
+    let mut book = get_workbook(template_as_buffer, &reserved_file.path, sheet_name)?;
 
     // We work with the first sheet in the book
     let sheet = book
@@ -126,6 +130,7 @@ fn reserve_file(base_dir: &str, report_name: &str) -> Result<StaticFile, ReportE
 fn get_workbook(
     template_as_buffer: &Option<Vec<u8>>,
     path: &str,
+    sheet_name: Option<&str>,
 ) -> Result<Spreadsheet, ReportError> {
     let book = match template_as_buffer {
         Some(template) => {
@@ -133,14 +138,19 @@ fn get_workbook(
             fs::write(path, template)
                 .map_err(|err| ReportError::DocGenerationError(format!("{err}")))?;
 
-            // Read in the template as a mutable XLSX book
+            // Read in the template as a mutable XLSX book. The template's own
+            // sheet name is kept
             umya_spreadsheet::reader::xlsx::read(path)
                 .map_err(|err| ReportError::DocGenerationError(format!("{err}")))?
         }
         None => {
             // Create a new xlsx file if no template is provided
             let mut book = umya_spreadsheet::new_file();
-            book.set_sheet_name(0, "Report")
+            let name = sheet_name
+                .map(sanitize_sheet_name)
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| "Report".to_string());
+            book.set_sheet_name(0, &name)
                 .map_err(|err| ReportError::DocGenerationError(err.to_string()))?;
             book
         }
@@ -780,18 +790,46 @@ mod report_to_excel_test {
 
     #[test]
     fn test_csv_to_excel_sets_sheet_name() {
-        let csv_data = "Name,Status\nHarry Potter,Picked\n";
-        let file_id =
-            csv_to_excel(".", csv_data, "test_sheet_name", Some("fsmclinic")).unwrap();
+        let read_sheet_name = |file_id: &str| {
+            let file_service = StaticFileService::new(".").unwrap();
+            let generated_file = file_service
+                .find_file(file_id, StaticFileCategory::Temporary)
+                .unwrap()
+                .unwrap();
+            let book = umya_spreadsheet::reader::xlsx::read(&generated_file.path).unwrap();
+            book.get_sheet(&0).unwrap().get_name().to_string()
+        };
 
-        let file_service = StaticFileService::new(".").unwrap();
-        let generated_file = file_service
-            .find_file(&file_id, StaticFileCategory::Temporary)
-            .unwrap()
-            .unwrap();
-        let book = umya_spreadsheet::reader::xlsx::read(&generated_file.path).unwrap();
-        let sheet = book.get_sheet(&0).unwrap();
-        assert_eq!(sheet.get_name(), "fsmclinic");
+        // sheet after the store code
+        let csv_data = "Name,Status\nHarry Potter,Picked\n";
+        let file_id = csv_to_excel(".", csv_data, "test_sheet_name", Some("fsmclinic")).unwrap();
+        assert_eq!(read_sheet_name(&file_id), "fsmclinic");
+
+        let export = |file_name: &str, store_code: Option<&str>| {
+            let report = GeneratedReport {
+                document: r#"
+              <table>
+                <thead><tr><th>Item</th></tr></thead>
+                <tbody><tr><td>Ibuprofen 200mg tabs</td></tr></tbody>
+              </table>
+            "#
+                .to_string(),
+                header: None,
+                footer: None,
+            };
+            export_html_report_to_excel(".", report, file_name.to_string(), &None, store_code)
+                .unwrap()
+        };
+
+        assert_eq!(
+            read_sheet_name(&export("test_sheet_store_code", Some("GEN"))),
+            "GEN"
+        );
+        // and falls back to "Report" without one
+        assert_eq!(
+            read_sheet_name(&export("test_sheet_fallback", None)),
+            "Report"
+        );
     }
 
     #[test]
@@ -810,8 +848,7 @@ mod report_to_excel_test {
         // mSupply allows store codes with crazy characters — make sure they
         // can't escape the temp dir or break the path on disk.
         let csv_data = "Name\nHarry\n";
-        let file_id =
-            csv_to_excel(".", csv_data, "../etc/passwd_stock", Some("any")).unwrap();
+        let file_id = csv_to_excel(".", csv_data, "../etc/passwd_stock", Some("any")).unwrap();
 
         let file_service = StaticFileService::new(".").unwrap();
         let generated_file = file_service
@@ -900,12 +937,14 @@ mod report_to_excel_test {
             footer: None,
         };
 
-        // Test the full export function with template
+        // Test the full export function with template. The store code must
+        // NOT override the template's own sheet name
         let result = export_html_report_to_excel(
             ".", // base_dir
             report,
             "test_with_template".to_string(),
             &Some(template_bytes),
+            Some("GEN"),
         );
 
         assert!(result.is_ok(), "Export should succeed with template");
@@ -919,6 +958,8 @@ mod report_to_excel_test {
             .unwrap();
         let generated_book = umya_spreadsheet::reader::xlsx::read(&generated_file.path).unwrap();
         let sheet = generated_book.get_sheet(&0).unwrap();
+
+        assert_eq!(sheet.get_name(), "Report Template");
 
         let get_value = |coord: &str| get_value(sheet, coord);
 

--- a/server/service/src/report/report_service.rs
+++ b/server/service/src/report/report_service.rs
@@ -203,6 +203,7 @@ pub trait ReportServiceTrait: Sync + Send {
                 document,
                 report_name,
                 &report.excel_template_buffer,
+                store_code,
             ),
             Some(PrintFormat::Pdf) | None => {
                 generate_html_report_to_pdf(base_dir, document, report_name, &current_language)

--- a/server/service/src/static_files.rs
+++ b/server/service/src/static_files.rs
@@ -241,12 +241,15 @@ fn delete_temporary_files(file_dir: &PathBuf, max_life_time_millis: u64) -> Resu
     for path in paths {
         let entry = path?;
         let entry_path = entry.path();
-        let metadata = entry.metadata()?;
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
         if !metadata.is_file() {
             continue;
         }
-        // creation time is not available on some file systems...
-        let file_time = metadata.modified()?;
+        let Ok(file_time) = metadata.modified() else {
+            continue;
+        };
         if SystemTime::now()
             .duration_since(file_time)
             .unwrap_or(Duration::from_secs(0))


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12091

Save store name as sheet name, failing back to default if not available (should always be available).

## 💌 Any notes for the reviewer?

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- With Inbound Shipment export to excel

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [ ] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
