### PR TITLE
Name the Breadcrumbs nav landmark so e2e can tell it from the drawer

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -941,6 +941,7 @@
   "label.breach-start": "Breach start",
   "label.breach-type": "Breach type",
   "label.breaches": "Breaches",
+  "label.breadcrumb": "Breadcrumb",
   "label.business": "Business",
   "label.by": "by",
   "label.calculate-demand": "Include in GAPS calculations",

--- a/client/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/client/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.test.tsx
@@ -24,6 +24,28 @@ describe('Breadcrumbs', () => {
 
     expect(queryByText(/distribution/i)).not.toBeInTheDocument();
   });
+  it('Renders as a navigation landmark named Breadcrumb', () => {
+    const { getByRole } = render(
+      <TestingProvider>
+        <TestingRouter
+          initialEntries={[
+            RouteBuilder.create(AppRoute.Distribution)
+              .addPart(AppRoute.OutboundShipment)
+              .build(),
+          ]}
+        >
+          <Route path="*" element={<Breadcrumbs />}></Route>
+        </TestingRouter>
+      </TestingProvider>
+    );
+
+    // The e2e suites locate the breadcrumb by this accessible name to tell
+    // it apart from the app drawer's <nav>.
+    expect(
+      getByRole('navigation', { name: /breadcrumb/i })
+    ).toBeInTheDocument();
+  });
+
   it('Renders the names of all the routes from the URL, excluding the first', () => {
     const { getByText } = render(
       <TestingProvider>

--- a/client/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
@@ -96,6 +96,12 @@ export const Breadcrumbs = ({
 
   return (
     <MuiBreadcrumbs
+      // MUI renders a <nav> but leaves it unnamed; the WAI-ARIA breadcrumb
+      // pattern names the landmark so it's distinguishable from the app
+      // drawer's <nav>. The deterministic e2e suites locate the breadcrumb
+      // by this accessible name (open-msupply-frontend e2e/TESTIDS.md §
+      // non-testid hooks).
+      aria-label={t('label.breadcrumb')}
       sx={{
         fontSize: '16px',
         color: theme => theme.typography.body1.color,


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Tracked in msupply-foundation/open-msupply-frontend#426 — the fix spans both repos; the suites PR (msupply-foundation/open-msupply-frontend#418) closes the ticket.

Adds `aria-label="Breadcrumb"` (new `label.breadcrumb` key, en only) to the `Breadcrumbs` component's `<nav>`, following the [WAI-ARIA breadcrumb pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/). MUI's Breadcrumbs renders a `<nav>` but leaves it unnamed.

**Why:** since #11863 (commit e8b1c142a3) made the AppDrawer a `<nav>` (the e2e "landed" signal), every page has two navigation landmarks, and the deterministic e2e suites' breadcrumb locator — `nav` filtered by section text — resolves to the drawer instead:

- the collapsed drawer keeps its link labels (e.g. "Outbound Shipments") in the DOM, and Playwright's `hasText` matches hidden text;
- the drawer's sync badge ("99+") satisfies the suite's contains-a-digit guard;
- the drawer's text doesn't *end* in a number, so the invoice-number parse returns `""`.

Result: `Distribution: Outbound Shipments › delete a New-status shipment via bulk action` has failed in every "E2E regression (hermetic)" run since July 16 (first failing run started seconds after that commit landed; July 15 runs passed).

Naming the landmark lets the suites — and assistive tech — tell the two navs apart. Companion PR msupply-foundation/open-msupply-frontend#418 switches the suites to locate the breadcrumb by accessible name (`getByRole('navigation', { name: /breadcrumb/i })`) and records the contract in TESTIDS.md.

## 💌 Any notes for the reviewer?

- **Merge order:** this PR first, then the suites PR. The delete-shipment e2e failure persists until *both* are merged (this repo's e2e workflow checks the suites out at `main`), so the e2e check on this PR is expected to still show that known failure.
- Markup-only change — no styling or behaviour difference; the aria-label is invisible except to AT and tests.
- New locale key added to `en/common.json` only (translations are a separate pass).

# 🧪 Tested

- Added a unit test asserting the breadcrumb renders as a navigation landmark with accessible name "Breadcrumb" (`Breadcrumbs.test.tsx`); all 6 tests in the suite pass.
- Ran the hermetic e2e stack locally (`yarn e2e:local distribution-regression`) with `FE_SUITES_DIR` pointed at the companion suites branch: **33/33 passed** (3.2m), including the previously failing `delete a New-status shipment via bulk action` — verifying the cross-repo combination CI can't test until both PRs merge.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (accessibility markup + e2e contract only)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`)
- [ ] **Developer docs needed** (`docs: internal`)


