### PR TITLE
12483 the default price of the item should populate in the cost price in the inbound shipments

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -259,6 +259,10 @@ export const InboundLineEditCards = ({
                     item?.defaultPackSize !== line.packSize &&
                     item?.itemStoreProperties?.defaultSellPricePerPack ===
                       line.sellPricePerPack;
+                  const shouldClearCostPrice =
+                    item?.defaultPackSize !== line.packSize &&
+                    item?.itemStoreProperties?.defaultSellPricePerPack ===
+                      line.costPricePerPack;
 
                   updateDraftLine({
                     volumePerPack:
@@ -269,6 +273,9 @@ export const InboundLineEditCards = ({
                     sellPricePerPack: shouldClearSellPrice
                       ? 0
                       : line.sellPricePerPack,
+                    costPricePerPack: shouldClearCostPrice
+                      ? 0
+                      : line.costPricePerPack,
                     packSize: value,
                     id: row.original.id,
                   });

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -256,11 +256,11 @@ export const InboundLineEditCards = ({
                 updateFn={(value: number) => {
                   const item = row.original.item;
                   const shouldClearSellPrice =
-                    item?.defaultPackSize !== line.packSize &&
+                    item?.defaultPackSize !== value &&
                     item?.itemStoreProperties?.defaultSellPricePerPack ===
                       line.sellPricePerPack;
                   const shouldClearCostPrice =
-                    item?.defaultPackSize !== line.packSize &&
+                    item?.defaultPackSize !== value &&
                     item?.itemStoreProperties?.defaultSellPricePerPack ===
                       line.costPricePerPack;
 

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/utils.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/utils.ts
@@ -35,7 +35,9 @@ const createDraftInboundLine = ({
     sellPricePerPack: seed
       ? seed.sellPricePerPack
       : (itemStoreProperties?.defaultSellPricePerPack ?? 0),
-    costPricePerPack: 0,
+    costPricePerPack: seed
+      ? seed.costPricePerPack
+      : (itemStoreProperties?.defaultSellPricePerPack ?? 0),
     numberOfPacks: 0,
     isCreated: !seed,
     expiryDate,


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12483 

<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

Populate the cost price field of a manual inbound shipment with the `defaultSellPricePerPack`

This also auto-clears if the user changes the pack size

On line creation:
<img width="1213" height="607" alt="Screenshot 2026-07-21 at 2 29 16 PM" src="https://github.com/user-attachments/assets/201617bf-4ad4-48c7-8cf0-8c00861c0b5d" />

## 💌 Any notes for the reviewer?

Fixed logic for the sell price clearing as well as the cost price clearing, when the default pack size is changed. It was only clearing after the line had already been saved at the default pack size

I noticed margin work is missing which was specified in the related issue #11743, this was done in develop

Unsure if there should be any auto-margin on manual inbound shipments? I haven't added any margin logic to this

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- In mSupply, In item details window General tab and set Default sell price for the preferred packsize
- In OMS, create a manual inbound shipment
- Add the item. See default pack size field. See Cost price and sell price are the same as what was entered in mSupply
- Change the default pack size -> see cost price clear to $0.00 (and sell price)

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
