### PR TITLE
Fix Android build: TS error on AppDrawer component="nav"

### DIFF
--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -100,7 +100,8 @@ const closedMixin = (theme: Theme) => ({
 
 const StyledDrawer = styled(Box, {
   shouldForwardProp: prop => prop !== 'isOpen',
-})<{ isOpen: boolean }>(({ isOpen, theme }) => ({
+  // styled() loses Box's polymorphic `component` prop, so redeclare it
+})<{ isOpen: boolean; component?: React.ElementType }>(({ isOpen, theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   height: '100%',


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes the [Android Build failure](https://github.com/msupply-foundation/open-msupply/actions/runs/29813803528/job/88580414712) on the `v3.00.00-develo-07212018` tag build.

e8b1c142a3 added `component="nav"` to `StyledDrawer` in `AppDrawer.tsx` so the drawer renders as a navigation landmark (used by the e2e suites as the post-login signal). `StyledDrawer` is `styled(Box)<{ isOpen: boolean }>`, and MUI's `styled()` loses Box's polymorphic `component` prop from the resulting type, so the Android release build (which type-checks via ts-loader) failed with TS2322.

This redeclares `component?: React.ElementType` on the styled component's props. The prop still forwards to Box (only `isOpen` is filtered by `shouldForwardProp`), so the rendered `<nav>` markup is unchanged — this is a type-level fix only.

## 💌 Any notes for the reviewer?

The error only surfaced in the Android build because the web dev/build paths don't run the same full type-check; `yarn android:build:release` does. `as="nav"` was the alternative fix but keeping `component` matches MUI's documented API and the intent of the original commit.

# 🧪 Tested

- Reproduced the exact TS2322 error locally with `tsc --project packages/host/tsconfig.json --noEmit` on develop
- Re-ran the same type-check with this fix applied: clean, zero errors
- No runtime change: the prop was already forwarded to Box at runtime; only the typing was broken

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`)
- [ ] **Developer docs needed** (`docs: internal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)