### PR TITLE
e2e: agree the stock filter test-ids across both front ends

### DIFF
--- a/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/DateFilter.tsx
@@ -78,7 +78,9 @@ export const DateFilter = ({
     label: name,
     // Locale-stable handle for e2e; a ranged filter needs one id per end,
     // since both halves share the same urlParameter.
-    textFieldTestId: `filter-input-${urlParameter}${range ? `-${range}` : ''}`,
+    textFieldTestId: `filter-input-${filterDefinition.testId ?? urlParameter}${
+      range ? `-${range}` : ''
+    }`,
     value,
     width: width ? width : FILTER_WIDTH,
     onChange: handleChange,

--- a/client/packages/common/src/ui/components/inputs/Filters/EnumFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/EnumFilter.tsx
@@ -22,6 +22,8 @@ export const EnumFilter: FC<{
   filterDefinition: EnumFilterDefinition;
 }> = ({ filterDefinition }) => {
   const { urlParameter, options, name, isMultiSelect } = filterDefinition;
+  // The e2e test-id stem, which may be overridden away from urlParameter.
+  const testIdStem = filterDefinition.testId ?? urlParameter;
   const { urlQuery, updateQuery } = useUrlQuery();
 
   const rawValue = urlQuery[urlParameter] as string | undefined;
@@ -47,7 +49,7 @@ export const EnumFilter: FC<{
 
     return (
       <Select
-        data-testid={`filter-input-${urlParameter}`}
+        data-testid={`filter-input-${testIdStem}`}
         options={optionsWithTestIds}
         label={name}
         value={selectedValues}
@@ -91,7 +93,7 @@ export const EnumFilter: FC<{
 
   return (
     <Select
-      data-testid={`filter-input-${urlParameter}`}
+      data-testid={`filter-input-${testIdStem}`}
       options={optionsWithTestIds}
       placeholder={name}
       sx={{ ...FilterLabelSx, width: FILTER_WIDTH }}

--- a/client/packages/common/src/ui/components/inputs/Filters/FilterMenu.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/FilterMenu.tsx
@@ -25,12 +25,25 @@ export interface FilterDefinitionCommon {
   name: string;
   urlParameter: string;
   isDefault?: boolean;
+  /**
+   * Overrides the `filter-option-*` / `filter-input-*` test-id stem, which
+   * otherwise derives from `urlParameter` (or, for a group, its name).
+   *
+   * The cross-front-end e2e suites locate filters by these ids, so the id is a
+   * shared contract rather than an implementation detail. A nested filter's
+   * `urlParameter` carries its GraphQL path (`location.codeOrName`), which the
+   * other front end has no reason to match; set this to the filter's own name
+   * so both sides agree. See `e2e/TESTIDS.md` in open-msupply-frontend.
+   */
+  testId?: string;
 }
 
 export interface GroupFilterDefinition {
   type: 'group';
   name: string;
   elements: FilterDefinition[];
+  /** See `FilterDefinitionCommon.testId`. */
+  testId?: string;
 }
 
 export type FilterDefinition =
@@ -135,9 +148,10 @@ export const FilterMenu = ({ filters }: FilterDefinitions) => {
                   : option.value.urlParameter
               }
               testId={`filter-option-${
-                option.value.type === 'group'
+                option.value.testId ??
+                (option.value.type === 'group'
                   ? option.value.name.toLowerCase().replace(/\s+/g, '-')
-                  : option.value.urlParameter
+                  : option.value.urlParameter)
               }`}
               onClick={() => handleSelect(option.value)}
               label={option.label}
@@ -166,7 +180,11 @@ const FilterMenuItem = ({
   label: string;
   testId?: string;
 }) => (
-  <DropdownMenuItem data-testid={testId} onClick={onClick} sx={{ fontSize: 14 }}>
+  <DropdownMenuItem
+    data-testid={testId}
+    onClick={onClick}
+    sx={{ fontSize: 14 }}
+  >
     {label}
   </DropdownMenuItem>
 );

--- a/client/packages/common/src/ui/components/inputs/Filters/TextFilter.tsx
+++ b/client/packages/common/src/ui/components/inputs/Filters/TextFilter.tsx
@@ -42,7 +42,9 @@ export const TextFilter: FC<{
   return (
     <BasicTextInput
       inputProps={{
-        'data-testid': `filter-input-${filterDefinition.urlParameter}`,
+        'data-testid': `filter-input-${
+          filterDefinition.testId ?? filterDefinition.urlParameter
+        }`,
       }}
       slotProps={{
         input: {

--- a/client/packages/system/src/Stock/Components/Repack/RepackEditForm.tsx
+++ b/client/packages/system/src/Stock/Components/Repack/RepackEditForm.tsx
@@ -145,6 +145,7 @@ export const RepackEditForm = ({
             <InputWithLabelRow
               label={t('label.new-location')}
               labelWidth="100%"
+              testId="repack-new-location"
               Input={
                 <LocationSearchInput
                   autoFocus={false}

--- a/client/packages/system/src/Stock/Components/StockLineForm.tsx
+++ b/client/packages/system/src/Stock/Components/StockLineForm.tsx
@@ -139,7 +139,11 @@ export const StockLineForm = ({
       <Grid container direction="column">
         {isInvalidLocation && (
           <Grid container justifyContent="center">
-            <Alert severity="warning" sx={{ maxWidth: 800 }}>
+            <Alert
+              severity="warning"
+              sx={{ maxWidth: 800 }}
+              data-testid="invalid-location-warning"
+            >
               {t('messages.stock-location-invalid')}
             </Alert>
           </Grid>

--- a/client/packages/system/src/Stock/ListView/Toolbar.tsx
+++ b/client/packages/system/src/Stock/ListView/Toolbar.tsx
@@ -46,6 +46,8 @@ export const Toolbar = ({ isGrouped }: { isGrouped: boolean }) => {
           type: 'enum',
           name: t('label.master-list'),
           urlParameter: 'masterList.id',
+          // Shared e2e id: the filter's own name, not its GraphQL path.
+          testId: 'masterList',
           options: masterLists.nodes.map(ml => ({
             label: ml.name,
             value: ml.id,
@@ -73,11 +75,16 @@ export const Toolbar = ({ isGrouped }: { isGrouped: boolean }) => {
       type: 'text',
       name: t('label.location'),
       urlParameter: 'location.codeOrName',
+      // Shared e2e id: the filter's own name, not its GraphQL path.
+      testId: 'location',
       placeholder: t('placeholder.search-by-location-code-or-name'),
     },
     {
       type: 'group',
       name: t('label.expiry'),
+      // Shared e2e id: the group entry would otherwise derive from the
+      // translated group name, which the other front end cannot match.
+      testId: 'expiryDate',
       elements: [
         {
           type: 'date',


### PR DESCRIPTION
Follow-up to #12583, which landed the bulk of the stock test-ids. Driving both front ends through the stock list turned up a gap #12583 does not cover.

## The problem

The cross-front-end stock suite locates filters by test-id. Both front ends emit `filter-option-<x>` / `filter-input-<x>`, each derived from **its own** filter parameter key — and four of five disagree:

| Filter      | open-msupply          | open-msupply-frontend |
| ----------- | --------------------- | --------------------- |
| Master list | `masterList.id`       | `masterList`          |
| Location    | `location.codeOrName` | `location`            |
| Expiry      | `expiry` (group name) | `expiryDate`          |
| VVM status  | `vvmStatusId`         | `vvmStatusId` ✅       |

Two distinct causes. A nested filter's `urlParameter` carries its GraphQL path, which the other front end has no reason to match. And a **group** entry derives its id from the group's *translated* name, which the other front end cannot match at all.

`OMS-REG-INV-02.4`–`.7`, `.22`, `.23` and `OMS-REG-INV-06.13` are all driven through these controls. A suite written against either app's ids passes there and fails on the other, and the tempting fix is to skip the test — which silently drops seven behaviours from the regression contract.

## The change

`FilterDefinitionCommon` and `GroupFilterDefinition` take an optional `testId` that overrides the id stem. It is **opt-in and the derived default is unchanged**, so no other vertical's filter ids move. Stock's toolbar then sets the three that disagree to the filter's own name — the id becomes a property of the filter rather than of its GraphQL path.

Also adds two ids the suite drives that #12583 missed:

- `repack-new-location` — the repack modal's New location picker
- `invalid-location-warning` — the invalid-location alert on the stock line form

## Verification

`tsc --project packages/host/tsconfig.json --noEmit` reports **no new errors**.

Two pre-existing conditions on `develop`, neither caused by this PR — both confirmed by re-running with these changes stashed:

- `Switch.tsx(120,30)` fails tsc (`data-testid` not assignable to `InputHTMLAttributes`).
- `Stock/ListView/Toolbar.tsx` already fails `prettier --check`. Running `--write` reformats ~60 unrelated lines, so it is deliberately left alone rather than reformatted inside a test-ids change.

## Not included

`cancel-button` was considered and dropped. The stock footer already emits the shared `dialog-button-cancel` / `dialog-button-close` via `DialogButton`, so the other front end will conform to that instead of a second id being added here. The variant swap is itself what `OMS-REG-INV-02.34` ("the footer reads Close while clean") asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)