### PR TITLE
#12522 Gate multi-device toggle behind enable_multi_device_site flag

### DIFF
--- a/client/packages/common/src/hooks/useFeatureFlags/useFeatureFlags.ts
+++ b/client/packages/common/src/hooks/useFeatureFlags/useFeatureFlags.ts
@@ -1,8 +1,13 @@
-/* 
+/*
   -- Feature Flags --
 
   Available feature flags should be listed below, with a description.
   To enable, set to true in local.yaml file.
+
+  - enable_multi_site: Central server only. Enables the "Multi device" toggle on
+    the Manage > Sites edit screen. Multi-device sync is not ready for general
+    use (only a subset of tables sync), so the toggle is disabled unless this
+    flag is set. See issue #12522.
 
   Example configuration/local.yaml:
 

--- a/client/packages/common/src/hooks/useFeatureFlags/useFeatureFlags.ts
+++ b/client/packages/common/src/hooks/useFeatureFlags/useFeatureFlags.ts
@@ -4,10 +4,10 @@
   Available feature flags should be listed below, with a description.
   To enable, set to true in local.yaml file.
 
-  - enable_multi_site: Central server only. Enables the "Multi device" toggle on
-    the Manage > Sites edit screen. Multi-device sync is not ready for general
-    use (only a subset of tables sync), so the toggle is disabled unless this
-    flag is set. See issue #12522.
+  - enable_multi_device_site: Central server only. Enables the "Multi device"
+    toggle on the Manage > Sites edit screen. Multi-device sync is not ready for
+    general use (only a subset of tables sync), so the toggle is disabled unless
+    this flag is set. See issue #12522.
 
   Example configuration/local.yaml:
 

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2491,7 +2491,7 @@
   "messages.no-stock-available": "There is no stock available",
   "messages.no-stock-movements": "No stock movements have been created yet.",
   "messages.move-all-or-partial": "Move all or a partial quantity (max {{max}}).",
-  "messages.multi-device-requires-flag": "Multi-device sync must be enabled in the server configuration (features: enable_multi_site) before it can be turned on here.",
+  "messages.multi-device-requires-flag": "Multi-device sync must be enabled in the server configuration (features: enable_multi_device_site) before it can be turned on here.",
   "messages.no-stock-movement-lines": "No lines have been added to this stock movement yet.",
   "messages.confirm-delete-stock-movement-lines_one": "Are you sure you want to delete this line?",
   "messages.confirm-delete-stock-movement-lines_other": "Are you sure you want to delete these {{count}} lines?",

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2491,6 +2491,7 @@
   "messages.no-stock-available": "There is no stock available",
   "messages.no-stock-movements": "No stock movements have been created yet.",
   "messages.move-all-or-partial": "Move all or a partial quantity (max {{max}}).",
+  "messages.multi-device-requires-flag": "Multi-device sync must be enabled in the server configuration (features: enable_multi_site) before it can be turned on here.",
   "messages.no-stock-movement-lines": "No lines have been added to this stock movement yet.",
   "messages.confirm-delete-stock-movement-lines_one": "Are you sure you want to delete this line?",
   "messages.confirm-delete-stock-movement-lines_other": "Are you sure you want to delete these {{count}} lines?",

--- a/client/packages/system/src/Manage/Sites/ListView/SiteEditModal.tsx
+++ b/client/packages/system/src/Manage/Sites/ListView/SiteEditModal.tsx
@@ -1,4 +1,4 @@
-// Disable camelcase should be removed once enable_multi_site feature flag is removed from the central server's configuration. See issue #12522.
+// Disable camelcase should be removed once enable_multi_device_site feature flag is removed from the central server's configuration. See issue #12522.
 /* eslint-disable camelcase */
 
 import React from 'react';
@@ -70,9 +70,9 @@ export const SiteEditModal = ({
   const { data: syncSettings } = useSync.settings.syncSettings();
   const currentSiteId = syncSettings?.syncSiteId;
   // Multi-device sync is not ready for general use (some data, e.g. stock, does
-  // not sync), so the toggle is gated behind the `enable_multi_site` feature flag
-  // in the central server's configuration. See issue #12522.
-  const { enable_multi_site } = useFeatureFlags();
+  // not sync), so the toggle is gated behind the `enable_multi_device_site`
+  // feature flag in the central server's configuration. See issue #12522.
+  const { enable_multi_device_site } = useFeatureFlags();
   // Hardware id / token are only safe to clear once the site has transitioned to
   // v7 (legacy v5/v6 sites still manage these via 4D). See issue #11784.
   const isV7 = syncVersion === SyncVersionNode.V7;
@@ -250,7 +250,7 @@ export const SiteEditModal = ({
                 <Box display="flex" justifyContent="flex-end" flex={1}>
                   <Tooltip
                     title={
-                      !enable_multi_site
+                      !enable_multi_device_site
                         ? t('messages.multi-device-requires-flag')
                         : ''
                     }
@@ -262,8 +262,8 @@ export const SiteEditModal = ({
                         onChange={() => confirmSetMultiDevice()}
                         // Don't allow a multi device site to become a single device site again
                         // TODO: Need to implement re-syncing of skipped changelog entries - #12401
-                        // Also disabled unless the enable_multi_site feature flag is set - #12522
-                        disabled={isMultiDevice || !enable_multi_site}
+                        // Also disabled unless the enable_multi_device_site feature flag is set - #12522
+                        disabled={isMultiDevice || !enable_multi_device_site}
                       />
                     </span>
                   </Tooltip>

--- a/client/packages/system/src/Manage/Sites/ListView/SiteEditModal.tsx
+++ b/client/packages/system/src/Manage/Sites/ListView/SiteEditModal.tsx
@@ -14,6 +14,8 @@ import {
   useConfirmationModal,
   SyncVersionNode,
   Switch,
+  Tooltip,
+  useFeatureFlags,
 } from '@openmsupply-client/common';
 import { DraftSite, useSiteStoresDraft } from '../api';
 import { SiteStoresSection } from './SiteStoresSection';
@@ -64,6 +66,10 @@ export const SiteEditModal = ({
   const isExisting = !isNew;
   const { data: syncSettings } = useSync.settings.syncSettings();
   const currentSiteId = syncSettings?.syncSiteId;
+  // Multi-device sync is not ready for general use (some data, e.g. stock, does
+  // not sync), so the toggle is gated behind the `enable_multi_site` feature flag
+  // in the central server's configuration. See issue #12522.
+  const { enable_multi_site } = useFeatureFlags();
   // Hardware id / token are only safe to clear once the site has transitioned to
   // v7 (legacy v5/v6 sites still manage these via 4D). See issue #11784.
   const isV7 = syncVersion === SyncVersionNode.V7;
@@ -239,13 +245,25 @@ export const SiteEditModal = ({
               labelWidth="130px"
               Input={
                 <Box display="flex" justifyContent="flex-end" flex={1}>
-                  <Switch
-                    checked={isMultiDevice}
-                    onChange={() => confirmSetMultiDevice()}
-                    // Don't allow a multi device site to become a single device site again
-                    // TODO: Need to implement re-syncing of skipped changelog entries - #12401
-                    disabled={isMultiDevice}
-                  />
+                  <Tooltip
+                    title={
+                      !enable_multi_site
+                        ? t('messages.multi-device-requires-flag')
+                        : ''
+                    }
+                  >
+                    {/* span wrapper so the tooltip still fires over a disabled Switch */}
+                    <span>
+                      <Switch
+                        checked={isMultiDevice}
+                        onChange={() => confirmSetMultiDevice()}
+                        // Don't allow a multi device site to become a single device site again
+                        // TODO: Need to implement re-syncing of skipped changelog entries - #12401
+                        // Also disabled unless the enable_multi_site feature flag is set - #12522
+                        disabled={isMultiDevice || !enable_multi_site}
+                      />
+                    </span>
+                  </Tooltip>
                 </Box>
               }
             />

--- a/client/packages/system/src/Manage/Sites/ListView/SiteEditModal.tsx
+++ b/client/packages/system/src/Manage/Sites/ListView/SiteEditModal.tsx
@@ -250,7 +250,7 @@ export const SiteEditModal = ({
                 <Box display="flex" justifyContent="flex-end" flex={1}>
                   <Tooltip
                     title={
-                      !enable_multi_device_site
+                      !isMultiDevice && !enable_multi_device_site
                         ? t('messages.multi-device-requires-flag')
                         : ''
                     }

--- a/client/packages/system/src/Manage/Sites/ListView/SiteEditModal.tsx
+++ b/client/packages/system/src/Manage/Sites/ListView/SiteEditModal.tsx
@@ -1,3 +1,6 @@
+// Disable camelcase should be removed once enable_multi_site feature flag is removed from the central server's configuration. See issue #12522.
+/* eslint-disable camelcase */
+
 import React from 'react';
 import {
   useTranslation,

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -73,7 +73,7 @@
 #   interval: 60 # in seconds
 # features:
 #   stock_movement: true
-#   enable_multi_site: true # central server only; enables the multi-device toggle on the Sites screen
+#   enable_multi_device_site: true # central server only; enables the multi-device toggle on the Sites screen
 # changelog_partition: # postgres-only; controls partitioning of the changelog table
 #   partition_size: 5000000      # cursor values per partition
 #   lookahead: 30000000          # number of insertable records headroom for changelog; also the lower bound — yaml values below this are clamped up

--- a/server/configuration/example.yaml
+++ b/server/configuration/example.yaml
@@ -73,6 +73,7 @@
 #   interval: 60 # in seconds
 # features:
 #   stock_movement: true
+#   enable_multi_site: true # central server only; enables the multi-device toggle on the Sites screen
 # changelog_partition: # postgres-only; controls partitioning of the changelog table
 #   partition_size: 5000000      # cursor values per partition
 #   lookahead: 30000000          # number of insertable records headroom for changelog; also the lower bound — yaml values below this are clamped up


### PR DESCRIPTION
Fixes #12522

# 👩🏻‍💻 What does this PR do?

When a site is switched to "multi device" (the codebase name for what the issue calls "multi site"), only a subset of tables sync — e.g. stock management does not. This is by design, but flipping it on without understanding the consequences is confusing, and the feature is not ready for general use yet.

This PR gates the **multi-device toggle** on the Manage → Sites edit screen behind a new `enable_multi_device_site` feature flag in the central server's configuration:

- The toggle now renders **visible but disabled** unless `features: { enable_multi_device_site: true }` is set in the server config, with a tooltip explaining why it's disabled.
- Reuses the existing feature-flag pipeline end to end (`features:` yaml → `Settings.features` → `featureFlags` GraphQL query → `useFeatureFlags()` hook), so there are **no server/GraphQL/schema changes** — just a new flag key consumed on the frontend, plus docs.
- Documents the flag in `configuration/example.yaml` and the `useFeatureFlags.ts` header comment.

The multi-device UI already only appears on the central server (the Sites screen is gated to central-standalone + ServerAdmin, and the toggle only shows for Sync V7 sites that aren't the server's own site), so this flag is an additional guard on top of that.

## 💌 Any notes for the reviewer?

- **Naming**: the flag is `enable_multi_device_site` to align with the codebase's "multi device" terminology (`isMultiDevice` / `setSiteMultiDevice`), even though the issue text says "multi site".
- **Design decisions** (confirmed with the requester): the toggle is shown-but-disabled (not hidden), and enforcement is **frontend-only** — no server-side guard on the `setSiteMultiDevice` mutation, since the flag lives on the central server where the mutation runs and this is an internal admin control.
- **Scope**: only the multi-device toggle is gated. The neighbouring "Clear hardware id" / "Clear sync token" buttons in the same modal are left untouched — they are separate site re-pairing/recovery tools.
- `useFeatureFlags()` was already exported but unused; this is its first real consumer. It returns an untyped map, so `enable_multi_device_site` is `any` — `!enable_multi_device_site` correctly handles the `undefined`/`false` cases.
- `configuration/local.yaml` is gitignored (it's a local copy of `example.yaml`), so only the `example.yaml` doc line is committed.
- Targets `v3.0.0-RC`.

Main file: `client/packages/system/src/Manage/Sites/ListView/SiteEditModal.tsx`.

# 🧪 Testing

- [ ] Run a central-standalone OMS server built from this PR, with **no** `enable_multi_device_site` in `local.yaml`
- [ ] Open Manage → Sites → edit an existing Sync V7 site (one that isn't this server's own site)
- [ ] Confirm the "Multi device" toggle is **visible but greyed/disabled**, and hovering shows the explanatory tooltip
- [ ] Confirm the "Clear hardware id" and "Clear sync token" buttons still work as before
- [ ] Add the flag and restart the server:
  ```yaml
  features:
    enable_multi_device_site: true
  ```
- [ ] Reload the client (the hook caches with `staleTime: Infinity`, so a fresh load is needed) and confirm the toggle is now **enabled** and the confirm dialog + set-multi-device flow works
- [ ] Confirm a site that is already multi-device still shows the switch checked and disabled regardless of the flag

# 📃 Documentation

- [x] **No documentation required**: gates a not-yet-released internal feature; the new `enable_multi_device_site` config flag is documented inline in `configuration/example.yaml` and `useFeatureFlags.ts`.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
