### PR TITLE
#12573 Add floating Docker tags for releases and nightlies

### DIFF
--- a/.github/scripts/cleanup-docker-tags.sh
+++ b/.github/scripts/cleanup-docker-tags.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 # Docker Hub Tag Cleanup
 #
 # Deletes non-release Docker Hub tags older than a configurable number of days.
-# Release tags (e.g. v2.19.1-sqlite-amd64) are always kept.
+# Release tags (e.g. v2.19.1-sqlite-amd64) are always kept, as are the floating
+# latest* tags (latest, latest-develop, latest-rc, plus -sqlite/-postgres variants).
 #
 # Runnable locally or in CI. Credentials via environment variables.
 #
@@ -151,8 +152,9 @@ while [[ "$PAGE_URL" != "null" && -n "$PAGE_URL" ]]; do
         TAG_NAME=$(echo "$tag_json" | jq -r '.name')
         LAST_UPDATED=$(echo "$tag_json" | jq -r '.last_updated')
 
-        # Protect special tags
-        if [[ "$TAG_NAME" == "latest" ]]; then
+        # Protect floating tags: latest, latest-develop, latest-rc,
+        # each optionally suffixed with -sqlite or -postgres
+        if [[ "$TAG_NAME" =~ ^latest(-develop|-rc)?(-sqlite|-postgres)?$ ]]; then
             echo "KEEP (protected):  $TAG_NAME"
             KEPT_COUNT=$((KEPT_COUNT + 1))
             continue

--- a/.github/workflows/dockerise.yaml
+++ b/.github/workflows/dockerise.yaml
@@ -11,6 +11,11 @@
 #   - no dev images, no plugin tests
 #
 # Images are pushed to: msupplyfoundation/omsupply:<tag>-<db>-<arch>[-dev]
+#
+# Floating tags are also repointed (amd64 images only; bare tag = sqlite flavour):
+#   release tag      -> latest, latest-sqlite, latest-postgres
+#   develop nightly  -> latest-develop, latest-develop-sqlite, latest-develop-postgres
+#   RC nightly       -> latest-rc, latest-rc-sqlite, latest-rc-postgres
 
 name: Dockerise
 
@@ -25,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.check.outputs.is_release }}
+      floating_prefix: ${{ steps.check.outputs.floating_prefix }}
     steps:
       - name: Determine if release tag
         id: check
@@ -32,9 +38,19 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "is_release=true" >> $GITHUB_OUTPUT
-            echo "Tag '$TAG' is a release tag"
+            echo "floating_prefix=latest" >> $GITHUB_OUTPUT
+            echo "Tag '$TAG' is a release tag (floating: latest)"
           else
             echo "is_release=false" >> $GITHUB_OUTPUT
+            # Nightly tags from create-nightly-tags.sh: v<version>-<develop|RC>-MMDDHHMM.
+            # Anything else (e.g. manual test tags) gets no floating tag.
+            if [[ "$TAG" =~ ^v[0-9][0-9.]*-develop-[0-9]{8}$ ]]; then
+              echo "floating_prefix=latest-develop" >> $GITHUB_OUTPUT
+            elif [[ "$TAG" =~ ^v[0-9][0-9.]*-RC-[0-9]{8}$ ]]; then
+              echo "floating_prefix=latest-rc" >> $GITHUB_OUTPUT
+            else
+              echo "floating_prefix=" >> $GITHUB_OUTPUT
+            fi
             echo "Tag '$TAG' is NOT a release tag (skipping arm64 and dev builds)"
           fi
 
@@ -257,6 +273,18 @@ jobs:
             echo "target_dev=postgres-dev" >> $GITHUB_OUTPUT
           fi
 
+          # Floating tags are repointed from amd64 images only (the release
+          # matrix includes arm64); the bare tag is the sqlite flavour.
+          TAGS="msupplyfoundation/omsupply:${VERSION}-${{ matrix.db }}-${{ matrix.arch }}"
+          FLOATING="${{ needs.check-tag.outputs.floating_prefix }}"
+          if [ -n "$FLOATING" ] && [ "${{ matrix.arch }}" = "amd64" ]; then
+            TAGS="$TAGS,msupplyfoundation/omsupply:${FLOATING}-${{ matrix.db }}"
+            if [ "${{ matrix.db }}" = "sqlite" ]; then
+              TAGS="$TAGS,msupplyfoundation/omsupply:${FLOATING}"
+            fi
+          fi
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v7
         with:
@@ -264,8 +292,7 @@ jobs:
           target: ${{ steps.vars.outputs.target }}
           platforms: linux/${{ matrix.arch }}
           push: true
-          tags: |
-            msupplyfoundation/omsupply:${{ env.VERSION }}-${{ matrix.db }}-${{ matrix.arch }}
+          tags: ${{ steps.vars.outputs.tags }}
 
       - name: Build and Push Docker Image Dev
         if: matrix.arch == 'amd64' && needs.check-tag.outputs.is_release == 'true'

--- a/docs/content/docker/_index.md
+++ b/docs/content/docker/_index.md
@@ -64,16 +64,49 @@ Non-release tags are typically created automatically by the nightly build proces
 
 Images are pushed to `msupplyfoundation/omsupply` with the naming convention:
 
-| Tag                          | Example                   | When built        |
-| ---------------------------- | ------------------------- | ----------------- |
-| `v{version}-{db}-{arch}`     | `v2.8.0-sqlite-amd64`     | All tags          |
-| `v{version}-{db}-{arch}-dev` | `v2.8.0-sqlite-amd64-dev` | Release tags only |
+| Tag                          | Example                     | When built / repointed             |
+| ---------------------------- | --------------------------- | ---------------------------------- |
+| `v{version}-{db}-{arch}`     | `v2.8.0-sqlite-amd64`       | All tags                           |
+| `v{version}-{db}-{arch}-dev` | `v2.8.0-sqlite-amd64-dev`   | Release tags only                  |
+| `latest[-{db}]`              | `latest`, `latest-postgres` | Repointed on every release tag     |
+| `latest-develop[-{db}]`      | `latest-develop`            | Repointed on every develop nightly |
+| `latest-rc[-{db}]`           | `latest-rc-postgres`        | Repointed on every RC nightly      |
 
 Dev images (which include Node/Yarn and the client source for frontend development) are only built for amd64 on release tags.
 
+The `latest*` floating tags always point at **amd64** images, and the bare tags (`latest`, `latest-develop`, `latest-rc`) are the **sqlite** flavour. If more than one RC branch (or more than one develop-family branch) receives commits on the same day, the nightly build tags each of them and the shared floating tag ends up on whichever build pushed last.
+
+### Auto-updating demo/test servers (Watchtower)
+
+The floating tags make it easy to run a demo or test server that always tracks the latest develop build. Example `docker-compose.yml` using [Watchtower](https://containrrr.dev/watchtower/) to poll Docker Hub and restart the container when `latest-develop` moves:
+
+```yaml
+services:
+  omsupply:
+    image: msupplyfoundation/omsupply:latest-develop
+    restart: unless-stopped
+    ports:
+      - "9000:8000"
+    volumes:
+      # Directory mount; the SQLite file inside must be named
+      # omsupply-database.sqlite (see "Running the images" below)
+      - ./database:/database
+
+  watchtower:
+    image: containrrr/watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WATCHTOWER_CLEANUP=true # delete superseded images after updating
+      - WATCHTOWER_POLL_INTERVAL=3600 # check for a new image every hour (seconds)
+```
+
+Floating tags are amd64-only. Nightly develop builds may include schema migrations that cannot be rolled back — treat the `/database` volume as disposable on servers tracking `latest-develop`.
+
 ### Docker Hub cleanup
 
-A separate `cleanup-docker-tags.yaml` workflow runs nightly to remove old non-release images from Docker Hub. Release images are always kept. Non-release images older than 30 days (configurable) are deleted.
+A separate `cleanup-docker-tags.yaml` workflow runs nightly to remove old non-release images from Docker Hub. Release images and the floating `latest*` tags are always kept. Non-release images older than 30 days (configurable) are deleted.
 
 The cleanup script can also be run locally:
 


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12573

Adds floating (moving) Docker Hub tags so demo/test servers can auto-update (e.g. via Watchtower) instead of being hand-edited to a new immutable tag after every build. The existing tag-triggered `dockerise.yaml` workflow now also repoints:

| Trigger git tag | Floating tags repointed |
|---|---|
| Release `vX.Y.Z` | `latest`, `latest-sqlite`, `latest-postgres` |
| Nightly `v*-develop-MMDDHHMM` | `latest-develop`, `latest-develop-sqlite`, `latest-develop-postgres` |
| Nightly `v*-RC-MMDDHHMM` | `latest-rc`, `latest-rc-sqlite`, `latest-rc-postgres` |

No new builds, triggers, or multi-arch manifests — the floating tags are extra entries on the existing `docker/build-push-action` push, so they point at the same digest as the immutable tag. Also:

- `.github/scripts/cleanup-docker-tags.sh` keep-list extended so `latest*` tags are never deleted (they would otherwise age out 30 days after a release).
- `docs/content/docker/_index.md`: tag table updated + new "Auto-updating demo/test servers (Watchtower)" section with a compose example.

## 💌 Any notes for the reviewer?

- Floating tags are **amd64 only** (the guard is an explicit `matrix.arch == amd64` check — the release matrix includes arm64, which must never move them). The bare tags (`latest`, `latest-develop`, `latest-rc`) are the **sqlite** flavour, matching the Dockerfile's default target.
- The nightly-tag regexes are intentionally strict (`-develop-`/`-RC-` uppercase + 8-digit date, exactly what `create-nightly-tags.sh` produces). Ad-hoc tags like `v2.18.00-test` get no floating tag — behaviour for them is byte-identical to today.
- Known caveats (accepted + documented): if two RC branches (or develop-family branches) get commits the same day, the shared floating tag lands on whichever build pushed last (`create-nightly-tags.sh` skips branches with no new commits, so this is rare); re-pushing an old `v*` git tag moves floating tags backwards; the sqlite and postgres matrix jobs finish at different times so `latest-rc` vs `latest-rc-postgres` can transiently point at different builds.
- No floating variants for the `-dev` images — nothing consumes them; trivial to add later.
- `trigger-plugin-tests` is untouched (still receives the immutable `${VERSION}-dev` tag).

# 🧪 Tested

- Simulated the new `check-tag` classification against real tag shapes (`v2.21.02` → `latest`, `v3.00.00-develop-07270725` → `latest-develop`, `v2.21.01-RC-07241648` → `latest-rc`, `v0.0.0-test`/`v2.18.00-test`/lowercase `-rc-` → none).
- Simulated the tag-list construction for all (db, arch, prefix) matrix combinations — arm64 jobs and unclassified tags produce exactly the current single immutable tag; sqlite/amd64 additionally gets `<prefix>-sqlite` + bare `<prefix>`, postgres/amd64 gets `<prefix>-postgres`.
- Verified the cleanup protection regex keeps all nine `latest*` names and does not over-match (`latest-foo`, `latestx`, `v2.19.1-sqlite-amd64` still eligible for cleanup rules).
- `bash -n` on the cleanup script; YAML parse of the workflow.
- Post-merge verification: push a throwaway nightly-shaped tag (e.g. `v0.00.01-develop-01010101`) on a commit containing this workflow, confirm `latest-develop*` appear on Docker Hub while `latest` does not, then delete the git tag.

# 📃 Documentation

- [ ] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [x] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  - Done in this PR: `docs/content/docker/_index.md` gains the floating-tag rows and a Watchtower auto-update example.
