### PR TITLE
Align inbound and outbound shipments

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/columns.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/columns.tsx
@@ -134,7 +134,7 @@ export const useInboundShipmentColumns = (
         accessorFn: row =>
           row.shippedNumberOfPacks == null
             ? null
-            : row.shippedNumberOfPacks - row.numberOfPacks,
+            : row.numberOfPacks - row.shippedNumberOfPacks,
         header: t('label.difference'),
         description: t('description.difference-packs'),
         columnType: ColumnType.Number,

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -370,7 +370,7 @@ export const InboundLineEditCards = ({
         accessorFn: row =>
           row.shippedNumberOfPacks == null
             ? null
-            : Math.abs(row.shippedNumberOfPacks - row.numberOfPacks),
+            : row.numberOfPacks - row.shippedNumberOfPacks,
       },
       ...(plugins.inboundShipmentLine?.editViewField ?? []).map(
         ({ header, Component }, index): ColumnDef<DraftInboundLine> => ({


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12461

<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

## 💌 Any notes for the reviewer?
Updated to remove the `Math.abs` and retain the negative numbers - this is more aligned with outbound shipments

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- _(e.g.)_ Added unit tests covering the issued-quantity calculation in the requisition service
- _(e.g.)_ Set up a Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR (sample datafile: _google drive link_)
- _(e.g.)_ Opened a requisition, added some lines, and made a couple of invoices supplying some of those lines
- _(e.g.)_ Confirmed the "Issued" column showed the sum of the amounts already issued in invoices for the requisition

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [ ] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
