### PR TITLE
#12490 Serve frontend from a directory; publish Android server lib

### DIFF
--- a/.github/workflows/build-android-server-lib.yaml
+++ b/.github/workflows/build-android-server-lib.yaml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build:
-    name: Build .so (debug + release)
+    name: Build .so (release)
     runs-on: self-hosted
     timeout-minutes: 60
     steps:
@@ -43,7 +43,9 @@ jobs:
           rustup toolchain install "${{ steps.rust_toolchain.outputs.channel }}" --profile minimal --no-self-update
           rustup target add aarch64-linux-android armv7-linux-androideabi --toolchain "${{ steps.rust_toolchain.outputs.channel }}"
 
-      - name: Build (debug + release)
+      # Release only. For a debuggable set-up, run the server on a dev
+      # machine and point the app at it via `adb reverse` instead.
+      - name: Build
         env:
           NDK_BIN: /Users/tmfmacmini/android/ndk/27.2.12479018/toolchains/llvm/prebuilt/darwin-x86_64/bin/
         # Update this version when upgrading the NDK version on the self-hosted machine
@@ -54,12 +56,10 @@ jobs:
           export CC_armv7_linux_androideabi="${NDK_BIN}armv7a-linux-androideabi22-clang"
           export PATH="$PATH:$NDK_BIN"
 
-          for PROFILE_FLAG in "" "--release"; do
-            cargo build $PROFILE_FLAG \
-              --manifest-path server/android/Cargo.toml \
-              --config server/android/.cargo/config.toml \
-              --target-dir "$PWD/server-lib"
-          done
+          cargo build --release \
+            --manifest-path server/android/Cargo.toml \
+            --config server/android/.cargo/config.toml \
+            --target-dir "$PWD/server-lib"
 
       - name: Package
         id: package
@@ -72,39 +72,26 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
           rm -rf dist
-          for PROFILE in debug release; do
-            OUT="dist/$PROFILE"
-            ZIP="${LIB_NAME}-${VERSION}-${PROFILE}.zip"
-            mkdir -p "$OUT/jniLibs/arm64-v8a" "$OUT/jniLibs/armeabi-v7a"
-            cp "server-lib/aarch64-linux-android/$PROFILE/libremote_server_android.so" "$OUT/jniLibs/arm64-v8a/"
-            cp "server-lib/armv7-linux-androideabi/$PROFILE/libremote_server_android.so" "$OUT/jniLibs/armeabi-v7a/"
+          ZIP="${LIB_NAME}-${VERSION}.zip"
+          mkdir -p dist/jniLibs/arm64-v8a dist/jniLibs/armeabi-v7a
+          cp "server-lib/aarch64-linux-android/release/libremote_server_android.so" dist/jniLibs/arm64-v8a/
+          cp "server-lib/armv7-linux-androideabi/release/libremote_server_android.so" dist/jniLibs/armeabi-v7a/
 
-            {
-              echo "version: $VERSION"
-              echo "profile: $PROFILE"
-              echo "commit: $GITHUB_SHA"
-              echo "abis: arm64-v8a armeabi-v7a"
-            } > "$OUT/VERSION.txt"
+          {
+            echo "version: $VERSION"
+            echo "commit: $GITHUB_SHA"
+            echo "abis: arm64-v8a armeabi-v7a"
+          } > dist/VERSION.txt
 
-            (cd "$OUT" && zip -r "$ZIP" jniLibs VERSION.txt && shasum -a 256 "$ZIP" > "$ZIP.sha256")
-          done
+          (cd dist && zip -r "$ZIP" jniLibs VERSION.txt && shasum -a 256 "$ZIP" > "$ZIP.sha256")
 
-      - name: Upload debug artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v6
         with:
-          name: ${{ env.LIB_NAME }}-debug
+          name: ${{ env.LIB_NAME }}
           path: |
-            dist/debug/*.zip
-            dist/debug/*.sha256
-          if-no-files-found: error
-
-      - name: Upload release artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ env.LIB_NAME }}-release
-          path: |
-            dist/release/*.zip
-            dist/release/*.sha256
+            dist/*.zip
+            dist/*.sha256
           if-no-files-found: error
 
   # Attach the zips to the GitHub release for real version tags. Nightly
@@ -122,8 +109,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.LIB_NAME }}-*
-          merge-multiple: true
+          name: ${{ env.LIB_NAME }}
           path: dist
 
       - name: Upload release assets

--- a/.github/workflows/build-android-server-lib.yaml
+++ b/.github/workflows/build-android-server-lib.yaml
@@ -6,8 +6,8 @@ name: Build Android server library
 # frontend repo (open-msupply-frontend), which pins a version and
 # fetches + checksum-verifies these zips at APK build time.
 #
-# Runs on stock GitHub runners with a stock NDK — deliberately no
-# dependency on the self-hosted Mac mini used for the legacy APK build.
+# Runs on the self-hosted Mac mini (same runner as the APK build), whose
+# NDK installation the team maintains — see the NDK_BIN env below.
 
 on:
   push:
@@ -16,23 +16,23 @@ on:
   workflow_dispatch:
 
 env:
-  # Keep in sync with the jniLibs layout expected by Android gradle projects
   LIB_NAME: remote-server-android
 
 jobs:
   build:
-    name: Build .so (${{ matrix.profile }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    strategy:
-      matrix:
-        profile: [debug, release]
+    name: Build .so (debug + release)
+    runs-on: self-hosted
+    timeout-minutes: 60
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Read Rust toolchain channel
         id: rust_toolchain
+        # Scope the toolchain to this job only via RUSTUP_TOOLCHAIN; do NOT set a
+        # global rustup default/override on the shared self-hosted runner, or it
+        # would leak into develop builds (which pin a different channel).
         run: |
           CHANNEL=$(grep '^channel' server/rust-toolchain.toml | cut -d '"' -f2)
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
@@ -43,39 +43,23 @@ jobs:
           rustup toolchain install "${{ steps.rust_toolchain.outputs.channel }}" --profile minimal --no-self-update
           rustup target add aarch64-linux-android armv7-linux-androideabi --toolchain "${{ steps.rust_toolchain.outputs.channel }}"
 
-      - name: Set up NDK
-        id: ndk
-        uses: nttld/setup-ndk@v1
-        with:
-          # server/android/.cargo/config.toml uses the API-22 clang wrappers
-          # (aarch64-linux-android22-clang etc.), present in this NDK
-          ndk-version: r27c
-          add-to-path: false
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: server
-          key: android-${{ matrix.profile }}
-
-      - name: Build
+      - name: Build (debug + release)
         env:
-          NDK_BIN: ${{ steps.ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin
+          NDK_BIN: /Users/tmfmacmini/android/ndk/27.2.12479018/toolchains/llvm/prebuilt/darwin-x86_64/bin/
+        # Update this version when upgrading the NDK version on the self-hosted machine
         run: |
-          # AR/CC env needed to build the `ring` crate
-          export AR="$NDK_BIN/llvm-ar"
-          export CC_armv7_linux_androideabi="$NDK_BIN/armv7a-linux-androideabi22-clang"
+          # AR/CC env needed to build the `ring` crate; the API-22 clang
+          # wrappers match server/android/.cargo/config.toml
+          export AR="${NDK_BIN}llvm-ar"
+          export CC_armv7_linux_androideabi="${NDK_BIN}armv7a-linux-androideabi22-clang"
           export PATH="$PATH:$NDK_BIN"
 
-          PROFILE_FLAG=""
-          if [ "${{ matrix.profile }}" = "release" ]; then
-            PROFILE_FLAG="--release"
-          fi
-
-          cargo build $PROFILE_FLAG \
-            --manifest-path server/android/Cargo.toml \
-            --config server/android/.cargo/config.toml \
-            --target-dir "$PWD/server-lib"
+          for PROFILE_FLAG in "" "--release"; do
+            cargo build $PROFILE_FLAG \
+              --manifest-path server/android/Cargo.toml \
+              --config server/android/.cargo/config.toml \
+              --target-dir "$PWD/server-lib"
+          done
 
       - name: Package
         id: package
@@ -85,32 +69,42 @@ jobs:
           else
             VERSION="$(git describe --tags --always)"
           fi
-          ZIP="${LIB_NAME}-${VERSION}-${{ matrix.profile }}.zip"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "zip=$ZIP" >> "$GITHUB_OUTPUT"
 
-          mkdir -p dist/jniLibs/arm64-v8a dist/jniLibs/armeabi-v7a
-          cp server-lib/aarch64-linux-android/${{ matrix.profile }}/libremote_server_android.so dist/jniLibs/arm64-v8a/
-          cp server-lib/armv7-linux-androideabi/${{ matrix.profile }}/libremote_server_android.so dist/jniLibs/armeabi-v7a/
+          rm -rf dist
+          for PROFILE in debug release; do
+            OUT="dist/$PROFILE"
+            ZIP="${LIB_NAME}-${VERSION}-${PROFILE}.zip"
+            mkdir -p "$OUT/jniLibs/arm64-v8a" "$OUT/jniLibs/armeabi-v7a"
+            cp "server-lib/aarch64-linux-android/$PROFILE/libremote_server_android.so" "$OUT/jniLibs/arm64-v8a/"
+            cp "server-lib/armv7-linux-androideabi/$PROFILE/libremote_server_android.so" "$OUT/jniLibs/armeabi-v7a/"
 
-          {
-            echo "version: $VERSION"
-            echo "profile: ${{ matrix.profile }}"
-            echo "commit: $GITHUB_SHA"
-            echo "abis: arm64-v8a armeabi-v7a"
-          } > dist/VERSION.txt
+            {
+              echo "version: $VERSION"
+              echo "profile: $PROFILE"
+              echo "commit: $GITHUB_SHA"
+              echo "abis: arm64-v8a armeabi-v7a"
+            } > "$OUT/VERSION.txt"
 
-          cd dist
-          zip -r "$ZIP" jniLibs VERSION.txt
-          sha256sum "$ZIP" > "$ZIP.sha256"
+            (cd "$OUT" && zip -r "$ZIP" jniLibs VERSION.txt && shasum -a 256 "$ZIP" > "$ZIP.sha256")
+          done
 
-      - name: Upload artifact
+      - name: Upload debug artifact
         uses: actions/upload-artifact@v6
         with:
-          name: ${{ env.LIB_NAME }}-${{ matrix.profile }}
+          name: ${{ env.LIB_NAME }}-debug
           path: |
-            dist/${{ steps.package.outputs.zip }}
-            dist/${{ steps.package.outputs.zip }}.sha256
+            dist/debug/*.zip
+            dist/debug/*.sha256
+          if-no-files-found: error
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ env.LIB_NAME }}-release
+          path: |
+            dist/release/*.zip
+            dist/release/*.sha256
           if-no-files-found: error
 
   # Attach the zips to the GitHub release for real version tags. Nightly
@@ -143,16 +137,18 @@ jobs:
           fi
           gh release upload "$TAG" dist/* --repo "$GITHUB_REPOSITORY" --clobber
 
+  # Runs on a GitHub-hosted runner so it still fires when the self-hosted
+  # runner is down (the build job's steps never execute in that case).
   notify-build-result:
     needs: [build, publish]
-    if: failure()
+    if: ${{ always() && (needs.build.result != 'success' || needs.publish.result == 'failure') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Notify Slack on failure
+      - name: Notify Slack
         env:
           WEBHOOK_URL: ${{ secrets.SLACK_DEV_RELEASE_WEBHOOK_URL }}
-          MESSAGE: ":warning: *Android server library build failed* for `${{ github.ref_name }}`\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MESSAGE: ":warning: *Android server library build did not succeed* for `${{ github.ref_name }}` (build: ${{ needs.build.result }}, publish: ${{ needs.publish.result }})\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |
           curl -sf -X POST -H 'Content-type: application/json' \
             --data "{\"text\": \"$MESSAGE\"}" "$WEBHOOK_URL"

--- a/server/android/README.md
+++ b/server/android/README.md
@@ -12,11 +12,12 @@ starting the server. No web bundle is compiled into the `.so`.
 
 CI ([build-android-server-lib.yaml](../../.github/workflows/build-android-server-lib.yaml))
 builds the library on every `v*` tag (and on demand via workflow dispatch) on
-stock GitHub runners with a stock NDK, in `debug` and `release` profiles, and
+the self-hosted Mac mini runner (same NDK the APK build uses; the workflow
+pins its path), in `debug` and `release` profiles, and
 uploads zips as workflow artifacts. For non-nightly tags the zips are also
 attached to the GitHub release, with `.sha256` checksums:
 
-```
+```text
 remote-server-android-<version>-<profile>.zip
 ├── jniLibs/
 │   ├── arm64-v8a/libremote_server_android.so

--- a/server/android/README.md
+++ b/server/android/README.md
@@ -13,17 +13,20 @@ starting the server. No web bundle is compiled into the `.so`.
 CI ([build-android-server-lib.yaml](../../.github/workflows/build-android-server-lib.yaml))
 builds the library on every `v*` tag (and on demand via workflow dispatch) on
 the self-hosted Mac mini runner (same NDK the APK build uses; the workflow
-pins its path), in `debug` and `release` profiles, and
-uploads zips as workflow artifacts. For non-nightly tags the zips are also
-attached to the GitHub release, with `.sha256` checksums:
+pins its path) and uploads a zip as a workflow artifact. For non-nightly tags
+the zip is also attached to the GitHub release, with a `.sha256` checksum:
 
 ```text
-remote-server-android-<version>-<profile>.zip
+remote-server-android-<version>.zip
 ├── jniLibs/
 │   ├── arm64-v8a/libremote_server_android.so
 │   └── armeabi-v7a/libremote_server_android.so
-└── VERSION.txt   (version, profile, commit, abis)
+└── VERSION.txt   (version, commit, abis)
 ```
+
+Only the release profile is published. For a debuggable set-up, run the
+server on a dev machine and point the app at it via `adb reverse` instead of
+debugging through the `.so`.
 
 Consumers (e.g. the [open-msupply-frontend](https://github.com/msupply-foundation/open-msupply-frontend)
 Android app) pin a version and fetch + checksum-verify the zip at build time,


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12490

Removes `rust_embed` from the server crate and serves the web frontend from a directory instead, then adds CI to publish the Android server library as a versioned, frontend-agnostic artifact for the [new frontend repo](https://github.com/msupply-foundation/open-msupply-frontend).

**Serve from `frontend_dir` (was: compile-time embed)**

- New `server.frontend_dir` setting (default `frontend`, relative to the working directory, mirroring `base_dir`). `serve_frontend.rs` reads assets from disk with identical routes, cache headers (`no-cache` for `index.html`/`locales/`, 1-year for hashed assets) and a canonicalize-based path-traversal guard.
- Debug builds fall back to `client/packages/host/dist` when `frontend_dir` doesn't exist, so `cargo run` works with zero config — same DX `rust_embed`'s debug mode provided. The server no longer needs the client built to compile at all.
- The version-match invariant moves to packaging:
  - **Windows**: `omsupply-build.bat` copies the dist to `omSupply\Server\frontend`; all three server-shipping Setup Factory projects (`omsupply_server/standalone/demo.suf`) gained a recursive `frontend\*.*` install entry targeting the folder next to each installer's server executable (its cwd at runtime).
  - **Mac demo**: `build/mac/build.sh` copies the dist to `$DESTINATION/frontend`.
  - **Docker**: the image `COPY`s the dist into the base stage; `dockerise.yaml` now downloads the `client-dist` artifact in the `dockerise` job (build context) instead of the `build-server` job (no longer needed at `cargo build` time).
- **Android app shell**: new `FrontendAssets.java` copies the APK-bundled web assets (`assets/public`, populated by `cap copy`) to `<filesDir>/frontend` before `RemoteServer.start()`, gated on versionCode (always refreshes in debuggable builds), staged-then-renamed so an interrupted copy self-heals. The `.so` passes `frontend_dir = <filesDir>/frontend`. WebView behaviour, certs and discovery are untouched — LAN clients still get this server's UI.

**CI publishes the Android server library** (`build-android-server-lib.yaml`)

- On every `v*` tag + `workflow_dispatch`, on the self-hosted Mac mini (same runner/NDK as the APK build, path pinned in the workflow; toolchain job-scoped via `RUSTUP_TOOLCHAIN`).
- Builds the release profile for arm64-v8a + armeabi-v7a; the zip uses the `jniLibs/` layout with a `VERSION.txt` and `.sha256` checksum. (No debug flavour: for a debuggable set-up, devs run the server on a dev machine and point the app at it via `adb reverse`.)
- Zips upload as workflow artifacts; non-nightly tags also get them attached to the GitHub release (created as prerelease if missing). Failure notification posts to Slack from a hosted runner so it fires even when the self-hosted runner is down.
- New `server/android/README.md` documents the artifact contract and local build steps.

## 💌 Any notes for the reviewer?

- **Sequencing (issue §3, schema floor):** the first artifact the FE repo pins must be tagged **after** #11173's `fe-auth-contract` work merges to `develop` — it isn't merged yet. Nothing in this PR enforces that; it's a release-ordering note.
- **Not in this PR (issue §4, coordination):** release-keystore handover off the Mac mini and documenting the versionCode floor (currently `3.00.00-RC` → 3,000,000) for the FE repo.
- The `.suf` files were edited programmatically (they're plain XML — entries cloned from existing ones). Please open them once in Setup Factory before the next Windows release to confirm the GUI accepts them.
- `FrontendAssets.java` hasn't been compiled/run on device — no Android toolchain in this session. Worth a device smoke test before release.
- `rust_embed` remains in the workspace for its unrelated uses (migrations version, standard reports, localisations) — only the `server/server` usage is removed.

# 🧪 Tested

- `cargo check` across server/service/cli; `cargo nextest run -p server` (21/21 pass)
- Ran the dev server and verified over HTTP: `index.html` + `locales/*` serve `cache-control: no-cache`, hashed JS serves `public, max-age=31536000`, `x-content-type-options: nosniff` everywhere, traversal attempts (`/../`, `/..%2F`) → 404, SPA routes → index
- Hot bundle swap: dropping a `frontend/` dir next to the server switches serving to it immediately (no restart); removing it resumes the debug fallback
- **End-to-end CI test**: pushed test tag `v3.0.0-RC-libtest1` — the workflow built on the Mac mini, uploaded the artifact, correctly skipped release publication for the nightly-style tag; downloaded zip verified (checksum OK, `jniLibs` layout + `VERSION.txt` correct). Note: the same tag exposed a pre-existing Dockerise `Build Client` failure on develop (corepack/yarn vs Node-24 runtimes) — unrelated to this PR
- Cross-compiled the `.so` locally with the workflow's exact commands (pinned 1.94 toolchain, NDK API-22 clang wrappers): both target `.so`s build (arm64 123 MB / armv7 83 MB) and export the `Java_org_openmsupply_client_RemoteServer_{start,stop}Server` JNI symbols
- Not tested: Android APK build/on-device flow, Windows installer build (Setup Factory)

# 📃 Documentation

- [ ] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [x] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  - Done in this PR: rewrote the "Serving front end" section of `docs/content/server/_index.md`; added `server/android/README.md` (artifact contract, local build)

