### PR TITLE
#12547 Disable AssignPrescriptionNumber processor for 2.21.02

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-msupply",
   "//": "Main version for the app, should be in semantic version format (any release candidate or test build should be separated by '-' i.e. 1.1.1-rc1 or 1.1.1-test",
-  "version": "2.21.01",
+  "version": "2.21.02",
   "private": true,
   "scripts": {
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",

--- a/server/service/src/processors/assign_prescription_number/test.rs
+++ b/server/service/src/processors/assign_prescription_number/test.rs
@@ -14,6 +14,7 @@ use crate::{
 /// Ensure the processor allocates a real number to them, is idempotent, and leaves
 /// non-prescription invoices untouched.
 #[tokio::test]
+#[ignore = "processor disabled (empty vec in ProcessorType::get_processors) for 2.21.02, see #12547"]
 async fn assigns_prescription_number_to_prescriptions() {
     let site_id = 26;
 

--- a/server/service/src/processors/general_processor.rs
+++ b/server/service/src/processors/general_processor.rs
@@ -20,7 +20,6 @@ use crate::{
 
 use super::{
     add_central_patient_visibility::AddPatientVisibilityForCentral,
-    assign_prescription_number::AssignPrescriptionNumber,
     assign_requisition_number::AssignRequisitionNumber, contact_form::QueueContactEmailProcessor,
     load_plugin::LoadPlugin, plugin_processor::PluginProcessor,
     requisition_auto_finalise::RequisitionAutoFinaliseProcessor,
@@ -66,7 +65,12 @@ impl ProcessorType {
             ProcessorType::ContactFormEmail => vec![Box::new(QueueContactEmailProcessor)],
             ProcessorType::LoadPlugin => vec![Box::new(LoadPlugin)],
             ProcessorType::AssignRequisitionNumber => vec![Box::new(AssignRequisitionNumber)],
-            ProcessorType::AssignPrescriptionNumber => vec![Box::new(AssignPrescriptionNumber)],
+            // Disabled: this processor's cursor starts at 0, so its first run walks the entire
+            // historical changelog synchronously on the single-threaded main runtime, freezing
+            // sync and all background tasks on servers with a large changelog (#12547).
+            // Re-enable (restore `vec![Box::new(AssignPrescriptionNumber)]` and un-ignore its
+            // test) once it is runtime-safe and cursor-seeded - see ideas in #12547.
+            ProcessorType::AssignPrescriptionNumber => vec![],
             ProcessorType::AddPatientVisibilityForCentral => {
                 vec![Box::new(AddPatientVisibilityForCentral)]
             }

--- a/server/service/src/processors/mod.rs
+++ b/server/service/src/processors/mod.rs
@@ -17,6 +17,8 @@ use self::transfer::{
 use general_processor::{process_records, ProcessorError};
 
 mod add_central_patient_visibility;
+// Processor currently disabled (not constructed in ProcessorType::get_processors), see #12547
+#[allow(dead_code, unused_imports)]
 mod assign_prescription_number;
 mod assign_requisition_number;
 mod contact_form;

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -323,8 +323,13 @@ impl Synchroniser {
         ctx.processors_trigger
             .trigger_processor(ProcessorType::AssignRequisitionNumber);
 
-        ctx.processors_trigger
-            .trigger_processor(ProcessorType::AssignPrescriptionNumber);
+        // Disabled: this processor's cursor starts at 0, so its first run walks the entire
+        // historical changelog synchronously on the single-threaded main runtime, freezing sync
+        // and all background tasks on servers with a large changelog (#12547). Not triggering it
+        // at all (rather than seeding the cursor) so it does no changelog scanning whatsoever.
+        // Re-enable once it is runtime-safe and cursor-seeded - see ideas in #12547.
+        // ctx.processors_trigger
+        //     .trigger_processor(ProcessorType::AssignPrescriptionNumber);
 
         ctx.processors_trigger
             .trigger_processor(ProcessorType::Plugins);

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -323,13 +323,8 @@ impl Synchroniser {
         ctx.processors_trigger
             .trigger_processor(ProcessorType::AssignRequisitionNumber);
 
-        // Disabled: this processor's cursor starts at 0, so its first run walks the entire
-        // historical changelog synchronously on the single-threaded main runtime, freezing sync
-        // and all background tasks on servers with a large changelog (#12547). Not triggering it
-        // at all (rather than seeding the cursor) so it does no changelog scanning whatsoever.
-        // Re-enable once it is runtime-safe and cursor-seeded - see ideas in #12547.
-        // ctx.processors_trigger
-        //     .trigger_processor(ProcessorType::AssignPrescriptionNumber);
+        ctx.processors_trigger
+            .trigger_processor(ProcessorType::AssignPrescriptionNumber);
 
         ctx.processors_trigger
             .trigger_processor(ProcessorType::Plugins);


### PR DESCRIPTION
Fixes #12547

# 👩🏻‍💻 What does this PR do?

Disables the `AssignPrescriptionNumber` processor by returning an empty vec for it in `ProcessorType::get_processors` — the processor is never constructed, so it does **zero** changelog scanning and no cursor reads/writes. The post-sync trigger still fires but is now a no-op. Also bumps the app version to 2.21.02.

Root cause of #12547 (full analysis in [this issue comment](https://github.com/msupply-foundation/open-msupply/issues/12547#issuecomment-5065665706)): the processor was added in 2.21 (for #12060) and its changelog cursor starts at 0, so its first run after an upgrade walks the **entire historical changelog** — batches of 20, synchronous diesel queries, no yield — on the single-threaded main runtime (`#[actix_web::main]`). On a central server with a large changelog this starves the sync driver, schedule plugin, and GraphQL subscriptions for hours: sync appears hung, manual sync does nothing, no status updates reach the frontend. GraphQL keeps responding (actix worker runtimes), which made the server look healthy.

Since no customer needs the #12060 fix urgently, 2.21.02 de-risks by disabling the processor entirely — deliberately chosen over seeding the cursor.

## 💌 Any notes for the reviewer?

- The disable lives in the processor registry (`general_processor.rs`) rather than the trigger site, so it stays disabled even if another trigger site is added. The restore path is documented in a comment there: reinstate `vec![Box::new(AssignPrescriptionNumber)]` and un-ignore its test.
- The processor code and its test are kept intact; the test is `#[ignore]`d (it drives the processor through the now-empty registry entry) and the module carries `#[allow(dead_code, unused_imports)]` while disabled.
- **Intentional behaviour regression**: prescriptions arriving with `invoice_number = -1` (Tamanu/FHIR flow, #12060) will not get numbers allocated until the processor returns in a runtime-safe form. Ideas for that (spawn_blocking/yield in `process_records`, cursor seeding, per-site enablement, or moving it to a processor plugin) are in the issue comment — a follow-up issue should be raised before #12547 closes.
- Once this is deployed, affected servers (e.g. Sierra Leone training) need no cursor SQL workaround — the processor simply never runs.
- The 2.20.0 migration that created the cursor key is untouched (harmless).

# 🧪 Testing

- [ ] `cargo check -p service` passes with no warnings (done locally)
- [ ] `cargo nextest run -p service processors::` — 19 passed, `assigns_prescription_number_to_prescriptions` ignored while disabled (done locally)
- [ ] Manual: on a central server with a populated changelog, trigger a sync and confirm the `Schedule plugin runner complete` log keeps appearing every minute afterwards, scheduled syncs continue at the configured interval, and no `ASSIGN_PRESCRIPTION_NUMBER_PROCESSOR_CURSOR` value appears/changes in `key_value_store`

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [ ] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [x] **These areas should be updated or checked**:
  1. 2.21.02 release notes: automatic allocation of `-1` prescription numbers (#12060) is temporarily disabled

# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
