### PR TITLE
invoice_stats totalVolume: stock lines only, matching stock totals

### DIFF
--- a/server/graphql/types/src/types/invoice_query.rs
+++ b/server/graphql/types/src/types/invoice_query.rs
@@ -647,11 +647,11 @@ impl PricingNode {
         &self.invoice_pricing.tax_percentage
     }
 
-    // volume total — the whole-invoice sum over non-service lines
-    // (placeholders included), for the detail-view footer roll-up that can't
+    // volume total — the whole-invoice sum over stock lines (same line set
+    // as the stock totals), for the detail-view footer roll-up that can't
     // be computed client-side once lines are server-paginated
 
-    /// Sum of number_of_packs * volume_per_pack
+    /// Sum of number_of_packs * volume_per_pack over stock lines
     pub async fn total_volume(&self) -> f64 {
         self.invoice_pricing.total_volume
     }

--- a/server/repository/src/db_diesel/invoice_line.rs
+++ b/server/repository/src/db_diesel/invoice_line.rs
@@ -46,9 +46,9 @@ pub struct PricingRow {
     pub service_total_after_tax: f64,
     pub tax_percentage: Option<f64>,
     pub foreign_currency_total_after_tax: Option<f64>,
-    /// Whole-invoice volume total over non-service lines (placeholders
-    /// included) — the detail-view footer roll-up, which the client can no
-    /// longer sum itself once lines are server-paginated.
+    /// Whole-invoice volume total over stock lines (same line set as the
+    /// stock totals) — the detail-view footer roll-up, which the client can
+    /// no longer sum itself once lines are server-paginated.
     pub total_volume: f64,
 }
 
@@ -449,10 +449,10 @@ impl InvoiceLine {
                     .map(|tax| price + (price * tax / 100.0))
                     .unwrap_or(price)
             }),
-            total_volume: if is_service {
-                0.0
-            } else {
+            total_volume: if is_stock {
                 row.number_of_packs * row.volume_per_pack
+            } else {
+                0.0
             },
         }
     }

--- a/server/repository/src/migrations/views/invoice_stats.rs
+++ b/server/repository/src/migrations/views/invoice_stats.rs
@@ -31,7 +31,7 @@ impl ViewMigrationFragment for ViewMigration {
                         COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type = 'SERVICE'), 0) AS service_total_after_tax,
                         COALESCE(SUM(invoice_line.total_before_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_before_tax,
                         COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_after_tax,
-                        COALESCE(SUM(invoice_line.number_of_packs * invoice_line.volume_per_pack) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_volume
+                        COALESCE(SUM(invoice_line.number_of_packs * invoice_line.volume_per_pack) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS total_volume
                     FROM
                         invoice_line
                     GROUP BY
@@ -55,7 +55,7 @@ impl ViewMigrationFragment for ViewMigration {
                         COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type = 'SERVICE'), 0) AS service_total_after_tax,
                         COALESCE(SUM(invoice_line.total_before_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_before_tax,
                         COALESCE(SUM(invoice_line.total_after_tax) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS stock_total_after_tax,
-                        COALESCE(SUM(invoice_line.number_of_packs * invoice_line.volume_per_pack) FILTER(WHERE invoice_line.type != 'SERVICE'), 0) AS total_volume
+                        COALESCE(SUM(invoice_line.number_of_packs * invoice_line.volume_per_pack) FILTER(WHERE invoice_line.type IN ('STOCK_IN','STOCK_OUT')), 0) AS total_volume
                     FROM
                         invoice_line
                     GROUP BY

--- a/server/repository/src/tests.rs
+++ b/server/repository/src/tests.rs
@@ -236,6 +236,9 @@ mod repository_test {
                 tax_percentage: None,
                 r#type: InvoiceLineType::UnallocatedStock,
                 number_of_packs: 5.0,
+                // Non-zero so the stats assertion pins that placeholder
+                // volume is excluded from total_volume
+                volume_per_pack: 2.0,
                 ..Default::default()
             }
         }
@@ -866,9 +869,9 @@ mod repository_test {
                 stock_total_after_tax: 3.0,
                 service_total_before_tax: 10.0,
                 service_total_after_tax: 15.0,
-                // The volume total covers non-service lines, placeholders
-                // included: line1 (2 packs × 0.5/pack) + line2 (0) +
-                // placeholder (0); the service line is excluded.
+                // The volume total covers stock lines only: line1
+                // (2 packs × 0.5/pack) + line2 (0); the placeholder
+                // (5 packs × 2.0/pack) and the service line are excluded.
                 total_volume: 1.0,
                 ..stats_invoice_1.clone()
             }


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Review follow-up to #12544. The new `total_volume` column filtered with `type != 'SERVICE'`, while the neighbouring stock totals in the same view use an explicit allowlist (`type IN ('STOCK_IN','STOCK_OUT')`). The denylist style hid which line types were in the sum, and meant any future `InvoiceLineType` variant would silently join the volume total while being silently excluded from the stock totals.

This aligns `total_volume` to the **same explicit line set as the stock totals** — `type IN ('STOCK_IN','STOCK_OUT')` — in both view bodies (sqlite + postgres), and mirrors it in the per-line `InvoiceLine::pricing()` (`is_stock` instead of `!is_service`). The one semantic change from #12544: placeholder (`UNALLOCATED_STOCK`) lines are now **excluded** from the volume total.

View-body-only SQL change, so no dated migration (views are dropped and rebuilt on every startup migration run, same as #12544 itself).

## 💌 Any notes for the reviewer?

- Excluding placeholders is a no-op for OMS-created data: every OMS placeholder path hardcodes `volume_per_pack: 0.0` (unallocated-line insert/update, requisition → create-shipment, `save_stock_out_item_lines`), and the invoice transfer processor drops placeholders entirely. The only rows that could differ are legacy-synced placeholder `trans_line`s, where sync copies `volume_per_pack` verbatim — if legacy ever sets one, its volume now stays out of the total, consistent with it not being counted in the stock money totals either.
- The test placeholder now carries a non-zero `volume_per_pack` so the assertion pins the exclusion — previously it defaulted to 0 and would have passed with either predicate.

# 🧪 Tested

- `cargo nextest run -p repository drop_and_rebuild_views test_invoice_line_query_repository` — both green; the volume assertion covers a mixed stock + placeholder + service invoice where the placeholder has non-zero volume that must not appear in the total.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:

🤖 Generated with [Claude Code](https://claude.com/claude-code)