### PR TITLE
Invoice lines: itemCodeOrName filter + whole-invoice volume total on PricingNode

### DIFF
--- a/server/graphql/invoice_line/src/invoice_line_queries.rs
+++ b/server/graphql/invoice_line/src/invoice_line_queries.rs
@@ -2,6 +2,7 @@ use async_graphql::*;
 use graphql_core::{
     generic_filters::{
         DatetimeFilterInput, EqualFilterBigFloatingNumberInput, EqualFilterStringInput,
+        StringFilterInput,
     },
     generic_inputs::{report_sort_to_typed_sort, PrintReportSortInput},
     map_filter,
@@ -15,7 +16,7 @@ use graphql_types::types::{
 };
 use repository::{
     DatetimeFilter, EqualFilter, InvoiceLineFilter, InvoiceLineSort, InvoiceLineSortField,
-    InvoiceLineType, InvoiceStatus, InvoiceType, PaginationOption,
+    InvoiceLineType, InvoiceStatus, InvoiceType, PaginationOption, StringFilter,
 };
 use service::{
     auth::{Resource, ResourceAccessRequest},
@@ -37,6 +38,8 @@ pub struct InvoiceLineFilterInput {
     pub invoice_id: Option<EqualFilterStringInput>,
     pub location_id: Option<EqualFilterStringInput>,
     pub item_id: Option<EqualFilterStringInput>,
+    /// Matches on item code OR item name
+    pub item_code_or_name: Option<StringFilterInput>,
     pub r#type: Option<EqualFilterInvoiceLineTypeInput>,
     pub requisition_id: Option<EqualFilterStringInput>,
     pub number_of_packs: Option<EqualFilterBigFloatingNumberInput>,
@@ -59,6 +62,7 @@ impl From<InvoiceLineFilterInput> for InvoiceLineFilter {
             invoice_id: f.invoice_id.map(EqualFilter::from),
             location_id: f.location_id.map(EqualFilter::from),
             item_id: f.item_id.map(EqualFilter::from),
+            item_code_or_name: f.item_code_or_name.map(StringFilter::from),
             r#type: f.r#type.map(|t| map_filter!(t, InvoiceLineType::from)),
             requisition_id: f.requisition_id.map(EqualFilter::from),
             number_of_packs: f.number_of_packs.map(|t| map_filter!(t, f64::from)),

--- a/server/graphql/types/src/types/invoice_query.rs
+++ b/server/graphql/types/src/types/invoice_query.rs
@@ -311,6 +311,9 @@ impl InvoiceNode {
             service_total_after_tax: 0.0,
             tax_percentage: self.row().tax_percentage,
             foreign_currency_total_after_tax: None,
+            total_number_of_packs: 0.0,
+            total_number_of_units: 0.0,
+            total_volume: 0.0,
         };
 
         let result_option = loader.load_one(self.row().id.to_string()).await?;
@@ -644,6 +647,24 @@ impl PricingNode {
 
     pub async fn tax_percentage(&self) -> &Option<f64> {
         &self.invoice_pricing.tax_percentage
+    }
+
+    // quantity totals — whole-invoice sums over non-service lines
+    // (placeholders included), for detail-view footer roll-ups that can't be
+    // computed client-side once lines are server-paginated
+
+    pub async fn total_number_of_packs(&self) -> f64 {
+        self.invoice_pricing.total_number_of_packs
+    }
+
+    /// Sum of number_of_packs * pack_size
+    pub async fn total_number_of_units(&self) -> f64 {
+        self.invoice_pricing.total_number_of_units
+    }
+
+    /// Sum of number_of_packs * volume_per_pack
+    pub async fn total_volume(&self) -> f64 {
+        self.invoice_pricing.total_volume
     }
 }
 

--- a/server/graphql/types/src/types/invoice_query.rs
+++ b/server/graphql/types/src/types/invoice_query.rs
@@ -311,8 +311,6 @@ impl InvoiceNode {
             service_total_after_tax: 0.0,
             tax_percentage: self.row().tax_percentage,
             foreign_currency_total_after_tax: None,
-            total_number_of_packs: 0.0,
-            total_number_of_units: 0.0,
             total_volume: 0.0,
         };
 
@@ -649,18 +647,9 @@ impl PricingNode {
         &self.invoice_pricing.tax_percentage
     }
 
-    // quantity totals — whole-invoice sums over non-service lines
-    // (placeholders included), for detail-view footer roll-ups that can't be
-    // computed client-side once lines are server-paginated
-
-    pub async fn total_number_of_packs(&self) -> f64 {
-        self.invoice_pricing.total_number_of_packs
-    }
-
-    /// Sum of number_of_packs * pack_size
-    pub async fn total_number_of_units(&self) -> f64 {
-        self.invoice_pricing.total_number_of_units
-    }
+    // volume total — the whole-invoice sum over non-service lines
+    // (placeholders included), for the detail-view footer roll-up that can't
+    // be computed client-side once lines are server-paginated
 
     /// Sum of number_of_packs * volume_per_pack
     pub async fn total_volume(&self) -> f64 {

--- a/server/repository/src/db_diesel/invoice_line.rs
+++ b/server/repository/src/db_diesel/invoice_line.rs
@@ -30,8 +30,6 @@ table! {
         service_total_after_tax -> Double,
         tax_percentage -> Nullable<Double>,
         foreign_currency_total_after_tax -> Nullable<Double>,
-        total_number_of_packs -> Double,
-        total_number_of_units -> Double,
         total_volume -> Double,
     }
 }
@@ -48,11 +46,9 @@ pub struct PricingRow {
     pub service_total_after_tax: f64,
     pub tax_percentage: Option<f64>,
     pub foreign_currency_total_after_tax: Option<f64>,
-    /// Whole-invoice quantity totals over non-service lines (placeholders
+    /// Whole-invoice volume total over non-service lines (placeholders
     /// included) — the detail-view footer roll-up, which the client can no
     /// longer sum itself once lines are server-paginated.
-    pub total_number_of_packs: f64,
-    pub total_number_of_units: f64,
     pub total_volume: f64,
 }
 
@@ -453,12 +449,6 @@ impl InvoiceLine {
                     .map(|tax| price + (price * tax / 100.0))
                     .unwrap_or(price)
             }),
-            total_number_of_packs: if is_service { 0.0 } else { row.number_of_packs },
-            total_number_of_units: if is_service {
-                0.0
-            } else {
-                row.number_of_packs * row.pack_size
-            },
             total_volume: if is_service {
                 0.0
             } else {

--- a/server/repository/src/db_diesel/invoice_line.rs
+++ b/server/repository/src/db_diesel/invoice_line.rs
@@ -8,10 +8,10 @@ use super::{
 use crate::{
     diesel_macros::{
         apply_date_time_filter, apply_equal_filter, apply_sort, apply_sort_asc_nulls_last,
-        apply_sort_no_case,
+        apply_sort_no_case, apply_string_filter, apply_string_or_filter,
     },
     repository_error::RepositoryError,
-    EqualFilter, InvoiceStatus, InvoiceType, ItemRow, Pagination, Sort, StockLineRow,
+    EqualFilter, InvoiceStatus, InvoiceType, ItemRow, Pagination, Sort, StockLineRow, StringFilter,
 };
 
 use diesel::{
@@ -30,6 +30,9 @@ table! {
         service_total_after_tax -> Double,
         tax_percentage -> Nullable<Double>,
         foreign_currency_total_after_tax -> Nullable<Double>,
+        total_number_of_packs -> Double,
+        total_number_of_units -> Double,
+        total_volume -> Double,
     }
 }
 
@@ -45,6 +48,12 @@ pub struct PricingRow {
     pub service_total_after_tax: f64,
     pub tax_percentage: Option<f64>,
     pub foreign_currency_total_after_tax: Option<f64>,
+    /// Whole-invoice quantity totals over non-service lines (placeholders
+    /// included) — the detail-view footer roll-up, which the client can no
+    /// longer sum itself once lines are server-paginated.
+    pub total_number_of_packs: f64,
+    pub total_number_of_units: f64,
+    pub total_volume: f64,
 }
 
 #[derive(PartialEq, Debug, Clone, Default)]
@@ -78,6 +87,7 @@ pub struct InvoiceLineFilter {
     pub store_id: Option<EqualFilter<String>>,
     pub invoice_id: Option<EqualFilter<String>>,
     pub item_id: Option<EqualFilter<String>>,
+    pub item_code_or_name: Option<StringFilter>,
     pub r#type: Option<EqualFilter<InvoiceLineType>>,
     pub location_id: Option<EqualFilter<String>>,
     pub requisition_id: Option<EqualFilter<String>>,
@@ -117,6 +127,11 @@ impl InvoiceLineFilter {
 
     pub fn item_id(mut self, filter: EqualFilter<String>) -> Self {
         self.item_id = Some(filter);
+        self
+    }
+
+    pub fn item_code_or_name(mut self, filter: StringFilter) -> Self {
+        self.item_code_or_name = Some(filter);
         self
     }
 
@@ -311,6 +326,7 @@ fn create_filtered_query(filter: Option<InvoiceLineFilter>) -> BoxedInvoiceLineQ
             store_id,
             invoice_id,
             item_id,
+            item_code_or_name,
             r#type,
             location_id,
             requisition_id,
@@ -328,6 +344,16 @@ fn create_filtered_query(filter: Option<InvoiceLineFilter>) -> BoxedInvoiceLineQ
             is_program_invoice,
         } = f;
 
+        // Matches on item code OR name (the item table is already inner-joined
+        // for the ItemCode/ItemName sorts) — same shape as ItemFilter's
+        // code_or_name. MUST be applied FIRST: or_filter ORs against the
+        // query's entire existing where clause, so this pair only groups as
+        // (code OR name) while the clause is still empty; every later filter
+        // then ANDs onto it (the item.rs code_or_name convention).
+        if item_code_or_name.is_some() {
+            apply_string_filter!(query, item_code_or_name.clone(), item::code);
+            apply_string_or_filter!(query, item_code_or_name, item::name);
+        }
         apply_equal_filter!(query, id, invoice_line::id);
         apply_equal_filter!(query, store_id, invoice::store_id);
         apply_equal_filter!(query, requisition_id, invoice::requisition_id);
@@ -427,6 +453,17 @@ impl InvoiceLine {
                     .map(|tax| price + (price * tax / 100.0))
                     .unwrap_or(price)
             }),
+            total_number_of_packs: if is_service { 0.0 } else { row.number_of_packs },
+            total_number_of_units: if is_service {
+                0.0
+            } else {
+                row.number_of_packs * row.pack_size
+            },
+            total_volume: if is_service {
+                0.0
+            } else {
+                row.number_of_packs * row.volume_per_pack
+            },
         }
     }
 }

--- a/server/repository/src/migrations/views/invoice_stats.rs
+++ b/server/repository/src/migrations/views/invoice_stats.rs
@@ -31,8 +31,6 @@ impl ViewMigrationFragment for ViewMigration {
                         COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type = 'SERVICE'), 0) AS service_total_after_tax,
                         COALESCE(SUM(invoice_line.total_before_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_before_tax,
                         COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_after_tax,
-                        COALESCE(SUM(invoice_line.number_of_packs) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_number_of_packs,
-                        COALESCE(SUM(invoice_line.number_of_packs * invoice_line.pack_size) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_number_of_units,
                         COALESCE(SUM(invoice_line.number_of_packs * invoice_line.volume_per_pack) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_volume
                     FROM
                         invoice_line
@@ -57,8 +55,6 @@ impl ViewMigrationFragment for ViewMigration {
                         COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type = 'SERVICE'), 0) AS service_total_after_tax,
                         COALESCE(SUM(invoice_line.total_before_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_before_tax,
                         COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_after_tax,
-                        COALESCE(SUM(invoice_line.number_of_packs) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_number_of_packs,
-                        COALESCE(SUM(invoice_line.number_of_packs * invoice_line.pack_size) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_number_of_units,
                         COALESCE(SUM(invoice_line.number_of_packs * invoice_line.volume_per_pack) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_volume
                     FROM
                         invoice_line

--- a/server/repository/src/migrations/views/invoice_stats.rs
+++ b/server/repository/src/migrations/views/invoice_stats.rs
@@ -30,7 +30,10 @@ impl ViewMigrationFragment for ViewMigration {
                         COALESCE(SUM(invoice_line.total_before_tax) FILTER(WHERE invoice_line.type = 'SERVICE'), 0) AS service_total_before_tax,
                         COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type = 'SERVICE'), 0) AS service_total_after_tax,
                         COALESCE(SUM(invoice_line.total_before_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_before_tax,
-                        COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_after_tax
+                        COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_after_tax,
+                        COALESCE(SUM(invoice_line.number_of_packs) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_number_of_packs,
+                        COALESCE(SUM(invoice_line.number_of_packs * invoice_line.pack_size) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_number_of_units,
+                        COALESCE(SUM(invoice_line.number_of_packs * invoice_line.volume_per_pack) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_volume
                     FROM
                         invoice_line
                     GROUP BY
@@ -53,7 +56,10 @@ impl ViewMigrationFragment for ViewMigration {
                         COALESCE(SUM(invoice_line.total_before_tax) FILTER(WHERE invoice_line.type = 'SERVICE'), 0) AS service_total_before_tax,
                         COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type = 'SERVICE'), 0) AS service_total_after_tax,
                         COALESCE(SUM(invoice_line.total_before_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_before_tax,
-                        COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_after_tax
+                        COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_after_tax,
+                        COALESCE(SUM(invoice_line.number_of_packs) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_number_of_packs,
+                        COALESCE(SUM(invoice_line.number_of_packs * invoice_line.pack_size) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_number_of_units,
+                        COALESCE(SUM(invoice_line.number_of_packs * invoice_line.volume_per_pack) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_volume
                     FROM
                         invoice_line
                     GROUP BY

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -162,14 +162,15 @@ mod repository_test {
                 stock_line_id: None,
                 batch: Some("".to_string()),
                 expiry_date: Some(NaiveDate::from_ymd_opt(2020, 9, 1).unwrap()),
-                pack_size: 1.0,
+                pack_size: 10.0,
                 cost_price_per_pack: 0.0,
                 sell_price_per_pack: 0.0,
                 total_before_tax: 1.0,
                 total_after_tax: 1.0,
                 tax_percentage: None,
                 r#type: InvoiceLineType::StockIn,
-                number_of_packs: 1.0,
+                number_of_packs: 2.0,
+                volume_per_pack: 0.5,
                 ..Default::default()
             }
         }
@@ -213,6 +214,28 @@ mod repository_test {
                 tax_percentage: None,
                 r#type: InvoiceLineType::StockOut,
                 number_of_packs: 1.0,
+                ..Default::default()
+            }
+        }
+
+        pub fn invoice_line_placeholder() -> InvoiceLineRow {
+            InvoiceLineRow {
+                id: "test_placeholder".to_string(),
+                item_id: item_1().id.to_string(),
+                item_name: item_1().name.to_string(),
+                item_code: item_1().code.to_string(),
+                invoice_id: invoice_1().id.to_string(),
+                stock_line_id: None,
+                batch: None,
+                expiry_date: None,
+                pack_size: 1.0,
+                cost_price_per_pack: 0.0,
+                sell_price_per_pack: 0.0,
+                total_before_tax: 0.0,
+                total_after_tax: 0.0,
+                tax_percentage: None,
+                r#type: InvoiceLineType::UnallocatedStock,
+                number_of_packs: 5.0,
                 ..Default::default()
             }
         }
@@ -284,7 +307,8 @@ mod repository_test {
         },
         requisition_row::RequisitionStatus,
         test_db, ActivityLogRowRepository, CurrencyRowRepository, InvoiceFilter,
-        InvoiceLineRepository, InvoiceLineRowRepository, InvoiceRepository, InvoiceRow,
+        InvoiceLineFilter, InvoiceLineRepository, InvoiceLineRowRepository, InvoiceRepository,
+        InvoiceRow,
         InvoiceRowRepository, InvoiceStatus, InvoiceType, ItemLinkRowRepository, ItemRow,
         ItemRowRepository, KeyType, KeyValueStoreRepository, MasterListFilter,
         MasterListLineFilter, MasterListLineRepository, MasterListLineRowRepository,
@@ -818,6 +842,10 @@ mod repository_test {
         InvoiceLineRowRepository::new(&connection)
             .upsert_one(&service_item)
             .unwrap();
+        let placeholder_item = data::invoice_line_placeholder();
+        InvoiceLineRowRepository::new(&connection)
+            .upsert_one(&placeholder_item)
+            .unwrap();
 
         // line stats
         let invoice_1_id = data::invoice_1().id;
@@ -838,9 +866,61 @@ mod repository_test {
                 stock_total_after_tax: 3.0,
                 service_total_before_tax: 10.0,
                 service_total_after_tax: 15.0,
+                // Quantity totals cover non-service lines, placeholders
+                // included: line1 (2 packs × size 10, volume 0.5/pack) +
+                // line2 (1 × 1) + placeholder (5 × 1); the service line
+                // (1 pack) is excluded.
+                total_number_of_packs: 8.0,
+                total_number_of_units: 26.0,
+                total_volume: 1.0,
                 ..stats_invoice_1.clone()
             }
         );
+
+        // item_code_or_name filters on the joined item's code OR name
+        let repo = InvoiceLineRepository::new(&connection);
+        let by_code = repo
+            .query_by_filter(
+                InvoiceLineFilter::new().item_code_or_name(StringFilter::like("code1")),
+            )
+            .unwrap();
+        assert_eq!(
+            {
+                let mut ids: Vec<String> =
+                    by_code.iter().map(|l| l.invoice_line_row.id.clone()).collect();
+                ids.sort();
+                ids
+            },
+            vec![
+                "test1".to_string(),
+                "test2-with-optional".to_string(),
+                "test_placeholder".to_string()
+            ]
+        );
+        let by_name = repo
+            .query_by_filter(
+                InvoiceLineFilter::new().item_code_or_name(StringFilter::like("item-2")),
+            )
+            .unwrap();
+        assert_eq!(
+            by_name
+                .iter()
+                .map(|l| l.invoice_line_row.id.clone())
+                .collect::<Vec<_>>(),
+            vec!["test3".to_string()]
+        );
+        // The (code OR name) pair must AND with the other filters — item-2 is
+        // only on invoice_2, so scoping to invoice_1 yields nothing (guards
+        // the or_filter grouping: it ORs against the whole existing clause,
+        // so item_code_or_name must be applied first).
+        let scoped = repo
+            .query_by_filter(
+                InvoiceLineFilter::new()
+                    .invoice_id(EqualFilter::equal_to(data::invoice_1().id))
+                    .item_code_or_name(StringFilter::like("item-2")),
+            )
+            .unwrap();
+        assert_eq!(scoped.len(), 0);
     }
 
     #[actix_rt::test]

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -866,12 +866,9 @@ mod repository_test {
                 stock_total_after_tax: 3.0,
                 service_total_before_tax: 10.0,
                 service_total_after_tax: 15.0,
-                // Quantity totals cover non-service lines, placeholders
-                // included: line1 (2 packs × size 10, volume 0.5/pack) +
-                // line2 (1 × 1) + placeholder (5 × 1); the service line
-                // (1 pack) is excluded.
-                total_number_of_packs: 8.0,
-                total_number_of_units: 26.0,
+                // The volume total covers non-service lines, placeholders
+                // included: line1 (2 packs × 0.5/pack) + line2 (0) +
+                // placeholder (0); the service line is excluded.
                 total_volume: 1.0,
                 ..stats_invoice_1.clone()
             }


### PR DESCRIPTION
Two additions the new front end's outbound detail-view alignment (msupply-foundation/open-msupply-frontend#428) needs once its detail line table is server-paginated. Companion FE PR: msupply-foundation/open-msupply-frontend#502 (draft; it should merge only after this lands on develop, since its committed generated types select the new fields).

## `InvoiceLineFilterInput.itemCodeOrName`

Contains-match on the joined item's **code OR name** — powers the detail table's always-on item search (the `stocktakeLines` equivalent already exists). The invoice-line query already inner-joins `item` for the ItemCode/ItemName sorts, so this is the direct `apply_string_filter`/`apply_string_or_filter` pair.

⚠️ It must be applied **first** in `create_filtered_query`: `or_filter` ORs against the query's whole existing where-clause, so applying it after `invoice_id` produced `(invoiceId AND code LIKE x) OR name LIKE x` — caught live (a shipment-scoped search returned 959 rows from other invoices) and pinned by a regression test asserting the scoped search returns nothing for an item on a different invoice.

## `invoice_stats` volume total → `PricingNode`

One new view column, surfaced as `PricingNode.totalVolume` (packs × volume_per_pack), summed over **non-service** lines with `FILTER (WHERE type != 'SERVICE')` — placeholders included, matching the FE's footer semantics. With lines server-paginated the client can no longer sum footer totals from loaded rows (a page is not the invoice); this arrives with the entity fetch via the existing `InvoiceStatsLoader`, no new plumbing. (Pack/unit quantity totals were initially included and dropped in review — counts summed across different items aren't meaningful roll-ups; the price total already exists as `stockTotalAfterTax`.)

View-body-only change: views are dropped and rebuilt by every startup migration run, so no dated migration is needed (same shape as prior view-column changes, e.g. 5610dd3bbd). `InvoiceLine::pricing()` (the per-line PricingRow) fills the new field per line with the same service exclusion.

## Testing

- `cargo test -p repository test_invoice_line_query_repository` extended: mixed stock + placeholder + service invoice asserts the volume sum (service excluded, placeholder included), code-OR-name matching, and the AND-grouping regression; `drop_and_rebuild_views` green.
- Verified live against a copy of a real datafile (Postgres, migrated in place at startup): scoped `itemCodeOrName` search correct, volume aggregate correct across a 387-line shipment, sqlite + postgres view bodies both updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)