### PR TITLE
12424 Add campaign column to stock export (CSV/Excel)

### DIFF
--- a/client/packages/system/src/utils.ts
+++ b/client/packages/system/src/utils.ts
@@ -66,6 +66,7 @@ export const stockLinesToCsv = (
     t('label.num-packs'),
     t('label.available-in-packs'),
     t('label.pack-cost-price'),
+    t('label.campaign-only'),
     t('label.supplier'),
   ];
 
@@ -81,6 +82,7 @@ export const stockLinesToCsv = (
     node.totalNumberOfPacks,
     node.availableNumberOfPacks,
     node.costPricePerPack,
+    node.campaign?.name,
     node.supplierName,
   ]);
   return Formatter.csv({ fields, data });


### PR DESCRIPTION
Fixes #12424

# 👩🏻‍💻 What does this PR do?
Adds the **Campaign** to the stock list export (CSV/Excel).

Stock lines can already have a campaign assigned via the stock input form (stored in `stock_line.campaign_id`), and the campaign is shown as a column in the Stock list view. However, it was missing from the exported file. This PR adds a `Campaign` column to the export so the exported data matches what's on screen.

No query, GraphQL, or server changes were needed — the campaign (`id`/`name`) is already fetched by the `StockLineListRow` fragment used by the export. The only change is in the CSV builder (`stockLinesToCsv`):

- Added a `Campaign` header (reusing the existing `label.campaign-only` key, the same label the on-screen column uses).
- Added `node.campaign?.name` to each exported row, positioned before the `Supplier` column to mirror the list view's column order.
- Empty cell when a stock line has no campaign.


<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

## 💌 Any notes for the reviewer?

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->

# 🧪 Tested

- Opened the Stock list view and used the export button to download both CSV and Excel.
- Confirmed a new **Campaign** column appears, in the same position and with the same header as the on-screen column.
- Verified the value shows the assigned campaign name, and is empty for stock lines with no campaign.
- Confirmed the VVM-status conditional column and all existing columns still export correctly (column/data alignment unchanged).

# 📃 Documentation

- [x] **Public docs needed** (`docs: external`) — user-facing change: the stock export (CSV/Excel) now includes a Campaign column.
  - New **Campaign** column in the Stock list CSV/Excel export, showing the campaign assigned to each stock line (blank when none).
