### PR TITLE
e2e datafile: stamp sync_version V7 so initialise-from-export takes the v7 path

### DIFF
--- a/server/data/e2e/export.json
+++ b/server/data/e2e/export.json
@@ -78680,5 +78680,6 @@
  ],
  "users": [],
  "site_id": 900,
- "central_site_id": 6
+ "central_site_id": 6,
+ "sync_version": "V7"
 }


### PR DESCRIPTION
## Why

Since #12422 merged and we changed to use develop for e2e, both repos' deterministic e2e workflows fail at `auth.setup` with "Invalid credentials" / a closed-browser timeout, and every test is skipped (this repo: e.g. run 29813727884 and the first post-merge run; open-msupply-frontend: every run since).

#12422 changed `initialise-from-export` to dispatch on the export's new `sync_version` field, defaulting to `V5_V6` when the field is absent — previously v7 exports were detected by the presence of `central_site_id`. The committed e2e export predates the field, so the restore now silently takes the v5/v6 path: the v7-stamped buffer rows never integrate and the v5/v6 user-initialisation step reads the export's `users` list, which is empty in v7 exports. The server still boots and reports INITIALISED (the sync log completes), so the failure only surfaces at login.

## What

Stamp the e2e export `"sync_version": "V7"` — a two-line JSON change.

Restoring `server/data/e2e` with a develop build of `remote_server_cli`, before and after:

| | without the field (current develop) | with `"sync_version": "V7"` |
|---|---|---|
| `Admin` user | absent entirely | present, active, bcrypt hash |
| `item` rows | 0 | 266 |

`server/data/reference1` is a genuine v5/v6 export (populated `users` list, no `central_site_id`), so the `V5_V6` default remains correct for it — server-build.yaml, docker entry and the mac build are unaffected. The breakage was confined to the one committed v7 export, i.e. the e2e stacks in both repos.

An alternative would be regenerating the datafile with the new `export-initialisation-v7` command, which writes the field itself — not done here to keep the diff reviewable and the data byte-identical.

## Shown to work: same results before the breakage and after the fix

This PR's own e2e run ([29874170501](https://github.com/msupply-foundation/open-msupply/actions/runs/29874170501)) restores exactly the pre-#12422 baseline ([29790577841](https://github.com/msupply-foundation/open-msupply/actions/runs/29790577841), the last run before the breakage):

| | baseline (pre-#12422) | broken (develop) | this PR |
|---|---|---|---|
| auth.setup | passed | **failed** | passed |
| passed | 36 | 0 | 36 |
| failed | 1 | 1 (63 skipped) | 4 |

The one baseline failure (Outbound Shipments bulk-delete) fails identically here — and the 3 additional failures are the volume-aware location-picker tests newly added to the shared suites since the baseline (61 → 64 tests), which had never run against this app. Nothing that passed before fails now.

The same fixed datafile was also verified against the new FE's full suite run locally (all three suites): auth passes and `stocktake-regression` goes 31/31 green.

## Related

Unblocks msupply-foundation/open-msupply-internal#219 (get the deterministic stocktake suite passing in CI) — every run there since this datafile broke has died at login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
