### PR TITLE
#10275 Restore Jenkins build bats so the old pipeline keeps working

### DIFF
--- a/build/windows/getVersion.js
+++ b/build/windows/getVersion.js
@@ -1,0 +1,9 @@
+const match = process.env.versionTag.match(/\d+\.\d+\.\d+/);
+let version = !match
+  ? '0.0.0'
+  : match[0]
+      .split('.')
+      .map((part) => String(parseInt(part, 10)))
+      .join('.');
+
+console.log(version);

--- a/build/windows/installers-build.bat
+++ b/build/windows/installers-build.bat
@@ -1,0 +1,21 @@
+@ECHO ##### Removing installers folder #####
+@rmdir "installers" /s /q
+
+@ECHO ##### Adjusting SUFS #####
+FOR /F "delims=*" %%i in ('more omSupply\version.txt') do SET versionTag=%%i
+for /F "delims=*" %%i in ('node omSupply\getVersion.js') do set version=%%i
+
+@ECHO "current tag = %versionTag%"
+@ECHO "current version = %version%"
+SET installersOutputFolder=%WORKSPACE%\installers
+
+@cd omSupply
+node "adjustSUFs.js"
+@cd ..
+
+@ECHO ##### Creating installers #####
+start "" /wait "C:\Program Files (x86)\Setup Factory 9\SUFDesign.exe" /BUILD /LOG:installers\setup-factory.log "omSupply\omsupply_server.suf"
+start "" /wait "C:\Program Files (x86)\Setup Factory 9\SUFDesign.exe" /BUILD /LOG:installers\setup-factory.log "omSupply\omsupply_desktop.suf"
+start "" /wait "C:\Program Files (x86)\Setup Factory 9\SUFDesign.exe" /BUILD /LOG:installers\setup-factory.log "omSupply\omsupply_demo.suf"
+start "" /wait "C:\Program Files (x86)\Setup Factory 9\SUFDesign.exe" /BUILD /LOG:installers\setup-factory.log "omSupply\omsupply_standalone.suf"
+@REM copy omSupply\open-msupply-*.apk installers\Open_mSupply_Android_%versionTag%.apk

--- a/build/windows/omsupply-android.bat
+++ b/build/windows/omsupply-android.bat
@@ -1,0 +1,8 @@
+@ECHO ##### Building omSupply apk #####
+@REM copy the keystore and local.properties for apk signing
+copy c:\android\local.properties client\packages\android\ /y && copy c:\android\release.keystore client\packages\android\app\ /y
+cd "client" && yarn android:build:release && copy packages\android\app\build\outputs\apk\release\*.apk ..\omSupply
+@if %errorlevel% neq 0 (
+    @ECHO ERROR: Failed to build android apk
+    exit /b %errorlevel%
+)

--- a/build/windows/omsupply-build.bat
+++ b/build/windows/omsupply-build.bat
@@ -1,0 +1,80 @@
+@ECHO ##### Removing previous builds #####
+@rmdir "omSupply" /s /q
+
+@ECHO ##### Starting omsupply builds #####
+mkdir "omSupply"
+mkdir "omSupply\Server"
+mkdir "omSupply\Desktop"
+xcopy "server\configuration" "omSupply\Server\configuration" /e /h /c /i
+xcopy "server\app_data" "omSupply\Server\app_data" /e /h /c /i
+
+@REM No local.yaml needed for the old UI: the server serves the frontend dir's
+@REM old-ui/ subdirectory at /old-ui/ by convention (the old_ui_frontend_dir
+@REM setting was dropped - see serve_frontend.rs).
+
+copy "server\server\omSupply.ico" "build\omSupply.ico"
+xcopy "build\*.*" "omSupply" /c
+xcopy "build\windows\*.*" "omSupply" /c
+xcopy "build\windows\demo" "omSupply\demo" /c /y /i
+copy "version.txt" "omSupply\version.txt"
+
+@REM note: the /b must come first, otherwise the command is not waited
+start /b /wait build\windows\omsupply-prepare.bat
+@if %errorlevel% neq 0 (
+    exit /b %errorlevel%
+)
+
+@ECHO ##### update cargo binary version #####
+@FOR /F "delims=*" %%i in ('more omSupply\version.txt') do SET versionTag=%%i
+@FOR /F "delims=*" %%i in ('node getVersion.js') do set version=%%i
+
+@cd server 
+
+cargo install cargo-edit
+cargo set-version %version%
+
+@ECHO ##### Building all sqlite binaries #####
+cargo build --release --bin omsupply_service --bin remote_server --bin remote_server_cli --bin test_connection
+@if %errorlevel% neq 0 ( exit /b %errorlevel% )
+
+copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-sqlite.exe"
+copy "target\release\remote_server.exe"    "..\omSupply\Server\omSupply-server-sqlite.exe"
+copy "target\release\remote_server_cli.exe" "..\omSupply\Server\omSupply-cli-sqlite.exe"
+copy "target\release\test_connection.exe"  "..\omSupply\Server\test-connection-sqlite.exe"
+
+@ECHO ##### Building all postgres binaries #####
+cargo build --release --bin omsupply_service --bin remote_server_cli --bin test_connection --features postgres
+@if %errorlevel% neq 0 ( exit /b %errorlevel% )
+
+copy "target\release\omsupply_service.exe" "..\omSupply\Server\omSupply-postgres.exe"
+copy "target\release\remote_server_cli.exe" "..\omSupply\Server\omSupply-cli-postgres.exe"
+copy "target\release\test_connection.exe"  "..\omSupply\Server\test-connection-postgres.exe"
+
+@cd..
+
+@ECHO ##### Fetching new frontend (served at / from frontend_dir) #####
+@REM The NEW FE lives in the private open-msupply-frontend repo and ships as a
+@REM pinned, checksum-verified dist zip. Jenkins must have FRONTEND_FETCH_TOKEN set
+@REM on the build box (a token with read access to that repo's release assets).
+@REM Until frontend-version.json is pinned to a real release, drive this with the
+@REM FRONTEND_DIST_URL override instead (see server/README.md, 'Serving front-end').
+@REM No unzip.exe needed: on Windows fetch-frontend.js falls back to `tar -xf`
+@REM (bsdtar, present on Windows 10+) - do NOT "fix" this by installing unzip.
+node build\fetch-frontend.js "omSupply\Server\frontend"
+@if %errorlevel% neq 0 ( exit /b %errorlevel% )
+
+@ECHO ##### Copying old UI (served at /old-ui/) #####
+@REM This repo's client build (PUBLIC_PATH=/old-ui/, see omsupply-prepare.bat) is
+@REM the OLD UI. Nest it inside the fetched frontend dir - the fetch above wipes and
+@REM replaces Server\frontend, so this xcopy must run AFTER it. The .suf's recursive
+@REM Server\frontend Source packages this subdir too, so no .suf change is needed.
+xcopy "client\packages\host\dist" "omSupply\Server\frontend\old-ui" /e /h /c /i
+@if %errorlevel% neq 0 ( exit /b %errorlevel% )
+
+@REM start /b /wait build\windows\omsupply-android.bat
+@REM @if %errorlevel% neq 0 exit /b %errorlevel%
+
+start /b /wait build\windows\omsupply-electron.bat
+@if %errorlevel% neq 0 (
+    exit /b %errorlevel%
+)

--- a/build/windows/omsupply-electron.bat
+++ b/build/windows/omsupply-electron.bat
@@ -1,0 +1,8 @@
+@REM keep electron last, as it exits the batch when complete
+@ECHO ##### Building omSupply for the desktop #####
+cd "client" && yarn electron:build && xcopy "packages\electron\out\Open mSupply-win32-x64\**" "..\omSupply\Desktop\" /e /h /c /i
+@if %errorlevel% neq 0 (
+    @ECHO ERROR: Failed to build electron app
+    exit /b %errorlevel%
+)
+

--- a/build/windows/omsupply-prepare.bat
+++ b/build/windows/omsupply-prepare.bat
@@ -1,0 +1,24 @@
+@ECHO ##### Prepare omsupply build #####
+
+@REM Clean up previous build artifacts - not strictly necessary,
+@REM but if the yarn commands below do not report errors there is a chance
+@REM that the server bundles the previous build's frontend
+@REM Should not be an issue now that 'call' is used for yarn commands
+@if exist "client\packages\host\dist" (
+    rd /s /q "client\packages\host\dist" 2>nul
+)
+
+
+@REM This repo's client build is the OLD UI: in the dual-frontend bundle it is
+@REM served under /old-ui/, so it must build with that public path (asset URLs +
+@REM router base). The NEW FE served at / is fetched as a pinned dist zip in
+@REM omsupply-build.bat, not built here.
+@REM (This .bat runs in its own cmd via `start /b /wait`, so PUBLIC_PATH does not
+@REM leak back to the caller; setting it here scopes it to the client build.)
+set "PUBLIC_PATH=/old-ui/"
+
+call corepack enable && cd "client" && call yarn install --immutable && call yarn build
+@if %errorlevel% neq 0 (
+    @ECHO ERROR: Failed to prepare client
+    exit /b %errorlevel%
+)


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Part of #10275 (tracker — intentionally not auto-closed).

Restores the six `build/windows` files deleted when the Windows installer build moved to GitHub Actions in #12543 (`d7999799be`), so the old Jenkins pipeline can keep producing installers until the GHA workflow is fully commissioned (installer signing and MEGA publish are still pending on the new runner):

- `installers-build.bat`
- `omsupply-build.bat`
- `omsupply-prepare.bat`
- `omsupply-electron.bat`
- `omsupply-android.bat`
- `getVersion.js`

All are restored verbatim from the pre-deletion state (`d7999799be^`), with one deliberate change: the `local.yaml` write in `omsupply-build.bat` that set `server.old_ui_frontend_dir` is dropped. That setting was removed after the deletion (`93c0af8727`) — the server now serves the frontend dir's `old-ui/` subdirectory at `/old-ui/` by convention, and the bat already nests the old UI at `omSupply\Server\frontend\old-ui`, so the dual-frontend bundle still works without any config.

## 💌 Any notes for the reviewer?

- This is a stopgap: once the GHA workflow (`build-windows-installers.yaml`) is signing and publishing in production, these files should be deleted again.
- `version.txt` at the repo root was never a committed file — the Jenkins job writes it before invoking the bats, so the restored scripts are self-consistent with the old job config.
- The two commits that touched `build/windows` since the deletion only *added* files (Setup Factory theme, `RefreshEnvironment.exe`), so nothing the bats depend on has drifted.

# 🧪 Tested

- Verified the restored files are byte-identical to `d7999799be^` apart from the removed `local.yaml` block (`git diff d7999799be^ -- build/windows` shows only that hunk).
- Confirmed `server/service/src/settings.rs` no longer has `old_ui_frontend_dir` and settings deserialisation ignores unknown keys, so dropping the `local.yaml` write matches current server behaviour (`/old-ui/` convention in `serve_frontend.rs`, covered by its unit tests).
- Not run through Jenkins from this branch — the real test is the next Jenkins build off develop.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (restores internal build scripts)
