### PR TITLE
Add data-testids to admin settings for cross-FE e2e

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Switch/Switch.tsx
+++ b/client/packages/common/src/ui/components/inputs/Switch/Switch.tsx
@@ -30,6 +30,8 @@ interface SwitchProps {
   value?: unknown;
   switchSx?: SxProps;
   labelSx?: SxProps;
+  /** Placed on the underlying checkbox input, for deterministic e2e hooks. */
+  testId?: string;
 }
 
 const getLabelStyle = (
@@ -70,6 +72,7 @@ export const Switch = ({
   value,
   switchSx,
   labelSx,
+  testId,
 }: SwitchProps) => {
   const isSmall = size === 'small';
   const switchStyle = {
@@ -114,6 +117,7 @@ export const Switch = ({
       size={size}
       sx={{ ...switchStyle, ...switchSx }}
       focusVisibleClassName=".Mui-focusVisibles"
+      inputProps={testId ? { 'data-testid': testId } : undefined}
     />
   );
   return (

--- a/client/packages/common/src/ui/components/inputs/TextInput/PasswordTextInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/PasswordTextInput.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from '@common/intl';
 
 export type PasswordTextInputProps = StandardTextFieldProps & {
   fixedHeight?: boolean;
+  /** Deterministic e2e hook on the show/hide-password toggle button. */
+  visibilityToggleTestId?: string;
 };
 
 export const PasswordTextInput = React.forwardRef<
@@ -14,7 +16,7 @@ export const PasswordTextInput = React.forwardRef<
 >((props, ref) => {
   // if the helper text is a space then the height of the component doesn't change
   // when the helper text is shown / removed
-  const { fixedHeight, ...rest } = props;
+  const { fixedHeight, visibilityToggleTestId, ...rest } = props;
   const defaultWarning = fixedHeight ? ' ' : '';
   const [showPassword, setShowPassword] = useState(false);
   const [warning, setWarning] = useState(defaultWarning);
@@ -23,6 +25,7 @@ export const PasswordTextInput = React.forwardRef<
     <IconButton
       aria-label="toggle password visibility"
       disabled={props.disabled}
+      data-testid={visibilityToggleTestId}
       title={t('label.toggle-password-visibility')}
       onClick={() => {
         setShowPassword(!showPassword);

--- a/client/packages/common/src/ui/components/popover/InfoTooltipIcon/InfoTooltipIcon.tsx
+++ b/client/packages/common/src/ui/components/popover/InfoTooltipIcon/InfoTooltipIcon.tsx
@@ -5,13 +5,18 @@ import { InfoIcon } from '../../../icons';
 export const InfoTooltipIcon = ({
   title,
   iconSx,
+  testId,
 }: {
   title: string;
   iconSx?: SxProps<Theme>;
+  testId?: string;
 }) =>
   !title ? null : (
     <Tooltip title={title}>
-      <div style={{ transform: 'scale(0.7)', cursor: 'help' }}>
+      <div
+        style={{ transform: 'scale(0.7)', cursor: 'help' }}
+        data-testid={testId}
+      >
         <InfoIcon fontSize="small" sx={iconSx} />
       </div>
     </Tooltip>

--- a/client/packages/host/src/Admin/ConfigurationSettings.tsx
+++ b/client/packages/host/src/Admin/ConfigurationSettings.tsx
@@ -44,6 +44,7 @@ export const ConfigurationSettings = () => {
           <BaseButton
             onClick={handleClick('gaps')}
             disabled={dataLoading || isLoading}
+            data-testid="initialise-gaps"
             title={t('tooltip.re-initialise-in-language', {
               language: currentLanguage,
             })}
@@ -62,6 +63,7 @@ export const ConfigurationSettings = () => {
           <BaseButton
             onClick={handleClick('forecasting')}
             disabled={dataLoading || isLoading}
+            data-testid="initialise-forecasting"
             title={t('tooltip.re-initialise-in-language', {
               language: currentLanguage,
             })}
@@ -75,7 +77,10 @@ export const ConfigurationSettings = () => {
       <Setting
         title={t('label.configure-supply-level')}
         component={
-          <BaseButton onClick={handleSupplyModalClick}>
+          <BaseButton
+            onClick={handleSupplyModalClick}
+            data-testid="configure-supply-levels"
+          >
             {t('label.edit')}
           </BaseButton>
         }

--- a/client/packages/host/src/Admin/DisplaySettings.tsx
+++ b/client/packages/host/src/Admin/DisplaySettings.tsx
@@ -121,6 +121,7 @@ export const DisplaySettings: React.FC = () => {
         onToggle={onToggleCustomTheme}
         title={t('heading.custom-theme')}
         visible={userHasPermission(UserPermission.ServerAdmin)}
+        testId="custom-theme"
       />
       <SettingTextArea
         defaultValue={customLogoValue}
@@ -129,6 +130,7 @@ export const DisplaySettings: React.FC = () => {
         infoText={t('heading.custom-logo-info')}
         title={t('heading.custom-logo')}
         visible={userHasPermission(UserPermission.ServerAdmin)}
+        testId="custom-logo"
       />
     </>
   );

--- a/client/packages/host/src/Admin/LabelPrinterSettings.tsx
+++ b/client/packages/host/src/Admin/LabelPrinterSettings.tsx
@@ -108,6 +108,7 @@ export const LabelPrinterSettings = () => {
                 checked={isUsb ?? false}
                 onChange={(_, checked) => setIsUsb(checked)}
                 color="primary"
+                testId="print-via-usb"
               />
             }
             title={t('settings.print-via-usb')}
@@ -128,6 +129,7 @@ export const LabelPrinterSettings = () => {
           <BasicTextInput
             value={draft.address}
             onChange={event => onChange({ address: event.target.value })}
+            slotProps={{ htmlInput: { 'data-testid': 'printer-address' } }}
           />
         }
         title={t('settings.printer-address')}
@@ -138,6 +140,7 @@ export const LabelPrinterSettings = () => {
             value={draft.port}
             noFormatting
             onChange={port => onChange({ port })}
+            slotProps={{ htmlInput: { 'data-testid': 'printer-port' } }}
           />
         }
         title={t('settings.printer-port')}
@@ -148,6 +151,9 @@ export const LabelPrinterSettings = () => {
             value={draft.labelHeight}
             onChange={labelHeight => {
               if (labelHeight !== undefined) onChange({ labelHeight });
+            }}
+            slotProps={{
+              htmlInput: { 'data-testid': 'printer-label-height' },
             }}
           />
         }
@@ -160,6 +166,7 @@ export const LabelPrinterSettings = () => {
             onChange={labelWidth => {
               if (labelWidth !== undefined) onChange({ labelWidth });
             }}
+            slotProps={{ htmlInput: { 'data-testid': 'printer-label-width' } }}
           />
         }
         title={t('settings.printer-label-width')}
@@ -171,6 +178,7 @@ export const LabelPrinterSettings = () => {
           onClick={test}
           disabled={isInvalid}
           label={t('button.test')}
+          data-testid="printer-test"
         />
         <ButtonWithIcon
           Icon={<SaveIcon />}
@@ -178,6 +186,7 @@ export const LabelPrinterSettings = () => {
           variant="contained"
           onClick={save}
           disabled={isInvalid}
+          data-testid="printer-save"
         />
       </Box>
     </>

--- a/client/packages/host/src/Admin/LogFileModal.tsx
+++ b/client/packages/host/src/Admin/LogFileModal.tsx
@@ -131,6 +131,7 @@ export const LogFileModal = ({
           <DropdownMenu
             label={logToRender ? logToRender : t('label.server-log')}
             selectSx={{ width: 400 }}
+            testId="server-log-file"
           >
             {logToRender && (
               <DropdownMenuItem

--- a/client/packages/host/src/Admin/ServerInfo.tsx
+++ b/client/packages/host/src/Admin/ServerInfo.tsx
@@ -25,8 +25,16 @@ const Label: FC<PropsWithChildren> = ({ children }) => (
   </Typography>
 );
 
-const Value: FC<PropsWithChildren> = ({ children }) => (
-  <Typography color={'gray.main'} component="div" sx={{ display: 'flex' }}>
+const Value: FC<PropsWithChildren<{ testId?: string }>> = ({
+  children,
+  testId,
+}) => (
+  <Typography
+    color={'gray.main'}
+    component="div"
+    sx={{ display: 'flex' }}
+    data-testid={testId}
+  >
     {children}
   </Typography>
 );
@@ -54,9 +62,15 @@ const ServerInfoComponent = ({ siteName }: { siteName?: string | null }) => {
               vertical: 'bottom',
               horizontal: 'center',
             }}
-            Content={<QRCode value={serverUrl} size={256} />}
+            Content={
+              <span data-testid="server-qr-expanded">
+                <QRCode value={serverUrl} size={256} />
+              </span>
+            }
           >
-            <QRCode value={serverUrl} size={50} />
+            <span data-testid="server-qr">
+              <QRCode value={serverUrl} size={50} />
+            </span>
           </PaperPopover>
         </Box>
       </Tooltip>
@@ -68,9 +82,9 @@ const ServerInfoComponent = ({ siteName }: { siteName?: string | null }) => {
             <Label>{t('label.app-version')}</Label>
           </Box>
           <Box display="flex" flexDirection="column">
-            <Value>{serverUrl}</Value>
-            {siteName && <Value>{siteName}</Value>}
-            <Value>{appVersion}</Value>
+            <Value testId="server-url">{serverUrl}</Value>
+            {siteName && <Value testId="server-site-name">{siteName}</Value>}
+            <Value testId="app-version">{appVersion}</Value>
           </Box>
         </Box>
         {isCentralServer && <Label>{t('label.central-server')}</Label>}

--- a/client/packages/host/src/Admin/ServerSettings.tsx
+++ b/client/packages/host/src/Admin/ServerSettings.tsx
@@ -83,7 +83,9 @@ export const ServerSettings = () => {
         title={t('label.server-log')}
         component={
           <>
-            {isLogShown && <LogFileModal onClose={hideLog} isOpen={isLogShown} />}
+            {isLogShown && (
+              <LogFileModal onClose={hideLog} isOpen={isLogShown} />
+            )}
             <BaseButton onClick={showLog}>{t('button.view')}</BaseButton>
           </>
         }
@@ -106,9 +108,7 @@ export const ServerSettings = () => {
                 startIcon={<DownloadIcon />}
                 onClick={async () => {
                   setIsDownloading(true);
-                  if (
-                    databaseSettings?.databaseType === DatabaseType.SqLite
-                  ) {
+                  if (databaseSettings?.databaseType === DatabaseType.SqLite) {
                     const vacuum = await fetch(
                       `${Environment.API_HOST}/support/vacuum`,
                       {
@@ -136,8 +136,12 @@ export const ServerSettings = () => {
         title={t('label.server-log')}
         component={
           <>
-            {isLogShown && <LogFileModal onClose={hideLog} isOpen={isLogShown} />}
-            <BaseButton onClick={showLog}>{t('button.view')}</BaseButton>
+            {isLogShown && (
+              <LogFileModal onClose={hideLog} isOpen={isLogShown} />
+            )}
+            <BaseButton onClick={showLog} data-testid="server-log-view">
+              {t('button.view')}
+            </BaseButton>
           </>
         }
       />
@@ -148,6 +152,7 @@ export const ServerSettings = () => {
             <span>
               <BaseButton
                 startIcon={<DownloadIcon />}
+                data-testid="download-database"
                 onClick={() => {
                   window.location.href = `${Environment.API_HOST}/support/database`;
                 }}

--- a/client/packages/host/src/Admin/Setting.tsx
+++ b/client/packages/host/src/Admin/Setting.tsx
@@ -11,6 +11,7 @@ interface SettingProps {
   component: JSX.Element;
   icon?: JSX.Element;
   infoText?: string;
+  infoTestId?: string;
   title: string;
 }
 
@@ -18,6 +19,7 @@ export const Setting: React.FC<SettingProps> = ({
   component,
   icon,
   infoText,
+  infoTestId,
   title,
 }) => {
   return (
@@ -28,7 +30,9 @@ export const Setting: React.FC<SettingProps> = ({
       <Grid flexShrink={0} flexGrow={1}>
         <Box display={'flex'}>
           <Typography style={{ fontSize: 16 }}>{title}</Typography>
-          {infoText ? <InfoTooltipIcon title={infoText} /> : null}
+          {infoText ? (
+            <InfoTooltipIcon title={infoText} testId={infoTestId} />
+          ) : null}
         </Box>
       </Grid>
       <Grid display="flex" justifyContent="flex-end">

--- a/client/packages/host/src/Admin/SettingTextArea.tsx
+++ b/client/packages/host/src/Admin/SettingTextArea.tsx
@@ -23,6 +23,11 @@ interface SettingTextAreaProps {
   infoText?: string;
   title: string;
   visible: boolean;
+  /**
+   * Base for deterministic e2e hooks: `${testId}-toggle` (switch),
+   * `${testId}-editor` (textarea), `${testId}-save` (save button).
+   */
+  testId?: string;
 }
 
 export const SettingTextArea: React.FC<SettingTextAreaProps> = ({
@@ -33,6 +38,7 @@ export const SettingTextArea: React.FC<SettingTextAreaProps> = ({
   infoText,
   title,
   visible,
+  testId,
 }) => {
   const t = useTranslation();
   const [value, setValue] = React.useState(defaultValue);
@@ -53,7 +59,11 @@ export const SettingTextArea: React.FC<SettingTextAreaProps> = ({
       <Setting
         infoText={infoText}
         component={
-          <Switch checked={value.enabled} onChange={onToggleChecked} />
+          <Switch
+            checked={value.enabled}
+            onChange={onToggleChecked}
+            testId={testId ? `${testId}-toggle` : undefined}
+          />
         }
         icon={icon}
         title={title}
@@ -73,6 +83,9 @@ export const SettingTextArea: React.FC<SettingTextAreaProps> = ({
               value={value.text}
               maxRows={10}
               minRows={10}
+              inputProps={
+                testId ? { 'data-testid': `${testId}-editor` } : undefined
+              }
               style={{ padding: '0 0 0 50px' }}
               slotProps={{
                 input: {
@@ -92,6 +105,7 @@ export const SettingTextArea: React.FC<SettingTextAreaProps> = ({
               variant="contained"
               sx={{ fontSize: '12px' }}
               onClick={() => onSave(value)}
+              data-testid={testId ? `${testId}-save` : undefined}
             />
           </Grid>
         </Grid>

--- a/client/packages/host/src/Admin/SettingTextArea.tsx
+++ b/client/packages/host/src/Admin/SettingTextArea.tsx
@@ -58,6 +58,7 @@ export const SettingTextArea: React.FC<SettingTextAreaProps> = ({
     <>
       <Setting
         infoText={infoText}
+        infoTestId={testId ? `${testId}-info` : undefined}
         component={
           <Switch
             checked={value.enabled}

--- a/client/packages/host/src/Admin/Settings.tsx
+++ b/client/packages/host/src/Admin/Settings.tsx
@@ -45,6 +45,7 @@ export const Settings: React.FC = () => {
         expanded={activeSection === 0}
         onChange={toggleSection(0)}
         visible={true}
+        testId="accordion-trigger-display-settings"
       >
         <DisplaySettings />
       </SettingsSection>
@@ -54,6 +55,7 @@ export const Settings: React.FC = () => {
         expanded={activeSection === 1}
         onChange={toggleSection(1)}
         visible={userHasPermission(UserPermission.ServerAdmin)}
+        testId="accordion-trigger-synchronisation"
       >
         <SyncSettings />
       </SettingsSection>
@@ -63,6 +65,7 @@ export const Settings: React.FC = () => {
         expanded={activeSection === 2}
         onChange={toggleSection(2)}
         visible={userHasPermission(UserPermission.ServerAdmin)}
+        testId="accordion-trigger-support"
       >
         <ServerSettings />
       </SettingsSection>
@@ -72,6 +75,7 @@ export const Settings: React.FC = () => {
         expanded={activeSection === 3}
         onChange={toggleSection(3)}
         visible={true}
+        testId="accordion-trigger-devices"
       >
         <LabelPrinterSettings />
         {userHasPermission(UserPermission.ServerAdmin) && (
@@ -86,6 +90,7 @@ export const Settings: React.FC = () => {
           expanded={activeSection === 5}
           onChange={toggleSection(5)}
           visible={userHasPermission(UserPermission.ServerAdmin)}
+          testId="accordion-trigger-configuration"
         >
           <ConfigurationSettings />
         </SettingsSection>

--- a/client/packages/host/src/Admin/SettingsSection.tsx
+++ b/client/packages/host/src/Admin/SettingsSection.tsx
@@ -16,6 +16,8 @@ interface SettingsSectionProps {
   onChange: () => void;
   titleKey: LocaleKey;
   visible: boolean;
+  /** Deterministic e2e hook on the section's expand/collapse header. */
+  testId?: string;
 }
 export const SettingsSubHeading = ({ title }: { title: string }) => (
   <Typography
@@ -38,12 +40,14 @@ export const SettingsSection: FC<PropsWithChildren<SettingsSectionProps>> = ({
   onChange,
   titleKey,
   visible,
+  testId,
 }) => {
   const t = useTranslation();
 
   return visible ? (
     <Accordion expanded={expanded} onChange={onChange}>
       <AccordionSummary
+        data-testid={testId}
         expandIcon={<ChevronDownIcon />}
         sx={{
           color: 'primary.main',

--- a/client/packages/host/src/Admin/SupplyLevelModal.tsx
+++ b/client/packages/host/src/Admin/SupplyLevelModal.tsx
@@ -114,6 +114,7 @@ export const SupplyLevelModal = ({
           <BasicTextInput
             sx={{ width: '250px' }}
             value={inputValue}
+            slotProps={{ htmlInput: { 'data-testid': 'supply-level-input' } }}
             onChange={e => setInputValue(e.target.value)}
             onKeyDown={e => {
               if (e.key === 'Enter') {
@@ -130,56 +131,58 @@ export const SupplyLevelModal = ({
             disabled={!inputValue.trim()}
           />
         </Box>
-        {supplyLevels.length > 0 ? (
-          supplyLevels.map(supplyLevel => {
-            const isInUse = supplyLevelsInUse.includes(supplyLevel);
+        <Box data-testid="supply-level-list">
+          {supplyLevels.length > 0 ? (
+            supplyLevels.map(supplyLevel => {
+              const isInUse = supplyLevelsInUse.includes(supplyLevel);
 
-            return (
-              <Box
-                key={supplyLevel}
-                sx={{
-                  mb: 1,
-                  pb: 0.5,
-                  display: 'flex',
-                  alignItems: 'center',
-                  '&:not(:last-child)': {
-                    borderBottom: '1px dashed',
-                  },
-                }}
-              >
-                <Typography sx={{ flex: 1 }}>
-                  {supplyLevel}
-                  {isInUse && (
-                    <Typography
-                      component="span"
-                      sx={{
-                        ml: 1,
-                        fontSize: '0.80rem',
-                        color: 'text.secondary',
-                        fontStyle: 'italic',
-                      }}
-                    >
-                      ({t('label.in-use')})
-                    </Typography>
-                  )}
-                </Typography>
-                <IconButton
-                  icon={<DeleteIcon />}
-                  label={t('label.delete-supply-level')}
-                  onClick={() => handleDeleteSupplyLevel(supplyLevel)}
-                  disabled={isInUse}
+              return (
+                <Box
+                  key={supplyLevel}
                   sx={{
-                    '&.Mui-disabled': {
-                      opacity: 0.5,
+                    mb: 1,
+                    pb: 0.5,
+                    display: 'flex',
+                    alignItems: 'center',
+                    '&:not(:last-child)': {
+                      borderBottom: '1px dashed',
                     },
                   }}
-                />
-              </Box>
-            );
-          })
-        ) : (
-          <Typography>{t('label.no-supply-levels-configured')}</Typography>
-        )}
+                >
+                  <Typography sx={{ flex: 1 }}>
+                    {supplyLevel}
+                    {isInUse && (
+                      <Typography
+                        component="span"
+                        sx={{
+                          ml: 1,
+                          fontSize: '0.80rem',
+                          color: 'text.secondary',
+                          fontStyle: 'italic',
+                        }}
+                      >
+                        ({t('label.in-use')})
+                      </Typography>
+                    )}
+                  </Typography>
+                  <IconButton
+                    icon={<DeleteIcon />}
+                    label={t('label.delete-supply-level')}
+                    onClick={() => handleDeleteSupplyLevel(supplyLevel)}
+                    disabled={isInUse}
+                    sx={{
+                      '&.Mui-disabled': {
+                        opacity: 0.5,
+                      },
+                    }}
+                  />
+                </Box>
+              );
+            })
+          ) : (
+            <Typography>{t('label.no-supply-levels-configured')}</Typography>
+          )}
+        </Box>
       </>
     </Modal>
   );

--- a/client/packages/host/src/Admin/SyncSettings.tsx
+++ b/client/packages/host/src/Admin/SyncSettings.tsx
@@ -61,8 +61,7 @@ const SyncSettingsForm = ({
   const onChangeBatchSize = (value: number | undefined): void => {
     setSyncSettings({
       ...settings,
-      batchSize:
-        value === undefined || value <= 0 ? null : Math.round(value),
+      batchSize: value === undefined || value <= 0 ? null : Math.round(value),
     });
   };
 
@@ -82,6 +81,7 @@ const SyncSettingsForm = ({
             value={url}
             onChange={e => setSettings('url', e.target.value)}
             disabled={isDisabled}
+            slotProps={{ htmlInput: { 'data-testid': 'sync-settings-url' } }}
           />
         }
       />
@@ -92,6 +92,9 @@ const SyncSettingsForm = ({
             value={username}
             onChange={e => setSettings('username', e.target.value)}
             disabled={isDisabled}
+            slotProps={{
+              htmlInput: { 'data-testid': 'sync-settings-username' },
+            }}
           />
         }
       />
@@ -101,7 +104,11 @@ const SyncSettingsForm = ({
           <PasswordTextInput
             value={password}
             onChange={e => setSettings('password', e.target.value)}
-            slotProps={{ input: { autoComplete: 'sync-password' } }}
+            slotProps={{
+              input: { autoComplete: 'sync-password' },
+              htmlInput: { 'data-testid': 'sync-settings-password' },
+            }}
+            visibilityToggleTestId="sync-settings-password-visibility"
             disabled={isDisabled}
             sx={{ width: 'calc(100% - 24px)' }}
           />
@@ -114,6 +121,9 @@ const SyncSettingsForm = ({
             value={intervalSeconds}
             onChange={onChangeSyncInterval}
             disabled={isDisabled}
+            slotProps={{
+              htmlInput: { 'data-testid': 'sync-settings-interval' },
+            }}
           />
         }
       />
@@ -138,6 +148,7 @@ const SyncSettingsForm = ({
           disabled={!isValid}
           onClick={onSave}
           label={t('button.save')}
+          data-testid="sync-settings-save"
         />
       </Grid>
     </form>

--- a/client/packages/host/src/components/Footer/Footer.tsx
+++ b/client/packages/host/src/components/Footer/Footer.tsx
@@ -29,6 +29,7 @@ interface PaddedCellProps {
   icon: ReactNode;
   tooltip?: string;
   onClick?: () => void;
+  testId?: string;
 }
 
 const PaddedCell: FC<PaddedCellProps> = ({
@@ -37,11 +38,13 @@ const PaddedCell: FC<PaddedCellProps> = ({
   icon,
   tooltip,
   onClick,
+  testId,
 }) => {
   const isExtraSmallScreen = useIsExtraSmallScreen();
   return (
     <Box
       onClick={onClick}
+      data-testid={testId}
       sx={{
         display: 'flex',
         alignItems: 'center',
@@ -117,6 +120,7 @@ export const Footer = ({ backgroundColor }: { backgroundColor?: string }) => {
         text={t('label.edit')}
         tooltip={t('label.edit-store-properties')}
         onClick={onOpen}
+        testId="footer-store-edit"
       />
       {user ? (
         <>

--- a/client/packages/host/src/components/LanguageMenu.tsx
+++ b/client/packages/host/src/components/LanguageMenu.tsx
@@ -28,6 +28,7 @@ export const LanguageMenu: React.FC = () => {
     <MenuItem
       key={option.value}
       value={option.value}
+      data-testid={`settings-language-option-${option.value}`}
       sx={isRtlLocale(`${option.value}`) ? { justifyContent: 'flex-end' } : {}}
     >
       {option.label}
@@ -40,6 +41,7 @@ export const LanguageMenu: React.FC = () => {
       options={languageOptions}
       value={currentLanguage}
       renderOption={renderOption}
+      data-testid="settings-language"
     />
   );
 };


### PR DESCRIPTION
## Why

The `settings-regression` deterministic Playwright suite (defined in `open-msupply-frontend` `e2e/`) drives **both** front ends off one shared test-id contract (`e2e/TESTIDS.md`). The admin Settings page here carried no `data-testid`s; this instruments it.

## What

Testids-only, **no behaviour change**:

- **Shared components** — `Switch`, `SettingsSection`, `SettingTextArea` (`-toggle`/`-editor`/`-save`/`-info`), `PasswordTextInput` (`visibilityToggleTestId`), `InfoTooltipIcon` (`testId`).
- **Admin sections** — `Settings.tsx` (`accordion-trigger-<key>`), `DisplaySettings`, `LanguageMenu` (`settings-language` + options), `SyncSettings`, `ServerSettings`, `LogFileModal`, `LabelPrinterSettings`, `ConfigurationSettings`, `SupplyLevelModal`, `ServerInfo` (app-bar version/site/server/QR), `Footer` (`footer-store-edit`).

## Verified

Suite green against this app on the hermetic e2e stack (**30/30**), via `FE_SUITES_DIR=… bash playwright/scripts/run-e2e.sh settings-regression`.

## Follow-up

Adding `settings-regression` to the filter in `.github/workflows/e2e-regression.yaml` is deferred until the suite lands on `open-msupply-frontend` `main` (the workflow pulls suites from there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)