### PR TITLE
Exit on PG dump file not mapped correctly

### DIFF
--- a/docker/entry-postgres.sh
+++ b/docker/entry-postgres.sh
@@ -5,6 +5,30 @@ PG_DATA="/database/postgres/data"
 PG_USER="postgres"
 PG_DB="${APP_DATABASE__DATABASE_NAME:-omsupply-database}"
 IMPORT_DUMP="/import.dump"
+# A dump mounted here instead of at IMPORT_DUMP is a common mistake; it is
+# detected and rejected below.
+MISPLACED_IMPORT_DUMP="/database/import.dump"
+
+# Fail fast on dump-mount mistakes. A mis-mounted dump is otherwise silent:
+# Postgres starts with an empty database and the server lands on the
+# initialisation screen, which is indistinguishable from a genuine sync/init
+# failure. Aborting here makes the mistake obvious in `docker logs` instead of
+# surfacing much later.
+
+# A dump mounted at the wrong path.
+if [ -e "$MISPLACED_IMPORT_DUMP" ]; then
+    echo "ERROR: a dump is mounted at '$MISPLACED_IMPORT_DUMP', but this image reads it from '$IMPORT_DUMP'." >&2
+    echo "       Update the mount target: -v /host/path/to.dump:$IMPORT_DUMP" >&2
+    exit 1
+fi
+
+# The bind-mount source does not exist on the host, so Docker created an empty
+# directory at the target instead of exposing a file.
+if [ -e "$IMPORT_DUMP" ] && [ ! -f "$IMPORT_DUMP" ]; then
+    echo "ERROR: '$IMPORT_DUMP' is not a regular file (Docker created an empty directory)." >&2
+    echo "       The host path in '-v <host>:$IMPORT_DUMP' does not exist — check it." >&2
+    exit 1
+fi
 
 # Ensure PG_DATA exists and is owned by the postgres user before initdb.
 # /database is root-owned (created in the Dockerfile / mounted as a volume),
@@ -40,7 +64,10 @@ if [ -f "$IMPORT_DUMP" ]; then
     echo "Importing database dump from $IMPORT_DUMP..."
     gosu $PG_USER pg_restore --no-owner --exit-on-error --dbname "$PG_DB" "$IMPORT_DUMP"
     echo "Database import complete."
+else
+    echo "No dump mounted at $IMPORT_DUMP — starting with the current database contents (empty on a fresh container)."
 fi
 
-# Hand off to the shared entry script for CLI commands, reference data loading, etc.
+# Hand off to the shared entry script for CLI commands, reference data loading,
+# etc.
 exec /usr/src/omsupply/server/entry.sh "$@"

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -9,9 +9,9 @@ if [ ! -s /etc/machine-id ]; then
     cat /proc/sys/kernel/random/uuid > /etc/machine-id
 fi
 
-# Whey MSUPPLY_NO_TEST_DB_TEMPLATE ?
-# Initialise uses testdb to setup database and migrated it, by default we create templates
-# which allows for faster testing, but requires finding workspace
+# Why MSUPPLY_NO_TEST_DB_TEMPLATE ?
+# Initialise uses testdb to setup database and migrated it, by default we create
+# templates which allows for faster testing, but requires finding workspace
 
 # If command line argument exists then just run cli
 if [ $# -gt 0 ]; then


### PR DESCRIPTION
Since @jmbrunskill changed the volume mapping for Postgres to `/import.dump` rather than `/database/import.dump`, the Postgres docker images haven't worked when launched from the on-demand demo server.

We can fix the path mapping, but the problem was when the Docker container launched with a mis-matched path, there was no feedback and the app would launch with a fresh database, which loaded the initialisation screen. And this looks the same as a data file that is still trying to sync (a common issue with provided data files). So it took me a lot longer than it should have to figure out why Craig's latest Postgres data file wasn't working properly. 

So anyway, I've sorted that now on the Conforma end, but this change just provides a bit more useful error handling for future troubleshooting -- if the pg_dump file is not mapped correctly, then the entry script will exit without launching OMS and leave an appropriate message in the log.

