### PR TITLE
Add a serverVersion query returning the real server version, on both schemas

### DIFF
--- a/server/graphql/general/src/lib.rs
+++ b/server/graphql/general/src/lib.rs
@@ -71,8 +71,7 @@ pub struct GeneralQueries;
 #[Object]
 impl GeneralQueries {
     /// The running server's version, from the repo-root package.json (e.g. "3.00.00-RC")
-    #[allow(non_snake_case)]
-    pub async fn apiVersion(&self) -> String {
+    pub async fn api_version(&self) -> String {
         repository::migrations::raw_app_version()
     }
 
@@ -687,8 +686,7 @@ impl InitialisationQueries {
     }
 
     /// The running server's version, from the repo-root package.json (e.g. "3.00.00-RC")
-    #[allow(non_snake_case)]
-    pub async fn apiVersion(&self) -> String {
+    pub async fn api_version(&self) -> String {
         repository::migrations::raw_app_version()
     }
 }

--- a/server/graphql/general/src/lib.rs
+++ b/server/graphql/general/src/lib.rs
@@ -70,9 +70,10 @@ pub struct GeneralQueries;
 
 #[Object]
 impl GeneralQueries {
+    /// The running server's version, from the repo-root package.json (e.g. "3.00.00-RC")
     #[allow(non_snake_case)]
     pub async fn apiVersion(&self) -> String {
-        env!("CARGO_PKG_VERSION").to_string()
+        repository::migrations::raw_app_version()
     }
 
     /// Authenticate with username + password. Issues an opaque session token, returned both in
@@ -683,6 +684,12 @@ impl InitialisationQueries {
     /// Available without authorisation/authentication
     pub async fn is_central_server(&self) -> bool {
         CentralServerConfig::is_central_server()
+    }
+
+    /// The running server's version, from the repo-root package.json (e.g. "3.00.00-RC")
+    #[allow(non_snake_case)]
+    pub async fn apiVersion(&self) -> String {
+        repository::migrations::raw_app_version()
     }
 }
 /// Auth is not checked during initialisation stage

--- a/server/graphql/general/src/lib.rs
+++ b/server/graphql/general/src/lib.rs
@@ -70,8 +70,12 @@ pub struct GeneralQueries;
 
 #[Object]
 impl GeneralQueries {
-    /// The running server's version, from the repo-root package.json (e.g. "3.00.00-RC")
     pub async fn api_version(&self) -> String {
+        env!("CARGO_PKG_VERSION").to_string()
+    }
+
+    /// The running server's version, from the repo-root package.json (e.g. "3.00.00-RC")
+    pub async fn server_version(&self) -> String {
         repository::migrations::raw_app_version()
     }
 
@@ -686,7 +690,7 @@ impl InitialisationQueries {
     }
 
     /// The running server's version, from the repo-root package.json (e.g. "3.00.00-RC")
-    pub async fn api_version(&self) -> String {
+    pub async fn server_version(&self) -> String {
         repository::migrations::raw_app_version()
     }
 }

--- a/server/repository/src/migrations/version.rs
+++ b/server/repository/src/migrations/version.rs
@@ -29,8 +29,11 @@ impl PackageJsonAsset {
 
     fn version() -> String {
         // strip out the -rc1 or -test detail from the version
-        let re = regex::Regex::new(r"\-.*").unwrap();
-        re.replace(&Self::raw_version(), "").to_string()
+        let mut version = Self::raw_version();
+        if let Some(idx) = version.find('-') {
+            version.truncate(idx);
+        }
+        version
     }
 }
 

--- a/server/repository/src/migrations/version.rs
+++ b/server/repository/src/migrations/version.rs
@@ -18,17 +18,27 @@ struct PackageJson {
 }
 
 impl PackageJsonAsset {
-    fn version() -> String {
+    fn raw_version() -> String {
         // Since #[folder] of RustEmbed is pointed at a file, need to use empty string to access the file
         let package_json = PackageJsonAsset::get("").expect("Embedded package json not found");
         let package: PackageJson = serde_json::from_slice(&package_json.data)
             .expect("Embedded package json cannot be parsed");
+
+        package.version
+    }
+
+    fn version() -> String {
         // strip out the -rc1 or -test detail from the version
         let re = regex::Regex::new(r"\-.*").unwrap();
-        let version = re.replace(&package.version, "").to_string();
-
-        version
+        re.replace(&Self::raw_version(), "").to_string()
     }
+}
+
+/// The app version exactly as written in the repo-root package.json (e.g. "3.00.00-RC"),
+/// for display. `Version::from_package_json()` instead normalises the numbers and drops
+/// the pre-release suffix, for comparisons (migrations, sync, plugin compatibility).
+pub fn raw_app_version() -> String {
+    PackageJsonAsset::raw_version()
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, TS)]
@@ -135,6 +145,16 @@ impl PartialEq for Version {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn raw_app_version_is_the_package_json_version() {
+        let raw = raw_app_version();
+        assert!(!raw.is_empty());
+        // Same version the migrations use, but with the package.json
+        // formatting (zero padding, pre-release suffix) intact.
+        assert_eq!(Version::from_str(&raw), Version::from_package_json());
+    }
+
     #[test]
     fn parsing_version() {
         assert_eq!(


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12566

Adds a **`serverVersion: String!`** query returning the app version exactly as written in the repo-root `package.json` (currently `3.00.00-RC`), via a new `repository::migrations::raw_app_version()`. Raw on purpose: `Version::from_package_json()` normalises the numbers and drops the pre-release suffix (`3.0.0`), which is right for migration/sync/plugin comparisons but wrong for display — that path is untouched.

The field lives on **both** the operational schema and the **initialisation schema** (next to `is_central_server`), so it's readable without authentication in every server state.

`apiVersion` is deliberately **left unchanged** (it still returns the `graphql-general` crate's `CARGO_PKG_VERSION`, `0.1.0`) — reserved in case we want real API versioning through it later.

Consumer: the new frontend shows the server's version on its login/initialisation screens (msupply-foundation/open-msupply-frontend#630). Against servers without this field the probe fails quietly and the frontend shows nothing.

## 💌 Any notes for the reviewer?

The `raw_version()` / `version()` split in `version.rs` is a refactor of the existing embedded-package.json read; the stripped version's behaviour is unchanged (covered by the existing tests).

# 🧪 Tested

- Added a unit test `raw_app_version_is_the_package_json_version`; `cargo test -p repository --lib migrations::version` — 6 passed.
- Built and ran `remote_server` against a restored e2e reference datafile: `{ serverVersion }` → `{"data":{"serverVersion":"3.00.00-RC"}}` and `{ apiVersion }` → `{"data":{"apiVersion":"0.1.0"}}` (unchanged). Also verified the field answers on the initialisation schema against a fresh uninitialised sqlite database.
- `cargo check -p repository -p graphql_general` clean.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change in this repo (the display lands in the new frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
