### PR TITLE
Login: 'Try the new UI' link, dual-frontend builds only

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2028,6 +2028,7 @@
   "login.body": "Welcome to Open mSupply. Your partner for managing health supply chains and improving medicine availability.",
   "login.heading": "Simple.\nPowerful.\nPharmaceutical\nManagement.",
   "login.store-changed": "Welcome to the {{store}} store",
+  "login.try-new-ui": "Try the new UI",
   "logout": "Logout",
   "manage": "Manage",
   "manage-equipment": "Equipment",

--- a/client/packages/host/src/components/Login/Login.tsx
+++ b/client/packages/host/src/components/Login/Login.tsx
@@ -9,6 +9,7 @@ import {
   LocalStorage,
   useFormatDateTime,
   BoxedErrorWithDetails,
+  MuiLink,
 } from '@openmsupply-client/common';
 import { LoginTextInput } from './LoginTextInput';
 import { useLoginForm } from './hooks';
@@ -16,6 +17,15 @@ import { LoginLayout } from './LoginLayout';
 import { LoginStoreSelectorPanel } from './LoginStoreSelectorPanel';
 import { SiteInfo } from '../SiteInfo';
 import { useHost } from '../../api';
+
+// Build-time base path (webpack DefinePlugin literal; see config.ts). Compared
+// directly — not via Environment.PUBLIC_PATH — so the minifier can constant-fold
+// the check: in a default build DefinePlugin substitutes '/', the "Try the new
+// UI" link's condition becomes statically false, and the whole link is
+// dead-code-eliminated. Only the dual-frontend build (PUBLIC_PATH=/old-ui/)
+// emits it. A cross-module property read (Environment.PUBLIC_PATH) is NOT
+// statically reducible, so it would ship the link in every build.
+declare const PUBLIC_PATH: string;
 
 export const Login = ({ fullSize = true }: { fullSize?: boolean }) => {
   const t = useTranslation();
@@ -209,6 +219,24 @@ export const Login = ({ fullSize = true }: { fullSize?: boolean }) => {
           label={t('button.login')}
           data-testid="login-button"
         />
+      }
+      TryNewUiLink={
+        // Dual-frontend packaging serves this (old) client at a subpath while
+        // the new frontend lives at '/'. Only then does linking to '/' make
+        // sense. Full document navigation (a plain anchor, not the router) so
+        // the browser loads the new frontend at the origin root. See the
+        // PUBLIC_PATH declaration above for why the check is dead-code-friendly.
+        PUBLIC_PATH !== '/' && (
+          <MuiLink
+            href="/"
+            underline="hover"
+            variant="body2"
+            color="secondary"
+            data-testid="try-new-ui-link"
+          >
+            {t('login.try-new-ui')}
+          </MuiLink>
+        )
       }
       ErrorMessage={
         error &&

--- a/client/packages/host/src/components/Login/LoginLayout.tsx
+++ b/client/packages/host/src/components/Login/LoginLayout.tsx
@@ -20,6 +20,7 @@ export type LoginLayoutProps = {
   fullSize: boolean;
   StoreSelector?: React.ReactNode;
   showStoreSelector?: boolean;
+  TryNewUiLink?: React.ReactNode;
 };
 
 export const LoginLayout = ({
@@ -32,6 +33,7 @@ export const LoginLayout = ({
   fullSize,
   StoreSelector,
   showStoreSelector = false,
+  TryNewUiLink,
 }: LoginLayoutProps) => {
   const t = useTranslation();
 
@@ -44,6 +46,7 @@ export const LoginLayout = ({
       SiteInfo={SiteInfo}
       onLogin={onLogin}
       fullSize={fullSize}
+      TryNewUiLink={TryNewUiLink}
     />
   );
 
@@ -159,6 +162,7 @@ const LoginForm = ({
   ErrorMessage,
   onLogin,
   fullSize,
+  TryNewUiLink,
 }: LoginLayoutProps) => {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
     if (e.key === 'Enter') {
@@ -180,6 +184,11 @@ const LoginForm = ({
         <Box display="flex" justifyContent="flex-end">
           {LoginButton}
         </Box>
+        {TryNewUiLink && (
+          <Box display="flex" justifyContent="center">
+            {TryNewUiLink}
+          </Box>
+        )}
       </Stack>
     </form>
   );


### PR DESCRIPTION
Closes #12537 (plan: msupply-foundation/open-msupply-frontend#401). Built on the dual-frontend train (#12524/#12525/#12534), which merged to develop while this was in flight — targets develop directly. FE counterpart: msupply-foundation/open-msupply-frontend#474.

Adds an unobtrusive secondary text link below the login button — a plain anchor to `/` (full document navigation, not the router), shown **only in dual-frontend packaging**.

The interesting bit: the gate compares the **DefinePlugin literal `PUBLIC_PATH` directly**, not `Environment.PUBLIC_PATH`. The issue suggested the latter, but terser can't statically reduce a cross-module property read, so the link would ship in every build. With the bare literal, DefinePlugin's textual substitution makes the condition `'/' !== '/'` in a default build → constant-folded → the whole link is dead-code-eliminated. Proven against the emitted bundles:

- default `yarn build`: `try-new-ui-link` **absent** from every emitted JS file
- `PUBLIC_PATH=/old-ui/ yarn build`: **present** in the login chunk (`…"data-testid":"try-new-ui-link"},o("login.try-new-ui")…`)

So legacy single-UI deployments can never render a self-referential link — no runtime probing needed.

Also: `login.try-new-ui` added to the `en` catalog only (other locales are Weblate-managed); typecheck + eslint green; no Login tests exist to extend (verified — host package has none), the DCE behaviour is verified directly against the bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
