### PR TITLE
Bump frontend pin to v0.0.8

### DIFF
--- a/frontend-version.json
+++ b/frontend-version.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Which open-msupply-frontend release this repo ships. Bump tag to an FE release tag and sha256 to the value from its published frontend-dist-<tag>.zip.sha256 sidecar; build/fetch-frontend.js fetches and verifies it (see server/README.md, Serving front-end). v0.0.0-rc* tags are pre-release trial pins for proving the pipelines.",
   "repo": "msupply-foundation/open-msupply-frontend",
-  "tag": "v0.0.0-rc2",
-  "sha256": "74f320e271410cd64cc58f8968669aead2d51680da49e987fa2a998f2f995dda"
+  "tag": "v0.0.8",
+  "sha256": "0355a623222dea8bcd53ac402fd5cfc257fb19d6c65b9d7b8641c10174b7fc60"
 }


### PR DESCRIPTION
Automated pin bump to the latest open-msupply-frontend release: [v0.0.8](https://github.com/msupply-foundation/open-msupply-frontend/releases/tag/v0.0.8). The sha256 was recomputed from the downloaded zip, not just copied from the sidecar. This rolling PR is force-updated whenever a newer FE release appears; merge it when this FE version should ship.