### PR TITLE
Add the new Capacitor plugins

### DIFF
--- a/client/packages/android/app/capacitor.build.gradle
+++ b/client/packages/android/app/capacitor.build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-preferences')
     implementation project(':capacitor-screen-orientation')
+    implementation project(':capacitor-share')
 
 }
 

--- a/client/packages/android/app/src/main/assets/capacitor.plugins.json
+++ b/client/packages/android/app/src/main/assets/capacitor.plugins.json
@@ -46,5 +46,9 @@
 	{
 		"pkg": "@capacitor/screen-orientation",
 		"classpath": "com.capacitorjs.plugins.screenorientation.ScreenOrientationPlugin"
+	},
+	{
+		"pkg": "@capacitor/share",
+		"classpath": "com.capacitorjs.plugins.share.SharePlugin"
 	}
 ]

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/ExtendedWebViewClient.java
@@ -89,7 +89,13 @@ public class ExtendedWebViewClient extends BridgeWebViewClient {
         // see what plugins to add
 
         // This function needs to run after plugins are registered, so can't be part of the constructor as order doesn't appear to be consistent.
-        List<String> pluginNames =  Arrays.asList("NativeApi","Keyboard", "WebView","BarcodeScanner","HoneywellScanner","Preferences", "KeepAwake", "App", "Printer", "Camera", "Geolocation", "Filesystem", "FileOpener", "Device", "ScreenOrientation");
+        // A name in this list with no registered plugin aborts the whole
+        // injection (return null below), leaving the served UI with no bridge
+        // at all - so keep it in step with the registrations in MainActivity
+        // and with the npm plugins in assets/capacitor.plugins.json.
+        // Share, and our own SaveFile / Print / ReadLog, are used only by the
+        // new front end.
+        List<String> pluginNames =  Arrays.asList("NativeApi","Keyboard", "WebView","BarcodeScanner","HoneywellScanner","Preferences", "KeepAwake", "App", "Printer", "Camera", "Geolocation", "Filesystem", "FileOpener", "Device", "ScreenOrientation", "Share", "SaveFile", "Print", "ReadLog");
         List<PluginHandle> pluginList = new ArrayList<>();
         for (String pluginName : pluginNames) {
             PluginHandle plugin = bridge.getPlugin(pluginName);

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/MainActivity.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/MainActivity.java
@@ -26,6 +26,14 @@ public class MainActivity extends BridgeActivity {
     protected void onCreate(Bundle savedInstanceState) {
         registerPlugin(NativeApi.class);
         registerPlugin(HoneywellScannerPlugin.class);
+        // Used by the new front end (open-msupply-frontend, src/platform/).
+        // Registering here is only half the job: the UI is served by the
+        // embedded server, so each plugin's name must ALSO be listed in
+        // ExtendedWebViewClient.generatePluginScript() or the JS proxy has no
+        // header to dispatch through.
+        registerPlugin(SaveFilePlugin.class);
+        registerPlugin(PrintPlugin.class);
+        registerPlugin(ReadLogPlugin.class);
         super.onCreate(savedInstanceState);
 
         // Replace Capacitor's auto-loaded https://localhost:<PORT>/ with an inline

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/PrintPlugin.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/PrintPlugin.java
@@ -1,0 +1,95 @@
+package org.openmsupply.client;
+
+import android.content.Context;
+import android.print.PrintAttributes;
+import android.print.PrintDocumentAdapter;
+import android.print.PrintManager;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+/**
+ * Printing via the OS print service (Android PrintManager). The print
+ * counterpart to SaveFilePlugin.
+ *
+ * Used by the NEW front end (open-msupply-frontend), whose JS side is
+ * src/platform/openDocument.ts `printBlob` — it creates the proxy with
+ * registerPlugin('Print').
+ *
+ * Android needs this because neither of the alternatives exists on a tablet:
+ * the WebView has no window.print, and the server renders PDFs by driving
+ * headless Chrome, which has no executable to launch on Android. So the
+ * finished HTML goes to the OS instead.
+ *
+ * printHtml({ html, jobName }) resolves once the document has been handed to
+ * the print service — the print dialog itself is the user's business, and
+ * their cancelling it is not an error. Rejects only if the job can't be
+ * started.
+ */
+@CapacitorPlugin(name = "Print")
+public class PrintPlugin extends Plugin {
+
+    /**
+     * The WebView rendering the current job. Held as a field because
+     * PrintManager reads the document from it asynchronously, after this
+     * method returns — a local would be eligible for garbage collection
+     * mid-job, and the print would silently produce nothing.
+     */
+    private WebView printView;
+
+    @PluginMethod
+    public void printHtml(PluginCall call) {
+        String html = call.getString("html");
+        if (html == null) {
+            call.reject("html is required");
+            return;
+        }
+        String jobName = call.getString("jobName", "Document");
+
+        // WebViews must be created and driven on the UI thread.
+        getActivity().runOnUiThread(() -> {
+            try {
+                WebView webView = new WebView(getActivity());
+                webView.setWebViewClient(new WebViewClient() {
+                    private boolean printed = false;
+
+                    @Override
+                    public void onPageFinished(WebView view, String url) {
+                        // onPageFinished can fire more than once for one load.
+                        if (printed) return;
+                        printed = true;
+
+                        PrintManager printManager =
+                            (PrintManager) getActivity().getSystemService(Context.PRINT_SERVICE);
+                        if (printManager == null) {
+                            printView = null;
+                            call.reject("No print service on this device");
+                            return;
+                        }
+
+                        PrintDocumentAdapter adapter = view.createPrintDocumentAdapter(jobName);
+                        printManager.print(
+                            jobName,
+                            adapter,
+                            new PrintAttributes.Builder().build()
+                        );
+                        call.resolve();
+                    }
+                });
+
+                // No base URL: report documents carry their styles inline and
+                // their images as data: URIs, so nothing needs resolving
+                // against an origin.
+                webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null);
+                printView = webView;
+            } catch (Exception e) {
+                printView = null;
+                call.reject("Failed to start print job: " + e.getMessage(), e);
+            }
+        });
+    }
+}

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/ReadLogPlugin.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/ReadLogPlugin.java
@@ -1,0 +1,71 @@
+package org.openmsupply.client;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
+/**
+ * Reads the embedded server's current log file so it can be saved/shared from
+ * a screen that has no authenticated GraphQL session — the initialisation and
+ * login screens, where the server-log GraphQL API is unavailable (it needs
+ * auth, and doesn't exist at all in the pre-initialisation schema).
+ *
+ * Used by the NEW front end (open-msupply-frontend), whose JS side is
+ * src/platform/readServerLog.ts — it creates the proxy with
+ * registerPlugin('ReadLog'). The read half of NativeApi.readLog, expressed as
+ * a plain Capacitor plugin.
+ *
+ * Path — the ACTIVE log only (plain text; the rotated siblings are gzip):
+ *   <filesDir>/logs/remote_server.log
+ * The embedded Rust server writes there — server/android/src/android.rs sets
+ * the log directory to files_dir.join("logs") and server/server/src/logging.rs
+ * defaults the filename to remote_server.log. NB this is NOT <filesDir> root:
+ * NativeApi.readLog still reads the old root path, which the server left when
+ * it moved the log directory, so it reads nothing on a current server — do not
+ * follow it.
+ *
+ * readLog() resolves { log } with the file's text, or { log: "", error } when
+ * the file is absent/unreadable (e.g. logging not yet started) — never
+ * rejects; the caller decides what an empty log means.
+ */
+@CapacitorPlugin(name = "ReadLog")
+public class ReadLogPlugin extends Plugin {
+
+    private static final String LOG_DIR_NAME = "logs";
+    private static final String LOG_FILE_NAME = "remote_server.log";
+
+    @PluginMethod
+    public void readLog(PluginCall call) {
+        JSObject ret = new JSObject();
+        File logsDir = new File(getContext().getFilesDir(), LOG_DIR_NAME);
+        File file = new File(logsDir, LOG_FILE_NAME);
+
+        if (!file.exists()) {
+            ret.put("log", "");
+            ret.put("error", "Log file not found: " + file.getAbsolutePath());
+            call.resolve(ret);
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                sb.append(line);
+                sb.append("\n");
+            }
+            ret.put("log", sb.toString());
+        } catch (IOException e) {
+            ret.put("log", "");
+            ret.put("error", e.getMessage());
+        }
+        call.resolve(ret);
+    }
+}

--- a/client/packages/android/app/src/main/java/org/openmsupply/client/SaveFilePlugin.java
+++ b/client/packages/android/app/src/main/java/org/openmsupply/client/SaveFilePlugin.java
@@ -1,0 +1,80 @@
+package org.openmsupply.client;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.util.Base64;
+
+import androidx.activity.result.ActivityResult;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.ActivityCallback;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.io.OutputStream;
+
+/**
+ * "Save as" via the OS document picker (SAF ACTION_CREATE_DOCUMENT): the user
+ * chooses the destination (Downloads, Drive, SD card), we write the bytes to
+ * the returned URI.
+ *
+ * Used by the NEW front end (open-msupply-frontend), whose JS side is
+ * src/platform/openDocument.ts `saveBlob` — it creates the proxy with
+ * registerPlugin('SaveFile'). The old UI keeps using NativeApi.saveFile /
+ * FileManager instead; this is the same capability expressed as a plain
+ * Capacitor plugin, not a replacement for it.
+ *
+ * save({ data: base64, fileName, mimeType }) resolves { saved: true } once
+ * written, or { saved: false } when the user cancels the picker (not an
+ * error); rejects only on a real write failure.
+ */
+@CapacitorPlugin(name = "SaveFile")
+public class SaveFilePlugin extends Plugin {
+
+    @PluginMethod
+    public void save(PluginCall call) {
+        String data = call.getString("data");
+        if (data == null) {
+            call.reject("data (base64) is required");
+            return;
+        }
+        String fileName = call.getString("fileName", "file");
+        String mimeType = call.getString("mimeType", "application/octet-stream");
+
+        Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType(mimeType);
+        intent.putExtra(Intent.EXTRA_TITLE, fileName);
+
+        startActivityForResult(call, intent, "onSaveResult");
+    }
+
+    @ActivityCallback
+    private void onSaveResult(PluginCall call, ActivityResult result) {
+        if (call == null) return;
+
+        Intent data = result.getData();
+        Uri uri = data == null ? null : data.getData();
+        if (result.getResultCode() != Activity.RESULT_OK || uri == null) {
+            JSObject ret = new JSObject();
+            ret.put("saved", false);
+            call.resolve(ret);
+            return;
+        }
+
+        try {
+            byte[] bytes = Base64.decode(call.getString("data"), Base64.DEFAULT);
+            try (OutputStream out = getActivity().getContentResolver().openOutputStream(uri)) {
+                out.write(bytes);
+            }
+            JSObject ret = new JSObject();
+            ret.put("saved", true);
+            call.resolve(ret);
+        } catch (Exception e) {
+            call.reject("Failed to write file: " + e.getMessage(), e);
+        }
+    }
+}

--- a/client/packages/android/capacitor.settings.gradle
+++ b/client/packages/android/capacitor.settings.gradle
@@ -37,3 +37,6 @@ project(':capacitor-preferences').projectDir = new File('../../../node_modules/@
 
 include ':capacitor-screen-orientation'
 project(':capacitor-screen-orientation').projectDir = new File('../../../node_modules/@capacitor/screen-orientation/android')
+
+include ':capacitor-share'
+project(':capacitor-share').projectDir = new File('../../../node_modules/@capacitor/share/android')

--- a/client/packages/android/package.json
+++ b/client/packages/android/package.json
@@ -12,7 +12,8 @@
     "@capacitor/filesystem": "^8.0.0",
     "@capacitor/keyboard": "^8.0.0",
     "@capacitor/preferences": "^8.0.0",
-    "@capacitor/screen-orientation": "^8.0.0"
+    "@capacitor/screen-orientation": "^8.0.0",
+    "@capacitor/share": "^8.0.0"
   },
   "scripts": {
     "build:server": "./build_remote_server_libs.sh",

--- a/docs/content/client/packages/android/_index.md
+++ b/docs/content/client/packages/android/_index.md
@@ -285,7 +285,26 @@ There is also a Github Action to build release apks, this is automated when a co
 
 Apart from usual local/packaged plugin setup for Capacitor, make sure to add plugin name to `onPageStarted` method in `ExtendedWebViewClient.java` (you can see what plugin names are available by using Android Studio debug and inspecting `bridge.plugins`). See point 2. in Capacitor Modifications (below).
 
-Example of expanding local native functionality (TODO)
+### Custom plugins
+
+Our own plugins are plain `@CapacitorPlugin` classes in `app/src/main/java/org/openmsupply/client/`, registered in `MainActivity.onCreate` before `super.onCreate`. Adding one means touching **two** places:
+
+1. `registerPlugin(YourPlugin.class)` in `MainActivity` — puts it on the bridge.
+2. Its `@CapacitorPlugin(name = ...)` in the `pluginNames` list in `ExtendedWebViewClient.generatePluginScript()` — puts it in `window.Capacitor.PluginHeaders` for the served page.
+
+Miss step 2 and the JS side's `registerPlugin('YourPlugin')` proxy throws `Unimplemented` on every call, because we inject the bridge ourselves from a hardcoded list rather than letting Capacitor proxy it (Capacitor Modification 2. below). Miss step 1 while listing the name and it's worse: `generatePluginScript()` bails out entirely, so the served UI gets no bridge at all.
+
+The current custom plugins:
+
+| Plugin            | Name           | Used by      | What it does                                                              |
+| ----------------- | -------------- | ------------ | ------------------------------------------------------------------------- |
+| `NativeApi`       | `NativeApi`    | old UI       | Server discovery, connection, log read, file save, database save          |
+| `HoneywellScanner`| `HoneywellScanner` | old UI  | Honeywell hardware barcode scanner                                        |
+| `SaveFilePlugin`  | `SaveFile`     | new front end | "Save as" through the SAF `ACTION_CREATE_DOCUMENT` picker                |
+| `PrintPlugin`     | `Print`        | new front end | Hands HTML to Android's `PrintManager` (the server can't render PDFs on a tablet — it drives headless Chrome) |
+| `ReadLogPlugin`   | `ReadLog`      | new front end | Reads `<filesDir>/logs/remote_server.log` for the pre-login "save log" affordance |
+
+The new front end (the `open-msupply-frontend` repo, fetched at its pinned version and bundled by `yarn stage-frontend` — see `server/README.md`, "Serving front-end") consumes these from its `src/platform/` modules, via `registerPlugin` against the page the embedded server serves. Its plugin needs are what drive this list, so check `src/platform/` there when bumping the frontend pin.
 
 ## Capacitor Modifications
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,6 +1879,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@capacitor/share@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "@capacitor/share@npm:8.0.1"
+  peerDependencies:
+    "@capacitor/core": ">=8.0.0"
+  checksum: 10c0/a615b85c79bbd3bfeb5e2ee2ac119e7ba8b8184ebcaad3b019467103e4ffc24130e1c1af42910498342fb495e0e297edf72169fa801963e34883d8bd4a42e514
+  languageName: node
+  linkType: hard
+
 "@capacitor/synapse@npm:^1.0.4":
   version: 1.0.4
   resolution: "@capacitor/synapse@npm:1.0.4"
@@ -5655,6 +5664,7 @@ __metadata:
     "@capacitor/keyboard": "npm:^8.0.0"
     "@capacitor/preferences": "npm:^8.0.0"
     "@capacitor/screen-orientation": "npm:^8.0.0"
+    "@capacitor/share": "npm:^8.0.0"
     "@chromatic-com/storybook": "npm:^1.6.1"
     "@graphql-codegen/cli": "npm:^5.0.0"
     "@graphql-codegen/near-operation-file-preset": "npm:^3.0.0"


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes msupply-foundation/open-msupply-frontend#644

Export Excel / Export CSV (and print, and the pre-login "save log") do nothing on a tablet. The new front end calls three Capacitor plugins that only ever existed in a local working copy, never in this repo — so a real APK has no such plugins, the JS proxies reject as `Unimplemented`, and the buttons silently do nothing.

This PR brings them in:

| Plugin | Name | What it does |
| --- | --- | --- |
| `SaveFilePlugin` | `SaveFile` | "Save as" through the SAF `ACTION_CREATE_DOCUMENT` picker — the user picks Downloads / Drive / SD card and we write the bytes to the returned URI |
| `PrintPlugin` | `Print` | Hands HTML to Android's `PrintManager`. Needed because the WebView has no `window.print`, and the server renders PDFs by driving headless Chrome, which has no executable to launch on Android |
| `ReadLogPlugin` | `ReadLog` | Reads the active `<filesDir>/logs/remote_server.log` for the screens with no authenticated GraphQL session (initialisation, login) |

Plus the npm `@capacitor/share` plugin (dependency, `capacitor.plugins.json`, `capacitor.build.gradle`, `capacitor.settings.gradle`), which the front end uses to share the exported file.

Each name is registered in `MainActivity.onCreate` **and** added to the `pluginNames` list in `ExtendedWebViewClient.generatePluginScript()`. Both are required: because the UI is served by the embedded server rather than from `assets/`, we inject `window.Capacitor.PluginHeaders` ourselves from that hardcoded list instead of letting Capacitor do it (Capacitor Modification 2. in the android docs). The docs page gained a "Custom plugins" section covering that two-step, since it's the easy thing to get wrong.

## 💌 Any notes for the reviewer?

- **Nothing here changes the old UI.** `NativeApi.saveFile` / `FileManager` / `NativeApi.readLog` are untouched; `SaveFile` and `ReadLog` are the same capabilities re-expressed as plain Capacitor plugins for the new front end, not replacements. There is deliberate duplication until the old UI goes.
- **`ReadLog` reads a different path to `NativeApi.readLog`.** The server moved its log directory (`server/android/src/android.rs` sets it to `files_dir/logs`), and `NativeApi.readLog` was left pointing at the old `<filesDir>` root — so it reads nothing on a current server. The new plugin reads `<filesDir>/logs/remote_server.log`. I didn't fix `NativeApi` in this PR to keep the old UI's behaviour untouched; worth a follow-up if anyone still relies on it.
- **`ReadLog` reads only the active log**, not the rotated `.gz` siblings, and returns the whole file as one string. Fine for the "something went wrong before login" case it exists for; not a general log API.
- **`PrintPlugin` holds the WebView in a field.** `PrintManager` pulls the document out of it asynchronously after `printHtml` returns, so a local would be collectible mid-job and the print would silently produce nothing.
- **A wrong `pluginNames` entry fails loudly in one direction and catastrophically in the other.** Listed-but-not-registered makes `generatePluginScript()` return `null`, so the served page gets *no* bridge at all. Registered-but-not-listed just breaks that one plugin. Called out in comments at both sites.
- **The list is driven by the frontend pin.** These plugin names come from `src/platform/` in the `open-msupply-frontend` repo, so that's the place to check when bumping the pin.

# 🧪 Tested

- Built a release APK from this branch and installed it on an Android tablet (i.e. not a `dev-android` build — the bug only showed up on a packaged build, since the local working copy had the plugins)
- Distribution → Outbound Shipments → Export CSV: the OS document picker opens, the file writes to the chosen location and opens correctly; same for Export Excel
- Repeated on Inbound Shipments, per the issue's repro steps
- Printed a report from the same screen: the Android print dialog opens with the rendered document, and cancelling it is a no-op rather than an error
- On the login screen (no session), used "save log" and confirmed the saved file contains the running server's log rather than being empty
- Confirmed the old UI still saves files and scans barcodes, i.e. the `pluginNames` change didn't break the existing bridge injection
