### PR TITLE
#12508 Disable setup-node@v5 default package-manager caching

### DIFF
--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -23,6 +23,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          # Don't auto-cache via packageManager: it runs the global yarn 1
+          # before corepack is enabled (#12508)
+          package-manager-cache: false
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/build-mac-demo.yaml
+++ b/.github/workflows/build-mac-demo.yaml
@@ -38,6 +38,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          # Don't auto-cache via packageManager: it runs the global yarn 1
+          # before corepack is enabled (#12508)
+          package-manager-cache: false
       - name: Build
         run: ./build/mac/build.sh ${{ inputs.architecture }} ${{ inputs.includeDemoData }}
       # Upload artifact would remove +x (execute) permission and attributes from files when zipping

--- a/.github/workflows/build-standard-reports.yaml
+++ b/.github/workflows/build-standard-reports.yaml
@@ -41,6 +41,9 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
+          # Don't auto-cache via packageManager: it runs the global yarn 1
+          # before corepack is enabled (#12508)
+          package-manager-cache: false
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/client-bundle-size-diff.yaml
+++ b/.github/workflows/client-bundle-size-diff.yaml
@@ -31,6 +31,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          # Don't auto-cache via packageManager: it runs the global yarn 1
+          # before corepack is enabled (#12508)
+          package-manager-cache: false
 
       # Install/Build tolerate failure so a broken base branch doesn't fail
       # the PR check. The compare job detects the missing artifact and posts
@@ -70,6 +73,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          # Don't auto-cache via packageManager: it runs the global yarn 1
+          # before corepack is enabled (#12508)
+          package-manager-cache: false
 
       - name: Install dependencies
         run: corepack enable && yarn install --immutable

--- a/.github/workflows/client-code-checks.yaml
+++ b/.github/workflows/client-code-checks.yaml
@@ -29,6 +29,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          # Don't auto-cache via packageManager: it runs the global yarn 1
+          # before corepack is enabled (#12508)
+          package-manager-cache: false
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/client-tests.yaml
+++ b/.github/workflows/client-tests.yaml
@@ -32,6 +32,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          # Don't auto-cache via packageManager: it runs the global yarn 1
+          # before corepack is enabled (#12508)
+          package-manager-cache: false
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/dockerise.yaml
+++ b/.github/workflows/dockerise.yaml
@@ -54,6 +54,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          # Don't auto-cache via packageManager: it runs the global yarn 1
+          # before corepack is enabled (#12508)
+          package-manager-cache: false
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/generate-schema.yml
+++ b/.github/workflows/generate-schema.yml
@@ -33,6 +33,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          # Don't auto-cache via packageManager: it runs the global yarn 1
+          # before corepack is enabled (#12508)
+          package-manager-cache: false
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/graphql-schema-compatibility.yaml
+++ b/.github/workflows/graphql-schema-compatibility.yaml
@@ -41,6 +41,9 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
+          # Don't auto-cache via packageManager: it runs the global yarn 1
+          # before corepack is enabled (#12508)
+          package-manager-cache: false
 
       - name: Export schema from PR
         working-directory: server


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12508

Since the Node 24 actions upgrade (#12489), every hosted-runner workflow that uses `actions/setup-node@v5` with Yarn fails inside the **setup-node step itself**:

```
##[error]error This project's package.json defines "packageManager": "yarn@4.13.0". However the current global version of Yarn is 1.22.22.
```

`setup-node@v5` enables package-manager caching by default (new `package-manager-cache` input, default `true`). Resolving the cache directory runs `yarn` — **before** our `Enable Corepack` step — and on GitHub-hosted runners that's the global Yarn 1.22 with corepack shims not enabled (recent Node runtimes no longer auto-enable corepack). With `packageManager: yarn@4.13.0` pinned in the root `package.json`, Yarn 1 refuses to run and the step fails.

This adds `package-manager-cache: false` to all 10 `setup-node@v5` usages (9 workflows), restoring the `setup-node@v4` behaviour — we never used setup-node's yarn caching before the upgrade, so nothing is lost.

## 💌 Any notes for the reviewer?

- Notably this unbreaks **Dockerise**, which has failed on every `v3.x` tag since the upgrade (no Docker images published from develop nightlies, e.g. `v3.00.00-develop-07162134`).
- The self-hosted Mac mini workflows (`build-android-apk`, `build-mac-demo`) weren't observed failing (the runner's environment resolves a working yarn), but they get the same opt-out for consistency — the auto-cache adds nothing there either.
- An alternative fix would be running `corepack enable` *before* `setup-node` and keeping the cache; opted for the minimal restore-previous-behaviour change instead. If we later want dependency caching in CI, that can be a deliberate follow-up.

# 🧪 Tested

- Diagnosed from failed runs: Dockerise `Build Client` on tags `v3.00.00-develop-07162134` / `v3.0.0-RC-libtest1`, and `client-code-checks` on `fe-auth-contract` — all failing at the setup-node step with the error above; branches still on `setup-node@v4` pass
- All 9 modified workflow files pass YAML lint
- The PR's own `client-code-checks` / `client-tests` runs on this branch exercise the fix directly — they fail without it (current develop) and should pass here

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
