### PR TITLE
test-ids: emit filter-option-<value> on enum filter options

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Filters/EnumFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/EnumFilter.tsx
@@ -26,6 +26,14 @@ export const EnumFilter: FC<{
 
   const rawValue = urlQuery[urlParameter] as string | undefined;
 
+  // Stamp each option with filter-option-<value> so e2e can pick a value.
+  // Test ids only, no behaviour change: Select's defaultRenderOption applies
+  // option.testId, and the multi-select renderOption reads the same field.
+  const optionsWithTestIds = options.map(option => ({
+    ...option,
+    testId: `filter-option-${option.value}`,
+  }));
+
   if (isMultiSelect) {
     const selectedValues = rawValue ? String(rawValue).split(',') : [];
 
@@ -40,7 +48,7 @@ export const EnumFilter: FC<{
     return (
       <Select
         data-testid={`filter-input-${urlParameter}`}
-        options={options}
+        options={optionsWithTestIds}
         label={name}
         value={selectedValues}
         sx={{ ...FilterLabelSx, width: FILTER_WIDTH }}
@@ -48,7 +56,7 @@ export const EnumFilter: FC<{
           <MenuItem
             key={option.value}
             value={option.value}
-            data-testid={`filter-option-${option.value}`}
+            data-testid={option.testId}
           >
             <Checkbox checked={selectedValues.includes(String(option.value))} />
             <ListItemText primary={option.label} />
@@ -84,7 +92,7 @@ export const EnumFilter: FC<{
   return (
     <Select
       data-testid={`filter-input-${urlParameter}`}
-      options={options}
+      options={optionsWithTestIds}
       placeholder={name}
       sx={{ ...FilterLabelSx, width: FILTER_WIDTH }}
       label={name}

--- a/client/packages/common/src/ui/components/inputs/Select/Select.tsx
+++ b/client/packages/common/src/ui/components/inputs/Select/Select.tsx
@@ -12,6 +12,8 @@ export type Option = {
   label: string;
   value: string | number;
   disabled?: boolean;
+  /** Optional test id stamped on the rendered option (e.g. e2e filter ids). */
+  testId?: string;
 };
 export interface SelectProps extends StandardTextFieldProps {
   options: Option[];
@@ -20,7 +22,12 @@ export interface SelectProps extends StandardTextFieldProps {
 }
 
 const defaultRenderOption = (option: Option) => (
-  <MenuItem key={option.value} value={option.value} disabled={option.disabled}>
+  <MenuItem
+    key={option.value}
+    value={option.value}
+    disabled={option.disabled}
+    data-testid={option.testId}
+  >
     {option.label}
   </MenuItem>
 );


### PR DESCRIPTION
## What

Enum-filter options now carry `data-testid="filter-option-<value>"` on **both** the single- and multi-select branches.

- `Select`'s `Option` gains an optional `testId`, and its `defaultRenderOption` applies `data-testid={option.testId}`.
- `EnumFilter` builds the `filter-option-<value>` ids once (`optionsWithTestIds`) and feeds both branches; the single-select branch no longer needs a bespoke `renderOption`, and the multi-select branch reads `option.testId` instead of rebuilding the string.

## Why test-ids only, no behaviour change

`testId` is optional and defaults to `undefined`, so `defaultRenderOption` omits the attribute — every other `Select` in the app renders exactly as before. The rendered option markup is otherwise unchanged (same key/value/disabled/label, and the multi-select checkbox render is untouched apart from the id source). Nothing about selection, display, or disabling changes.

Previously only the multi-select branch emitted the id; the single-select branch rendered through `defaultRenderOption` with none, so cross-front-end e2e couldn't pick a value on a single-select filter (e.g. the stocktake list **Status** filter).

## Context

Required by the stocktake list-view (`OMS-REG-INV-05`) deterministic suite: **open-msupply-frontend#514**. Verified hermetically against this app: the single-select path (stocktake Status filter) and the multi-select path (outbound-shipment Status filter) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
