### PR TITLE
Pin self-hosted workflows to the macOS runner

### DIFF
--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -8,7 +8,10 @@ name: Android Build
 
 jobs:
   create-android-build:
-    runs-on: self-hosted
+    # Must run on the mac mini - the bare `self-hosted` label also matches the
+    # Windows self-hosted runner, which can't run this job (unix shell steps,
+    # darwin NDK path).
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-mac-demo.yaml
+++ b/.github/workflows/build-mac-demo.yaml
@@ -23,7 +23,7 @@ name: Build mac demo
 jobs:
   build_and_test:
     name: Build mac demo
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 30
     env:
       RUSTFLAGS: '--cfg recursion_limit_256'

--- a/.github/workflows/generate-schema.yml
+++ b/.github/workflows/generate-schema.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   test:
     name: Test
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/.github/workflows/graphql-schema-compatibility.yaml
+++ b/.github/workflows/graphql-schema-compatibility.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   schema-diff:
     name: Detect breaking GraphQL schema changes
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 30
     # Add the `Breaking API change` label to a PR to acknowledge an intentional
     # breaking change and skip this check.

--- a/.github/workflows/integration-test-check.yaml
+++ b/.github/workflows/integration-test-check.yaml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   check:
     name: cargo check --features integration_test
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 15
     env:
       CARGO_TARGET_DIR: /tmp/target/integration_test

--- a/.github/workflows/server-build.yaml
+++ b/.github/workflows/server-build.yaml
@@ -5,7 +5,7 @@ name: Remote Server Mac Build
 jobs:
   build_and_test:
     name: Remote Server Mac Build
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 30
     env:
       RUSTFLAGS: '--cfg recursion_limit_256'

--- a/.github/workflows/server-cargo-clean.yaml
+++ b/.github/workflows/server-cargo-clean.yaml
@@ -8,7 +8,7 @@ name: Manual Cargo Clean
 jobs:
   build_and_test:
     name: Run cargo clean against self-hosted
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 25
     steps:
       - name: Delete Postgres CARGO_TARGET_DIR

--- a/.github/workflows/server-tests.yaml
+++ b/.github/workflows/server-tests.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build_and_test:
     name: Remote Server Tests (sqlite)
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 25
     env:
       CARGO_TARGET_DIR: /tmp/target/sqlite
@@ -67,7 +67,7 @@ jobs:
         run: rm -f server/target/nextest/ci-sqlite/sqlite-test-results.xml
   build_and_test_pg:
     name: Remote Server Tests (postgres)
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 25
     env:
       CARGO_TARGET_DIR: /tmp/target/postgres

--- a/.github/workflows/validate-db-migration-with-views.yml
+++ b/.github/workflows/validate-db-migration-with-views.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   test-migration-sqlite:
     name: Test Database Migration (SQLite)
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 25
     env:
       CARGO_TARGET_DIR: /tmp/target/sqlite
@@ -72,7 +72,7 @@ jobs:
 
   test-migration-pg:
     name: Test Database Migration (Postgres)
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 25
     env:
       CARGO_TARGET_DIR: /tmp/target/postgres


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Changes `runs-on: self-hosted` to `runs-on: [self-hosted, macOS]` in all nine workflows that target the self-hosted mac mini.

The bare `self-hosted` label matches *any* self-hosted runner in the org. Since the Windows self-hosted runner (`windowsbuildserver`) joined the pool, it can pick up jobs written for the mac mini — which is what broke the [v2.21.01 Android Build](https://github.com/msupply-foundation/open-msupply/actions/runs/30055382568): the job landed on Windows, where the bash-syntax `Read .nvmrc` step silently produced no output under PowerShell (so no Node was installed) and `corepack enable` then failed with "the term 'corepack' is not recognized". The job would also have failed later at the darwin NDK path used by the build step.

GitHub automatically assigns each self-hosted runner an OS label (`macOS`, `windows`, `linux`), so adding `macOS` pins these jobs to the mac without any runner reconfiguration.

Workflows changed: `build-android-apk`, `build-mac-demo`, `server-tests`, `server-build`, `server-cargo-clean`, `integration-test-check`, `generate-schema`, `graphql-schema-compatibility`, `validate-db-migration-with-views`.

## 💌 Any notes for the reviewer?

- No linked issue — this fixes a CI infrastructure failure discovered on the v2.21.01 release tag build.
- Test tag `v2.21.02-RC-apk` was pushed on this branch's commit to verify the fix end-to-end (see Testing below).
- This PR targets `main` so the fix is on the release lineage (release tags are cut from main, and tag builds read the workflow file from the tagged commit). When develop is next updated from main, note these workflow files have diverged between the branches — the merge may need manual resolution to apply the same one-line `runs-on` change to develop's versions.
- Pushing the test tag also triggered the Dockerise workflow, which treats `-RC-apk` as a non-release tag (reduced amd64-only image set) — expected behaviour, no action needed.

# 🧪 Testing

- [x] The [Android Build run for tag `v2.21.02-RC-apk`](https://github.com/msupply-foundation/open-msupply/actions/runs/30058559787) is picked up by the mac mini runner (not `windowsbuildserver`) and produces the Universal and Arm64 APK artifacts — ✅ completed successfully on runner `tmfmacmini`
- [ ] No workflow in this PR still contains a bare `runs-on: self-hosted` (`grep -rn "runs-on: self-hosted" .github/workflows/` returns nothing)

# 📃 Documentation

- [ ] Part of an epic: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] These areas should be updated or checked:

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
