### PR TITLE
Re-process options so that shipment_variance options show up even if …

### DIFF
--- a/server/repository/src/migrations/v2_21_00/mod.rs
+++ b/server/repository/src/migrations/v2_21_00/mod.rs
@@ -5,6 +5,7 @@ mod add_help_document_table;
 mod add_stock_movement_report_context;
 mod add_stock_relocation_line_table;
 mod recreate_stock_relocation_table;
+mod reprocess_options_for_shipment_variance;
 
 pub(crate) struct V2_21_00;
 impl Migration for V2_21_00 {
@@ -22,6 +23,7 @@ impl Migration for V2_21_00 {
             Box::new(add_stock_relocation_line_table::Migrate),
             Box::new(add_help_document_table::Migrate),
             Box::new(add_stock_movement_report_context::Migrate),
+            Box::new(reprocess_options_for_shipment_variance::Migrate),
         ]
     }
 }

--- a/server/repository/src/migrations/v2_21_00/reprocess_options_for_shipment_variance.rs
+++ b/server/repository/src/migrations/v2_21_00/reprocess_options_for_shipment_variance.rs
@@ -1,0 +1,27 @@
+use crate::{
+    migrations::{sql, MigrationFragment},
+    StorageConnection,
+};
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "reprocess_options_for_shipment_variance"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // Re-translate  options on the next sync.
+        // This needed because a new shipment_variance option type was added in v2.20.0
+        // But if the options have already been syned to an old version of the client the reasons won't show up as the sync buffer records had already failed to integrate.
+
+        sql!(
+            connection,
+            r#"
+            UPDATE sync_buffer SET integration_datetime = NULL WHERE table_name = 'options';
+        "#,
+        )?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
…they failed on an older version

# 👩🏻‍💻 What does this PR do?

Fixes https://github.com/msupply-foundation/haiti-plugins/issues/17

In v2.20 Open-mSupply added support for a new reason option type `SHIPMENT_VARIANCE`
However if the reasons where created in legacy mSupply server with this type while a remotes site is on an older version, we fail to integrate the sync buffer. Unless this is re-processed we won't ever see those reason on that site.
Hence this PR.

record_id | received_datetime | integration_datetime | integration_error | table_name | action | data | source_site_id
-- | -- | -- | -- | -- | -- | -- | --
9D37B6FF63DC0447956A0E722A3C4642 | 2026-06-29 04:26:09.512251181 | 2026-06-29 04:26:13.635860101 | unknown variant `shipmentVariance`, expected one of `positiveInventoryAdjustment`, `negativeInventoryAdjustment`, `openVialWastage`, `returnReason`, `requisitionLineVariance`, `closedVialWastage` at line 1 column 101 | options | UPSERT | {"ID":"9D37B6FF63DC0447956A0E722A3C4642","isActive":true,"title":"Positive","type":"shipmentVariance"} | 1

## 💌 Any notes for the reviewer?

I think we need to have table_name indexed on Sync V7 Sync buffer so this works in future...

Technically could add a test for this in the code but I don't think it's necessary with manual testing. Shouldn't be a regression...

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- Maria is testing by re-initialising on 2.19 (which doesn't support SHIPMENT_VARIANCE)
- Upgrading to 2.21 (pre this fix)
- Upgrading to this fix PR

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [X] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
