### PR TITLE
#12523 APK workflow: download the NDK instead of using a host install

### DIFF
--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -9,8 +9,7 @@ name: Android Build
 jobs:
   create-android-build:
     # Must run on the mac mini - the bare `self-hosted` label also matches the
-    # Windows self-hosted runner, which can't run this job (unix shell steps,
-    # darwin NDK path).
+    # Windows self-hosted runner, which can't run this job (unix shell steps).
     runs-on: [self-hosted, macOS]
     timeout-minutes: 30
     steps:
@@ -62,6 +61,18 @@ jobs:
         # config.toml of the self-hosted machine.
         run: rustup target add aarch64-linux-android armv7-linux-androideabi --toolchain "${{ steps.rust_toolchain.outputs.channel }}"
 
+      - name: Set up NDK
+        id: ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          # server/android/.cargo/config.toml uses the API-22 clang wrappers
+          # (aarch64-linux-android22-clang etc.), present in this NDK. Downloaded
+          # into the runner tool cache (persists on the self-hosted mac), so no
+          # pre-installed NDK or hardcoded host path is needed. Keep in step with
+          # build-android-server-lib.yaml.
+          ndk-version: r27c
+          add-to-path: false
+
       - name: Set Up Java
         uses: actions/setup-java@v5
         with:
@@ -92,8 +103,9 @@ jobs:
         working-directory: client
         run: yarn android:build:release
         env:
-          NDK_BIN: /Users/tmfmacmini/android/ndk/27.2.12479018/toolchains/llvm/prebuilt/darwin-x86_64/bin/
-          # Update this version when upgrading the NDK version on the self-hosted machine
+          # The NDK's mac prebuilt toolchain dir is named darwin-x86_64 on Apple
+          # silicon too (the binaries themselves are universal).
+          NDK_BIN: ${{ steps.ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/darwin-x86_64/bin/
           # Transition APK ships the new FE at / and this repo's build as the old UI
           # at /old-ui/. stage-transition-frontend.sh fetches the pinned new FE, which
           # with a short-lived token minted above from the same GitHub App the e2e


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Part of #12523 (does not close it).

The Android APK build hardcoded the self-hosted mac's NDK path (`/Users/tmfmacmini/android/ndk/27.2.12479018/...`) — an invisible host dependency that breaks if the NDK is upgraded on the machine or the runner ever moves. This replaces it with the same `nttld/setup-ndk` (r27c, node24) step that `build-android-server-lib.yaml` already uses; `NDK_BIN` now comes from the step's output.

The action installs into the runner tool cache, which persists on the self-hosted mac — so the ~1GB download happens once, then it's a local cache hit on every subsequent build.

## 💌 Any notes for the reviewer?

- Only `build_remote_server_libs.sh` consumes `NDK_BIN` (cargo cross-compile of the server lib); Gradle just packages the prebuilt `.so` files, so nothing else touches the host NDK.
- r27c is the release name of the previously hardcoded 27.2.12479018, so the toolchain is unchanged.
- The toolchain subdir stays `darwin-x86_64` — that's the NDK's directory name on Apple silicon macs too.
- The host NDK at `/Users/tmfmacmini/android/ndk` can be deleted once this is confirmed working, if nothing else on the machine uses it.

# 🧪 Tested

- Not runnable pre-merge (self-hosted workflow). After merge, dispatch **Android Build**: the new "Set up NDK" step should download/cache r27c, and the cargo step should link with it exactly as before.
- Verified `nttld/setup-ndk@v1` (v1.6.0) runs on node24, matching the deprecation cleanup in #12551/#12553.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`)
- [ ] **Developer docs needed** (`docs: internal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)