### PR TITLE
Postgres script to apply v2.21 fragments to existing v7 datafiles

### DIFF
--- a/scripts/v2_21_on_v7_postgres.sql
+++ b/scripts/v2_21_on_v7_postgres.sql
@@ -1,0 +1,156 @@
+-- =============================================================================
+-- Apply the v2.21.0 migration fragments to an EXISTING sync-v7 (3.0.0) PostgreSQL
+-- datafile.  Companion to scripts/v2_20_on_v7_postgres.sql (see issue #12323).
+--
+-- WHY THIS SCRIPT EXISTS
+-- ---------------------
+-- The v2.21.0 fragments were merged into the sync-v7 branch AFTER existing COMS
+-- datafiles had already been migrated to database version 3.0.0 (e.g. full
+-- migration of OG stores).  The migration runner only runs a migration's
+-- fragments when `migration_version >= database_version`
+-- (server/repository/src/migrations/mod.rs).  Since 2.21.0 >= 3.0.0 is false,
+-- the five 2.21.0 fragments are silently skipped on those datafiles.  The most
+-- visible symptom is a startup panic loading the standard reports:
+--     invalid input value for enum context_type: "STOCK_MOVEMENT"
+-- (same failure class as #12439).  Re-initialising is expensive, so this script
+-- applies the same changes by hand.
+--
+-- HOW TO USE
+-- ----------
+-- 1. BACK UP THE DATABASE FIRST.
+-- 2. If the datafile is also missing the v2.20 fragments (e.g. no
+--    `reason_option_type` value 'SHIPMENT_VARIANCE'), run
+--    scripts/v2_20_on_v7_postgres.sql first.
+-- 3. Run this file against the COMS database, stopping on the first error:
+--        psql -d <database> -v ON_ERROR_STOP=1 -f v2_21_on_v7_postgres.sql
+-- 4. The `migration_fragment_log` inserts at the end mark each fragment as run,
+--    so the server won't try to re-run them once the runner fix lands.
+--
+-- TRANSACTIONS
+-- ------------
+-- This file is intentionally NOT wrapped in a single BEGIN/COMMIT.  `ALTER TYPE
+-- ... ADD VALUE` cannot run inside a transaction block on older PostgreSQL, and a
+-- newly added enum value cannot be used in the same transaction even where it
+-- can (see migrations README "Migration fragments in transactions").  Each
+-- statement here is individually idempotent and atomic, so running them
+-- statement-by-statement is safe.
+--
+-- IDEMPOTENCY
+-- -----------
+-- Statements use IF NOT EXISTS / ADD VALUE IF NOT EXISTS (or guard DO blocks) so
+-- the script is safe to re-run.
+--
+-- NOTE ON changelog_table_name
+-- ----------------------------
+-- The original v2.20/v2.21 fragments also ran
+--     ALTER TYPE changelog_table_name ADD VALUE ...
+-- for the new tables.  That is NOT replayed here: the v7 migration
+-- `alter_changelog_table_for_sync_v7` dropped the `changelog_table_name` type
+-- (`changelog.table_name` is plain TEXT on 3.0.0 datafiles), so those statements
+-- would fail and are no longer needed.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. recreate_stock_relocation_table (schema)
+-- -----------------------------------------------------------------------------
+-- The original fragment drops the old-shape table (from the v2.20 fragment
+-- `add_stock_relocation_table`) and recreates it with the final shape.  On an
+-- affected datafile the old table usually never existed (the v2.20 fragments
+-- were skipped too), but scripts/v2_20_on_v7_postgres.sql creates the old shape
+-- if it was run first — so handle both: drop the old shape if present, then
+-- create the final shape.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns
+               WHERE table_name = 'stock_relocation'
+                 AND column_name = 'from_stock_line_id') THEN
+        -- Old (v2.20) shape: replay the original fragment's cleanup.
+        DELETE FROM changelog WHERE table_name = 'stock_relocation';
+        DROP TABLE stock_relocation;
+        DROP TYPE stock_relocation_status;
+    END IF;
+END$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'stock_relocation_status') THEN
+        CREATE TYPE stock_relocation_status AS ENUM ('NEW', 'CONFIRMED', 'FINALISED');
+    END IF;
+END$$;
+
+CREATE TABLE IF NOT EXISTS stock_relocation (
+    id TEXT NOT NULL PRIMARY KEY,
+    store_id TEXT NOT NULL REFERENCES store(id),
+    stock_movement_number BIGINT NOT NULL,
+    status stock_relocation_status NOT NULL,
+    created_datetime TIMESTAMP NOT NULL,
+    created_by TEXT NOT NULL,
+    confirmed_datetime TIMESTAMP,
+    finalised_datetime TIMESTAMP,
+    comment TEXT
+);
+
+-- -----------------------------------------------------------------------------
+-- 2. add_stock_relocation_line_table (schema)
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS stock_relocation_line (
+    id TEXT NOT NULL PRIMARY KEY,
+    stock_relocation_id TEXT NOT NULL REFERENCES stock_relocation(id),
+    stock_line_id TEXT NOT NULL REFERENCES stock_line(id),
+    destination_stock_line_id TEXT REFERENCES stock_line(id),
+    source_location_id TEXT REFERENCES location(id),
+    destination_location_id TEXT REFERENCES location(id),
+    number_of_packs DOUBLE PRECISION NOT NULL DEFAULT 0
+);
+
+-- -----------------------------------------------------------------------------
+-- 3. add_help_document_table (schema)
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS help_document (
+    id TEXT NOT NULL PRIMARY KEY,
+    title TEXT NOT NULL,
+    created_datetime TIMESTAMP NOT NULL,
+    deleted_datetime TIMESTAMP
+);
+
+-- -----------------------------------------------------------------------------
+-- 4. add_stock_movement_report_context (schema, PG enum)
+-- -----------------------------------------------------------------------------
+-- This is the fragment whose absence panics startup: StandardReports::load_reports
+-- inserts the stock movement report with this context.
+ALTER TYPE context_type ADD VALUE IF NOT EXISTS 'STOCK_MOVEMENT';
+
+-- -----------------------------------------------------------------------------
+-- 5. reprocess_options_for_shipment_variance (DATA, v7-adapted)
+-- -----------------------------------------------------------------------------
+-- The original fragment ran:
+--     UPDATE sync_buffer SET integration_datetime = NULL WHERE table_name = 'options';
+-- ...so options records are re-translated on next sync, making SHIPMENT_VARIANCE
+-- reason options show up even where they had failed to integrate on an older
+-- version.
+--
+-- That statement is a no-op on a v7 datafile: `rebuild_sync_buffer` repartitioned
+-- `sync_buffer` BY LIST (is_integrated) and the pending query filters on
+-- `is_integrated`, so `integration_datetime` alone no longer controls
+-- re-integration.  The v7 equivalent below follows the pattern already used in
+-- production by the v3.0.0 reintegrate_* fragments (e.g.
+-- reintegrate_categories_for_custom_field_options): flipping `is_integrated`
+-- moves the rows back to the pending partition.  Options records are few, so
+-- this is cheap.
+UPDATE sync_buffer
+    SET is_integrated = FALSE,
+        integration_datetime = NULL,
+        integration_error = NULL
+    WHERE table_name = 'options';
+
+-- -----------------------------------------------------------------------------
+-- Mark all five fragments as run so the migration runner skips them.
+-- (version_and_identifier = '<migration version>-<fragment identifier>')
+-- -----------------------------------------------------------------------------
+INSERT INTO migration_fragment_log (version_and_identifier, datetime) VALUES
+    ('2.21.0-recreate_stock_relocation_table', now()),
+    ('2.21.0-add_stock_relocation_line_table', now()),
+    ('2.21.0-add_help_document_table', now()),
+    ('2.21.0-add_stock_movement_report_context', now()),
+    ('2.21.0-reprocess_options_for_shipment_variance', now())
+ON CONFLICT (version_and_identifier) DO NOTHING;


### PR DESCRIPTION
Related to #12323 — same problem for the v2.21.0 fragments; the v2.20.0 equivalent is #12324. No dedicated issue for the v2.21 instance.

# 👩🏻‍💻 What does this PR do?

Adds a standalone Postgres script, `scripts/v2_21_on_v7_postgres.sql`, that applies the v2.21.0 migration fragments by hand to an **existing sync-v7 (3.0.0) datafile**. Companion to `scripts/v2_20_on_v7_postgres.sql` (#12324).

The v2.21.0 fragments were merged into the sync-v7 branch *after* existing COMS datafiles had already been migrated to database version `3.0.0`. The migration runner only runs a migration's fragments when `migration_version >= database_version` ([mod.rs](../server/repository/src/migrations/mod.rs)). Since `2.21.0 >= 3.0.0` is false, the five 2.21.0 fragments are silently skipped on those datafiles. The most visible symptom is a startup panic loading the standard reports:

```
invalid input value for enum context_type: "STOCK_MOVEMENT"
```

(same failure class as #12439). Re-initialising takes too long, so this script lets QA bring an already-migrated test datafile up to date without re-init.

The script:
- Applies the 4 schema fragments (`stock_relocation` recreate + type, `stock_relocation_line`, `help_document`, and the `context_type` enum `ADD VALUE`).
- Applies the 1 data fragment (`reprocess_options_for_shipment_variance`) in v7-adapted form — see reviewer notes.
- Seeds `migration_fragment_log` so the runner won't re-run any of the five.

It is idempotent (`IF NOT EXISTS` / `ADD VALUE IF NOT EXISTS` / guard `DO` blocks) and intentionally **not** wrapped in a single transaction, because `ALTER TYPE ... ADD VALUE` can't run inside a transaction block on older Postgres.

## 💌 Any notes for the reviewer?

> ⚠️ **Draft — not for merge.** This is for the QA team to apply to existing migrated test datafiles. It does not touch the migration runner; the underlying `migration_version >= database_version` gate is still in place (tracked separately).

- **Postgres only.** SQLite datafiles re-initialise quickly, so no SQLite equivalent is provided.
- **`changelog_table_name` enum additions are deliberately skipped.** The original v2.20/v2.21 fragments run `ALTER TYPE changelog_table_name ADD VALUE ...` for new tables, but the v7 migration `alter_changelog_table_for_sync_v7` dropped that type (`changelog.table_name` is plain TEXT on 3.0.0), so those statements would fail and are no longer needed. Note: the v2.20 script in #12324 still contains `ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'stock_relocation'` (section 11), which will fail on a v7 datafile for the same reason — flagged there separately.
- **The data migration IS executed here** (unlike the two deferred ones in #12324). The original fragment nulls `sync_buffer.integration_datetime` for `options` rows, which is a no-op on v7 (the buffer is partitioned `BY LIST (is_integrated)` and the pending query filters on `is_integrated`). The script uses the v7-correct pattern already used in production by the v3.0.0 `reintegrate_*` fragments (e.g. `reintegrate_categories_for_custom_field_options`): flip `is_integrated = FALSE` (+ clear `integration_datetime`/`integration_error`), which moves the rows back to the pending partition. Options records are few, so this is cheap.
- **`stock_relocation` handles both starting states.** Usually the old (v2.20-shape) table never existed on an affected datafile, but if `scripts/v2_20_on_v7_postgres.sql` was run first it created the old shape. The script detects the old shape (via the `from_stock_line_id` column), replays the original recreate fragment's cleanup (changelog delete, drop table + type), then creates the final shape.

# 🧪 Testing

Done locally against a real 3.0.0 Postgres datafile (a clone of the `migration_3.0.0` test database):

- [x] Stripped all traces of the 2.21 fragments (dropped the three tables + `stock_relocation_status` type, deleted the `2.21.0-*` fragment log rows), ran `psql -d <database> -v ON_ERROR_STOP=1 -f scripts/v2_21_on_v7_postgres.sql` — confirmed the final 9-column `stock_relocation` shape, the 3-value status enum in correct order, `stock_relocation_line` + `help_document`, `STOCK_MOVEMENT` in `context_type`, and all five `migration_fragment_log` rows.
- [x] Re-ran the script — clean no-op (idempotent).
- [x] Recreated the old v2.20 `stock_relocation` shape (as left by the #12324 script), re-ran — old table and 2-value enum correctly replaced with the final shape.

For QA on a real datafile:

- [ ] Take an existing COMS Postgres datafile already migrated to v7 (`DATABASE_VERSION = 3.0.0`) that is missing the 2.21 schema (e.g. startup panics with the `context_type` error above, or no `help_document` table).
- [ ] Back it up.
- [ ] If it is also missing the 2.20 schema, run `scripts/v2_20_on_v7_postgres.sql` first.
- [ ] Run `psql -d <database> -v ON_ERROR_STOP=1 -f scripts/v2_21_on_v7_postgres.sql`.
- [ ] Confirm the `stock_relocation` (with `confirmed_datetime`), `stock_relocation_line` and `help_document` tables and the `context_type` value `STOCK_MOVEMENT` exist.
- [ ] Confirm `migration_fragment_log` now contains the five `2.21.0-*` identifiers.
- [ ] Start the server against the datafile and confirm it boots without the standard-reports panic.

# 📃 Documentation

- [x] **No documentation required**: internal QA tooling, no user-facing change.

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
