### PR TITLE
Fix install-plugin-bundle: CLI still sent the pre-refactor auth cookie

### DIFF
--- a/server/cli/src/graphql/mod.rs
+++ b/server/cli/src/graphql/mod.rs
@@ -91,10 +91,12 @@ impl Api {
     pub async fn upload_file(&self, path: PathBuf) -> Result<UploadedFile, Error> {
         let url = self.url.join("upload").unwrap();
 
-        let auth_cooke_value = format!(r#"auth={{"token": "{}"}}"#, self.token);
+        // Bearer auth, same as gql requests — the pre-refactor `auth={"token"}` cookie is
+        // no longer accepted, and the CLI can't know the `session_{port}` cookie name
+        // (the server names it after its own port, which differs behind port mapping).
         let built_request = reqwest::Client::new()
             .post(url.clone())
-            .header("Cookie", auth_cooke_value);
+            .header("Authorization", format!("Bearer {}", self.token));
 
         // Add file to request
         let mut file_handle =

--- a/server/server/src/authentication.rs
+++ b/server/server/src/authentication.rs
@@ -4,13 +4,21 @@ use service::{
     auth_data::AuthData,
 };
 
-/// Validates a request by reading the `session_{suffix}` HttpOnly cookie and calling
-/// [`validate_auth`]. Used by HTTP endpoints outside the GraphQL pipeline.
+/// Validates a request for HTTP endpoints outside the GraphQL pipeline. Reads
+/// `Authorization: Bearer …` first (used by API integrations and the server CLI,
+/// which can't know the `session_{suffix}` cookie name behind port mapping), then
+/// falls back to the HttpOnly `session_{suffix}` cookie used by the web client —
+/// the same precedence as the GraphQL pipeline's `auth_data_from_request`.
 pub(crate) fn validate_cookie_auth(
     request: HttpRequest,
     auth_data: &AuthData,
 ) -> Result<ValidatedUserAuth, AuthError> {
     let cookie_name = format!("session_{}", auth_data.cookie_suffix);
-    let token = request.cookie(&cookie_name).map(|c| c.value().to_string());
+    let token = request
+        .headers()
+        .get("Authorization")
+        .and_then(|header_value| header_value.to_str().ok())
+        .and_then(|header| header.strip_prefix("Bearer ").map(|t| t.to_string()))
+        .or_else(|| request.cookie(&cookie_name).map(|c| c.value().to_string()));
     validate_auth(auth_data, &token)
 }


### PR DESCRIPTION
## Problem

Since the auth refactor (fe3d306549), REST endpoints validate the `session_{port}` HttpOnly cookie — but `remote_server_cli`'s `Api::upload_file` still crafts the legacy `Cookie: auth={"token": …}`. Every `install-plugin-bundle` against a 3.0 server fails with `You need to be logged in` (the `/upload` step rejects; the GraphQL steps use Bearer and are fine). The civ-plugins release-test harness also strands on this — its install container dies and the run hangs.

Reproduced against `v3.00.00-develop-07270725` while validating CIV backend plugins through the new FE (msupply-foundation/open-msupply-frontend#249).

## Why not just fix the cookie name

The suffix is the **server's own port** (`cookie_suffix = server_settings.port`), which the CLI can't know behind port mapping — e.g. the plugin test harness maps `-p 9000:8000`, so the CLI talks to `:9000` but the cookie is `session_8000`.

## Fix (both sides, same precedence as the GraphQL pipeline)

`auth_data_from_request` already reads `Authorization: Bearer` first and falls back to the session cookie, and `AuthToken.token`'s doc comment says the bearer token is kept "for backwards-compatible API integrations". This PR extends that to the REST routes:

- `validate_cookie_auth` (server): accept `Authorization: Bearer …` first, fall back to the `session_{suffix}` cookie. Covers `/upload`, `/upload-fridge-tag`, and the static-files routes uniformly.
- `upload_file` (CLI): send `Authorization: Bearer` — the same auth its gql calls already use — instead of the dead legacy cookie.

## Verification

- `cargo check -p server -p cli` green.
- The manual equivalent verified end-to-end against the 3.00.00-develop docker image while working #249: token → `POST /upload` (with valid auth) → `centralServer.plugins.installUploadedPlugin` installs the CIV bundle successfully, and the plugin runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)