### PR TITLE
e2e testids: patient create wizard (cross-FE patients suite)

### DIFF
--- a/client/packages/programs/src/JsonForms/common/components/Text.tsx
+++ b/client/packages/programs/src/JsonForms/common/components/Text.tsx
@@ -101,6 +101,9 @@ const UIComponent = (props: ControlProps) => {
         label={t(label as LocaleKey)}
         inputProps={{
           value: text ?? '',
+          // Locale-stable e2e hook, keyed by the control's data path (e.g.
+          // `input-firstName`) — see open-msupply-frontend e2e/TESTIDS.md.
+          inputProps: { 'data-testid': `input-${path}` },
           sx: { width },
           style: { flexBasis },
           onChange: e =>

--- a/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
+++ b/client/packages/system/src/Patient/CreatePatientModal/PatientResultsTab.tsx
@@ -249,7 +249,13 @@ export const PatientResultsTab: FC<
           )}
           <Box display="flex" flexDirection="row" marginLeft="auto">
             {isCentralConnectionFailure ? (
-              <InfoTooltipIcon title={t('messages.failed-to-reach-central')} />
+              // data-testid: locale-stable e2e hook for the central-unreachable
+              // state — see open-msupply-frontend e2e/TESTIDS.md § Patients.
+              <Box data-testid="central-search-error">
+                <InfoTooltipIcon
+                  title={t('messages.failed-to-reach-central')}
+                />
+              </Box>
             ) : null}
             {isLoadingCentral || isCentralConnectionFailure ? (
               <LoadingButton

--- a/client/packages/system/src/Patient/ListView/AppBarButtons.tsx
+++ b/client/packages/system/src/Patient/ListView/AppBarButtons.tsx
@@ -27,7 +27,8 @@ export const AppBarButtons = ({
   sortBy,
 }: AppBarButtonsComponentProps) => {
   const t = useTranslation();
-  const { isPending: isLoading, mutateAsync } = usePatient.document.listAll(sortBy);
+  const { isPending: isLoading, mutateAsync } =
+    usePatient.document.listAll(sortBy);
   const [createModalOpen, setCreateModalOpen] = useState(false);
 
   const handleClick = useCallbackWithPermission(
@@ -44,6 +45,7 @@ export const AppBarButtons = ({
     <AppBarButtonsPortal>
       <Grid container gap={1}>
         <ButtonWithIcon
+          data-testid="new-patient-button"
           Icon={<PlusCircleIcon />}
           label={t('button.new-patient')}
           onClick={handleClick}


### PR DESCRIPTION
Testids-only, no behaviour change — instruments the patient create wizard for the cross-FE `patients-regression` suite (defined in open-msupply-frontend; contract in its `e2e/TESTIDS.md` § Patients). Pairs with msupply-foundation/open-msupply-frontend#744.

- `new-patient-button` on the patient list's New-patient action
- `input-<path>` derived from the JSON-form control's data path on the shared `Text` control (e.g. `input-firstName` on the wizard's search step) — generic, so every JSON-form text control gains a locale-stable hook
- `central-search-error` wrapping the results tab's failed-to-reach-central notice

Verified by the suite running hermetically against this branch: 22/22 passed (`FE_SUITES_DIR=<fe-checkout> bash playwright/scripts/run-e2e.sh patients-regression`). Same pattern as #12559 / #12583 / #12584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)