### PR TITLE
12444  stocktake] user cannot re enter stocktake line without being re prompted to select item variant

### DIFF
--- a/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
+++ b/client/packages/inventory/src/Stocktake/DetailView/modal/StocktakeLineEdit/StocktakeLineEdit.tsx
@@ -124,6 +124,8 @@ export const StocktakeLineEdit = ({
   }, [currentItem?.id]);
 
   useEffect(() => {
+    // draft lines are loading or don't exist, don't open the variants selection panel
+    if (draftLines.length === 0) return;
     if (!currentItem || !hasVariants) return;
     if (variantShownForItem === currentItem.id) return;
     // Wait for the source queries before deciding, to avoid popping


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12444

<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->
Fixes the item variant selector behaviour in stocktakes. The user is prompted to select an Item Variant only when the line/batch is new (and item variants are avaiable)


## 💌 Any notes for the reviewer?

It's not the same as the fix I think Mark was describing -  draftLines starts empty and loads asynchronously. The auto-open useEffect ran before the lines loaded, so always opened the item variant selector - I added an early return condition if no draft lines

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->
Testing that the selector opens when it should, not when it shouldn't

- Had an item with item variants. On a blank stocktake:
- Create a line for the item -> add batch -> see item variant selector -> choose one (selector closes & enter other line details)
- Add another batch -> choose another variant. Ok, modal closed
- Reopen the item -> no item variant selector pops up
- On a new stocktake -> add all items on creation
- Open an line that has item variants enabled -> item variant selector opens

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
