### PR TITLE
#12487 Initialise rustls-platform-verifier on Android

### DIFF
--- a/client/packages/android/app/build.gradle
+++ b/client/packages/android/app/build.gradle
@@ -15,6 +15,27 @@ def getVersionCodeFromVersionName(versionName) {
     return (major.toInteger() * 1000000) + (minor.toInteger() * 10000) + (patch.toInteger() * 100)
 }
 
+// Locates the Kotlin AAR bundled inside the rustls-platform-verifier-android
+// crate checkout (in the cargo registry), so the version always matches the
+// Rust side resolved in server/Cargo.lock. The Rust server initialises
+// rustls-platform-verifier at startup (see server/android/src/android.rs and
+// issue #12487); its certificate verification calls into this Kotlin
+// component at runtime. Requires `cargo` on PATH (already true for app
+// builds, which compile the Rust server first).
+// From https://github.com/rustls/rustls-platform-verifier README, adapted to
+// use paths relative to this project instead of the gradle daemon's CWD.
+String findRustlsPlatformVerifierProject() {
+    def serverAndroidManifest = new File(rootDir, "../../../server/android/Cargo.toml").canonicalPath
+    def dependencyText = providers.exec {
+        it.workingDir = projectDir
+        commandLine("cargo", "metadata", "--format-version", "1", "--filter-platform", "aarch64-linux-android", "--manifest-path", serverAndroidManifest)
+    }.standardOutput.asText.get()
+
+    def dependencyJson = new JsonSlurper().parseText(dependencyText)
+    def manifestPath = file(dependencyJson.packages.find { it.name == "rustls-platform-verifier-android" }.manifest_path)
+    return new File(manifestPath.parentFile, "maven").path
+}
+
 
 android {
     namespace = "org.openmsupply.client"
@@ -90,6 +111,10 @@ repositories {
     flatDir{
         dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'
     }
+    maven {
+        url = findRustlsPlatformVerifierProject()
+        metadataSources.artifact()
+    }
 }
 
 // Exclude the unbundled Play Services barcode scanning dependency
@@ -114,6 +139,10 @@ dependencies {
     // Use bundled MLKit barcode scanning instead of unbundled Play Services version
     // This bundles the model with the app, avoiding runtime downloads
     implementation 'com.google.mlkit:barcode-scanning:17.3.0'
+
+    // Kotlin side of rustls-platform-verifier, resolved from the cargo
+    // registry checkout (see findRustlsPlatformVerifierProject above)
+    implementation "rustls:rustls-platform-verifier:latest.release"
 }
 
 apply from: 'capacitor.build.gradle'

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/MainActivity.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/MainActivity.java
@@ -99,7 +99,7 @@ public class MainActivity extends BridgeActivity {
 
         String path = getFilesDir().getAbsolutePath();
         String cache = getCacheDir().getAbsolutePath();
-        server.start(discoveryConstants.PORT, path, cache, discoveryConstants.hardwareId);
+        server.start(discoveryConstants.PORT, path, cache, discoveryConstants.hardwareId, getApplicationContext());
     }
 
     @Override

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/RemoteServer.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/RemoteServer.java
@@ -1,5 +1,7 @@
 package org.openmsupply.client;
 
+import android.content.Context;
+
 import com.getcapacitor.Logger;
 
 public class RemoteServer {
@@ -13,9 +15,12 @@ public class RemoteServer {
 
     }
 
-    public void start(int port, String filesDir, String cacheDir, String androidId) {
+    // The Context is used to initialise rustls-platform-verifier on the Rust
+    // side (see #12487) so TLS verification in any default-configured reqwest
+    // client uses the Android system CA store instead of panicking.
+    public void start(int port, String filesDir, String cacheDir, String androidId, Context context) {
         Logger.info("Starting OMS Rust Server");
-        startServer(port, filesDir, cacheDir, androidId);
+        startServer(port, filesDir, cacheDir, androidId, context);
     }
 
     public void stop() {
@@ -23,7 +28,7 @@ public class RemoteServer {
     }
 
     // Mapping to methods in server/android/src/android.lib
-    private static native void startServer(int port, String filesDir, String cacheDir, String androidId);
+    private static native void startServer(int port, String filesDir, String cacheDir, String androidId, Context context);
 
     private static native void stopServer();
 }

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "once_cell",
  "rcgen",
  "repository",
+ "rustls-platform-verifier",
  "server",
  "service",
  "simple-log",
@@ -2157,7 +2158,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3006,7 +3007,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3582,7 +3583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9235,7 +9236,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9299,13 +9300,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.21.1",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls 0.23.37",
@@ -9315,7 +9316,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10595,7 +10596,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12178,7 +12179,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/server/android/Cargo.toml
+++ b/server/android/Cargo.toml
@@ -25,5 +25,11 @@ tokio = { workspace = true }
 android_logger = { version = "0.15.1" }
 simple-log = { workspace = true }
 
+# Keep in lockstep with the version reqwest resolves (see server/Cargo.lock) —
+# the Kotlin AAR bundled into the app via gradle comes from this crate's
+# checkout, so a version skew breaks certificate verification at runtime.
+[target.'cfg(target_os = "android")'.dependencies]
+rustls-platform-verifier = "0.7"
+
 [lints]
 workspace = true

--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -13,7 +13,7 @@ pub mod android {
     use tokio::sync::mpsc;
 
     use self::jni::errors::LogErrorAndDefault;
-    use self::jni::objects::{JClass, JString};
+    use self::jni::objects::{JClass, JObject, JString};
     use self::jni::EnvUnowned;
 
     struct ServerBucket {
@@ -31,14 +31,33 @@ pub mod android {
         files_dir: JString,
         cache_dir: JString,
         android_id: JString,
+        context: JObject,
     ) {
         let (off_switch, off_switch_receiver) = mpsc::channel(1);
-        let (files_dir, android_id, cache_dir) = unowned_env
+        let (files_dir, android_id, cache_dir, verifier_init) = unowned_env
             .with_env(|env| -> Result<_, jni::errors::Error> {
+                // Safety net for #12487: reqwest's default TLS stack verifies
+                // certificates via rustls-platform-verifier, which on Android
+                // panics at the first HTTPS handshake unless initialised with
+                // a JVM context. Production code must still build clients via
+                // util::https_client_builder() (bundled roots) — this init only
+                // contains the blast radius of a missed call site, which then
+                // verifies against the Android system CA store instead.
+                // Non-fatal: helper-based clients never touch the verifier.
+                #[cfg(target_os = "android")]
+                let verifier_init =
+                    rustls_platform_verifier::android::init_with_env(env, context)
+                        .err()
+                        .map(|e| format!("{e:?}"));
+                #[cfg(not(target_os = "android"))]
+                let verifier_init = {
+                    let _ = &context;
+                    None::<String>
+                };
                 let files_dir = files_dir.try_to_string(env)?;
                 let android_id = android_id.try_to_string(env)?;
                 let cache_dir = cache_dir.try_to_string(env)?;
-                Ok((files_dir, android_id, cache_dir))
+                Ok((files_dir, android_id, cache_dir, verifier_init))
             })
             .resolve::<LogErrorAndDefault>();
         let files_dir = PathBuf::from(&files_dir);
@@ -93,6 +112,10 @@ pub mod android {
         logging_init(settings.logging.clone(), None);
         log_panics::init();
         log::info!("omSupply server starting...");
+        match &verifier_init {
+            None => log::info!("rustls-platform-verifier initialised"),
+            Some(e) => log::error!("Failed to initialise rustls-platform-verifier: {e}"),
+        }
 
         // run server in background thread
         let thread = thread::spawn(move || {


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Hardening follow-up for #12487 — the direct fix (building the V7 login client via `util::https_client_builder()`) lands via the `v3.0.0-RC` hotfix branch and will flow to develop with the RC integration. This PR does **not** include that change; develop's `central_user_login.rs` is corrected by the hotfix merge.

reqwest 0.13's default TLS stack verifies certificates through `rustls-platform-verifier`, which on Android **panics at the first HTTPS handshake** unless it has been initialised with a JVM context. In #12487 the new `/central/user/login` client was built with a plain `ClientBuilder::new()`, and that panic tore down the WebView↔localhost HTTP/2 connection, breaking login whenever the central server URL was https. No reqwest feature flag avoids this — both `rustls` and `rustls-no-provider` hard-depend on the platform verifier, and the 0.12-era webpki-roots features were removed in 0.13.

This PR initialises the verifier at server startup so that class of mistake can never take the app down again:

- `server/android`: `startServer` now receives the app `Context` and calls `rustls_platform_verifier::android::init_with_env(...)` inside the existing `with_env` block, before the server thread starts. Non-fatal — the outcome is logged once file logging is up. Gated to `target_os = "android"` (the crate is also host-checked).
- Bumps `rustls-platform-verifier` 0.6.2 → 0.7.0 (within reqwest 0.13.3's `>=0.6, <0.8` range) so its jni version (0.22) matches the android crate's jni 0.22.4 — no raw-pointer bridging needed.
- `RemoteServer.java` / `MainActivity.java`: pass `getApplicationContext()` through the JNI boundary.
- `app/build.gradle`: bundles the verifier's Kotlin AAR (required at verification time), resolved out of the cargo registry checkout via `cargo metadata`, so the Kotlin and Rust sides can't drift apart. Snippet from the crate README, adapted to use project-relative paths instead of the gradle daemon's CWD.

With this in place, a default-configured reqwest client on Android verifies TLS against the **system CA store** instead of panicking. `util::https_client_builder()` (bundled webpki-roots, PR #11788) remains the required pattern for production HTTP — this is failure containment, not a new sanctioned code path.

## 💌 Any notes for the reviewer?

- This is essentially the wiring proposed in the closed #11609, but as a safety net underneath #11788's bundled-roots helper rather than as the primary trust path.
- **Why keep `util::https_client_builder()` at all, now that the verifier works?** (a) #11788's rationale still holds: bundled roots make HTTPS depend only on the app version, not on each host's store state — field machines with stale system stores (e.g. the Let's Encrypt ISRG-root transition) stay working. (b) Sync/login parity: one client config means "if sync works, login works". (c) The verifier path has runtime preconditions (init ran + AAR in the APK); the helper has none — as a safety net a wiring regression costs nothing, but as the primary path it would take down all HTTPS including sync. Switching wholesale to platform trust (better behind TLS-inspecting proxies, OS-level revocation) would be a deliberate revisit of #11788/#11609 in its own issue.
- Trust model: an accidental default client now trusts the Android system store (including user/enterprise-installed CAs), while sanctioned clients keep bundled Mozilla roots. Intentional — survivable beats consistent-but-crashing.
- The gradle `findRustlsPlatformVerifierProject()` runs `cargo metadata` at configuration time; cargo is already required for app builds (the Rust server compiles first, and it's on PATH in `build-android-apk.yaml`).
- I could not compile the android target locally (no NDK on this machine); the JNI signatures were verified against the jni 0.22.4 and rustls-platform-verifier 0.7.0 sources. The APK build in CI/QA is the real compile check for `server/android`.

# 🧪 Tested

- `cargo check -p server -p service -p util` clean with the bumped lockfile
- `cargo nextest run -p service login -p util tls` — 8/8 pass (includes the `https_client_builds` guard that catches rustls/reqwest version drift)
- Verified `cargo metadata --filter-platform aarch64-linux-android` resolves `rustls-platform-verifier-android` from `server/android/Cargo.toml`, and that the AAR exists at the maven path the gradle function returns (`.../rustls-platform-verifier-android-0.1.1/maven/rustls/rustls-platform-verifier/0.1.1/*.aar`)
- Still needed (no NDK/emulator on this machine): build the APK; on a device initialised against an **https** central server, confirm `remote_server.log` shows `rustls-platform-verifier initialised`. To prove the safety net end-to-end, temporarily revert the hotfix commit so the login client uses the default verifier again — login should now succeed instead of panicking (#12487's original failure).

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
