### PR TITLE
#12500 Increase location list limit to 5000

### DIFF
--- a/client/packages/system/src/Location/api/hooks/useLocationList.ts
+++ b/client/packages/system/src/Location/api/hooks/useLocationList.ts
@@ -52,7 +52,9 @@ const useGetList = (enabled?: boolean, queryParams?: ListParams) => {
 
   const queryFn = async () => {
     const query = await locationApi.locations({
-      first: first ?? 1000,
+      // Stopgap for large warehouses until location search is server-side,
+      // see https://github.com/msupply-foundation/open-msupply/issues/12500
+      first: first ?? 5000,
       offset: offset ?? 0,
       sort: toSortInput(sortBy),
       filter: filterBy,


### PR DESCRIPTION
Fixes #12500

# 👩🏻‍💻 What does this PR do?

Location dropdowns (stocktake line edit, change-location modal, inbound shipment line edit, repack, stock line form, sensors, stock movement, cold chain equipment) only showed the first 1000 locations, so stores with more than 1000 locations couldn't select the rest.

Investigation showed there is **no backend limit** — the location list service defaults to unlimited pagination. The cap was the frontend default in `useLocationList` (`first: first ?? 1000`). This PR raises that default to 5000 as a hotfix for larger warehouses.

## 💌 Any notes for the reviewer?

- One-line change (plus a comment linking the issue). All location dropdowns go through this single hook, so this covers every affected screen. Other surfaces were audited and are fine: the stock view and cold chain monitoring location filters are server-side text searches, the location CSV export is unpaginated (unlimited), and the location list page is a paginated table.
- Perf: `volumeUsed` and `stock.totalCount` on `LocationNode` resolve via batched DataLoaders, so 5000 rows won't cause an N+1 query storm — just a larger payload.
- Proper fix (server-side location search with pagination) is tracked in follow-up #12504, which also notes other entity dropdowns with the same 1000-row pattern.

# 🧪 Testing

- [ ] Created 4000 locations into a local sqlite database using the helper script posted on the issue: https://github.com/msupply-foundation/open-msupply/issues/12500#issuecomment-5018444713 (e.g. `./add_test_locations.sh <store_id>` adds 4000)
- [ ] Checked I can find location 4000 from this list when editing a stocktake line
- [ ] Tested stockview also works for 4000 locations

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
