### PR TITLE
Change to use new shared method for client tls connections

### DIFF
--- a/server/service/src/apis/central_user_login.rs
+++ b/server/service/src/apis/central_user_login.rs
@@ -39,7 +39,7 @@ pub async fn central_user_login(
         .and_then(|u| u.join("/central/user/login"))
         .map_err(|e| CentralUserLoginError::Unreachable(format!("invalid central url: {e}")))?;
 
-    let client = ClientBuilder::new()
+    let client = util::https_client_builder()
         .connect_timeout(Duration::from_secs(CONNECTION_TIMEOUT_SEC))
         .timeout(Duration::from_secs(REQUEST_TIMEOUT_SEC))
         .build()


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12487

On android the default behaviour of reqwest was changed and identified way back.
However the fix when doing the upgrade relies on us following utils pattern when creating a client which wasn't followed with sync v7. For now we just use this shared pattern again.

## 💌 Any notes for the reviewer?

Also researching option options. Probably a good idea to add (android::init_with_env(...)) or something to avoid this whol class of errors

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- Haven't tested yet, Building with the CI on this branch and will test from there.
# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [X] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
