### PR TITLE
names: add customer-detail-modal testid + wire names-regression into e2e CI

### DIFF
--- a/.github/workflows/e2e-regression.yaml
+++ b/.github/workflows/e2e-regression.yaml
@@ -112,7 +112,7 @@ jobs:
           E2E_META_PR: ${{ github.event.pull_request.number }}
           E2E_META_BRANCH: ${{ github.head_ref || github.ref_name }}
           E2E_META_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: cd client && yarn e2e:local stocktake-regression distribution-regression
+        run: cd client && yarn e2e:local stocktake-regression distribution-regression names-regression
 
       - name: Upload Playwright report (html + results.json)
         uses: actions/upload-artifact@v4

--- a/client/packages/system/src/Name/ListView/ListView.tsx
+++ b/client/packages/system/src/Name/ListView/ListView.tsx
@@ -88,6 +88,7 @@ export const NameListView = ({ type }: NameListProps): ReactElement => {
       {type === 'customer' && (
         <Modal
           title=""
+          testId="customer-detail-modal"
           okButton={<DialogButton variant="ok" onClick={hideDialog} />}
           slideAnimation={false}
           Transition={Transition}


### PR DESCRIPTION
## What does this PR do?

Instruments the current app for the cross-FE **names** deterministic regression suite (defined in open-msupply-frontend, `e2e/specs/names-regression.spec.ts`), and wires that suite into the hermetic e2e CI here.

- **`Name/ListView/ListView.tsx`** — add `testId="customer-detail-modal"` to the read-only customer detail modal so the suite can locate it. The modal's **OK** button already emits the shared `dialog-button-ok` id (`DialogButton variant="ok"`), so nothing else is needed there. Testid-only; no behaviour change.
- **`.github/workflows/e2e-regression.yaml`** — add `names-regression` to the hermetic run list (it ran `stocktake-regression distribution-regression` only).

Paired open-msupply-frontend PR (the suite + testid contract): <!-- link --> — that PR is where the suite lives.

## Tested

- Hermetic run against this app: **15 passed, 4 skipped, 0 failed**. Skips are principled: 2 **search** (a UI-only addition on the new FE, absent here — DIVERGENCES D25) and 2 **pagination** (the reference datafile has fewer than 21 names). Green against the new FE too.
