### PR TITLE
#12523 Frontend pin bumps commit straight to develop; app-token v3

### DIFF
--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -77,7 +77,7 @@ jobs:
         run: npx cap update android
 
       - name: Mint token for the frontend repo
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: fe-token
         with:
           app-id: ${{ vars.FE_APP_ID }}

--- a/.github/workflows/build-mac-demo.yaml
+++ b/.github/workflows/build-mac-demo.yaml
@@ -42,7 +42,7 @@ jobs:
           # before corepack is enabled (#12508)
           package-manager-cache: false
       - name: Mint token for the frontend repo
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: fe-token
         with:
           app-id: ${{ vars.FE_APP_ID }}

--- a/.github/workflows/build-windows-installers.yaml
+++ b/.github/workflows/build-windows-installers.yaml
@@ -82,7 +82,7 @@ jobs:
         run: rustup toolchain install --profile minimal --no-self-update
 
       - name: Mint token for the frontend repo
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: fe-token
         with:
           app-id: ${{ vars.FE_APP_ID }}

--- a/.github/workflows/bump-frontend-pin.yaml
+++ b/.github/workflows/bump-frontend-pin.yaml
@@ -4,15 +4,18 @@ name: Bump frontend pin
 # release. The FE repo auto-releases on every merge to its main (its
 # release-dist.yaml); this workflow polls for the newest release,
 # verifies the published sha256 by recomputing it from the actual zip,
-# and opens (or force-updates) a single rolling PR bumping the pin.
-# Merging that PR stays a human decision — the pin is the compatibility
-# record (open-msupply-frontend#401 / #12523).
+# and commits the bump straight to develop. While the new FE iterates
+# fast, a human merge gate on every release is more friction than
+# signal — if the pin should become a reviewed compatibility record
+# again, restore the rolling-PR step (git history of this file, or
+# open-msupply-frontend#401 / #12523).
 #
 # Auth: the FE repo is private — reading its releases reuses the same
 # GitHub App (FE_APP_ID / FE_APP_PRIVATE_KEY) the packaging workflows
-# use to fetch the dist. The PR is pushed with NIGHTLY_BUILD_GITHUB_PAT
-# (as integrate-rc-to-develop does) so CI runs on it — PRs created with
-# the default GITHUB_TOKEN don't trigger workflows.
+# use to fetch the dist. The commit is pushed with
+# NIGHTLY_BUILD_GITHUB_PAT; develop's protection requires PR reviews,
+# so that PAT's account must be allowed to bypass them (repo admin, or
+# on the branch-protection bypass list).
 
 on:
   schedule:
@@ -24,7 +27,6 @@ concurrency:
 
 env:
   FE_REPO: msupply-foundation/open-msupply-frontend
-  PIN_BRANCH: bump-frontend-pin
 
 jobs:
   bump:
@@ -38,7 +40,7 @@ jobs:
           token: ${{ secrets.NIGHTLY_BUILD_GITHUB_PAT }}
 
       - name: Mint token for the frontend repo
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: fe-token
         with:
           app-id: ${{ vars.FE_APP_ID }}
@@ -92,28 +94,15 @@ jobs:
             fs.writeFileSync("frontend-version.json", JSON.stringify(pin, null, 2) + "\n");
           '
 
-      - name: Push branch and open or update the rolling PR
+      - name: Commit the bump to develop
         if: steps.check.outputs.bump == 'true'
         env:
-          GH_TOKEN: ${{ secrets.NIGHTLY_BUILD_GITHUB_PAT }}
           TAG: ${{ steps.check.outputs.latest }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -B "$PIN_BRANCH"
           git add frontend-version.json
           git commit -m "Bump frontend pin to $TAG"
-          git push -f origin "$PIN_BRANCH"
-
-          TITLE="Bump frontend pin to $TAG"
-          BODY="Automated pin bump to the latest open-msupply-frontend release: \
-          [$TAG](https://github.com/$FE_REPO/releases/tag/$TAG). The sha256 was \
-          recomputed from the downloaded zip, not just copied from the sidecar. \
-          This rolling PR is force-updated whenever a newer FE release appears; \
-          merge it when this FE version should ship."
-          if gh pr view "$PIN_BRANCH" --repo "$GITHUB_REPOSITORY" --json state -q .state 2>/dev/null | grep -qx OPEN; then
-            gh pr edit "$PIN_BRANCH" --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body "$BODY"
-          else
-            gh pr create --repo "$GITHUB_REPOSITORY" --base develop --head "$PIN_BRANCH" \
-              --title "$TITLE" --body "$BODY"
-          fi
+          # develop may have moved since checkout — rebase our one commit onto it.
+          git pull --rebase origin develop
+          git push origin develop

--- a/.github/workflows/dockerise.yaml
+++ b/.github/workflows/dockerise.yaml
@@ -89,7 +89,7 @@ jobs:
       # real. To unblock before then, set the FRONTEND_DIST_URL repo variable to a
       # dist zip (the same override the mac build documents) — empty vars are ignored.
       - name: Mint token for the frontend repo
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: fe-token
         with:
           app-id: ${{ vars.FE_APP_ID }}

--- a/.github/workflows/e2e-regression.yaml
+++ b/.github/workflows/e2e-regression.yaml
@@ -49,7 +49,7 @@ jobs:
       # reads THIS repo — a GitHub App scoped to reading that repo mints a
       # short-lived token per run (no PAT to expire or rotate).
       - name: Mint token for the suites repo
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: fe-token
         with:
           app-id: ${{ vars.FE_APP_ID }}

--- a/.github/workflows/server-build.yaml
+++ b/.github/workflows/server-build.yaml
@@ -17,7 +17,7 @@ jobs:
         working-directory: ./server
         run: cargo run --bin remote_server_cli -- initialise-from-export -n 'reference1' -r
       - name: Mint token for the frontend repo
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: fe-token
         with:
           app-id: ${{ vars.FE_APP_ID }}


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Part of #12523 (does not close it).

Two CI changes:

- **`bump-frontend-pin.yaml` now commits the pin bump directly to `develop`** instead of maintaining a rolling PR. While the new FE auto-releases on every merge, a human merge gate on each release proved more friction than signal — the rolling PR sat unmerged while APK builds kept shipping the stale `v0.0.0-rc2` pin (no "Switch to old UI" button). The safety that matters is unchanged: the sha256 is still recomputed from the downloaded zip before anything lands. The header comment documents how to restore the reviewed rolling-PR flow from this file's git history if the pin should become a compatibility record again.
- **`actions/create-github-app-token` bumped `v2` → `v3`** in all seven workflows that use it. v2 targets node20, which GitHub has deprecated (every run currently logs a "forced to run on Node.js 24" warning). Checked v3's breaking changes: our self-hosted runners are on 2.335.1/2.336.0 (v3 needs ≥ 2.327.1) and no workflow uses an HTTP proxy.

## 💌 Any notes for the reviewer?

- **Branch protection caveat**: `develop` requires 1 PR review and `enforce_admins` is off. The direct push will only succeed if the `NIGHTLY_BUILD_GITHUB_PAT` account is a repo admin (or gets added to the bypass allowances, like `weblate-msupply-foundation`). Neither this workflow nor `integrate-rc-to-develop` has pushed to `develop` directly before, so the first run is the real test — if it fails with a protected-branch error, that's the knob.
- After merge, the rolling PR #12550 ("Bump frontend pin to v0.0.8") and its `bump-frontend-pin` branch are obsolete — close/delete them.
- The scheduled run executes the workflow from `develop`, so nothing changes behaviour until this merges.

# 🧪 Tested

- Verified the failing piece end-to-end earlier: pin history shows `develop` still at `v0.0.0-rc2` while the FE repo has released up to v0.0.8; the rolling-PR run (30062718454) only refreshed PR #12550 without touching `develop`.
- Confirmed runner versions from recent run logs (macOS self-hosted 2.336.0, Windows self-hosted 2.335.1) satisfy v3's ≥ 2.327.1 requirement, and that `checkout@v5` is already node24.
- YAML changes are logic-preserving up to the final step (same check/verify steps); the new commit step is plain git. Not runnable pre-merge — after merging, trigger via **workflow_dispatch**: it should commit "Bump frontend pin to v0.0.8" to `develop` (or fail on branch protection per the reviewer note).

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`)
- [ ] **Developer docs needed** (`docs: internal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
