### PR TITLE
#11099 Simplify getNextLocation guard in useLocationList

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -208,9 +208,6 @@ export const StocktakeLineEdit = ({
         onClose();
         break;
     }
-
-    // Returning true here triggers the slide animation
-    return true;
   };
 
   const onOk = async () => {

--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEditForm.tsx
@@ -41,6 +41,7 @@ export const StocktakeLineEditForm: FC<StocktakeLineEditProps> = ({
         <ModalLabel label={t('label.item', { count: 1 })} />
         <Grid flex={1} padding={1}>
           <StockItemSearchInput
+            key={item?.id}
             autoFocus={!item}
             openOnFocus={!item}
             disabled={disabled}

--- a/client/packages/invoices/src/Returns/modals/CustomerReturn/CustomerReturn.tsx
+++ b/client/packages/invoices/src/Returns/modals/CustomerReturn/CustomerReturn.tsx
@@ -221,6 +221,7 @@ export const CustomerReturnEditModal = ({
       >
         {returnId && (
           <ItemSelector
+            key={itemId}
             disabled={!!itemId}
             itemId={itemId}
             onChangeItemId={setItemId}

--- a/client/packages/invoices/src/Returns/modals/SupplierReturn/SupplierReturn.tsx
+++ b/client/packages/invoices/src/Returns/modals/SupplierReturn/SupplierReturn.tsx
@@ -211,6 +211,7 @@ export const SupplierReturnEditModal = ({
       >
         {returnId && (
           <ItemSelector
+            key={itemId}
             disabled={!!itemId}
             itemId={itemId}
             onChangeItemId={setItemId}

--- a/client/packages/system/src/Location/ListView/LocationEditModal/LocationEditModal.tsx
+++ b/client/packages/system/src/Location/ListView/LocationEditModal/LocationEditModal.tsx
@@ -49,6 +49,7 @@ interface UseDraftLocationControl {
   onChangeLocation: () => void;
   onSave: () => Promise<void>;
   isLoading: boolean;
+  hasNext: boolean;
 }
 
 const useDraftLocation = (
@@ -60,7 +61,7 @@ const useDraftLocation = (
   const [location, setLocation] = useState<LocationRowFragment>(() =>
     createNewLocation(seed)
   );
-  const { nextLocation } = useLocationList(
+  const { nextLocation, hasNext } = useLocationList(
     {
       sortBy,
       filterBy,
@@ -98,6 +99,7 @@ const useDraftLocation = (
     onChangeLocation,
     onSave,
     isLoading: isUpdating || isCreating,
+    hasNext,
   };
 };
 
@@ -112,7 +114,7 @@ export const LocationEditModal: FC<LocationEditModalProps> = ({
   const { Modal } = useDialog({ isOpen, onClose });
   const t = useTranslation();
   const { error } = useNotification();
-  const { draft, onUpdate, onChangeLocation, onSave, isLoading } =
+  const { draft, onUpdate, onChangeLocation, onSave, isLoading, hasNext } =
     useDraftLocation(location, mode, sortBy, filterBy);
   const isInvalid = !draft.code.trim() || !draft.name.trim();
 
@@ -141,7 +143,7 @@ export const LocationEditModal: FC<LocationEditModalProps> = ({
       nextButton={
         <DialogButton
           variant="next-and-ok"
-          disabled={isInvalid}
+          disabled={isInvalid || (!hasNext && mode === ModalMode.Update)}
           onClick={async () => {
             if (await handleSave()) onChangeLocation();
             return true;

--- a/client/packages/system/src/Location/api/hooks/useLocationList.ts
+++ b/client/packages/system/src/Location/api/hooks/useLocationList.ts
@@ -33,6 +33,7 @@ export const useLocationList = (
   return {
     query: { data, isLoading, isError, isFetching },
     nextLocation: next,
+    hasNext: next !== null,
   };
 };
 
@@ -75,9 +76,8 @@ const getNextLocation = (
   currentLocation?: LocationRowFragment | null
 ) => {
   const idx = data?.findIndex(l => l.id === currentLocation?.id);
-  if (idx == undefined) return null;
-  const next = data[(idx + 1) % data.length];
-
+  if (idx == undefined || idx === -1) return null;
+  const next = data[idx + 1];
   return next ?? null;
 };
 

--- a/client/packages/system/src/Location/api/hooks/useLocationList.ts
+++ b/client/packages/system/src/Location/api/hooks/useLocationList.ts
@@ -75,10 +75,9 @@ const getNextLocation = (
   data: LocationRowFragment[],
   currentLocation?: LocationRowFragment | null
 ) => {
-  const idx = data?.findIndex(l => l.id === currentLocation?.id);
-  if (idx == undefined || idx === -1) return null;
-  const next = data[idx + 1];
-  return next ?? null;
+  const idx = data.findIndex(l => l.id === currentLocation?.id);
+  if (idx === -1) return null;
+  return data[idx + 1] ?? null;
 };
 
 const toSortInput = (sortBy?: SortBy<LocationRowFragment>) =>


### PR DESCRIPTION
Follow-up to #12462 (issue #11099) — a small review suggestion, no issue of its own.

> [!NOTE]
> Stacked on #12462: until that PR merges, the diff here shows its commits too. The actual change is the single commit `Simplify getNextLocation guard in useLocationList` (one file, +3/−4).

# 👩🏻‍💻 What does this PR do?

Simplifies the `getNextLocation` helper in `useLocationList.ts` introduced in #12462:

- Drops the `idx == undefined` guard — the `data` parameter is always an array (the caller passes `data?.nodes ?? []`), so `findIndex` always returns a number and only the `-1` check does any work. Removed the now-unneeded `?.` on `data` for the same reason.
- Collapses the temporary `next` variable into a direct `return data[idx + 1] ?? null`.

No behaviour change — `hasNext` and OK & Next stepping work exactly as in #12462.

## 💌 Any notes for the reviewer?

- Pure cleanup, zero functional difference; happy to just close this if you'd rather fold it into #12462 directly.

# 🧪 Testing

- [ ] Open Locations list → edit a location → OK & Next steps through locations in list order
- [ ] On the last location, OK & Next is disabled (no cycling back to the start)
- [ ] `yarn re-compile` and eslint on the changed file pass (verified locally)

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
