### PR TITLE
11099 ok & next behaviour fixes

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -208,9 +208,6 @@ export const StocktakeLineEdit = ({
         onClose();
         break;
     }
-
-    // Returning true here triggers the slide animation
-    return true;
   };
 
   const onOk = async () => {

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
@@ -41,6 +41,7 @@ export const StocktakeLineEditForm: FC<StocktakeLineEditProps> = ({
         <ModalLabel label={t('label.item', { count: 1 })} />
         <Grid flex={1} padding={1}>
           <StockItemSearchInput
+            key={item?.id}
             autoFocus={!item}
             openOnFocus={!item}
             disabled={disabled}

--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/CustomerReturn.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/CustomerReturn.tsx
@@ -221,6 +221,7 @@ export const CustomerReturnEditModal = ({
       >
         {returnId && (
           <ItemSelector
+            key={itemId}
             disabled={!!itemId}
             itemId={itemId}
             onChangeItemId={setItemId}

--- a/client/packages/invoices/src/Returns/modals/SupplierReturn/SupplierReturn.tsx
+++ b/client/packages/invoices/src/Returns/modals/SupplierReturn/SupplierReturn.tsx
@@ -211,6 +211,7 @@ export const SupplierReturnEditModal = ({
       >
         {returnId && (
           <ItemSelector
+            key={itemId}
             disabled={!!itemId}
             itemId={itemId}
             onChangeItemId={setItemId}

--- a/client/packages/system/src/Location/ListView/LocationEditModal/LocationEditModal.tsx
+++ b/client/packages/system/src/Location/ListView/LocationEditModal/LocationEditModal.tsx
@@ -49,6 +49,7 @@ interface UseDraftLocationControl {
   onChangeLocation: () => void;
   onSave: () => Promise<void>;
   isLoading: boolean;
+  hasNext: boolean;
 }
 
 const useDraftLocation = (
@@ -60,7 +61,7 @@ const useDraftLocation = (
   const [location, setLocation] = useState<LocationRowFragment>(() =>
     createNewLocation(seed)
   );
-  const { nextLocation } = useLocationList(
+  const { nextLocation, hasNext } = useLocationList(
     {
       sortBy,
       filterBy,
@@ -98,6 +99,7 @@ const useDraftLocation = (
     onChangeLocation,
     onSave,
     isLoading: isUpdating || isCreating,
+    hasNext,
   };
 };
 
@@ -112,7 +114,7 @@ export const LocationEditModal: FC<LocationEditModalProps> = ({
   const { Modal } = useDialog({ isOpen, onClose });
   const t = useTranslation();
   const { error } = useNotification();
-  const { draft, onUpdate, onChangeLocation, onSave, isLoading } =
+  const { draft, onUpdate, onChangeLocation, onSave, isLoading, hasNext } =
     useDraftLocation(location, mode, sortBy, filterBy);
   const isInvalid = !draft.code.trim() || !draft.name.trim();
 
@@ -141,7 +143,7 @@ export const LocationEditModal: FC<LocationEditModalProps> = ({
       nextButton={
         <DialogButton
           variant="next-and-ok"
-          disabled={isInvalid}
+          disabled={isInvalid || (!hasNext && mode === ModalMode.Update)}
           onClick={async () => {
             if (await handleSave()) onChangeLocation();
             return true;

--- a/client/packages/system/src/Location/api/hooks/useLocationList.ts
+++ b/client/packages/system/src/Location/api/hooks/useLocationList.ts
@@ -33,6 +33,7 @@ export const useLocationList = (
   return {
     query: { data, isLoading, isError, isFetching },
     nextLocation: next,
+    hasNext: next !== null,
   };
 };
 
@@ -75,9 +76,8 @@ const getNextLocation = (
   currentLocation?: LocationRowFragment | null
 ) => {
   const idx = data?.findIndex(l => l.id === currentLocation?.id);
-  if (idx == undefined) return null;
-  const next = data[(idx + 1) % data.length];
-
+  if (idx == undefined || idx === -1) return null;
+  const next = data[idx + 1];
   return next ?? null;
 };
 


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #11099 

2 things were raised from QA in the issue, both fixed here:

1 - When using Ok & Next button the item name (in the item selector) now updates. This is fixed in `Customer Returns`, `Supplier Returns`, and `Stocktakes`. Previously this was stale (always showed the first selected item)
2 - In the `Locations` edit modal, Ok & Next button is now disabled when edited the last Location in the list. Previously this cycled back to the start of the list, which no other modal does.

<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

## 💌 Any notes for the reviewer?

Invalidated the key in order to remount the item search. Other modals do this either by the key, or by using the slide mechanisim which remounts the whole modal.
Went with the simpler 'fix the ones not working' approach rather than make a fix in the common component for future use cases, as it's all about to be changed soon anyway 🤷‍♀️ 

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- Went each of `Customer Returns`, `Supplier Returns`, and `Stocktakes` -> added some lines. Confirmed using OK & Next still works for line creation + pops open the item selector. 
- Closed the modal, opened again on the first line, and confirmed that the item name in the item search component is changed correctly with each OK & Next 
- Confirmed it didn't create any extra queries for Stocktakes which is already the slowest line edit view
- Added some locations, confirmed using OK & Next still works for location creation
- Closed the modal, opened again on the first location, and confirmed that OK & Next went through the locations in order, and was disabled on the last location in the list

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
