### PR TITLE
Prevent negative display of pack difference

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -218,8 +218,8 @@ export const InboundLineEditCards = ({
                 helperText={
                   isPlaceholder
                     ? t('error.field-must-be-specified', {
-                      field: t('label.packs-received'),
-                    })
+                        field: t('label.packs-received'),
+                      })
                     : undefined
                 }
               />
@@ -258,7 +258,7 @@ export const InboundLineEditCards = ({
                   const shouldClearSellPrice =
                     item?.defaultPackSize !== line.packSize &&
                     item?.itemStoreProperties?.defaultSellPricePerPack ===
-                    line.sellPricePerPack;
+                      line.sellPricePerPack;
 
                   updateDraftLine({
                     volumePerPack:
@@ -370,7 +370,7 @@ export const InboundLineEditCards = ({
         accessorFn: row =>
           row.shippedNumberOfPacks == null
             ? null
-            : row.shippedNumberOfPacks - row.numberOfPacks,
+            : Math.abs(row.shippedNumberOfPacks - row.numberOfPacks),
       },
       ...(plugins.inboundShipmentLine?.editViewField ?? []).map(
         ({ header, Component }, index): ColumnDef<DraftInboundLine> => ({
@@ -481,7 +481,10 @@ export const InboundLineEditCards = ({
                 disabled={isDisabled || !isManualShipment}
                 decimalsLimit={5}
                 updateFn={value =>
-                  updateDraftLine({ id: row.original.id, costPricePerPack: value })
+                  updateDraftLine({
+                    id: row.original.id,
+                    costPricePerPack: value,
+                  })
                 }
               />
             </span>
@@ -837,9 +840,9 @@ export const InboundLineEditCards = ({
   const groupIcons = simplified
     ? undefined
     : {
-      stockLineDetails: <StockIcon />,
-      moreInfo: <InfoIcon />,
-    };
+        stockLineDetails: <StockIcon />,
+        moreInfo: <InfoIcon />,
+      };
 
   return (
     <>


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12461

Wraps the difference in `Math.abs` so that it always displays as a positive number

<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

## 💌 Any notes for the reviewer?
z

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- Created an outbound shipment to a store, switched to the customer store, marked the inbound as delivered
- Adjusted the received quantity 

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [ ] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
