### PR TITLE
12517 Fix transfer inbound shipment cost and sell price

### DIFF
--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -218,8 +218,8 @@ export const InboundLineEditCards = ({
                 helperText={
                   isPlaceholder
                     ? t('error.field-must-be-specified', {
-                      field: t('label.packs-received'),
-                    })
+                        field: t('label.packs-received'),
+                      })
                     : undefined
                 }
               />
@@ -258,7 +258,11 @@ export const InboundLineEditCards = ({
                   const shouldClearSellPrice =
                     item?.defaultPackSize !== line.packSize &&
                     item?.itemStoreProperties?.defaultSellPricePerPack ===
-                    line.sellPricePerPack;
+                      line.sellPricePerPack;
+                  const shouldClearCostPrice =
+                    item?.defaultPackSize !== line.packSize &&
+                    item?.itemStoreProperties?.defaultSellPricePerPack ===
+                      line.costPricePerPack;
 
                   updateDraftLine({
                     volumePerPack:
@@ -269,6 +273,9 @@ export const InboundLineEditCards = ({
                     sellPricePerPack: shouldClearSellPrice
                       ? 0
                       : line.sellPricePerPack,
+                    costPricePerPack: shouldClearCostPrice
+                      ? 0
+                      : line.costPricePerPack,
                     packSize: value,
                     id: row.original.id,
                   });
@@ -481,7 +488,10 @@ export const InboundLineEditCards = ({
                 disabled={isDisabled || !isManualShipment}
                 decimalsLimit={5}
                 updateFn={value =>
-                  updateDraftLine({ id: row.original.id, costPricePerPack: value })
+                  updateDraftLine({
+                    id: row.original.id,
+                    costPricePerPack: value,
+                  })
                 }
               />
             </span>
@@ -837,9 +847,9 @@ export const InboundLineEditCards = ({
   const groupIcons = simplified
     ? undefined
     : {
-      stockLineDetails: <StockIcon />,
-      moreInfo: <InfoIcon />,
-    };
+        stockLineDetails: <StockIcon />,
+        moreInfo: <InfoIcon />,
+      };
 
   return (
     <>

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/InboundLineEdit/InboundLineEditCards.tsx
@@ -113,9 +113,7 @@ export const InboundLineEditCards = ({
     isAddOrDeleteLinesDisabled,
   } = useInboundShipment();
   const isManualShipment =
-    !inboundData?.purchaseOrder &&
-    !inboundData?.linkedShipment &&
-    !inboundData?.otherParty?.store;
+    !inboundData?.purchaseOrder && !inboundData?.linkedShipment;
 
   const showLineStatus =
     lines.some(line => line.status != null) ||

--- a/client/packages/invoices/src/InboundShipment/DetailView/modals/utils.ts
+++ b/client/packages/invoices/src/InboundShipment/DetailView/modals/utils.ts
@@ -35,7 +35,9 @@ const createDraftInboundLine = ({
     sellPricePerPack: seed
       ? seed.sellPricePerPack
       : (itemStoreProperties?.defaultSellPricePerPack ?? 0),
-    costPricePerPack: 0,
+    costPricePerPack: seed
+      ? seed.costPricePerPack
+      : (itemStoreProperties?.defaultSellPricePerPack ?? 0),
     numberOfPacks: 0,
     isCreated: !seed,
     expiryDate,

--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -784,39 +784,72 @@ mod test {
         .is_ok());
     }
 
+    // Expected cost price editability by case:
+    //
+    // | Case                                       | Pack cost price enabled? |
+    // |---------------------------------------------|---------------------------|
+    // | External supplier + purchase order         | Disabled                 |
+    // | Internal supplier + linked to outbound/IO  | Disabled                 |
+    // | External supplier, created manually        | Enabled                  |
+    // | Internal supplier, created manually        | Enabled                  |
+    //
+
+    fn cost_price_test_invoice(
+        id: &str,
+        purchase_order_id: Option<String>,
+        linked_invoice_id: Option<String>,
+        name_store_id: Option<String>,
+    ) -> InvoiceRow {
+        InvoiceRow {
+            id: id.to_string(),
+            store_id: mock_store_b().id,
+            name_id: mock_name_store_b().id,
+            purchase_order_id,
+            linked_invoice_id,
+            name_store_id,
+            r#type: InvoiceType::InboundShipment,
+            status: InvoiceStatus::New,
+            ..Default::default()
+        }
+    }
+
+    fn cost_price_test_line(id: &str, invoice_id: &str) -> InvoiceLineRow {
+        InvoiceLineRow {
+            id: id.to_string(),
+            invoice_id: invoice_id.to_string(),
+            item_id: mock_item_a().id,
+            r#type: InvoiceLineType::StockIn,
+            cost_price_per_pack: 100_000.0,
+            number_of_packs: 1.0,
+            pack_size: 1.0,
+            ..Default::default()
+        }
+    }
+
     #[actix_rt::test]
     async fn update_stock_in_line_cannot_edit_cost_price() {
-        fn internal_supplier_inbound() -> InvoiceRow {
-            InvoiceRow {
-                id: "internal_supplier_inbound".to_string(),
-                store_id: mock_store_b().id,
-                name_id: mock_name_store_b().id,
-                name_store_id: Some(mock_store_b().id),
-                r#type: InvoiceType::InboundShipment,
-                status: InvoiceStatus::New,
-                ..Default::default()
-            }
-        }
+        let po_invoice = cost_price_test_invoice(
+            "po_linked_inbound",
+            Some("some_purchase_order".to_string()),
+            None,
+            None,
+        );
+        let line = cost_price_test_line("po_linked_line", &po_invoice.id);
 
-        fn internal_supplier_line() -> InvoiceLineRow {
-            InvoiceLineRow {
-                id: "internal_supplier_line".to_string(),
-                invoice_id: internal_supplier_inbound().id,
-                item_id: mock_item_a().id,
-                r#type: InvoiceLineType::StockIn,
-                cost_price_per_pack: 100_000.0,
-                number_of_packs: 1.0,
-                pack_size: 1.0,
-                ..Default::default()
-            }
-        }
+        let linked_invoice = cost_price_test_invoice(
+            "transfer_linked_inbound",
+            None,
+            Some("some_outbound_invoice".to_string()),
+            None,
+        );
+        let linked_line = cost_price_test_line("transfer_linked_line", &linked_invoice.id);
 
         let (_, _, connection_manager, _) = setup_all_with_data(
             "update_stock_in_line_cannot_edit_cost_price",
             MockDataInserts::all(),
             MockData {
-                invoices: vec![internal_supplier_inbound()],
-                invoice_lines: vec![internal_supplier_line()],
+                invoices: vec![po_invoice, linked_invoice],
+                invoice_lines: vec![line.clone(), linked_line.clone()],
                 ..Default::default()
             },
         )
@@ -827,12 +860,27 @@ mod test {
             .context(mock_store_b().id, mock_user_account_a().id)
             .unwrap();
 
-        // CannotEditCostPrice: changing cost price on internal supplier invoice
+        // CannotEditCostPrice: changing cost price on a PO-linked invoice
         assert_eq!(
             update_stock_in_line(
                 &context,
                 UpdateStockInLine {
-                    id: internal_supplier_line().id,
+                    id: line.id.clone(),
+                    r#type: StockInType::InboundShipment,
+                    cost_price_per_pack: Some(999.0),
+                    ..Default::default()
+                },
+                None
+            ),
+            Err(ServiceError::CannotEditCostPrice)
+        );
+
+        // CannotEditCostPrice: changing cost price on a transfer-linked invoice
+        assert_eq!(
+            update_stock_in_line(
+                &context,
+                UpdateStockInLine {
+                    id: linked_line.id.clone(),
                     r#type: StockInType::InboundShipment,
                     cost_price_per_pack: Some(999.0),
                     ..Default::default()
@@ -846,7 +894,7 @@ mod test {
         assert!(update_stock_in_line(
             &context,
             UpdateStockInLine {
-                id: internal_supplier_line().id,
+                id: line.id.clone(),
                 r#type: StockInType::InboundShipment,
                 cost_price_per_pack: Some(100_000.0),
                 ..Default::default()
@@ -861,7 +909,7 @@ mod test {
         assert!(update_stock_in_line(
             &context,
             UpdateStockInLine {
-                id: internal_supplier_line().id,
+                id: line.id.clone(),
                 r#type: StockInType::InboundShipment,
                 cost_price_per_pack: Some(nearly_same),
                 ..Default::default()
@@ -874,8 +922,70 @@ mod test {
         assert!(update_stock_in_line(
             &context,
             UpdateStockInLine {
-                id: internal_supplier_line().id,
+                id: line.id.clone(),
                 r#type: StockInType::InboundShipment,
+                ..Default::default()
+            },
+            None
+        )
+        .is_ok());
+    }
+
+    #[actix_rt::test]
+    async fn update_stock_in_line_can_edit_cost_price() {
+        // Plain manual inbound shipment (no purchase_order_id, no linked_invoice_id):
+        // cost price must remain editable.
+        let invoice = cost_price_test_invoice("manual_inbound", None, None, None);
+        let line = cost_price_test_line("manual_line", &invoice.id);
+
+        // Manual inbound shipment whose other party is an internal store, but with
+        // no PO and no linked transfer invoice: still editable. `name_store_id` alone
+        // is not a valid reason to lock cost price (#12496).
+        let internal_supplier_invoice = cost_price_test_invoice(
+            "manual_inbound_internal_supplier",
+            None,
+            None,
+            Some(mock_store_b().id),
+        );
+        let internal_supplier_line = cost_price_test_line(
+            "manual_line_internal_supplier",
+            &internal_supplier_invoice.id,
+        );
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "update_stock_in_line_can_edit_cost_price",
+            MockDataInserts::all(),
+            MockData {
+                invoices: vec![invoice, internal_supplier_invoice],
+                invoice_lines: vec![line.clone(), internal_supplier_line.clone()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_b().id, mock_user_account_a().id)
+            .unwrap();
+
+        assert!(update_stock_in_line(
+            &context,
+            UpdateStockInLine {
+                id: line.id,
+                r#type: StockInType::InboundShipment,
+                cost_price_per_pack: Some(999.0),
+                ..Default::default()
+            },
+            None
+        )
+        .is_ok());
+
+        assert!(update_stock_in_line(
+            &context,
+            UpdateStockInLine {
+                id: internal_supplier_line.id,
+                r#type: StockInType::InboundShipment,
+                cost_price_per_pack: Some(999.0),
                 ..Default::default()
             },
             None

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -148,11 +148,11 @@ pub fn validate(
         }
     }
 
-    // Cost price is read-only for internal suppliers and external suppliers linked to a PO.
+    // Cost price is read-only for PO-linked shipments and auto-generated transfer shipments.
     // Use epsilon comparison to allow unchanged values that may have drifted
     // through floating point serialization (Rust f64 → JSON → JS Number → JSON → f64).
     if let Some(new_cost_price) = input.cost_price_per_pack {
-        if (invoice.name_store_id.is_some() || invoice.purchase_order_id.is_some())
+        if (invoice.linked_invoice_id.is_some() || invoice.purchase_order_id.is_some())
             && !f64_approx_eq(new_cost_price, line_row.cost_price_per_pack)
         {
             return Err(CannotEditCostPrice);

--- a/server/service/src/processors/transfer/invoice/common.rs
+++ b/server/service/src/processors/transfer/invoice/common.rs
@@ -1,7 +1,6 @@
 use repository::{
     EqualFilter, Invoice, InvoiceLineFilter, InvoiceLineRepository, InvoiceLineType, InvoiceRow,
-    InvoiceType, ItemRow, ItemStoreJoinRow, ItemStoreJoinRowRepository,
-    ItemStoreJoinRowRepositoryTrait, NameFilter, NameRepository, Pagination,
+    InvoiceType, ItemRow,
 };
 use repository::{InvoiceLineRow, RepositoryError, StorageConnection};
 use util::uuid::uuid;
@@ -11,13 +10,12 @@ use crate::invoice::inbound_shipment::{
     update_inbound_shipment, InboundShipmentType, UpdateInboundShipment,
     UpdateInboundShipmentStatus,
 };
-use crate::preference::{InboundShipmentAutoVerify, ItemMarginOverridesSupplierMargin, Preference};
+use crate::preference::{InboundShipmentAutoVerify, Preference};
 use crate::service_provider::ServiceContext;
 
 pub(crate) fn generate_inbound_lines(
     connection: &StorageConnection,
     inbound_invoice_id: &str,
-    inbound_store_id: &str,
     source_invoice: &Invoice,
 ) -> Result<Vec<InvoiceLineRow>, RepositoryError> {
     let invoice_row = &source_invoice.invoice_row;
@@ -29,7 +27,6 @@ pub(crate) fn generate_inbound_lines(
             // when duplicating lines from outbound invoice to inbound invoice
             .r#type(InvoiceLineType::UnallocatedStock.not_equal_to()),
     )?;
-    let item_properties_repo = ItemStoreJoinRowRepository::new(connection);
 
     let inbound_lines = outbound_lines
         .into_iter()
@@ -74,42 +71,27 @@ pub(crate) fn generate_inbound_lines(
                     purchase_order_line_id,
                     received_number_of_packs: _,
                 },
-                ItemRow {
-                    id: item_id,
-                    default_pack_size,
-                    ..
-                },
+                ItemRow { id: item_id, .. },
             )| {
-                let item_properties = item_properties_repo
-                    .find_one_by_item_and_store_id(&item_id, inbound_store_id)
-                    .unwrap_or(None);
-
-                let supplier_id = &source_invoice.store_row.name_id;
-
-                let trans_cost_price = sell_price_per_pack;
+                // Prices carried onto the inbound (receiving) line. For an outbound shipment ->
+                // inbound shipment transfer, the sending store's cost and sell prices are carried
+                // straight through, so the receiving store's cost price is the sending store's cost
+                // price and its sell price is the sending store's sell price. For a supplier return
+                // -> customer return, both use the cost price. `line_total_price` is the per-pack
+                // price used for the line total (cost price on a transfer, matching 4D's price
+                // extension = cost price * quantity).
+                let (inbound_cost_price_per_pack, inbound_sell_price_per_pack, line_total_price) =
+                    match invoice_row.r#type {
+                        InvoiceType::SupplierReturn => {
+                            (cost_price_per_pack, cost_price_per_pack, sell_price_per_pack)
+                        }
+                        _ => (cost_price_per_pack, sell_price_per_pack, cost_price_per_pack),
+                    };
 
                 let total_before_tax = match r#type {
                     // Service lines don't work in packs
                     InvoiceLineType::Service => total_before_tax,
-                    _ => trans_cost_price * number_of_packs,
-                };
-
-                let default_price_per_default_pack = item_properties
-                    .as_ref()
-                    .map_or(0.0, |i| i.default_sell_price_per_pack);
-
-                let default_price_for_inbound_pack = get_default_price_for_pack(
-                    default_price_per_default_pack,
-                    default_pack_size,
-                    pack_size,
-                );
-
-                // Default price per pack takes priority over cost + margin
-                let adjusted_sell_price_per_pack = if default_price_for_inbound_pack > 0.0 {
-                    default_price_for_inbound_pack
-                } else {
-                    get_cost_plus_margin(connection, trans_cost_price, item_properties, supplier_id)
-                        .unwrap_or(trans_cost_price)
+                    _ => line_total_price * number_of_packs,
                 };
 
                 InvoiceLineRow {
@@ -125,10 +107,7 @@ pub(crate) fn generate_inbound_lines(
                     pack_size,
                     total_before_tax,
                     total_after_tax: calculate_total_after_tax(total_before_tax, tax_percentage),
-                    cost_price_per_pack: match invoice_row.r#type {
-                        InvoiceType::SupplierReturn => cost_price_per_pack,
-                        _ => sell_price_per_pack,
-                    },
+                    cost_price_per_pack: inbound_cost_price_per_pack,
                     r#type: match r#type {
                         InvoiceLineType::Service => InvoiceLineType::Service,
                         _ => InvoiceLineType::StockIn,
@@ -147,10 +126,7 @@ pub(crate) fn generate_inbound_lines(
                     program_id,
                     shipped_number_of_packs,
                     volume_per_pack,
-                    sell_price_per_pack: match invoice_row.r#type {
-                        InvoiceType::SupplierReturn => cost_price_per_pack,
-                        _ => adjusted_sell_price_per_pack,
-                    },
+                    sell_price_per_pack: inbound_sell_price_per_pack,
                     shipped_pack_size,
                     reason_option_id,
                     linked_invoice_line_id: Some(source_line_id),
@@ -236,209 +212,3 @@ pub(crate) fn auto_verify_if_store_preference(
     Ok(())
 }
 
-pub(super) fn get_default_price_for_pack(
-    default_sell_price_per_pack: f64,
-    default_pack_size: f64,
-    inbound_pack_size: f64,
-) -> f64 {
-    if default_pack_size == 0.0 {
-        return 0.0;
-    }
-    let price_per_unit = default_sell_price_per_pack / default_pack_size;
-    price_per_unit * inbound_pack_size
-}
-
-pub(super) fn get_cost_plus_margin(
-    connection: &StorageConnection,
-    cost_price_per_pack: f64,
-    item_properties: Option<ItemStoreJoinRow>,
-    supplier_id: &String,
-) -> Result<f64, RepositoryError> {
-    let item_margin_overrides_supplier_margin = ItemMarginOverridesSupplierMargin
-        .load(connection, None)
-        .unwrap_or(false);
-
-    let margin = if item_margin_overrides_supplier_margin {
-        get_item_margin(item_properties)
-            .filter(|&m| m != 0.0)
-            .or_else(|| get_supplier_margin(connection, supplier_id))
-    } else {
-        get_supplier_margin(connection, supplier_id)
-            .filter(|&m| m != 0.0)
-            .or_else(|| get_item_margin(item_properties))
-    }
-    .unwrap_or(0.0);
-
-    Ok(cost_price_per_pack + (cost_price_per_pack * margin) / 100.0)
-}
-
-fn get_item_margin(item_properties: Option<ItemStoreJoinRow>) -> Option<f64> {
-    item_properties.as_ref().map(|i| i.margin)
-}
-
-fn get_supplier_margin(connection: &StorageConnection, supplier_id: &String) -> Option<f64> {
-    let suppliers = NameRepository::new(connection)
-        .query(
-            supplier_id,
-            Pagination::all(),
-            Some(NameFilter::new().id(EqualFilter::equal_to(supplier_id.to_string()))),
-            None,
-        )
-        .ok()?;
-
-    suppliers
-        .into_iter()
-        .next()
-        .and_then(|name| name.name_row.margin)
-}
-
-#[cfg(test)]
-mod test {
-    use super::{get_cost_plus_margin, get_default_price_for_pack};
-
-    use repository::{
-        mock::{
-            mock_item_a_join_store_a, mock_store_a, mock_store_b, mock_store_c, MockDataInserts,
-        },
-        test_db::setup_all,
-        PreferenceRow, PreferenceRowRepository,
-    };
-
-    use crate::{
-        preference::{ItemMarginOverridesSupplierMargin, Preference},
-        service_provider::ServiceProvider,
-    };
-
-    #[actix_rt::test]
-    async fn test_get_cost_plus_margin() {
-        let (_, _, connection_manager, _) =
-            setup_all("transfer_invoice_processor", MockDataInserts::all()).await;
-
-        let service_provider = ServiceProvider::new(connection_manager);
-        let context = service_provider
-            .context(mock_store_a().id, "".to_string())
-            .unwrap();
-
-        let connection = context.connection;
-
-        let cost_price_per_pack = 5.0;
-
-        let outbound_store = mock_store_b();
-        let supplier_id = outbound_store.name_id;
-        let item_properties = mock_item_a_join_store_a();
-
-        // Set preference to true -> item margin has priority
-        PreferenceRowRepository::new(&connection)
-            .upsert_one(&PreferenceRow {
-                id: "item margin overrides supplier margin".to_string(),
-                store_id: None,
-                key: ItemMarginOverridesSupplierMargin.key().to_string(),
-                value: "true".to_string(),
-            })
-            .unwrap();
-
-        assert_eq!(
-            get_cost_plus_margin(
-                &connection,
-                cost_price_per_pack,
-                Some(item_properties.clone()),
-                &supplier_id
-            ),
-            Ok(cost_price_per_pack + (cost_price_per_pack * 15.0) / 100.0)
-        );
-
-        // No item properties, fallback to supplier margin
-        assert_eq!(
-            get_cost_plus_margin(&connection, cost_price_per_pack, None, &supplier_id),
-            Ok(cost_price_per_pack + (cost_price_per_pack * 10.0) / 100.0)
-        );
-
-        // Set preference to false -> supplier margin has priority
-        PreferenceRowRepository::new(&connection)
-            .upsert_one(&PreferenceRow {
-                id: "item margin overrides supplier margin".to_string(),
-                store_id: None,
-                key: ItemMarginOverridesSupplierMargin.key().to_string(),
-                value: "false".to_string(),
-            })
-            .unwrap();
-
-        assert_eq!(
-            get_cost_plus_margin(
-                &connection,
-                cost_price_per_pack,
-                Some(item_properties.clone()),
-                &supplier_id
-            ),
-            Ok(cost_price_per_pack + (cost_price_per_pack * 10.0) / 100.0)
-        );
-
-        let store_c = mock_store_c();
-        let supplier_no_margin_id = store_c.name_id;
-
-        // No supplier margin, fallback to item margin
-        assert_eq!(
-            get_cost_plus_margin(
-                &connection,
-                cost_price_per_pack,
-                Some(item_properties),
-                &supplier_no_margin_id
-            ),
-            Ok(cost_price_per_pack + (cost_price_per_pack * 15.0) / 100.0)
-        );
-
-        // No item properties or supplier margin, use cost price (margin 0%)
-        assert_eq!(
-            get_cost_plus_margin(
-                &connection,
-                cost_price_per_pack,
-                None,
-                &supplier_no_margin_id
-            ),
-            Ok(cost_price_per_pack)
-        );
-    }
-
-    #[test]
-    fn test_get_default_price_for_pack_conversion() {
-        let default_price = 5.0;
-        let default_pack_size = 10.0;
-
-        // Exact pack
-        let inbound_pack_size = 10.0;
-        assert_eq!(
-            get_default_price_for_pack(default_price, default_pack_size, inbound_pack_size),
-            5.0
-        );
-
-        // Pack of one
-        let inbound_pack_size = 1.0;
-        assert_eq!(
-            get_default_price_for_pack(default_price, default_pack_size, inbound_pack_size),
-            0.5
-        );
-
-        // Larger pack
-        let inbound_pack_size = 100.0;
-        assert_eq!(
-            get_default_price_for_pack(default_price, default_pack_size, inbound_pack_size),
-            50.0
-        );
-
-        // Zero default pack size
-        let default_pack_size = 0.0;
-        let inbound_pack_size = 10.0;
-        assert_eq!(
-            get_default_price_for_pack(default_price, default_pack_size, inbound_pack_size),
-            0.0
-        );
-
-        // Zero default price
-        let default_price = 0.0;
-        let inbound_pack_size = 10.0;
-        assert_eq!(
-            get_default_price_for_pack(default_price, default_pack_size, inbound_pack_size),
-            0.0
-        );
-    }
-}

--- a/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
@@ -156,7 +156,6 @@ impl InvoiceTransferProcessor for CreateInboundInvoiceProcessor {
         let new_inbound_lines = generate_inbound_lines(
             &ctx.connection,
             &new_inbound_invoice.id,
-            &new_inbound_invoice.store_id,
             outbound_invoice,
         )?;
         let store_preferences =

--- a/server/service/src/processors/transfer/invoice/test.rs
+++ b/server/service/src/processors/transfer/invoice/test.rs
@@ -3,8 +3,7 @@ use repository::{
     mock::{insert_extra_mock_data, MockData, MockDataInserts},
     EqualFilter, InvoiceFilter, InvoiceLineFilter, InvoiceLineRepository, InvoiceLineRow,
     InvoiceLineRowRepository, InvoiceLineType, InvoiceRepository, InvoiceRow, InvoiceRowRepository,
-    InvoiceStatus, InvoiceType, ItemRow, ItemRowRepository, ItemStoreJoinRow,
-    ItemStoreJoinRowRepository, ItemStoreJoinRowRepositoryTrait, KeyType, KeyValueStoreRow,
+    InvoiceStatus, InvoiceType, ItemRow, ItemStoreJoinRow, KeyType, KeyValueStoreRow,
     LocationRow, NameLinkRow, NameRow, RequisitionFilter, RequisitionRepository, RequisitionRow,
     RequisitionRowRepository, RequisitionStatus, RequisitionType, StockLineRow, StorageConnection,
     StoreRow,
@@ -21,7 +20,7 @@ use crate::{
         supplier_return::update::{UpdateSupplierReturn, UpdateSupplierReturnStatus},
     },
     invoice_line::stock_out_line::{StockOutType, UpdateStockOutLine},
-    processors::{test_helpers::exec_concurrent, transfer::invoice::common::get_cost_plus_margin},
+    processors::test_helpers::exec_concurrent,
     requisition::request_requisition::{UpdateRequestRequisition, UpdateRequestRequisitionStatus},
     service_provider::ServiceProvider,
     test_helpers::{setup_all_with_data_and_service_provider, ServiceTestContext},
@@ -602,8 +601,6 @@ pub(crate) struct InvoiceTransferTester {
     inbound_shipment: Option<InvoiceRow>,
     response_requisition: Option<RequisitionRow>,
     extra_mock_data: MockData,
-    // outbound_name: NameRow
-    outbound_name: Option<NameRow>,
 }
 
 impl InvoiceTransferTester {
@@ -816,7 +813,6 @@ impl InvoiceTransferTester {
             supplier_return_line,
             supplier_return,
             outbound_shipment,
-            outbound_name: outbound_name.cloned(),
             customer_return: None,
             inbound_shipment: None,
             response_requisition: None,
@@ -983,14 +979,7 @@ impl InvoiceTransferTester {
             &self.outbound_shipment_line1,
         );
 
-        check_line_pricing(
-            connection,
-            &inbound_shipment.id,
-            &inbound_shipment.store_id,
-            &self.outbound_shipment_line1,
-            self.outbound_shipment_line1.item_id.clone(),
-            self.outbound_name.as_ref(),
-        );
+        check_line_pricing(connection, &inbound_shipment.id, &self.outbound_shipment_line1);
 
         check_line(
             connection,
@@ -998,14 +987,7 @@ impl InvoiceTransferTester {
             &self.outbound_shipment_line2,
         );
 
-        check_line_pricing(
-            connection,
-            &inbound_shipment.id,
-            &inbound_shipment.store_id,
-            &self.outbound_shipment_line2,
-            self.outbound_shipment_line2.item_id.clone(),
-            self.outbound_name.as_ref(),
-        );
+        check_line_pricing(connection, &inbound_shipment.id, &self.outbound_shipment_line2);
 
         check_line(
             connection,
@@ -1013,14 +995,7 @@ impl InvoiceTransferTester {
             &self.outbound_shipment_line3,
         );
 
-        check_line_pricing(
-            connection,
-            &inbound_shipment.id,
-            &inbound_shipment.store_id,
-            &self.outbound_shipment_line3,
-            self.outbound_shipment_line3.item_id.clone(),
-            self.outbound_name.as_ref(),
-        );
+        check_line_pricing(connection, &inbound_shipment.id, &self.outbound_shipment_line3);
         check_line(
             connection,
             &inbound_shipment.id,
@@ -1546,14 +1521,11 @@ fn check_line(connection: &StorageConnection, inbound_id: &str, outbound_line: &
     assert_eq!(inbound_line.tax_percentage, outbound_line.tax_percentage);
 }
 
-// Check pricing is calculated correctly for each line
+// Check pricing is carried onto each transferred inbound line
 fn check_line_pricing(
     connection: &StorageConnection,
     inbound_id: &str,
-    inbound_store: &str,
     outbound_line: &InvoiceLineRow,
-    item_id: String,
-    outbound_name: Option<&NameRow>,
 ) {
     let inbound_line = InvoiceLineRepository::new(connection)
         .query_one(
@@ -1565,22 +1537,6 @@ fn check_line_pricing(
 
     assert!(inbound_line.is_some());
     let inbound_line = inbound_line.unwrap().invoice_line_row;
-
-    let item = ItemRowRepository::new(connection)
-        .find_one_by_item_link_id(&item_id)
-        .unwrap_or(None);
-
-    let item_properties = ItemStoreJoinRowRepository::new(connection)
-        .find_one_by_item_and_store_id(&item_id, inbound_store)
-        .unwrap_or(None);
-
-    let default_sell_price_per_pack = item_properties
-        .as_ref()
-        .map_or(0.0, |i| i.default_sell_price_per_pack);
-
-    let margin = item_properties.as_ref().map_or(0.0, |i| i.margin);
-
-    let default_pack_size = item.as_ref().map_or(0.0, |i| i.default_pack_size);
 
     match outbound_line.r#type {
         InvoiceLineType::Service => {
@@ -1596,42 +1552,26 @@ fn check_line_pricing(
         }
         _ => {
             assert_eq!(inbound_line.r#type, InvoiceLineType::StockIn);
+            // A stock transfer carries the sending store's cost and sell prices straight
+            // through, and the line total is based on the cost price (matching 4D's price
+            // extension = cost price * quantity).
             assert_eq!(
                 inbound_line.total_before_tax,
-                outbound_line.sell_price_per_pack * outbound_line.number_of_packs
+                outbound_line.cost_price_per_pack * outbound_line.number_of_packs
             );
             assert_eq!(
                 inbound_line.total_after_tax,
-                outbound_line.sell_price_per_pack * outbound_line.number_of_packs
+                outbound_line.cost_price_per_pack * outbound_line.number_of_packs
             );
         }
     }
 
     assert_eq!(
         inbound_line.cost_price_per_pack,
+        outbound_line.cost_price_per_pack
+    );
+    assert_eq!(
+        inbound_line.sell_price_per_pack,
         outbound_line.sell_price_per_pack
     );
-
-    if default_sell_price_per_pack > 0.0 {
-        let price_per_new_pack =
-            (default_sell_price_per_pack / default_pack_size) * inbound_line.pack_size;
-
-        assert_eq!(inbound_line.sell_price_per_pack, price_per_new_pack)
-    } else if margin > 0.0 {
-        let supplier_id = outbound_name.map_or_else(String::new, |n| n.id.clone());
-        let margin_price = get_cost_plus_margin(
-            connection,
-            inbound_line.cost_price_per_pack,
-            item_properties,
-            &supplier_id,
-        )
-        .unwrap();
-
-        assert_eq!(inbound_line.sell_price_per_pack, margin_price)
-    } else {
-        assert_eq!(
-            inbound_line.sell_price_per_pack,
-            inbound_line.cost_price_per_pack
-        )
-    };
 }

--- a/server/service/src/processors/transfer/invoice/update_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/update_inbound_invoice.rs
@@ -82,7 +82,6 @@ impl InvoiceTransferProcessor for UpdateInboundInvoiceProcessor {
         let new_inbound_lines = generate_inbound_lines(
             &ctx.connection,
             &inbound_invoice.invoice_row.id,
-            &inbound_invoice.store_row.id,
             outbound_invoice,
         )?;
 


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12517

Fixes the **cost and sell prices on a transferred inbound shipment** (the supplier invoice auto-created in the receiving store when an outbound shipment is sent to an internal store).

Previously the transfer processor:

- set the inbound **cost price** from the outbound line's **sell price**, and
- recomputed the inbound **sell price** as `store default price → cost + margin`, which collapsed to the cost price whenever no margin/default price was configured (so the inbound line showed `sell = cost`).

This did not match legacy 4D mSupply. In 4D (`translineCreateForLinkedSI` + `getCustomerLinePrice`), a stock transfer carries the **sending store's cost and sell prices straight through** to the receiving supplier invoice, and the margin is simply derived for display from those two values.

This PR aligns open-mSupply with that behaviour. For an **outbound shipment → inbound shipment** transfer, the inbound line now takes:

- **cost price** = the outbound line's cost price (the sending store's stock cost),
- **sell price** = the outbound line's sell price (the sending store's stock sell price),
- **total (price extension)** = `cost price × quantity` (matching 4D's `price_extension`).

So a transfer of stock costing `1.50` and selling at `2.00` now produces an inbound line with cost `1.50`, sell `2.00` and a derived margin of `33.33%`, matching 4D exactly.

The **supplier return → customer return** transfer path is unchanged.

### Files touched

- `server/service/src/processors/transfer/invoice/common.rs` — `generate_inbound_lines()` now copies cost→cost and sell→sell for shipment transfers; removed the now-unused default-price / cost-plus-margin helpers (`get_cost_plus_margin`, `get_default_price_for_pack`, `get_item_margin`, `get_supplier_margin`) and the unused `inbound_store_id` parameter.
- `server/service/src/processors/transfer/invoice/create_inbound_invoice.rs` and `update_inbound_invoice.rs` — updated call sites for the dropped parameter.
- `server/service/src/processors/transfer/invoice/test.rs` — updated `check_line_pricing` assertions to the new behaviour.

## 💌 Any notes for the reviewer?

- **Behaviour change worth a look:** because both prices are now carried on the invoice line, the **outbound shipment** line displays its real sell price (e.g. `2.00`), whereas legacy 4D displays the outbound (customer invoice) sell price as the cost. The **inbound** result matches 4D exactly (cost `1.50`, sell `2.00`); only the outbound display differs. This approach was chosen deliberately so the transfer relies only on invoice-line data (which syncs with the invoice) and never needs to look up the sending store's stock line on the receiving site.
- The inbound sell price is taken from the outbound line's `sell_price_per_pack`, which `calculate_sell_price` can adjust when the internal-store customer has customer-specific default pricing configured. For a plain internal store with no special pricing this is the raw stock sell price, as expected.
- Removed the `default sell price / cost + margin` logic for the shipment-transfer sell price, since it no longer applies. If any deployment relied on that margin-based inbound sell price, this changes their behaviour (now matches legacy 4D).

# 🧪 Tested

**Automated (regression cover):** Updated the invoice-transfer processor integration tests (`check_line_pricing`) to assert the new behaviour — inbound `cost = outbound cost`, inbound `sell = outbound sell`, `total = cost × quantity` — and removed obsolete helper tests. All transfer + stock-out-line tests pass.

**manual test cases**
Setup: two stores on the same system (a **sending** store and a **receiving** store that is an internal store / customer). Pick an item whose stock line has a **cost price and sell price that differ** (example below uses cost `1.50`, sell `2.00`).

- [ ] **Cost and sell price carry through a stock transfer**
  1. In the **sending** store, confirm the item has stock with cost `1.50` and sell `2.00`.
  2. Create an **Outbound Shipment** to the **receiving** internal store.
  3. Add a line for the item with a quantity (e.g. `20`).
  4. Set the outbound shipment to **Picked / Shipped**.
  5. Switch to the **receiving** store and open the auto-created **Inbound Shipment** (banner: "created automatically, as the result of an outbound shipment in another store").
  6. **Expected:** the inbound line shows **Cost per unit = 1.50**, **Price/Sell per pack = 2.00**, **Total = cost × qty** (`30.00` for qty `20`), and margin (if shown) derives to `33.33%`.

- [ ] **Inbound cost price is read-only and attributed to the supplier**
  1. On the transferred inbound shipment, hover the **Cost price** field.
  2. **Expected:** tooltip states the cost price is controlled by the supplying store / purchase order and cannot be edited here; the field is not editable.

- [ ] **Outbound shipment shows the real prices** (note the deliberate divergence from legacy 4D)
  1. Re-open the originating outbound shipment in the sending store.
  2. **Expected:** it shows **cost = 1.50** and **sell = 2.00** (the item's real prices). NB: legacy 4D mSupply displays the outbound sell as the cost for internal transfers — see reviewer notes for why OMS intentionally differs here.

- [ ] **Different pack sizes** — repeat case 1 with an item whose pack size > 1 and confirm the cost/sell prices per pack transfer correctly (and, if the receiving store has the "pack to one" preference, convert consistently).

- [ ] **Supplier return → customer return is unchanged** — perform a supplier return to an internal store and confirm the resulting customer return pricing behaves exactly as before this change (no regression).

- [ ] **Parity check vs legacy** — run the same transfer (same item, same two stores) in 4D mSupply and confirm the **inbound** cost, sell and derived margin match open-mSupply.

# 📃 Documentation

- [x] **No documentation required** — this is a bug fix that aligns transferred inbound shipment pricing with legacy 4D mSupply behaviour; no new user-facing feature.
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
