### PR TITLE
12496 inbound shipment  cost price is disabled even on a manually created shipment

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -113,9 +113,7 @@ export const InboundLineEditCards = ({
     isAddOrDeleteLinesDisabled,
   } = useInboundShipment();
   const isManualShipment =
-    !inboundData?.purchaseOrder &&
-    !inboundData?.linkedShipment &&
-    !inboundData?.otherParty?.store;
+    !inboundData?.purchaseOrder && !inboundData?.linkedShipment;
 
   const showLineStatus =
     lines.some(line => line.status != null) ||

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -260,7 +260,7 @@ export const InboundLineEditCards = ({
                     item?.itemStoreProperties?.defaultSellPricePerPack ===
                       line.sellPricePerPack;
                   const shouldClearCostPrice =
-                    item?.defaultPackSize !== value &&
+                    item?.defaultPackSize !== line.packSize &&
                     item?.itemStoreProperties?.defaultSellPricePerPack ===
                       line.costPricePerPack;
 

--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -784,39 +784,72 @@ mod test {
         .is_ok());
     }
 
+    // Expected cost price editability by case:
+    //
+    // | Case                                       | Pack cost price enabled? |
+    // |---------------------------------------------|---------------------------|
+    // | External supplier + purchase order         | Disabled                 |
+    // | Internal supplier + linked to outbound/IO  | Disabled                 |
+    // | External supplier, created manually        | Enabled                  |
+    // | Internal supplier, created manually        | Enabled                  |
+    //
+
+    fn cost_price_test_invoice(
+        id: &str,
+        purchase_order_id: Option<String>,
+        linked_invoice_id: Option<String>,
+        name_store_id: Option<String>,
+    ) -> InvoiceRow {
+        InvoiceRow {
+            id: id.to_string(),
+            store_id: mock_store_b().id,
+            name_id: mock_name_store_b().id,
+            purchase_order_id,
+            linked_invoice_id,
+            name_store_id,
+            r#type: InvoiceType::InboundShipment,
+            status: InvoiceStatus::New,
+            ..Default::default()
+        }
+    }
+
+    fn cost_price_test_line(id: &str, invoice_id: &str) -> InvoiceLineRow {
+        InvoiceLineRow {
+            id: id.to_string(),
+            invoice_id: invoice_id.to_string(),
+            item_id: mock_item_a().id,
+            r#type: InvoiceLineType::StockIn,
+            cost_price_per_pack: 100_000.0,
+            number_of_packs: 1.0,
+            pack_size: 1.0,
+            ..Default::default()
+        }
+    }
+
     #[actix_rt::test]
     async fn update_stock_in_line_cannot_edit_cost_price() {
-        fn internal_supplier_inbound() -> InvoiceRow {
-            InvoiceRow {
-                id: "internal_supplier_inbound".to_string(),
-                store_id: mock_store_b().id,
-                name_id: mock_name_store_b().id,
-                name_store_id: Some(mock_store_b().id),
-                r#type: InvoiceType::InboundShipment,
-                status: InvoiceStatus::New,
-                ..Default::default()
-            }
-        }
+        let po_invoice = cost_price_test_invoice(
+            "po_linked_inbound",
+            Some("some_purchase_order".to_string()),
+            None,
+            None,
+        );
+        let line = cost_price_test_line("po_linked_line", &po_invoice.id);
 
-        fn internal_supplier_line() -> InvoiceLineRow {
-            InvoiceLineRow {
-                id: "internal_supplier_line".to_string(),
-                invoice_id: internal_supplier_inbound().id,
-                item_id: mock_item_a().id,
-                r#type: InvoiceLineType::StockIn,
-                cost_price_per_pack: 100_000.0,
-                number_of_packs: 1.0,
-                pack_size: 1.0,
-                ..Default::default()
-            }
-        }
+        let linked_invoice = cost_price_test_invoice(
+            "transfer_linked_inbound",
+            None,
+            Some("some_outbound_invoice".to_string()),
+            None,
+        );
+        let linked_line = cost_price_test_line("transfer_linked_line", &linked_invoice.id);
 
         let (_, _, connection_manager, _) = setup_all_with_data(
             "update_stock_in_line_cannot_edit_cost_price",
             MockDataInserts::all(),
             MockData {
-                invoices: vec![internal_supplier_inbound()],
-                invoice_lines: vec![internal_supplier_line()],
+                invoices: vec![po_invoice, linked_invoice],
+                invoice_lines: vec![line.clone(), linked_line.clone()],
                 ..Default::default()
             },
         )
@@ -827,12 +860,27 @@ mod test {
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();
 
-        // CannotEditCostPrice: changing cost price on internal supplier invoice
+        // CannotEditCostPrice: changing cost price on a PO-linked invoice
         assert_eq!(
             update_stock_in_line(
                 &context,
                 UpdateStockInLine {
-                    id: internal_supplier_line().id,
+                    id: line.id.clone(),
+                    r#type: StockInType::InboundShipment,
+                    cost_price_per_pack: Some(999.0),
+                    ..Default::default()
+                },
+                None
+            ),
+            Err(ServiceError::CannotEditCostPrice)
+        );
+
+        // CannotEditCostPrice: changing cost price on a transfer-linked invoice
+        assert_eq!(
+            update_stock_in_line(
+                &context,
+                UpdateStockInLine {
+                    id: linked_line.id.clone(),
                     r#type: StockInType::InboundShipment,
                     cost_price_per_pack: Some(999.0),
                     ..Default::default()
@@ -846,7 +894,7 @@ mod test {
         assert!(update_stock_in_line(
             &context,
             UpdateStockInLine {
-                id: internal_supplier_line().id,
+                id: line.id.clone(),
                 r#type: StockInType::InboundShipment,
                 cost_price_per_pack: Some(100_000.0),
                 ..Default::default()
@@ -861,7 +909,7 @@ mod test {
         assert!(update_stock_in_line(
             &context,
             UpdateStockInLine {
-                id: internal_supplier_line().id,
+                id: line.id.clone(),
                 r#type: StockInType::InboundShipment,
                 cost_price_per_pack: Some(nearly_same),
                 ..Default::default()
@@ -874,8 +922,70 @@ mod test {
         assert!(update_stock_in_line(
             &context,
             UpdateStockInLine {
-                id: internal_supplier_line().id,
+                id: line.id.clone(),
                 r#type: StockInType::InboundShipment,
+                ..Default::default()
+            },
+            None
+        )
+        .is_ok());
+    }
+
+    #[actix_rt::test]
+    async fn update_stock_in_line_can_edit_cost_price() {
+        // Plain manual inbound shipment (no purchase_order_id, no linked_invoice_id):
+        // cost price must remain editable.
+        let invoice = cost_price_test_invoice("manual_inbound", None, None, None);
+        let line = cost_price_test_line("manual_line", &invoice.id);
+
+        // Manual inbound shipment whose other party is an internal store, but with
+        // no PO and no linked transfer invoice: still editable. `name_store_id` alone
+        // is not a valid reason to lock cost price (#12496).
+        let internal_supplier_invoice = cost_price_test_invoice(
+            "manual_inbound_internal_supplier",
+            None,
+            None,
+            Some(mock_store_b().id),
+        );
+        let internal_supplier_line = cost_price_test_line(
+            "manual_line_internal_supplier",
+            &internal_supplier_invoice.id,
+        );
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "update_stock_in_line_can_edit_cost_price",
+            MockDataInserts::all(),
+            MockData {
+                invoices: vec![invoice, internal_supplier_invoice],
+                invoice_lines: vec![line.clone(), internal_supplier_line.clone()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_b().id, mock_user_account_a().id)
+            .unwrap();
+
+        assert!(update_stock_in_line(
+            &context,
+            UpdateStockInLine {
+                id: line.id,
+                r#type: StockInType::InboundShipment,
+                cost_price_per_pack: Some(999.0),
+                ..Default::default()
+            },
+            None
+        )
+        .is_ok());
+
+        assert!(update_stock_in_line(
+            &context,
+            UpdateStockInLine {
+                id: internal_supplier_line.id,
+                r#type: StockInType::InboundShipment,
+                cost_price_per_pack: Some(999.0),
                 ..Default::default()
             },
             None

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -148,11 +148,11 @@ pub fn validate(
         }
     }
 
-    // Cost price is read-only for internal suppliers and external suppliers linked to a PO.
+    // Cost price is read-only for PO-linked shipments and auto-generated transfer shipments.
     // Use epsilon comparison to allow unchanged values that may have drifted
     // through floating point serialization (Rust f64 → JSON → JS Number → JSON → f64).
     if let Some(new_cost_price) = input.cost_price_per_pack {
-        if (invoice.name_store_id.is_some() || invoice.purchase_order_id.is_some())
+        if (invoice.linked_invoice_id.is_some() || invoice.purchase_order_id.is_some())
             && !f64_approx_eq(new_cost_price, line_row.cost_price_per_pack)
         {
             return Err(CannotEditCostPrice);


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12496 

Case | Enabled?
-- | --
External supplier + purchase order | Disabled
Internal supplier + linked to outbound/IO | Disabled
External supplier, created manually | Enabled
Internal supplier, created manually | Enabled <- Fixed this case

Inbound shipments created manually allow editing of the cost price field

This was disabled as a response to the service layer validation throwing an error when there was an other party id present on the inbound shipment. The intention is that this is editible, so I have allowed it in the validation 

The same logic applies to manually added lines - eg a manual line on a PO linked shipment will also have a disabled cost price field (the price will populate from the default price if it exists)

Added test coverage for all of the cases and a comment with the table above to quickly reference the expectation
<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

## 💌 Any notes for the reviewer?

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->


# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- Created an internal order matching each of the scenarios in the table -> got expected enabled/disabled result

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
