### PR TITLE
Upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -20,7 +20,7 @@ jobs:
         id: nvm
 
       - name: Use Node.js (.nvmrc)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
@@ -46,25 +46,18 @@ jobs:
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "RUSTUP_TOOLCHAIN=$CHANNEL" >> "$GITHUB_ENV"
       - name: Set Up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
-          override: false
-          default: false
-          targets: aarch64-linux-android
-            armv7-linux-androideabi
-        # Targets need to match in the config.toml of the self-hosted machine
+        run: rustup toolchain install "${{ steps.rust_toolchain.outputs.channel }}" --profile minimal --no-self-update
 
       - name: Add Android targets for pinned toolchain
         # The self-hosted runner pre-installs the Android targets for its default
         # (stable) toolchain only. Now that cargo runs under the pinned channel
         # (RUSTUP_TOOLCHAIN), those targets must be installed for it explicitly or
-        # the std crate can't be found (E0463). actions-rs/toolchain's `targets`
-        # input doesn't reliably cover the named channel on this runner.
+        # the std crate can't be found (E0463). Targets need to match those in the
+        # config.toml of the self-hosted machine.
         run: rustup target add aarch64-linux-android armv7-linux-androideabi --toolchain "${{ steps.rust_toolchain.outputs.channel }}"
 
       - name: Set Up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version-file: client/.java-version
@@ -81,23 +74,21 @@ jobs:
         run: npx cap update android
 
       - name: Build Android App
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: android:build:release
-          dir: 'client'
+        working-directory: client
+        run: yarn android:build:release
         env:
           NDK_BIN: /Users/tmfmacmini/android/ndk/27.2.12479018/toolchains/llvm/prebuilt/darwin-x86_64/bin/
         # Update this version when upgrading the NDK version on the self-hosted machine
 
       - name: Upload Universal APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Open_mSupply_Universal_Build
           path: ./client/packages/android/app/build/outputs/apk/universal/release/*.apk
           retention-days: 3
 
       - name: Upload Arm64 APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Open_mSupply_Arm64_Build
           path: ./client/packages/android/app/build/outputs/apk/arm64/release/*.apk
@@ -123,7 +114,7 @@ jobs:
     if: ${{ always() && needs.create-android-build.result != 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Send build completion notification
         env:
           SLACK_DEV_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_DEV_RELEASE_WEBHOOK_URL }}

--- a/.github/workflows/build-changelog-bench.yaml
+++ b/.github/workflows/build-changelog-bench.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -39,7 +39,7 @@ jobs:
           cp -r syncdoc/content/changelog/bench/index-configs changelog-bench-linux-x64/
           cp -r syncdoc/content/changelog/bench/partition-configs changelog-bench-linux-x64/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: changelog-bench-linux-x64
           path: changelog-bench-linux-x64/
@@ -52,7 +52,7 @@ jobs:
     env:
       PQ_LIB_DIR: C:\Program Files\PostgreSQL\17\lib
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -82,7 +82,7 @@ jobs:
           cp "/c/Program Files/PostgreSQL/17/bin/libintl-9.dll" changelog-bench-windows-x64/ || true
           cp "/c/Program Files/PostgreSQL/17/bin/libiconv-2.dll" changelog-bench-windows-x64/ || true
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: changelog-bench-windows-x64
           path: changelog-bench-windows-x64/

--- a/.github/workflows/build-mac-demo.yaml
+++ b/.github/workflows/build-mac-demo.yaml
@@ -28,15 +28,14 @@ jobs:
     env:
       RUSTFLAGS: '--cfg recursion_limit_256'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v5
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
       - name: Read .nvmrc
         run: echo "NVMRC=$(cat ./client/.nvmrc)" >> "$GITHUB_OUTPUT"
         id: nvm
       - name: Use Node.js (.nvmrc)
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v5
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
       - name: Build
@@ -52,7 +51,7 @@ jobs:
           # Below would add it env.artifactName and env.zippedArtifactName, so it can be used in upload-artifact action
           echo "artifactName=${ARTIFACT_NAME}" >> $GITHUB_ENV
           echo "zippedArtifactName=${ZIPPED_ARTIFACT_NAME}" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: ${{ env.artifactName }}
           path: ${{ env.zippedArtifactName }}

--- a/.github/workflows/build-standard-reports.yaml
+++ b/.github/workflows/build-standard-reports.yaml
@@ -25,23 +25,22 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.base.ref || inputs.branch }}
           token: ${{ secrets.JSON_SORT_PAT }}
           fetch-depth: 1
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: server
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Enable Corepack
         run: corepack enable
@@ -53,7 +52,7 @@ jobs:
         working-directory: ./server
         run: cargo run --bin remote_server_cli -- build-reports
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: ${{ github.event.pull_request.base.ref || inputs.branch }}
           commit_message: "chore: regenerate standard reports/forms"

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -32,7 +32,7 @@ jobs:
             --method POST \
             -f content="eyes"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload Claude logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: claude-logs
           path: /home/runner/work/_temp/claude-execution-output.json

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -34,7 +34,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/cleanup-docker-tags.yaml
+++ b/.github/workflows/cleanup-docker-tags.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run cleanup script
         env:

--- a/.github/workflows/client-bundle-size-comment.yaml
+++ b/.github/workflows/client-bundle-size-comment.yaml
@@ -14,7 +14,7 @@ jobs:
       actions: read
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: pr-artifact
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,7 +26,7 @@ jobs:
           echo "pr_number=$(cat pr_number)" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/client-bundle-size-diff.yaml
+++ b/.github/workflows/client-bundle-size-diff.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.base_ref }}
 
@@ -28,7 +28,7 @@ jobs:
         id: nvm
 
       - name: Use Node.js (.nvmrc)
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v5
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload base stats.json
         if: ${{ steps.build.outcome == 'success' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: base
           path: ./client/packages/host/dist/stats.json
@@ -60,14 +60,14 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Read .nvmrc
         run: echo "NVMRC=$(cat ./client/.nvmrc)" >> "$GITHUB_OUTPUT"
         id: nvm
 
       - name: Use Node.js (.nvmrc)
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v5
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
 
@@ -78,7 +78,7 @@ jobs:
         run: cd ./client && yarn build-stats
 
       - name: Upload PR stats.json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pr-stats
           path: ./client/packages/host/dist/stats.json
@@ -90,18 +90,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download base stats
         id: download-base
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: base
           path: base
 
       - name: Download PR stats
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: pr-stats
           path: pr
@@ -109,10 +109,27 @@ jobs:
       - name: Calculate diff
         if: ${{ steps.download-base.outcome == 'success' }}
         id: get-diff
-        uses: NejcZdovc/bundle-size-diff@v1
-        with:
-          base_path: './base/stats.json'
-          pr_path: './pr/stats.json'
+        # Sums .assets[].size from the webpack stats files, replicating the
+        # retired NejcZdovc/bundle-size-diff action (unmaintained, node12).
+        run: |
+          base=$(jq '[.assets[].size] | add // 0' base/stats.json)
+          pr=$(jq '[.assets[].size] | add // 0' pr/stats.json)
+          diff=$((pr - base))
+          human() {
+            awk -v b="$1" 'BEGIN {
+              sign = b < 0 ? "-" : ""; b = b < 0 ? -b : b
+              split("B KB MB GB TB", u, " "); i = 1
+              while (b >= 1024 && i < 5) { b /= 1024; i++ }
+              printf "%s%.2f %s", sign, b, u[i]
+            }'
+          }
+          percent=$(awk -v o="$base" -v n="$pr" 'BEGIN { printf "%.2f", o ? (n - o) / o * 100 : 0 }')
+          {
+            echo "base_file_string=$(human "$base")"
+            echo "pr_file_string=$(human "$pr")"
+            echo "diff_file_string=$(human "$diff")"
+            echo "percent=$percent"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Save comparison data
         run: |
@@ -135,7 +152,7 @@ jobs:
           fi
 
       - name: Upload comparison artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pr-artifact
           path: |

--- a/.github/workflows/client-code-checks.yaml
+++ b/.github/workflows/client-code-checks.yaml
@@ -19,14 +19,14 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Read .nvmrc
         run: echo "NVMRC=$(cat ./client/.nvmrc)" >> "$GITHUB_OUTPUT"
         id: nvm
 
       - name: Set Up Node JS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
 

--- a/.github/workflows/client-tests.yaml
+++ b/.github/workflows/client-tests.yaml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
 
@@ -29,7 +29,7 @@ jobs:
         id: nvm
 
       - name: Use Node.js (.nvmrc)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
 

--- a/.github/workflows/dockerise.yaml
+++ b/.github/workflows/dockerise.yaml
@@ -44,14 +44,14 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Read .nvmrc
         run: echo "NVMRC=$(cat ./client/.nvmrc)" >> "$GITHUB_OUTPUT"
         id: nvm
 
       - name: Use Node.js (.nvmrc)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
 
@@ -65,7 +65,7 @@ jobs:
         run: NODE_OPTIONS="--max_old_space_size=4096" cd ./client && yarn build
 
       - name: Save artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: client-dist
           path: client/packages/host/dist
@@ -95,10 +95,10 @@ jobs:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Load client artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: client-dist
           path: client/packages/host/dist
@@ -148,7 +148,7 @@ jobs:
           fi
 
       - name: Save server executable artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: server-executables-${{ matrix.db }}-${{ matrix.arch }}
           path: |
@@ -170,25 +170,25 @@ jobs:
       image_tag: ${{ env.VERSION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Load server artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: server-executables-${{ matrix.db }}-${{ matrix.arch }}
           path: server/
 
       - name: Set up QEMU
         if: matrix.arch == 'arm64'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
@@ -209,7 +209,7 @@ jobs:
           fi
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: ${{ steps.vars.outputs.target }}
@@ -220,7 +220,7 @@ jobs:
 
       - name: Build and Push Docker Image Dev
         if: matrix.arch == 'amd64' && needs.check-tag.outputs.is_release == 'true'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: ${{ steps.vars.outputs.target_dev }}

--- a/.github/workflows/generate-database-schema.yaml
+++ b/.github/workflows/generate-database-schema.yaml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Extract version
         run: |
@@ -64,12 +64,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpq-dev
 
       - name: Set up Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        run: rustup toolchain install stable --profile minimal --no-self-update
 
       - name: Cache Rust build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/generate-schema.yml
+++ b/.github/workflows/generate-schema.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
 
@@ -30,7 +30,7 @@ jobs:
         id: nvm
 
       - name: Use Node.js (.nvmrc)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
 

--- a/.github/workflows/get_team_assign_label_milestone.yaml
+++ b/.github/workflows/get_team_assign_label_milestone.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/graphql-schema-compatibility.yaml
+++ b/.github/workflows/graphql-schema-compatibility.yaml
@@ -29,7 +29,7 @@ jobs:
         run: mkdir -p /tmp/schema-diff
 
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -38,7 +38,7 @@ jobs:
         id: nvm
         run: echo "NVMRC=$(cat ./client/.nvmrc)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
 

--- a/.github/workflows/integrate-rc-to-develop.yaml
+++ b/.github/workflows/integrate-rc-to-develop.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.NIGHTLY_BUILD_GITHUB_PAT }}

--- a/.github/workflows/integration-test-check.yaml
+++ b/.github/workflows/integration-test-check.yaml
@@ -28,6 +28,6 @@ jobs:
     steps:
       - name: Update PATH
         run: echo "$HOME/.cargo/bin:/opt/homebrew/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: cargo check --features integration_test --tests
         run: cargo check --features integration_test --tests --manifest-path server/Cargo.toml

--- a/.github/workflows/nightly-automated-builds.yaml
+++ b/.github/workflows/nightly-automated-builds.yaml
@@ -14,7 +14,7 @@ jobs:
       AFFECTED_BRANCHES: ${{ steps.create_tags.outputs.AFFECTED_BRANCHES }}
       HAS_TAGS: ${{ steps.create_tags.outputs.HAS_TAGS }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.NIGHTLY_BUILD_GITHUB_PAT }}
@@ -33,7 +33,7 @@ jobs:
     if: needs.create-tags.outputs.HAS_TAGS == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Send Slack notifications
         env:
           SLACK_DEV_RELEASE_WEBHOOK_URL: ${{ secrets.SLACK_DEV_RELEASE_WEBHOOK_URL }}

--- a/.github/workflows/pr-issue-label-sync.yaml
+++ b/.github/workflows/pr-issue-label-sync.yaml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Sync labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             core.debug(`where the PR? ${context.repo.repo} ${context.repo.owner} ${context.issue.number}`);

--- a/.github/workflows/server-build.yaml
+++ b/.github/workflows/server-build.yaml
@@ -10,16 +10,15 @@ jobs:
     env:
       RUSTFLAGS: '--cfg recursion_limit_256'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v5
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
       - name: Initialise
         working-directory: ./server
         run: cargo run --bin remote_server_cli -- initialise-from-export -n 'reference1' -r
       - name: Build
         run: ./build/mac/build.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v6
         with:
           name: mac_sqlite
           path: |

--- a/.github/workflows/server-tests.yaml
+++ b/.github/workflows/server-tests.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Update PATH
         run: echo "$HOME/.cargo/bin:/opt/homebrew/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Read Rust toolchain channel
         id: rust_toolchain
         # Scope the toolchain to this job only via RUSTUP_TOOLCHAIN; do NOT set a
@@ -33,21 +33,16 @@ jobs:
           CHANNEL=$(grep '^channel' server/rust-toolchain.toml | cut -d '"' -f2)
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "RUSTUP_TOOLCHAIN=$CHANNEL" >> "$GITHUB_ENV"
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
-          override: false
-          default: false
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install "${{ steps.rust_toolchain.outputs.channel }}" --profile minimal --no-self-update
       - name: Install cargo-nextest
         run: command -v cargo-nextest || cargo install cargo-nextest --locked
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clean
-          args: -p repository -p graphql_types -p graphql_plugin -p graphql_invoice --manifest-path server/Cargo.toml
+      - name: Clean changed crates
+        run: cargo clean -p repository -p graphql_types -p graphql_plugin -p graphql_invoice --manifest-path server/Cargo.toml
       - name: Run tests and generate report
         run: cargo nextest run --profile=ci-sqlite --features=sqlite --manifest-path server/Cargo.toml
       - name: Upload JUnit test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: (!cancelled())
         with:
           name: test-results-sqlite
@@ -74,7 +69,7 @@ jobs:
     steps:
       - name: Update PATH
         run: echo "$HOME/.cargo/bin/:/opt/homebrew/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Read Rust toolchain channel
         id: rust_toolchain
         # Scope the toolchain to this job only via RUSTUP_TOOLCHAIN; do NOT set a
@@ -84,21 +79,16 @@ jobs:
           CHANNEL=$(grep '^channel' server/rust-toolchain.toml | cut -d '"' -f2)
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "RUSTUP_TOOLCHAIN=$CHANNEL" >> "$GITHUB_ENV"
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ steps.rust_toolchain.outputs.channel }}
-          override: false
-          default: false
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install "${{ steps.rust_toolchain.outputs.channel }}" --profile minimal --no-self-update
       - name: Install cargo-nextest
         run: command -v cargo-nextest || cargo install cargo-nextest --locked
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clean
-          args: -p repository -p graphql_types -p graphql_plugin -p graphql_invoice --manifest-path server/Cargo.toml
+      - name: Clean changed crates
+        run: cargo clean -p repository -p graphql_types -p graphql_plugin -p graphql_invoice --manifest-path server/Cargo.toml
       - name: Run test and generate report
         run: cargo nextest run --profile=ci-postgres --features=postgres --manifest-path server/Cargo.toml
       - name: Upload JUnit test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: (!cancelled())
         with:
           name: test-results-postgres

--- a/.github/workflows/sort-json.yaml
+++ b/.github/workflows/sort-json.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
           token: ${{ secrets.JSON_SORT_PAT }}
@@ -23,7 +23,7 @@ jobs:
         run: |
           chmod +x .github/scripts/sort-json.sh 
           .github/scripts/sort-json.sh
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "Sorted JSON translation files"
           commit_options: "--no-verify"

--- a/.github/workflows/validate-db-migration-with-views.yml
+++ b/.github/workflows/validate-db-migration-with-views.yml
@@ -28,7 +28,7 @@ jobs:
       CARGO_TARGET_DIR: /tmp/target/sqlite
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       # Resolve the commit to stamp the database from. The base ref tip can move
@@ -56,9 +56,8 @@ jobs:
         run: |
           git checkout ${{ steps.base.outputs.sha }}
           echo "Checked out base commit: ${{ steps.base.outputs.sha }}"
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
       - name: Initialize database with base branch code
         working-directory: server
         run: APP__DATABASE__DATABASE_NAME=validate_views cargo run --bin remote_server_cli -- initialise-database
@@ -78,7 +77,7 @@ jobs:
       CARGO_TARGET_DIR: /tmp/target/postgres
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Resolve base commit
@@ -94,9 +93,8 @@ jobs:
         run: |
           git checkout ${{ steps.base.outputs.sha }}
           echo "Checked out base commit: ${{ steps.base.outputs.sha }}"
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
       - name: Initialize database with base branch code
         working-directory: server
         run: APP__DATABASE__DATABASE_NAME=validate_views cargo run --bin remote_server_cli --features postgres -- initialise-database


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12489

GitHub Actions is deprecating the Node 20 action runtime, so this bumps every workflow action to a node24-based release, and replaces the archived node12 actions with plain `run:` steps.

**Version bumps** (node20 → node24 runtime):

| Action | From | To |
|---|---|---|
| `actions/checkout` | v3 / v4 | v5 |
| `actions/setup-node` | v1 / v4 | v5 |
| `actions/upload-artifact` | v3 / v4 | v6 (v5 is still node20) |
| `actions/download-artifact` | v4 | v7 (v6 is still node20) |
| `actions/setup-python` | v4 | v6 |
| `actions/setup-java` | v4 | v5 |
| `actions/cache` | v4 | v5 |
| `actions/github-script` | v7 | v8 |
| `docker/build-push-action` | v5 | v7 |
| `docker/login-action`, `setup-buildx`, `setup-qemu` | v3 | v4 |
| `stefanzweifel/git-auto-commit-action` | v5 | v7 |

**Archived node12 actions replaced with run steps:**

- `actions-rs/toolchain` → `rustup toolchain install … --profile minimal --no-self-update`. Deliberately **not** `dtolnay/rust-toolchain`: that action runs `rustup default`, which we avoid on the shared self-hosted runners (see the RUSTUP_TOOLCHAIN comments in server-tests / build-android-apk). With `override: false, default: false` the old action only ever installed the toolchain, so a plain rustup install is behaviour-identical.
- `actions-rs/cargo` → plain `cargo clean …` (server-tests).
- `borales/actions-yarn` → `run: yarn android:build:release` with `working-directory: client` (latest borales release is still node20 anyway).
- `NejcZdovc/bundle-size-diff` → a small jq/awk step that sums `.assets[].size` from the webpack stats files and emits the same step outputs (`base_file_string`, `pr_file_string`, `diff_file_string`, `percent`), so the PR comment table is unchanged.

Also bumps the hardcoded `node-version: 20` in build-standard-reports to 24, matching `client/.nvmrc` (v24.12.0).

## 💌 Any notes for the reviewer?

- ⚠️ **Self-hosted runners must be on Actions Runner ≥ v2.327.1** to execute node24 actions. The mac minis (server tests, mac/android/standard-reports builds) should be checked/updated before merging, or those workflows will fail to start.
- `upload-artifact` v3→v6 crosses the v4 breaking changes (immutable artifacts, one artifact per name). Our workflows all upload uniquely-named artifacts once per run, so nothing should be affected — but the little-used `server-build.yaml` (workflow_dispatch, mac) was on v3 and is worth a glance.
- Target versions were verified against each action's `action.yml` (`runs.using`) upstream rather than assuming latest majors — that's why upload-artifact goes to v6 but download-artifact goes to v7.
- Left as-is: `Swatinem/rust-cache@v2` (floating tag already node24), docker-container actions (`EnricoMi/publish-unit-test-result-action`, `shalzz/zola-deploy-action`), composite actions (`dtolnay/rust-toolchain`, `anthropics/claude-code-action`, `upload-pages-artifact`), and the pages actions in deploy-developer-docs which are already node24.

# 🧪 Tested

- Verified the runtime (`runs.using`) of every target action version from its upstream `action.yml` — all replacements are node24 (or composite/docker).
- Parsed all 27 workflow files with a YAML loader to confirm they're still valid.
- Ran the new bundle-size jq/awk script locally against sample webpack stats files; output format matches the old action (`1.50 MB` / `99.05 KB` / `6.45`).
- CI on this PR exercises the ubuntu-hosted workflows (client tests/checks, bundle-size diff); the self-hosted ones (server tests) will run here too, and mac/android builds can be smoke-tested via workflow_dispatch after the runners are updated.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:

🤖 Generated with [Claude Code](https://claude.com/claude-code)