### PR TITLE
Sync modal: test ids for the cross-front-end e2e suite

### DIFF
--- a/client/packages/common/src/ui/components/steppers/HorizontalStepper/HorizontalStepper.tsx
+++ b/client/packages/common/src/ui/components/steppers/HorizontalStepper/HorizontalStepper.tsx
@@ -21,6 +21,12 @@ export interface StepDefinition {
   icon?: React.ReactNode;
   label: string;
   optional?: React.ReactNode;
+  /**
+   * Locale-stable test hook for this step, on the label. The Step element's
+   * own data-testid carries the active/completed state and is not unique, so
+   * identifying a particular step needs its own id.
+   */
+  testId?: string;
 }
 
 export type StepperColour = 'primary' | 'secondary';
@@ -256,6 +262,7 @@ export const HorizontalStepper = ({
                   justifyContent="center"
                 >
                   <Typography
+                    data-testid={step.testId}
                     sx={getLabelStyle(colour, completed, error, nowrap)}
                     variant="body2"
                     fontSize="12px"

--- a/client/packages/host/src/components/Sync/SyncModal.tsx
+++ b/client/packages/host/src/components/Sync/SyncModal.tsx
@@ -210,6 +210,7 @@ export const SyncModal = ({ onCancel, open, width = 900 }: SyncModalProps) => {
           onClick={onCancel}
           sx={{ position: 'absolute', right: 0, top: 0, padding: 2 }}
           label={t('button.close')}
+          testId="sync-modal-close"
         />
 
         <Box
@@ -225,7 +226,11 @@ export const SyncModal = ({ onCancel, open, width = 900 }: SyncModalProps) => {
           })}
           flexWrap="nowrap"
         >
-          <Typography textAlign="center" marginBottom="10">
+          <Typography
+            textAlign="center"
+            marginBottom="10"
+            data-testid="sync-status-line"
+          >
             {getSyncStatusMessage()}
           </Typography>
           {syncStatus && (
@@ -250,6 +255,7 @@ export const SyncModal = ({ onCancel, open, width = 900 }: SyncModalProps) => {
             icon={
               <CheckCircleIcon fontSize="small" sx={{ color: 'gray.dark' }} />
             }
+            data-testid="sync-last-successful"
           >
             {lastSuccessfulSyncMessage(
               latestSuccessfulSyncDate,
@@ -268,6 +274,7 @@ export const SyncModal = ({ onCancel, open, width = 900 }: SyncModalProps) => {
             disabled={false}
             onClick={sync}
             label={t('button.sync-now')}
+            data-testid="sync-now-button"
             sx={theme => ({
               marginRight: 1,
               color: theme.palette.common.white,

--- a/client/packages/host/src/components/SyncProgress/SyncProgress.tsx
+++ b/client/packages/host/src/components/SyncProgress/SyncProgress.tsx
@@ -85,7 +85,9 @@ export const SyncProgress: FC<SyncProgressProps> = ({
   return (
     <Box display="flex" flexDirection={'column'} alignItems="center">
       {!isExtraSmallScreen && (
-        <HorizontalStepper steps={steps} colour={colour} />
+        <Box width="100%" data-testid="sync-phases">
+          <HorizontalStepper steps={steps} colour={colour} />
+        </Box>
       )}
       {isSyncStatusV7(syncStatus) &&
         syncStatus.linkedDescriptions.length > 0 && (
@@ -112,9 +114,7 @@ const getStepElapsed = (
   if (!progress?.started) return undefined;
   const startMs = new Date(progress.started).getTime();
   if (!Number.isFinite(startMs)) return undefined;
-  const endMs = progress.finished
-    ? new Date(progress.finished).getTime()
-    : now;
+  const endMs = progress.finished ? new Date(progress.finished).getTime() : now;
 
   // Compute directly from the elapsed milliseconds so that durations over a day
   // fold into the hours field rather than being dropped (a long initial sync on
@@ -227,6 +227,12 @@ type RawStep = {
   icon: React.ReactNode;
 };
 
+// Locale-stable per-phase test hook, derived from the phase's locale key
+// ('sync-status.pull-central' -> 'sync-phase-pull-central') so the id can't
+// drift from the phase it marks.
+const phaseTestId = (labelKey: LocaleKey): string =>
+  `sync-phase-${labelKey.replace(/^sync-status\./, '')}`;
+
 const toStepDefinition = (
   t: TypedTFunction<LocaleKey>,
   colour: StepperColour,
@@ -257,6 +263,7 @@ const toStepDefinition = (
     error: isActiveAndError,
     icon: isActiveAndError ? <AlertIcon sx={{ color: 'error.main' }} /> : icon,
     label: t(labelKey),
+    testId: phaseTestId(labelKey),
     optional: (
       <ProgressIndicator
         progress={progress}


### PR DESCRIPTION
Test ids only — no behaviour change, no styling change.

The deterministic **sync-modal regression suite** is defined in
[open-msupply-frontend](https://github.com/msupply-foundation/open-msupply-frontend)
(`e2e/`, contract in `e2e/TESTIDS.md`) and runs unchanged against _both_ front
ends, so this app needs the same hooks the rewrite exposes. Paired PR (the
suite + the contract entries): **[open-msupply-frontend#810](https://github.com/msupply-foundation/open-msupply-frontend/pull/810)**

Three PRs land this one suite — this is the set:

| PR                                                                                                | repo         | what it carries                                                                       |
| ------------------------------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------- |
| [open-msupply-frontend#810](https://github.com/msupply-foundation/open-msupply-frontend/pull/810) | frontend     | the suite itself, the `TESTIDS.md` contract entries, and the rewrite's own hooks      |
| **this PR (#12596)**                                                                              | open-msupply | the same hooks on the current app — the nightly's current-app leg is red without it   |
| [#12600](https://github.com/msupply-foundation/open-msupply/pull/12600)                           | open-msupply | the harness's server-role pin — the suite's triggering tests record no run without it |

Independent of each other; #810 needs both merged (in any order) before the
nightly's current-app leg goes green.

| id                     | element                                                                                         |
| ---------------------- | ----------------------------------------------------------------------------------------------- |
| `sync-modal-close`     | the modal's close `IconButton`                                                                  |
| `sync-status-line`     | the single precedence status line (syncing / count / nothing to push)                           |
| `sync-phases`          | the phase-list container                                                                        |
| `sync-phase-<phase>`   | one phase, derived from its locale key (`sync-status.pull-central` → `sync-phase-pull-central`) |
| `sync-last-successful` | the last-successful-sync notice                                                                 |
| `sync-now-button`      | the Sync-now trigger                                                                            |

Two notes for review:

- **Why `HorizontalStepper` gains a `testId` on `StepDefinition`.** The `Step`
  element's own `data-testid` carries `active`/`completed` state and is not
  unique, so identifying a _particular_ phase needs an id of its own. It goes on
  the label `Typography`, opt-in per step — every existing caller is unchanged.
- **Ids are derived, not literal.** `SyncProgress` maps each phase's locale key
  to its id, so a phase can't end up wearing another phase's id.
  `sync-now-button` survives the busy flip because `LoadingButton` spreads
  `...rest` in both branches.

Verified: `tsc --noEmit` on `packages/host` (the one pre-existing `Switch.tsx`
error is untouched), and the suite runs green against this app on the hermetic
stack — 14/14, `bash playwright/scripts/run-e2e.sh sync-modal-regression`.
