### PR TITLE
11885 Tolerate transient errors when polling central site status

### DIFF
--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -202,18 +202,33 @@ impl SyncApiV5 {
     /// Poll `/sync/v5/site_status` until central reports `Idle`. Used to wait out a
     /// "central busy" response (another sync session for this site is in progress;
     /// legacy central gates sync per-site) before retrying. Errors on timeout.
-    pub(crate) async fn wait_until_central_idle(&self) -> Result<(), SyncApiError> {
+    pub(crate) async fn wait_until_central_idle(
+        &self,
+        poll_period_seconds: u64,
+        timeout_seconds: u64,
+    ) -> Result<(), SyncApiError> {
         let route = "/sync/v5/site_status";
         let start = std::time::SystemTime::now();
-        let poll_period = std::time::Duration::from_secs(CENTRAL_BUSY_POLL_PERIOD_SECONDS);
-        let timeout = std::time::Duration::from_secs(CENTRAL_BUSY_TIMEOUT_SECONDS);
+        let poll_period = std::time::Duration::from_secs(poll_period_seconds);
+        let timeout = std::time::Duration::from_secs(timeout_seconds);
         log::info!("Central server busy with another sync session for this site; waiting for it to become idle...");
         loop {
             tokio::time::sleep(poll_period).await;
 
-            if self.get_site_status().await?.code == SiteStatusCodeV5::Idle {
-                log::info!("Central server is idle; retrying request");
-                return Ok(());
+            match self.get_site_status().await {
+                Ok(status) if status.code == SiteStatusCodeV5::Idle => {
+                    log::info!("Central server is idle; retrying request");
+                    return Ok(());
+                }
+                Ok(_) => {}
+                // Transient poll failures don't mean central is still busy; retry until timeout.
+                Err(error) if error.is_transient() => {
+                    log::warn!(
+                        "Polling central site status failed while waiting for idle (will retry): {:#?}",
+                        error
+                    );
+                }
+                Err(error) => return Err(error),
             }
 
             if start.elapsed().unwrap_or(timeout) >= timeout {
@@ -230,8 +245,8 @@ impl SyncApiV5 {
 
 // When central is busy with another sync session for this site, poll site status
 // this often, up to this long, before giving up.
-const CENTRAL_BUSY_POLL_PERIOD_SECONDS: u64 = 15;
-const CENTRAL_BUSY_TIMEOUT_SECONDS: u64 = 30 * 60;
+pub(crate) const CENTRAL_BUSY_POLL_PERIOD_SECONDS: u64 = 15;
+pub(crate) const CENTRAL_BUSY_TIMEOUT_SECONDS: u64 = 30 * 60;
 
 #[derive(Error, Debug)]
 pub enum ParsingResponseError {
@@ -323,6 +338,7 @@ pub async fn validate_site_auth(
 mod tests {
     use httpmock::{Method::POST, MockServer};
     use reqwest::header::AUTHORIZATION;
+    use util::assert_matches;
 
     use super::*;
 
@@ -379,5 +395,25 @@ mod tests {
             .await;
 
         assert!(result_with_auth.is_err());
+    }
+
+    /// A transient (connection) failure polling `/sync/v5/site_status` must not abort the wait
+    /// outright - it should be tolerated and retried until the timeout below, same as central
+    /// genuinely still being busy. (Old behaviour: a bare `?` on the failing poll would return
+    /// `Err` immediately here, on the very first iteration, well before the 1s timeout - this is
+    /// the regression this PR followup fixes.)
+    #[actix_rt::test]
+    async fn test_wait_until_central_idle_tolerates_transient_poll_errors() {
+        let api = SyncApiV5::new_test("http://localhost:9999", "", "", "site_id");
+
+        let result = api.wait_until_central_idle(0, 1).await;
+
+        assert_matches!(
+            result,
+            Err(SyncApiError {
+                source: SyncApiErrorVariantV5::Other(_),
+                ..
+            })
+        );
     }
 }

--- a/server/service/src/sync/api/error.rs
+++ b/server/service/src/sync/api/error.rs
@@ -134,6 +134,12 @@ impl SyncApiError {
         matches!(self.source, SyncApiErrorVariantV5::Other(_))
     }
 
+    /// Transient transport-level failure (dropped connection, unknown/unparseable error).
+    /// Safe to retry within a bounded polling loop rather than aborting it outright.
+    pub(crate) fn is_transient(&self) -> bool {
+        self.is_connection() || self.is_unknown()
+    }
+
     /// Central is busy with another session for this site (sync / integration / initialisation in
     /// progress). Caller should wait for central to be idle and retry.
     pub(crate) fn is_central_busy(&self) -> bool {
@@ -404,5 +410,32 @@ mod test {
             .expect_err("Should result in error");
         assert!(!result.is_central_busy());
         assert!(result.is_connection());
+    }
+
+    #[actix_rt::test]
+    async fn test_is_transient() {
+        // Connection error - transient (safe to retry within a poll loop).
+        let connection_error = create_api("http://localhost:9999", "", "")
+            .post_initialise()
+            .await
+            .expect_err("Should result in error");
+        assert!(connection_error.is_transient());
+
+        // Unknown error - also transient.
+        let unknown_error =
+            SyncApiError::new_test(SyncApiErrorVariantV5::Other(anyhow::anyhow!("boom")));
+        assert!(unknown_error.is_transient());
+
+        // A parsed business error (e.g. central-busy) is not transient - it's an authoritative
+        // response, not a transport failure, so it shouldn't be silently retried as such.
+        let parsed_error = SyncApiError::new_test(SyncApiErrorVariantV5::ParsedError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            source: ParsedError {
+                code: SyncErrorCodeV5::Other("initialisation_in_progress".to_string()),
+                message: "busy".to_string(),
+                data: None,
+            },
+        });
+        assert!(!parsed_error.is_transient());
     }
 }

--- a/server/service/src/sync/central_data_synchroniser.rs
+++ b/server/service/src/sync/central_data_synchroniser.rs
@@ -1,7 +1,10 @@
 use std::cmp;
 
 use super::{
-    api::{CommonSyncRecord, ParsingSyncRecordError, SyncApiError, SyncApiV5},
+    api::{
+        CommonSyncRecord, ParsingSyncRecordError, SyncApiError, SyncApiV5,
+        CENTRAL_BUSY_POLL_PERIOD_SECONDS, CENTRAL_BUSY_TIMEOUT_SECONDS,
+    },
     sync_status::logger::{SyncLogger, SyncLoggerError, SyncStepProgress},
 };
 use crate::{cursor_controller::CursorController, sync::api::CentralSyncBatchV5};
@@ -60,7 +63,12 @@ impl CentralDataSynchroniser {
                 {
                     Ok(batch) => break batch,
                     Err(error) if error.is_central_busy() => {
-                        self.sync_api_v5.wait_until_central_idle().await?;
+                        self.sync_api_v5
+                            .wait_until_central_idle(
+                                CENTRAL_BUSY_POLL_PERIOD_SECONDS,
+                                CENTRAL_BUSY_TIMEOUT_SECONDS,
+                            )
+                            .await?;
                     }
                     Err(error) => return Err(error.into()),
                 }

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -97,6 +97,12 @@ impl RemoteDataSynchroniser {
     /// gate the POST on live worker status (`site_status`), not the persisted `initialisation_status`:
     /// a crashed worker leaves status stuck at `started`, and gating on liveness lets it self-heal on
     /// the next cycle while still avoiding a duplicate POST when a worker is genuinely running.
+    ///
+    /// Known compatibility gap: this liveness gating only helps clients running this code. An old
+    /// (pre-#12068) OMS client treats `/sync/v5/initialise` returning as "queue ready" (the previous
+    /// blocking semantics) and will pull before the queue exists if talking to an upgraded,
+    /// asynchronously-behaving 4D central - that can only be closed by 4D-side version gating (see
+    /// 4D PR msupply-foundation/msupply#18406), not from here.
     pub(crate) async fn request_initialisation(
         &self,
         _site_info: &SiteInfoV5,
@@ -148,7 +154,7 @@ impl RemoteDataSynchroniser {
             let site_info = match self.sync_api_v5.get_site_info().await {
                 Ok(info) => info,
                 // Transient poll failures don't affect the worker; retry until the stall timeout.
-                Err(error) if error.is_connection() || error.is_unknown() => {
+                Err(error) if error.is_transient() => {
                     log::warn!("Polling central site info failed (will retry): {:#?}", error);
                     if last_progress.elapsed() >= stall_timeout {
                         return Err(WaitForInitialisationError::TimeoutReached);
@@ -170,12 +176,27 @@ impl RemoteDataSynchroniser {
                 InitialisationStatus::New | InitialisationStatus::Started => {}
             }
 
-            let worker_alive = matches!(
-                self.sync_api_v5.get_site_status().await?.code,
-                SiteStatusCodeV5::InitialisationInProgress
-                    | SiteStatusCodeV5::SyncIsRunning
-                    | SiteStatusCodeV5::IntegrationInProgress
-            );
+            let worker_alive = match self.sync_api_v5.get_site_status().await {
+                Ok(status) => matches!(
+                    status.code,
+                    SiteStatusCodeV5::InitialisationInProgress
+                        | SiteStatusCodeV5::SyncIsRunning
+                        | SiteStatusCodeV5::IntegrationInProgress
+                ),
+                // Transient poll failures don't affect the worker; retry until the stall timeout,
+                // same as the get_site_info poll above.
+                Err(error) if error.is_transient() => {
+                    log::warn!(
+                        "Polling central site status failed (will retry): {:#?}",
+                        error
+                    );
+                    if last_progress.elapsed() >= stall_timeout {
+                        return Err(WaitForInitialisationError::TimeoutReached);
+                    }
+                    continue;
+                }
+                Err(error) => return Err(error.into()),
+            };
 
             let queue_length = site_info.queue_length.unwrap_or(0);
             let progressing =
@@ -235,7 +256,12 @@ impl RemoteDataSynchroniser {
                 match self.sync_api_v5.get_queued_records(batch_size).await {
                     Ok(batch) => break batch,
                     Err(error) if error.is_central_busy() => {
-                        self.sync_api_v5.wait_until_central_idle().await?;
+                        self.sync_api_v5
+                            .wait_until_central_idle(
+                                CENTRAL_BUSY_POLL_PERIOD_SECONDS,
+                                CENTRAL_BUSY_TIMEOUT_SECONDS,
+                            )
+                            .await?;
                     }
                     Err(error) => return Err(error.into()),
                 }
@@ -318,7 +344,12 @@ impl RemoteDataSynchroniser {
                 // (legacy central gates sync per-site). Cursor hasn't advanced, so wait
                 // for idle then rebuild this batch.
                 Err(error) if error.is_central_busy() => {
-                    self.sync_api_v5.wait_until_central_idle().await?;
+                    self.sync_api_v5
+                        .wait_until_central_idle(
+                            CENTRAL_BUSY_POLL_PERIOD_SECONDS,
+                            CENTRAL_BUSY_TIMEOUT_SECONDS,
+                        )
+                        .await?;
                     continue;
                 }
                 Err(error) => return Err(error.into()),
@@ -352,11 +383,20 @@ impl RemoteDataSynchroniser {
         loop {
             tokio::time::sleep(poll_period).await;
 
-            let response = self.sync_api_v5.get_site_status().await?;
-
-            if response.code == SiteStatusCodeV5::Idle {
-                info!("Central server operation finished");
-                break;
+            match self.sync_api_v5.get_site_status().await {
+                Ok(response) if response.code == SiteStatusCodeV5::Idle => {
+                    info!("Central server operation finished");
+                    break;
+                }
+                Ok(_) => {}
+                // Transient poll failures don't mean the operation failed; retry until timeout.
+                Err(error) if error.is_transient() => {
+                    log::warn!(
+                        "Polling central site status failed (will retry): {:#?}",
+                        error
+                    );
+                }
+                Err(error) => return Err(error.into()),
             }
 
             let elapsed = start.elapsed().unwrap_or(timeout);
@@ -516,6 +556,31 @@ mod test {
             .wait_for_initialisation(0, 0)
             .await;
         assert_matches!(result, Err(WaitForInitialisationError::TimeoutReached));
+    }
+
+    /// A transient (connection) failure polling central must not abort the wait outright - it
+    /// should be tolerated and retried until the stall timeout, same as a genuine stall.
+    /// (Old behaviour: a bare `?` on the failing poll would return `Err` immediately here, on the
+    /// very first iteration, well before the 1s stall timeout below - this is the regression this
+    /// PR followup fixes. No mock server is registered at all, so every poll - both `get_site_info`
+    /// and `get_site_status` - hits a real connection-refused error.)
+    #[actix_rt::test]
+    async fn test_wait_for_initialisation_tolerates_transient_poll_errors() {
+        let result = synchroniser("http://localhost:9999")
+            .wait_for_initialisation(0, 1)
+            .await;
+        assert_matches!(result, Err(WaitForInitialisationError::TimeoutReached));
+    }
+
+    /// Same regression as above, isolated to the `get_site_status` poll specifically:
+    /// `wait_for_sync_operation` only ever calls `get_site_status`, so a transient failure here
+    /// can only be tolerated by the fix in that function's own match arm, not by `get_site_info`'s.
+    #[actix_rt::test]
+    async fn test_wait_for_sync_operation_tolerates_transient_poll_errors() {
+        let result = synchroniser("http://localhost:9999")
+            .wait_for_sync_operation(0, 1)
+            .await;
+        assert_matches!(result, Err(WaitForSyncOperationError::TimeoutReached));
     }
 
     /// No live worker (idle) -> `request_initialisation` re-POSTs `/sync/v5/initialise`.


### PR DESCRIPTION
<!-- Follow-up to the review posted on #12068 -->

Fixes the 🟡 should-fix flagged in the [code review on #12068](https://github.com/msupply-foundation/open-msupply/pull/12068#issuecomment-5028964513): the `get_site_info` poll in `wait_for_initialisation` tolerates transient errors (dropped connections, unknown errors) and retries until the stall timeout, but three sibling `get_site_status` polls used a bare `?` and aborted the whole wait on the first transient error - exactly the failure mode issue #11885 exists to eliminate.

# 👩🏻‍💻 What does this PR do?
- Adds `SyncApiError::is_transient()` (`is_connection() || is_unknown()`) and applies it consistently to all four polls:
  - `wait_for_initialisation`'s `get_site_status` call (`remote_data_synchroniser.rs`)
  - `wait_until_central_idle` (`api/core.rs`)
  - `wait_for_sync_operation` (`remote_data_synchroniser.rs`)
  - (and the pre-existing `get_site_info` branch now uses the same named predicate instead of the inline `||`)
- `wait_until_central_idle` gains `poll_period_seconds`/`timeout_seconds` parameters, mirroring its two sibling functions, so its retry loop is unit-testable; its 3 call sites now pass the existing `CENTRAL_BUSY_POLL_PERIOD_SECONDS`/`CENTRAL_BUSY_TIMEOUT_SECONDS` constants explicitly instead of them being hardcoded inside it.
- Documents the separately-flagged, client-side-unfixable compatibility gap: an old OMS client talking to an upgraded async-behaving 4D central still treats "POST accepted" as "queue ready" and could pull before the queue exists - needs 4D-side version gating (see [4D PR msupply-foundation/msupply#18406](https://github.com/msupply-foundation/msupply/pull/18406)).

## 💌 Any notes for the reviewer?
Base branch is `11885-fix-initialization-process-crash-on-long-delay-response-from-central-server` (PR #12068), not `v2.21.01-RC` - this is a follow-up fix for separate review, to be merged into that branch rather than folded silently into #12068.

# 🧪 Testing
- [x] `cargo nextest run -p service sync:: -p util api_helper` - all passing (170 + 3 tests), including 4 new tests added here: `test_wait_for_initialisation_tolerates_transient_poll_errors`, `test_wait_for_sync_operation_tolerates_transient_poll_errors`, `test_wait_until_central_idle_tolerates_transient_poll_errors`, `test_is_transient`.
- [x] `cargo check -p service -p repository` clean.

# 📃 Documentation
- [x] **No documentation required**: bug fix, no user-facing change in behaviour.
