### PR TITLE
Dual-frontend serving: optional old UI at /old-ui/, new FE at /

### DIFF
--- a/client/packages/common/src/intl/context/IntlContext.tsx
+++ b/client/packages/common/src/intl/context/IntlContext.tsx
@@ -38,7 +38,10 @@ export function initialiseI18n({
   // Served with frontend bundle
   // Electron `main` window translations should be served with relative path
   // for electron, the preloaded script path is `file://:` we don't get a valid API_HOST url until we connect to the server and re-initialise the window
-  const defaultTranslationsLoadPath = `${!!isElectron ? '.' : ''}/locales/{{lng}}/{{ns}}.json`;
+  // For web the locales live under the build-time base path (Environment.PUBLIC_PATH,
+  // '/' by default, '/old-ui/' for the sub-path build) so they resolve alongside the bundle.
+  const localesBase = isElectron ? './' : Environment.PUBLIC_PATH;
+  const defaultTranslationsLoadPath = `${localesBase}locales/{{lng}}/{{ns}}.json`;
 
   // Served from backend, on electron we use a dummy but valid url https://localhost:8000 which shouldn't actually be used.
   // The `lng` query param lets the backend return language-specific custom

--- a/client/packages/common/src/ui/components/errors/GenericErrorFallback.tsx
+++ b/client/packages/common/src/ui/components/errors/GenericErrorFallback.tsx
@@ -4,11 +4,16 @@ import { ErrorBoundaryFallbackProps } from './types';
 import { UnhappyMan } from '@common/icons';
 import { BaseButton } from '../buttons';
 import { useTranslation } from '@openmsupply-client/common';
+import { Environment } from '@openmsupply-client/config';
 
 export const GenericErrorFallback: FC<ErrorBoundaryFallbackProps> = ({
   onClearError,
 }) => {
   const t = useTranslation();
+  // Return to the app root, respecting the build-time base path so the sub-path
+  // build ('/old-ui/') doesn't jump out to the root-served app. Default '/' is
+  // unchanged.
+  const dashboardUrl = `${window.location.origin}${Environment.PUBLIC_PATH}`;
   return (
     <Box
       display="flex"
@@ -26,12 +31,12 @@ export const GenericErrorFallback: FC<ErrorBoundaryFallbackProps> = ({
         <BaseButton onClick={onClearError} color="secondary">
           {t('button.try-again')}
         </BaseButton>
-        <Tooltip title={window.location.origin}>
+        <Tooltip title={dashboardUrl}>
           <BaseButton
             color="secondary"
             onClick={() => {
               onClearError;
-              window.location.href = window.location.origin;
+              window.location.href = dashboardUrl;
             }}
           >
             {t('button.dashboard')}

--- a/client/packages/config/src/config.ts
+++ b/client/packages/config/src/config.ts
@@ -1,4 +1,5 @@
 declare const API_HOST: string;
+declare const PUBLIC_PATH: string;
 
 // For production, API is on the same domain/ip and port as web app, available through sub-route
 // i.e. web app is on https://my.openmsupply.com/, then graphql will be available https://my.openmsupply.com/graphql
@@ -23,8 +24,15 @@ const apiHost = isProductionBuild ? productionApiHost : developmentApiHost;
 
 const pluginUrl = `${apiHost}/plugins`;
 
+// Build-time base path the app is served from (webpack output.publicPath, wired
+// via DefinePlugin). Default '/'; the dual-FE packaging builds the old UI with
+// '/old-ui/'. Always ends with '/'. Used for the router basename and for
+// same-origin asset paths that don't go through webpack (e.g. i18n locales).
+const publicPath = (typeof PUBLIC_PATH !== 'undefined' && PUBLIC_PATH) || '/';
+
 export const Environment = {
   API_HOST: apiHost,
+  PUBLIC_PATH: publicPath,
   FILE_URL: `${apiHost}/files?id=`,
   GRAPHQL_URL: `${apiHost}/graphql`,
   PLUGIN_URL: pluginUrl,

--- a/client/packages/host/public/index.html
+++ b/client/packages/host/public/index.html
@@ -11,6 +11,9 @@
         </div>
       </div>
     </div>
-    <script type="text/javascript" src="/BrowserPrint-3.1.250.min.js"></script>
+    <script
+      type="text/javascript"
+      src="<%= htmlWebpackPlugin.files.publicPath %>BrowserPrint-3.1.250.min.js"
+    ></script>
   </body>
 </html>

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -67,8 +67,7 @@ const PreInit: React.FC<React.PropsWithChildren> = ({ children }) => {
   // Query still loading — don't render children yet, but don't logout either
   if (!data?.data) return null;
 
-  if (data.data.status == InitialisationStatusType.Initialised)
-    return children;
+  if (data.data.status == InitialisationStatusType.Initialised) return children;
 
   // Server is not initialised — wipe locally cached auth so the route guard sends the user to
   // /login. Skip the server-side logout: PreInit renders outside the Router (so useNavigate is
@@ -119,6 +118,14 @@ EnvUtils.deviceInfo.then(info => {
   }
 });
 
+// Router base path derived from the build-time publicPath ('/' by default, so
+// no basename in the default build). React Router expects it without a trailing
+// slash, so strip it for anything other than the root.
+const basename =
+  Environment.PUBLIC_PATH === '/'
+    ? undefined
+    : Environment.PUBLIC_PATH.replace(/\/$/, '');
+
 const router = createBrowserRouter(
   createRoutesFromElements(
     <Route
@@ -154,7 +161,8 @@ const router = createBrowserRouter(
         </ErrorBoundary>
       }
     />
-  )
+  ),
+  { basename }
 );
 
 initialiseI18n();

--- a/client/packages/host/webpack.config.js
+++ b/client/packages/host/webpack.config.js
@@ -16,6 +16,10 @@ class DummyWebpackPlugin {
 
 module.exports = env => {
   const isProduction = !!env.production;
+  // Base path the app is served from. Default '/' (unchanged); the dual-FE
+  // packaging builds the old UI with PUBLIC_PATH=/old-ui/. Normalised to always
+  // end with a single '/' so asset URLs and the router basename line up.
+  const publicPath = (process.env.PUBLIC_PATH || '/').replace(/\/*$/, '/');
   const bundleAnalyzerPlugin = !!env.stats
     ? new BundleAnalyzerPlugin({
         /**
@@ -55,7 +59,7 @@ module.exports = env => {
       conditionNames: ['require', '...'],
     },
     output: {
-      publicPath: '/',
+      publicPath,
       path: path.resolve(__dirname, 'dist'),
       filename: '[name].[contenthash].js',
       chunkFilename: '[contenthash].js',
@@ -76,9 +80,7 @@ module.exports = env => {
           loader: isProduction ? 'ts-loader' : 'swc-loader',
           exclude: /node_modules/,
           options: isProduction
-            ? {
-                /* ts-loader options */
-              }
+            ? {/* ts-loader options */}
             : {
                 /* swc-loader options */
                 jsc: {
@@ -112,6 +114,7 @@ module.exports = env => {
       new ReactRefreshWebpackPlugin(),
       new webpack.DefinePlugin({
         API_HOST: JSON.stringify(env.API_HOST),
+        PUBLIC_PATH: JSON.stringify(publicPath),
         LOCAL_PLUGINS: JSON.stringify(require('./getLocalPlugins.js')),
         LANG_VERSION: Date.now(),
       }),

--- a/server/README.md
+++ b/server/README.md
@@ -2,3 +2,18 @@
 
 - **Docs site**: [https://dev-docs.msupply.foundation/](https://dev-docs.msupply.foundation/docs/introduction/)
 - **Source**: [docs/content/server/\_index.md](../docs/content/server/_index.md)
+
+## Serving front-end
+
+The server serves the web frontend at runtime from `server.frontend_dir`
+(default `frontend`, resolved relative to the working directory). Packaging
+ships the built bundle there; on Android the app shell copies its bundled web
+assets there on startup. In debug builds this falls back to
+`client/packages/host/dist` when the configured directory doesn't exist, so
+`cargo run` serves the frontend without any configuration.
+
+An optional second ("old UI") frontend can be served under the `/old-ui/` URL
+prefix by setting `server.old_ui_frontend_dir`. When unset (the default),
+nothing is mounted at `/old-ui/` and root serving is unaffected. The old UI
+must be built with its `publicPath`/router base set to `/old-ui/` (see the
+client's `PUBLIC_PATH` build variable).

--- a/server/android/src/android.rs
+++ b/server/android/src/android.rs
@@ -66,6 +66,7 @@ pub mod android {
                 // The app shell copies its APK-bundled web UI here on startup,
                 // before starting the server (see MainActivity.copyFrontendAssets)
                 frontend_dir: files_dir.join("frontend").to_string_lossy().to_string(),
+                old_ui_frontend_dir: None,
             },
             database: DatabaseSettings {
                 username: "n/a".to_string(),

--- a/server/cli/src/load_test.rs
+++ b/server/cli/src/load_test.rs
@@ -493,6 +493,7 @@ impl LoadTest {
                 inactivity_timeout_seconds: service::settings::DEFAULT_INACTIVITY_TIMEOUT_SECONDS,
                 token_refresh_interval_seconds: service::settings::DEFAULT_TOKEN_REFRESH_INTERVAL_SECONDS,
                 frontend_dir: "frontend".to_string(),
+                old_ui_frontend_dir: None,
             },
             database: DatabaseSettings {
                 username: "postgres".to_string(),
@@ -592,6 +593,7 @@ impl LoadTest {
                     inactivity_timeout_seconds: service::settings::DEFAULT_INACTIVITY_TIMEOUT_SECONDS,
                     token_refresh_interval_seconds: service::settings::DEFAULT_TOKEN_REFRESH_INTERVAL_SECONDS,
                     frontend_dir: "frontend".to_string(),
+                    old_ui_frontend_dir: None,
                 },
                 database: DatabaseSettings {
                     username: "postgres".to_string(),

--- a/server/configuration/base.yaml
+++ b/server/configuration/base.yaml
@@ -13,6 +13,9 @@ server:
   # Directory the web frontend is served from, relative to the working directory.
   # Packaging ships the built frontend bundle here.
   frontend_dir: "frontend"
+  # Optional directory for the legacy ("old UI") frontend, served under /old-ui/.
+  # Leave unset to mount nothing at /old-ui/ (default; root serving is unaffected).
+  # old_ui_frontend_dir: "frontend/old-ui"
 database:
   host: "localhost"
   port: 5432

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -26,6 +26,9 @@
 #   # Directory the web frontend is served from, relative to the working directory.
 #   # Debug builds fall back to client/packages/host/dist when this doesn't exist.
 #   frontend_dir: "frontend"
+#   # Optional directory for the legacy ("old UI") frontend, served under /old-ui/.
+#   # Leave unset to mount nothing at /old-ui/ (default; root serving is unaffected).
+#   old_ui_frontend_dir: "frontend/old-ui"
 # sync:
 #   # url/username/password_sha256/interval_seconds are all-or-nothing: set them all, or omit them
 #   # all to carry only flags (e.g. on a central server). A partial set is a startup error.

--- a/server/server/src/serve_frontend.rs
+++ b/server/server/src/serve_frontend.rs
@@ -7,7 +7,7 @@ use actix_web::{
 };
 use mime_guess::{from_path, mime};
 use service::settings::Settings;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const INDEX: &str = "index.html";
 const CACHE_MAX_AGE: u32 = 365 * 60 * 60 * 24; // 1 year
@@ -16,16 +16,25 @@ const CACHE_MAX_AGE: u32 = 365 * 60 * 60 * 24; // 1 year
 /// alongside the server by packaging (or copied there by the Android app
 /// shell), so it can be swapped without rebuilding the server.
 fn get_asset(settings: &Settings, path: &str) -> Option<Vec<u8>> {
-    let root = frontend_root(settings)?;
+    read_asset(&frontend_root(settings)?, path)
+}
+
+/// Read an asset from `server.old_ui_frontend_dir` (served under `/old-ui/`).
+fn get_old_ui_asset(settings: &Settings, path: &str) -> Option<Vec<u8>> {
+    read_asset(&old_ui_frontend_root(settings)?, path)
+}
+
+/// Read `path` relative to `root`, guarding against path traversal outside it.
+fn read_asset(root: &Path, path: &str) -> Option<Vec<u8>> {
     let asset_path = root.join(path).canonicalize().ok()?;
     // no path traversal outside the frontend directory
-    if !asset_path.starts_with(&root) {
+    if !asset_path.starts_with(root) {
         return None;
     }
     std::fs::read(asset_path).ok()
 }
 
-fn frontend_root(settings: &Settings) -> Option<std::path::PathBuf> {
+fn frontend_root(settings: &Settings) -> Option<PathBuf> {
     let configured = Path::new(&settings.server.frontend_dir).canonicalize().ok();
 
     // In debug builds fall back to the in-repo client build, so `cargo run`
@@ -43,33 +52,54 @@ fn frontend_root(settings: &Settings) -> Option<std::path::PathBuf> {
     configured
 }
 
-fn serve_frontend(settings: &Settings, path: &str) -> HttpResponse {
-    if let Some(content) = get_asset(settings, path) {
-        let cache_control = if path == "index.html" {
-            // The index and config files can change so we don't want to cache them
-            // The other files are generally static and can be cached
-            // Technically the config.js shouldn't change either but if it did we'd want pick it up immediately.
-            header::CacheControl(vec![header::CacheDirective::NoCache])
-        } else if path.starts_with("locales/") {
-            // These are the translation json files, in the typescript code they are cached in local storage and invalidated after a yarn build
-            // So we don't want to cache them here...
-            header::CacheControl(vec![header::CacheDirective::NoCache])
-        } else {
-            // Cache everything else for 1 year
-            header::CacheControl(vec![
-                header::CacheDirective::Public,
-                header::CacheDirective::MaxAge(CACHE_MAX_AGE),
-            ])
-        };
+/// Root for the optional legacy ("old UI") frontend. `None` when
+/// `old_ui_frontend_dir` is unset or the directory doesn't exist, so nothing
+/// is mounted at `/old-ui/` by default. No debug fallback: the old UI is only
+/// served when explicitly configured.
+fn old_ui_frontend_root(settings: &Settings) -> Option<PathBuf> {
+    let dir = settings.server.old_ui_frontend_dir.as_ref()?;
+    Path::new(dir).canonicalize().ok()
+}
 
-        return HttpResponse::Ok()
-            .content_type(from_path(path).first_or_octet_stream().as_ref())
-            .append_header(("x-content-type-options", "nosniff"))
-            .append_header(cache_control)
-            .body(content);
+/// Cache-control for a frontend asset by path. The index and translation files
+/// can change so we don't want to cache them; everything else is static and
+/// cached for a year. (config.js technically shouldn't change either but if it
+/// did we'd want to pick it up immediately, hence no-cache on index.)
+fn cache_control_for(path: &str) -> header::CacheControl {
+    if path == INDEX {
+        header::CacheControl(vec![header::CacheDirective::NoCache])
+    } else if path.starts_with("locales/") {
+        // Translation json files: cached in local storage in the frontend and
+        // invalidated after a build, so we don't want to cache them here.
+        header::CacheControl(vec![header::CacheDirective::NoCache])
+    } else {
+        header::CacheControl(vec![
+            header::CacheDirective::Public,
+            header::CacheDirective::MaxAge(CACHE_MAX_AGE),
+        ])
     }
+}
 
-    HttpResponse::NotFound().body("file not found")
+fn asset_response(path: &str, content: Vec<u8>) -> HttpResponse {
+    HttpResponse::Ok()
+        .content_type(from_path(path).first_or_octet_stream().as_ref())
+        .append_header(("x-content-type-options", "nosniff"))
+        .append_header(cache_control_for(path))
+        .body(content)
+}
+
+fn serve_frontend(settings: &Settings, path: &str) -> HttpResponse {
+    match get_asset(settings, path) {
+        Some(content) => asset_response(path, content),
+        None => HttpResponse::NotFound().body("file not found"),
+    }
+}
+
+fn serve_old_ui_frontend(settings: &Settings, path: &str) -> HttpResponse {
+    match get_old_ui_asset(settings, path) {
+        Some(content) => asset_response(path, content),
+        None => HttpResponse::NotFound().body("file not found"),
+    }
 }
 
 // Match file paths (ending  ($) with dot (\.) and at least one character (.+) )
@@ -97,6 +127,209 @@ async fn index(settings: Data<Settings>) -> impl Responder {
     }
 }
 
+// Legacy ("old UI") frontend served under /old-ui/. Files (paths ending with an
+// extension) are served directly from `old_ui_frontend_dir`.
+#[get(r#"/old-ui/{filename:.*\..+$}"#)]
+async fn old_ui_file(req: HttpRequest, settings: Data<Settings>) -> impl Responder {
+    let filename: String = req.match_info().query("filename").parse().unwrap();
+    serve_old_ui_frontend(&settings, &filename)
+}
+
+// SPA fallback for the old UI: `/old-ui`, `/old-ui/` and extension-less
+// `/old-ui/*` routes all serve the old UI's index.html. The `(/.*)?` tail
+// matches an empty tail (bare `/old-ui`) or `/...` without also matching
+// unrelated root paths like `/old-uixyz`.
+#[get(r#"/old-ui{_:(/.*)?}"#)]
+async fn old_ui_index(settings: Data<Settings>) -> impl Responder {
+    let result = serve_old_ui_frontend(&settings, INDEX);
+
+    // Unset setting or missing bundle: respond with a plain-text hint, mirroring
+    // the root index behaviour rather than a bare 404.
+    if result.status() == StatusCode::NOT_FOUND {
+        HttpResponse::Ok()
+            .content_type(ContentType(mime::TEXT_PLAIN))
+            .body(format!(
+                "Cannot find index.html in old UI frontend directory ({}). See https://github.com/msupply-foundation/open-msupply/tree/develop/server#serving-front-end",
+                settings.server.old_ui_frontend_dir.as_deref().unwrap_or("<unset>")
+            ))
+    } else {
+        result
+    }
+}
+
 pub fn config_serve_frontend(cfg: &mut ServiceConfig) {
-    cfg.service(file).service(index);
+    // The old-ui scoped routes must be registered before `file`/`index`, which
+    // are catch-alls that would otherwise swallow every `/old-ui/*` request.
+    cfg.service(old_ui_file)
+        .service(old_ui_index)
+        .service(file)
+        .service(index);
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use actix_web::{test, App};
+    use service::settings::test_settings;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Build a `Settings` whose frontend dirs point at temp dirs. Each dir gets
+    /// an `index.html` with distinguishable content and a nested `assets/x.js`.
+    fn write_dist(dir: &Path, marker: &str) {
+        fs::write(dir.join("index.html"), format!("<html>{marker} index</html>")).unwrap();
+        fs::create_dir_all(dir.join("assets")).unwrap();
+        fs::write(dir.join("assets/x.js"), format!("// {marker} js")).unwrap();
+    }
+
+    fn settings_with(frontend: &Path, old_ui: Option<&Path>) -> Settings {
+        let mut settings = test_settings(
+            repository::database_settings::DatabaseSettings {
+                username: String::new(),
+                password: String::new(),
+                port: 0,
+                host: String::new(),
+                database_name: String::new(),
+                database_path: None,
+                connection_pool_max_connections: None,
+                connection_pool_min_idle: None,
+                connection_pool_timeout_seconds: None,
+                init_sql: None,
+            },
+            None,
+        );
+        settings.server.frontend_dir = frontend.to_str().unwrap().to_string();
+        settings.server.old_ui_frontend_dir =
+            old_ui.map(|p| p.to_str().unwrap().to_string());
+        settings
+    }
+
+    async fn body_string(resp: actix_web::dev::ServiceResponse) -> String {
+        let bytes = test::read_body(resp).await;
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[actix_web::test]
+    async fn serves_root_and_old_ui_from_separate_dirs() {
+        let new_dir = TempDir::new().unwrap();
+        let old_dir = TempDir::new().unwrap();
+        write_dist(new_dir.path(), "NEW");
+        write_dist(old_dir.path(), "OLD");
+
+        let settings = settings_with(new_dir.path(), Some(old_dir.path()));
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(settings))
+                .configure(config_serve_frontend),
+        )
+        .await;
+
+        // Root -> new index
+        let resp = test::call_service(&app, test::TestRequest::get().uri("/").to_request()).await;
+        assert!(resp.status().is_success());
+        assert!(body_string(resp).await.contains("NEW index"));
+
+        // Root SPA route -> new index
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get().uri("/some/route").to_request(),
+        )
+        .await;
+        assert!(body_string(resp).await.contains("NEW index"));
+
+        // /old-ui/ -> old index
+        let resp =
+            test::call_service(&app, test::TestRequest::get().uri("/old-ui/").to_request()).await;
+        assert!(body_string(resp).await.contains("OLD index"));
+
+        // Bare /old-ui -> old index
+        let resp =
+            test::call_service(&app, test::TestRequest::get().uri("/old-ui").to_request()).await;
+        assert!(body_string(resp).await.contains("OLD index"));
+
+        // /old-ui SPA route -> old index
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get().uri("/old-ui/some/route").to_request(),
+        )
+        .await;
+        assert!(body_string(resp).await.contains("OLD index"));
+
+        // /old-ui asset -> old js with long cache header
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get().uri("/old-ui/assets/x.js").to_request(),
+        )
+        .await;
+        let cache = resp
+            .headers()
+            .get("cache-control")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(cache.contains("max-age=31536000"), "got {}", cache);
+        assert!(body_string(resp).await.contains("OLD js"));
+
+        // Root asset -> new js
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get().uri("/assets/x.js").to_request(),
+        )
+        .await;
+        assert!(body_string(resp).await.contains("NEW js"));
+    }
+
+    #[actix_web::test]
+    async fn old_ui_unset_is_graceful_and_root_still_works() {
+        let new_dir = TempDir::new().unwrap();
+        write_dist(new_dir.path(), "NEW");
+
+        let settings = settings_with(new_dir.path(), None);
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(settings))
+                .configure(config_serve_frontend),
+        )
+        .await;
+
+        // Root still works
+        let resp = test::call_service(&app, test::TestRequest::get().uri("/").to_request()).await;
+        assert!(resp.status().is_success());
+        assert!(body_string(resp).await.contains("NEW index"));
+
+        // /old-ui/anything is graceful (plain-text hint, not a swallow of the new app)
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get().uri("/old-ui/anything").to_request(),
+        )
+        .await;
+        assert!(resp.status().is_success());
+        let body = body_string(resp).await;
+        assert!(body.contains("Cannot find index.html in old UI"), "got {}", body);
+        assert!(!body.contains("NEW index"));
+    }
+
+    #[actix_web::test]
+    async fn index_html_is_not_cached() {
+        let new_dir = TempDir::new().unwrap();
+        write_dist(new_dir.path(), "NEW");
+        let settings = settings_with(new_dir.path(), None);
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(settings))
+                .configure(config_serve_frontend),
+        )
+        .await;
+
+        let resp = test::call_service(&app, test::TestRequest::get().uri("/").to_request()).await;
+        let cache = resp
+            .headers()
+            .get("cache-control")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(cache.contains("no-cache"), "got {}", cache);
+    }
 }

--- a/server/service/src/processors/support_upload_files/support_upload_files.rs
+++ b/server/service/src/processors/support_upload_files/support_upload_files.rs
@@ -467,6 +467,7 @@ mod tests {
                 inactivity_timeout_seconds: crate::settings::DEFAULT_INACTIVITY_TIMEOUT_SECONDS,
                 token_refresh_interval_seconds: crate::settings::DEFAULT_TOKEN_REFRESH_INTERVAL_SECONDS,
                 frontend_dir: "frontend".to_string(),
+                old_ui_frontend_dir: None,
             },
             database: db_settings,
             sync: None,

--- a/server/service/src/settings.rs
+++ b/server/service/src/settings.rs
@@ -77,6 +77,13 @@ pub struct ServerSettings {
     /// on Android the app shell copies its bundled web assets here on startup.
     #[serde(default = "default_frontend_dir")]
     pub frontend_dir: String,
+
+    /// Optional directory for the legacy ("old UI") web frontend, resolved
+    /// relative to the working directory and served under the `/old-ui/` URL
+    /// prefix. When unset nothing is mounted at `/old-ui/` (fully backwards
+    /// compatible); root serving from `frontend_dir` is unaffected.
+    #[serde(default)]
+    pub old_ui_frontend_dir: Option<String>,
 }
 
 pub const DEFAULT_INACTIVITY_TIMEOUT_SECONDS: u32 = 900;
@@ -122,6 +129,7 @@ pub fn test_settings(
             inactivity_timeout_seconds: DEFAULT_INACTIVITY_TIMEOUT_SECONDS,
             token_refresh_interval_seconds: DEFAULT_TOKEN_REFRESH_INTERVAL_SECONDS,
             frontend_dir: default_frontend_dir(),
+            old_ui_frontend_dir: None,
         },
         database,
         sync: None,

--- a/server/service/src/test_helpers.rs
+++ b/server/service/src/test_helpers.rs
@@ -55,6 +55,7 @@ pub(crate) async fn setup_all_with_data_and_service_provider(
             inactivity_timeout_seconds: crate::settings::DEFAULT_INACTIVITY_TIMEOUT_SECONDS,
             token_refresh_interval_seconds: crate::settings::DEFAULT_TOKEN_REFRESH_INTERVAL_SECONDS,
             frontend_dir: "frontend".to_string(),
+            old_ui_frontend_dir: None,
         },
         database: db_settings,
         sync: None,


### PR DESCRIPTION
Part of #12523 (plan: msupply-foundation/open-msupply-frontend#401).

During the transition to the new frontend, the app ships **both** UIs from one origin (one cookie session — switching UIs is a link): the new FE default at `/`, this repo's FE at `/old-ui/`. This PR makes both halves possible; it changes nothing by default.

### Server

- Optional `server.old_ui_frontend_dir` setting (settings.rs, commented examples in `base.yaml`/`example.yaml`).
- `serve_frontend.rs`: `/old-ui/**` served from that directory — extension paths as files, extension-less paths (incl. bare `/old-ui`) fall back to its `index.html`; same cache-control rules and path-traversal guard as the root frontend. Routes registered ahead of the root catch-alls. Unset or missing dir → plain-text hint; root serving byte-identical to today.
- `README.md`: `## Serving front-end` section documenting both directories (matches the anchor the not-found messages link to).

### Client (buildable at a subpath; default unchanged)

- New build-time `PUBLIC_PATH` env (default `/`), wired through webpack `output.publicPath` + `DefinePlugin`, `createBrowserRouter` `basename`, i18n locale `loadPath`, the HTML template's hardcoded BrowserPrint script/favicon, and the `GenericErrorFallback` "dashboard" redirect (which bypassed the router with bare `origin`).
- Origin-based URLs (GraphQL, files, plugins, sync files) audited and deliberately untouched — they're served at fixed backend paths independent of the FE base.

### Verification

- `cargo check -p server`; 3 new `actix_web::test` integration tests (`serve_frontend`) cover the matrix: `/` and `/some/route` → new index, `/old-ui/`, `/old-ui` and `/old-ui/some/route` → old index, `/old-ui/assets/x.js` → old asset with 1-year cache, index no-cache, unset setting → graceful hint with root unaffected.
- `PUBLIC_PATH=/old-ui/ yarn build` emits `/old-ui/`-prefixed asset URLs in `index.html` and bundle; default build output is **byte-identical** to pre-change.

### Trying it manually

```sh
# old UI, built for the subpath
cd client && PUBLIC_PATH=/old-ui/ yarn build && cp -R packages/host/dist /tmp/old-ui-dist

# any second dist for the root mount (a real open-msupply-frontend build,
# or just a hand-made index.html to tell the two apart)
```

Point the server at both (env vars shown; `local.yaml` works the same):

```sh
cd server
APP__SERVER__FRONTEND_DIR=/path/to/new-fe-dist APP__SERVER__OLD_UI_FRONTEND_DIR=/tmp/old-ui-dist cargo run --bin remote_server
```

Then: `/` serves the root dist, `/old-ui/` the old UI — log in, click around, hard-refresh a deep `/old-ui/...` route (SPA fallback), and confirm the URL bar stays under `/old-ui/`. With `OLD_UI_FRONTEND_DIR` unset, `/old-ui/` shows a plain-text hint and `/` is untouched.

(Or just ask Claude to set it up — it'll build both dists, boot a throwaway sqlite server from the e2e datafile on a spare port, and leave it running for you. The [manual-pass comment below](https://github.com/msupply-foundation/open-msupply/pull/12524#issuecomment-5041963679) is the output of exactly that.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

