### PR TITLE
e2e: add stock test-ids for the cross-front-end regression suite

### DIFF
--- a/client/packages/common/src/ui/components/inputs/DateTimePickers/DateTimePickerInput/DateTimePickerInput.tsx
+++ b/client/packages/common/src/ui/components/inputs/DateTimePickers/DateTimePickerInput/DateTimePickerInput.tsx
@@ -53,6 +53,7 @@ export const DateTimePickerInput = ({
   errorText,
   required,
   textFieldSx: inputSx,
+  textFieldTestId,
   slotProps,
   formError,
   customError,
@@ -74,6 +75,9 @@ export const DateTimePickerInput = ({
   disableFuture?: boolean;
   required?: boolean;
   textFieldSx?: SxProps;
+  // Stamps data-testid on the underlying text input so e2e can locate the
+  // picker without depending on its translated label.
+  textFieldTestId?: string;
   formError?: FormErrorBinding;
   customError?: CustomErrorValue;
   validate?: (value: Date | null | undefined) => string | null;
@@ -202,6 +206,9 @@ export const DateTimePickerInput = ({
               width,
               minWidth: showTime ? 200 : undefined,
             },
+            ...(textFieldTestId
+              ? { inputProps: { 'data-testid': textFieldTestId } }
+              : {}),
           },
 
           tabs: {

--- a/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
@@ -76,6 +76,9 @@ export const DateFilter = ({
 
   const componentProps = {
     label: name,
+    // Locale-stable handle for e2e; a ranged filter needs one id per end,
+    // since both halves share the same urlParameter.
+    textFieldTestId: `filter-input-${urlParameter}${range ? `-${range}` : ''}`,
     value,
     width: width ? width : FILTER_WIDTH,
     onChange: handleChange,

--- a/client/packages/common/src/ui/components/inputs/TextInput/InputWithLabelRow.tsx
+++ b/client/packages/common/src/ui/components/inputs/TextInput/InputWithLabelRow.tsx
@@ -9,6 +9,11 @@ export interface InputWithLabelRowProps {
   labelWidth?: string | null;
   labelRight?: boolean;
   sx?: SxProps<Theme>;
+  /**
+   * Stamps data-testid on the row container so e2e can locate a field without
+   * depending on its translated label. The control itself is the input inside.
+   */
+  testId?: string;
 }
 
 export const InputWithLabelRow = ({
@@ -18,11 +23,13 @@ export const InputWithLabelRow = ({
   labelWidth = '120px',
   labelRight = false,
   sx,
+  testId,
 }: InputWithLabelRowProps) => {
   const { sx: labelSx, ...labelPropsRest } = labelProps || {};
 
   return (
     <Box
+      data-testid={testId}
       sx={{
         display: 'flex',
         alignItems: 'center',

--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/AdjustmentForm.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/AdjustmentForm.tsx
@@ -77,6 +77,7 @@ export const AdjustmentForm = ({
           }}
         >
           <InventoryAdjustmentDirectionInput
+            data-testid="adjust-direction"
             value={draft.adjustmentType}
             onChange={adjustmentType => {
               const type = adjustmentType ?? AdjustmentTypeInput.Addition;
@@ -98,6 +99,7 @@ export const AdjustmentForm = ({
           <Typography sx={{ alignSelf: 'center' }}>{t('label.by')}</Typography>
           <NumericTextInput
             id="by"
+            data-testid="adjust-amount"
             width="unset"
             decimalLimit={2}
             value={draft.adjustment}
@@ -133,6 +135,7 @@ export const AdjustmentForm = ({
               }
               maxDate={new Date()}
               minDate={minDate}
+              textFieldTestId="adjust-date"
             />
           </Box>
         </Box>
@@ -145,6 +148,7 @@ export const AdjustmentForm = ({
 
         <ReasonOptionsSearchInput
           id="reason"
+          data-testid="adjust-reason"
           disabled={draft.adjustment === 0}
           onChange={reason => setDraft(state => ({ ...state, reason }))}
           value={draft.reason}

--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/AdjustmentStats.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/AdjustmentStats.tsx
@@ -59,6 +59,7 @@ export const ItemDetailAndStats = ({
           originalValue={availableNumberOfPacks}
           variation={variation}
           label={t('label.available-packs')}
+          testId="adjust-tile-available"
           isHistorical={historicalAvailableNumberOfPacks != null}
           isLoading={isLoading}
         />
@@ -66,6 +67,7 @@ export const ItemDetailAndStats = ({
           originalValue={totalNumberOfPacks}
           variation={variation}
           label={t('label.packs-on-hand')}
+          testId="adjust-tile-total"
           isHistorical={historicalTotalNumberOfPacks != null}
           isLoading={isLoading}
         />
@@ -95,17 +97,20 @@ const AdjustmentStats = ({
   label,
   isHistorical,
   isLoading,
+  testId,
 }: {
   originalValue: number;
   variation: number;
   label: string;
   isHistorical?: boolean;
   isLoading?: boolean;
+  testId?: string;
 }) => {
   const t = useTranslation();
 
   return (
     <Box
+      data-testid={testId}
       sx={{
         backgroundColor: 'background.secondary',
         padding: '1em',

--- a/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
+++ b/client/packages/system/src/Stock/Components/InventoryAdjustment/InventoryAdjustmentModal.tsx
@@ -81,6 +81,7 @@ export const InventoryAdjustmentModal = ({
       contentProps={{ sx: { paddingTop: 0 } }}
       slideAnimation={false}
       title={t('title.stock-adjustment')}
+      testId="adjust-modal"
       okButton={
         <DialogButton variant="ok" disabled={saveDisabled} onClick={save} />
       }

--- a/client/packages/system/src/Stock/Components/Ledger/LedgerTable.tsx
+++ b/client/packages/system/src/Stock/Components/Ledger/LedgerTable.tsx
@@ -28,5 +28,9 @@ export const LedgerTable = ({ stockLine }: LedgerTableProps) => {
     noDataElement: <NothingHere body={t('messages.no-ledger')} />,
   });
 
-  return <MaterialTable table={table} />;
+  return (
+    <div data-testid="ledger-table">
+      <MaterialTable table={table} />
+    </div>
+  );
 };

--- a/client/packages/system/src/Stock/Components/NewStockLineModal.tsx
+++ b/client/packages/system/src/Stock/Components/NewStockLineModal.tsx
@@ -146,6 +146,7 @@ export const NewStockLineModal = ({
       height={575}
       slideAnimation={false}
       title={t('title.stock-line-details')}
+      testId="new-stock-modal"
       okButton={
         <DialogButton variant="ok" disabled={isDisabled} onClick={save} />
       }

--- a/client/packages/system/src/Stock/Components/Repack/RepackEditForm.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackEditForm.tsx
@@ -43,6 +43,7 @@ export const RepackEditForm = ({
           {isNew && (
             <InputWithLabelRow
               label={t('label.packs-available')}
+              testId="repack-packs-available"
               labelWidth="100%"
               Input={
                 <NumericTextDisplay
@@ -54,6 +55,7 @@ export const RepackEditForm = ({
           )}
           <InputWithLabelRow
             label={t('label.packs-to-repack')}
+            testId="repack-number-of-packs"
             labelWidth="100%"
             Input={
               <NumericTextInput
@@ -102,6 +104,7 @@ export const RepackEditForm = ({
           {isNew && <Box height={24} />}
           <InputWithLabelRow
             label={t('label.new-num-packs')}
+            testId="repack-new-number-of-packs"
             labelWidth="100%"
             Input={
               <NumericTextDisplay
@@ -115,6 +118,7 @@ export const RepackEditForm = ({
           />
           <InputWithLabelRow
             label={t('label.new-pack-size')}
+            testId="repack-new-pack-size"
             labelWidth="100%"
             Input={
               <NumericTextInput

--- a/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackModal.tsx
@@ -166,6 +166,7 @@ export const RepackModal: FC<RepackModalControlProps> = ({
       height={700}
       slideAnimation={false}
       title={t('title.repack-details')}
+      testId="repack-modal"
       okButton={
         <DialogButton
           variant="save"

--- a/client/packages/system/src/Stock/Components/StatusHistory/StatusHistory.tsx
+++ b/client/packages/system/src/Stock/Components/StatusHistory/StatusHistory.tsx
@@ -63,6 +63,7 @@ export const StatusHistory = ({
         }}
       >
         <ButtonWithIcon
+          data-testid="new-vvm-status-button"
           label={t('button.new-status-entry')}
           Icon={<PlusCircleIcon />}
           onClick={handleAddClick}

--- a/client/packages/system/src/Stock/Components/StatusHistory/VvmStatusLogModal.tsx
+++ b/client/packages/system/src/Stock/Components/StatusHistory/VvmStatusLogModal.tsx
@@ -68,6 +68,7 @@ export const VvmStatusLogModal = ({
       title={
         isCreating ? t('label.new-vvm-status') : t('label.edit-vvm-status')
       }
+      testId="vvm-status-modal"
       cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
       okButton={<DialogButton variant="ok" onClick={handleConfirm} disabled={isCreating && !selectedStatus} />}
     >
@@ -79,6 +80,7 @@ export const VvmStatusLogModal = ({
         }}
       >
         <InputWithLabelRow
+          testId="vvm-status-select"
           label={t('label.vvm-status')}
           Input={
             <VVMStatusSearchInput
@@ -93,6 +95,7 @@ export const VvmStatusLogModal = ({
           }}
         />
         <InputWithLabelRow
+          testId="vvm-comment"
           label={t('label.comment')}
           Input={
             <TextArea

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -198,6 +198,7 @@ export const StockLineForm = ({
               <Grid container flex={1} flexDirection="column" gap={1}>
                 <StyledInputRow
                   label={t('label.pack-quantity')}
+                  testId="field-pack-quantity"
                   Input={
                     <NumericTextInput
                       autoFocus
@@ -217,6 +218,7 @@ export const StockLineForm = ({
                   <>
                     <StyledInputRow
                       label={t('label.available-packs')}
+                      testId="field-available-packs"
                       Input={
                         <NumericTextInput
                           autoFocus
@@ -238,6 +240,7 @@ export const StockLineForm = ({
                   <>
                     <StyledInputRow
                       label={t('label.available-soh')}
+                      testId="field-available-stock"
                       Input={
                         <NumericTextInput
                           autoFocus
@@ -255,6 +258,7 @@ export const StockLineForm = ({
                     />
                     <StyledInputRow
                       label={t('label.soh')}
+                      testId="field-soh"
                       Input={
                         <NumericTextInput
                           autoFocus
@@ -274,6 +278,7 @@ export const StockLineForm = ({
                 )}
                 <StyledInputRow
                   label={t('label.cost-price')}
+                  testId="field-cost-price"
                   Input={
                     <CurrencyInput
                       autoFocus={!packEditable}
@@ -286,6 +291,7 @@ export const StockLineForm = ({
                 />
                 <StyledInputRow
                   label={t('label.sell-price')}
+                  testId="field-sell-price"
                   Input={
                     <CurrencyInput
                       value={draft.sellPricePerPack}
@@ -297,6 +303,7 @@ export const StockLineForm = ({
                 />
                 <StyledInputRow
                   label={t('label.batch')}
+                  testId="field-batch"
                   Input={
                     <BufferedTextInput
                       value={draft.batch ?? ''}
@@ -306,6 +313,7 @@ export const StockLineForm = ({
                 />
                 <StyledInputRow
                   label={t('label.barcode')}
+                  testId="field-barcode"
                   Input={
                     <Box
                       display="flex"
@@ -344,6 +352,7 @@ export const StockLineForm = ({
                 {isNewModal && (
                   <StyledInputRow
                     label={t('label.reason')}
+                    testId="field-reason"
                     Input={
                       <ReasonOptionsSearchInput
                         width={INPUT_WIDTH}
@@ -357,6 +366,7 @@ export const StockLineForm = ({
                 )}
                 <StyledInputRow
                   label={t('label.manufacture-date')}
+                  testId="field-manufacture-date"
                   Input={
                     <DateTimePickerInput
                       value={DateUtils.getNaiveDate(draft.manufactureDate)}
@@ -379,6 +389,7 @@ export const StockLineForm = ({
               <Grid container flex={1} flexDirection="column" gap={1}>
                 <StyledInputRow
                   label={t('label.pack-size')}
+                  testId="field-pack-size"
                   Input={
                     <NumericTextInput
                       disabled={!packEditable}
@@ -403,6 +414,7 @@ export const StockLineForm = ({
                 />
                 <StyledInputRow
                   label={t('label.expiry')}
+                  testId="field-expiry-date"
                   Input={
                     <ExpiryDateInput
                       value={DateUtils.getNaiveDate(draft.expiryDate)}
@@ -415,6 +427,7 @@ export const StockLineForm = ({
                 />
                 <StyledInputRow
                   label={t('label.on-hold')}
+                  testId="field-on-hold"
                   Input={
                     <Checkbox
                       checked={draft.onHold}
@@ -425,6 +438,7 @@ export const StockLineForm = ({
                 />
                 <StyledInputRow
                   label={t('label.location')}
+                  testId="field-location"
                   Input={
                     <LocationSearchInput
                       autoFocus={false}
@@ -446,6 +460,7 @@ export const StockLineForm = ({
                 />
                 <StyledInputRow
                   label={t('label.volume-per-pack')}
+                  testId="field-volume-per-pack"
                   Input={
                     <NumericTextInput
                       width={160}
@@ -458,6 +473,7 @@ export const StockLineForm = ({
                 {!packEditable && (
                   <StyledInputRow
                     label={t('label.total-volume')}
+                    testId="field-total-volume"
                     Input={
                       <NumericTextInput
                         disabled
@@ -473,6 +489,7 @@ export const StockLineForm = ({
                 )}
                 <StyledInputRow
                   label={t('label.manufacturer')}
+                  testId="field-manufacturer"
                   Input={
                     <ManufacturerSearchInput
                       value={draft.manufacturer ?? null}
@@ -495,6 +512,7 @@ export const StockLineForm = ({
                 {showVVMStatus && (
                   <StyledInputRow
                     label={t('label.vvm-status')}
+                    testId="field-vvm-status"
                     Input={
                       <VVMStatusSearchInput
                         selected={draft?.vvmStatus ?? null}
@@ -509,6 +527,7 @@ export const StockLineForm = ({
                 {preferences.allowTrackingOfStockByDonor && (
                   <StyledInputRow
                     label={t('label.donor')}
+                    testId="field-donor"
                     Input={
                       <DonorSearchInput
                         donorId={draft.donor?.id ?? null}
@@ -521,6 +540,7 @@ export const StockLineForm = ({
                 )}
                 <StyledInputRow
                   label={t('label.campaign')}
+                  testId="field-campaign-or-program"
                   Input={
                     <CampaignOrProgramSelector
                       campaignId={draft.campaign?.id}

--- a/client/packages/system/src/Stock/Components/StyledInputRow.tsx
+++ b/client/packages/system/src/Stock/Components/StyledInputRow.tsx
@@ -10,10 +10,12 @@ export const StyledInputRow = ({
   label,
   Input,
   labelWidth,
+  testId,
 }: InputWithLabelRowProps) => (
   <InputWithLabelRow
     label={label}
     Input={Input}
+    testId={testId}
     labelProps={{ sx: { textAlign: 'end' } }}
     labelWidth={labelWidth ?? '100px'}
     sx={{

--- a/client/packages/system/src/Stock/DetailView/AppBarButtons.tsx
+++ b/client/packages/system/src/Stock/DetailView/AppBarButtons.tsx
@@ -27,11 +27,13 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
           label={t('button.repack')}
           Icon={<StockIcon />}
           onClick={openRepack}
+          data-testid="repack-button"
         />
         <ButtonWithIcon
           label={t('button.adjust')}
           Icon={<BarChartIcon />}
           onClick={openAdjust}
+          data-testid="adjust-button"
         />
       </Grid>
     </AppBarButtonsPortal>

--- a/client/packages/system/src/Stock/DetailView/Footer.tsx
+++ b/client/packages/system/src/Stock/DetailView/Footer.tsx
@@ -65,6 +65,7 @@ export const Footer: FC<FooterProps> = ({
               }
               startIcon={<SaveIcon />}
               shouldShrink={false}
+              data-testid="save-button"
             />
           </Box>
         </Box>

--- a/client/packages/system/src/Stock/ListView/AppBarButtons.tsx
+++ b/client/packages/system/src/Stock/ListView/AppBarButtons.tsx
@@ -43,6 +43,7 @@ export const AppBarButtonsComponent = ({
           Icon={<PlusCircleIcon />}
           label={t('button.new-stock')}
           onClick={onOpen}
+          data-testid="new-stock-button"
         />
         {!simplifiedTabletView && (
           <ExportSelector


### PR DESCRIPTION
The deterministic regression suites live in [open-msupply-frontend's `e2e/`](https://github.com/msupply-foundation/open-msupply-frontend/tree/main/e2e) and run against **both** this app and the rewrite, locating every interaction point by a `data-testid` documented in that repo's `e2e/TESTIDS.md`. That is what lets one suite definition hold both front ends to the same behaviour.

The **stock** vertical is being covered next. Its 23 files under `packages/system/src/Stock/` carry **no test-ids at all** today — every id currently visible on the stock list comes from shared components — so the suite has nothing to grip.

**Test-ids only. No behaviour change, no styling change.** 17 files, +68 / −1.

## Screen ids (41)

The detail form's field rows · the adjust, repack, new-stock and VVM modals and their controls · the two adjustment stat tiles · the ledger table · the Adjust / Repack / New stock / New status entry actions.

Names match what the rewrite already emits, so one suite locates the same things on both apps.

## Three shared components gain an optional id seam

All additive — an optional prop that stamps an attribute and changes nothing when unset.

| Component | Prop | Why |
| --- | --- | --- |
| `InputWithLabelRow` | `testId` | stamped on the row container. The stock detail form is ~20 of these; one prop beats threading `data-testid` through eleven different input components. The control is the input inside |
| `DateTimePickerInput` | `textFieldTestId` | **merged into** the existing `textField` slotProps rather than replacing them — passing `slotProps.textField` from a caller would drop the component's own `onBlur`, error and `sx` handling, which would be a behaviour change |
| `DateFilter` | — | derives `filter-input-<urlParameter>` from the filter definition, matching what the text, enum and number filters already do. Date filters had **no** id at all, so this unblocks every vertical's date filter, not just stock's expiry range. A ranged filter gets one id per end (`-from` / `-to`) since both halves share a `urlParameter` |

## Verification

- `packages/system` typechecks clean
- `packages/common` carries the **same two pre-existing errors as `develop`** and no more (verified by stashing and re-running)
- `eslint` clean on all 17 files
- Formatting deliberately left alone on files `develop` had not run prettier over — running it reformatted ~59 lines of unrelated pre-existing code in `StatusHistory.tsx`, so those files were restored and the ids re-applied by hand to keep the diff to the ids themselves

## What follows

Once this merges, the suite (`stock-regression.spec.ts`) and the matching **Stock** section of `TESTIDS.md` land together in open-msupply-frontend, greened against this app first. A one-line follow-up here then adds `stock-regression` to this workflow's enumerated suite list, at which point stock behaviour is checked on every PR to this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
