### PR TITLE
Replace workflow PATs with tmf-ci-bot GitHub App tokens

### DIFF
--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -87,6 +87,7 @@ jobs:
           private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply-frontend
+          permission-contents: read
 
       - name: Build Android App
         working-directory: client

--- a/.github/workflows/build-android-apk.yaml
+++ b/.github/workflows/build-android-apk.yaml
@@ -83,8 +83,8 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: fe-token
         with:
-          client-id: ${{ vars.FE_APP_ID }}
-          private-key: ${{ secrets.FE_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply-frontend
 

--- a/.github/workflows/build-mac-demo.yaml
+++ b/.github/workflows/build-mac-demo.yaml
@@ -49,6 +49,7 @@ jobs:
           private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply-frontend
+          permission-contents: read
       - name: Build
         run: ./build/mac/build.sh ${{ inputs.architecture }} ${{ inputs.includeDemoData }}
         env:

--- a/.github/workflows/build-mac-demo.yaml
+++ b/.github/workflows/build-mac-demo.yaml
@@ -45,8 +45,8 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: fe-token
         with:
-          client-id: ${{ vars.FE_APP_ID }}
-          private-key: ${{ secrets.FE_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply-frontend
       - name: Build

--- a/.github/workflows/build-windows-installers.yaml
+++ b/.github/workflows/build-windows-installers.yaml
@@ -89,6 +89,7 @@ jobs:
           private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply-frontend
+          permission-contents: read
 
       # omSupply\ is the staging dir the .suf projects package from
       # (#PROJECTFILEDIR# in their Source paths), so the sufs, adjustSUFs.js,

--- a/.github/workflows/build-windows-installers.yaml
+++ b/.github/workflows/build-windows-installers.yaml
@@ -85,8 +85,8 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: fe-token
         with:
-          client-id: ${{ vars.FE_APP_ID }}
-          private-key: ${{ secrets.FE_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply-frontend
 

--- a/.github/workflows/bump-frontend-pin.yaml
+++ b/.github/workflows/bump-frontend-pin.yaml
@@ -10,12 +10,11 @@ name: Bump frontend pin
 # again, restore the rolling-PR step (git history of this file, or
 # open-msupply-frontend#401 / #12523).
 #
-# Auth: the FE repo is private — reading its releases reuses the same
-# GitHub App (FE_APP_ID / FE_APP_PRIVATE_KEY) the packaging workflows
-# use to fetch the dist. The commit is pushed with
-# NIGHTLY_BUILD_GITHUB_PAT; develop's protection requires PR reviews,
-# so that PAT's account must be allowed to bypass them (repo admin, or
-# on the branch-protection bypass list).
+# Auth: one token minted from the tmf-ci-bot GitHub App (the same app
+# the packaging workflows use), scoped to this repo plus the private FE
+# repo — it reads FE releases and pushes the pin commit. develop's
+# protection requires PR reviews, so tmf-ci-bot must be on the
+# branch-protection bypass list.
 
 on:
   schedule:
@@ -34,24 +33,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Mint tmf-ci-bot token
+        uses: actions/create-github-app-token@v3
+        id: bot-token
+        with:
+          client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
+          owner: msupply-foundation
+          repositories: open-msupply,open-msupply-frontend
+
       - uses: actions/checkout@v5
         with:
           ref: develop
-          token: ${{ secrets.NIGHTLY_BUILD_GITHUB_PAT }}
-
-      - name: Mint token for the frontend repo
-        uses: actions/create-github-app-token@v3
-        id: fe-token
-        with:
-          client-id: ${{ vars.FE_APP_ID }}
-          private-key: ${{ secrets.FE_APP_PRIVATE_KEY }}
-          owner: msupply-foundation
-          repositories: open-msupply-frontend
+          token: ${{ steps.bot-token.outputs.token }}
 
       - name: Compare latest FE release with the pin
         id: check
         env:
-          GH_TOKEN: ${{ steps.fe-token.outputs.token }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
         run: |
           # `gh release view` with no tag resolves the latest
           # non-prerelease release; empty while only -rc releases exist.
@@ -72,7 +71,7 @@ jobs:
       - name: Verify sha256 and update frontend-version.json
         if: steps.check.outputs.bump == 'true'
         env:
-          GH_TOKEN: ${{ steps.fe-token.outputs.token }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
           TAG: ${{ steps.check.outputs.latest }}
         run: |
           gh release download "$TAG" --repo "$FE_REPO" --dir /tmp/fe-dist \

--- a/.github/workflows/bump-frontend-pin.yaml
+++ b/.github/workflows/bump-frontend-pin.yaml
@@ -10,11 +10,12 @@ name: Bump frontend pin
 # again, restore the rolling-PR step (git history of this file, or
 # open-msupply-frontend#401 / #12523).
 #
-# Auth: one token minted from the tmf-ci-bot GitHub App (the same app
-# the packaging workflows use), scoped to this repo plus the private FE
-# repo — it reads FE releases and pushes the pin commit. develop's
-# protection requires PR reviews, so tmf-ci-bot must be on the
-# branch-protection bypass list.
+# Auth: two tokens, both minted from the tmf-ci-bot GitHub App (the
+# same app the packaging workflows use) — one read-only on the private
+# FE repo to read its releases, one with write on this repo to push the
+# pin commit. Kept separate so reading a release never needs write on
+# the FE repo. develop's protection requires PR reviews, so tmf-ci-bot
+# must be on the branch-protection bypass list.
 
 on:
   schedule:
@@ -33,14 +34,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Mint tmf-ci-bot token
+      - name: Mint tmf-ci-bot token for the frontend repo
+        uses: actions/create-github-app-token@v3
+        id: fe-token
+        with:
+          client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
+          owner: msupply-foundation
+          repositories: open-msupply-frontend
+          permission-contents: read
+
+      - name: Mint tmf-ci-bot token for this repo
         uses: actions/create-github-app-token@v3
         id: bot-token
         with:
           client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
           private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
-          repositories: open-msupply,open-msupply-frontend
+          repositories: open-msupply
+          permission-contents: write
 
       - uses: actions/checkout@v5
         with:
@@ -50,7 +62,7 @@ jobs:
       - name: Compare latest FE release with the pin
         id: check
         env:
-          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          GH_TOKEN: ${{ steps.fe-token.outputs.token }}
         run: |
           # `gh release view` with no tag resolves the latest
           # non-prerelease release; empty while only -rc releases exist.
@@ -71,7 +83,7 @@ jobs:
       - name: Verify sha256 and update frontend-version.json
         if: steps.check.outputs.bump == 'true'
         env:
-          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
+          GH_TOKEN: ${{ steps.fe-token.outputs.token }}
           TAG: ${{ steps.check.outputs.latest }}
         run: |
           gh release download "$TAG" --repo "$FE_REPO" --dir /tmp/fe-dist \

--- a/.github/workflows/dockerise.yaml
+++ b/.github/workflows/dockerise.yaml
@@ -97,8 +97,8 @@ jobs:
       # New FE served at / : fetch the pinned, checksum-verified dist host-side (no
       # network fetch inside docker build) and ship it into the image as files.
       # The FE repo is private and GITHUB_TOKEN only grants this repo, so a
-      # short-lived token is minted from the same GitHub App the e2e workflow uses
-      # to read open-msupply-frontend (vars.FE_APP_ID / secrets.FE_APP_PRIVATE_KEY —
+      # short-lived token is minted from the tmf-ci-bot GitHub App
+      # (vars.TMF_CI_BOT_APP_ID / secrets.TMF_CI_BOT_PRIVATE_KEY —
       # no PAT to expire or rotate). Until the FE repo cuts a release the pin is a placeholder
       # and this step fails loudly (matching the mac build's "wrong FE at / is worse
       # than a loud failure" stance); nightly tags will fail here until the pin is
@@ -108,8 +108,8 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: fe-token
         with:
-          client-id: ${{ vars.FE_APP_ID }}
-          private-key: ${{ secrets.FE_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply-frontend
 
@@ -315,4 +315,4 @@ jobs:
     with:
       image_tag: ${{ needs.dockerise.outputs.image_tag }}-dev
     secrets:
-      ORG_WORKFLOW_TOKEN: ${{ secrets.ORG_WORKFLOW_TOKEN }}
+      TMF_CI_BOT_PRIVATE_KEY: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}

--- a/.github/workflows/dockerise.yaml
+++ b/.github/workflows/dockerise.yaml
@@ -112,6 +112,7 @@ jobs:
           private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply-frontend
+          permission-contents: read
 
       - name: Fetch new frontend (pinned dist)
         env:

--- a/.github/workflows/generate-database-schema.yaml
+++ b/.github/workflows/generate-database-schema.yaml
@@ -3,9 +3,10 @@ name: Generate Database Schema
 # Generates static database schema documentation using SchemaSpy and publishes
 # it to the open-msupply-database-schema repository (GitHub Pages).
 #
-# Required secret: DATABASE_SCHEMA_REPO_TOKEN
-#   A GitHub Personal Access Token (PAT) with write access to
-#   msupply-foundation/open-msupply-database-schema.
+# Auth: a short-lived token is minted from the tmf-ci-bot GitHub App
+# (vars.TMF_CI_BOT_APP_ID / secrets.TMF_CI_BOT_PRIVATE_KEY), which must be
+# installed on msupply-foundation/open-msupply-database-schema with
+# contents write.
 #
 # The published schema is accessible at:
 #   https://msupply-foundation.github.io/open-msupply-database-schema/<version>/
@@ -104,11 +105,20 @@ jobs:
             -v "$PWD/schemaspy.properties:/schemaspy.properties" \
             schemaspy/schemaspy:latest
 
+      - name: Mint tmf-ci-bot token for the schema repo
+        uses: actions/create-github-app-token@v3
+        id: bot-token
+        with:
+          client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
+          owner: msupply-foundation
+          repositories: open-msupply-database-schema
+
       - name: Publish schema to open-msupply-database-schema
         env:
-          DATABASE_SCHEMA_REPO_TOKEN: ${{ secrets.DATABASE_SCHEMA_REPO_TOKEN }}
+          SCHEMA_REPO_TOKEN: ${{ steps.bot-token.outputs.token }}
         run: |
-          git clone https://x-access-token:${DATABASE_SCHEMA_REPO_TOKEN}@github.com/msupply-foundation/open-msupply-database-schema.git /tmp/schema-repo
+          git clone https://x-access-token:${SCHEMA_REPO_TOKEN}@github.com/msupply-foundation/open-msupply-database-schema.git /tmp/schema-repo
           mkdir -p /tmp/schema-repo/docs/${VERSION}
           cp -r schemaspy/output/. /tmp/schema-repo/docs/${VERSION}/
           cd /tmp/schema-repo

--- a/.github/workflows/generate-database-schema.yaml
+++ b/.github/workflows/generate-database-schema.yaml
@@ -113,6 +113,7 @@ jobs:
           private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply-database-schema
+          permission-contents: write
 
       - name: Publish schema to open-msupply-database-schema
         env:

--- a/.github/workflows/get_team_assign_label_milestone.yaml
+++ b/.github/workflows/get_team_assign_label_milestone.yaml
@@ -4,6 +4,11 @@ on:
   issues:
     types: [assigned, unassigned]
 
+# Labelling and milestone work uses the tmf-ci-bot token minted below;
+# GITHUB_TOKEN is only used by actions/checkout.
+permissions:
+  contents: read
+
 jobs:
   assign-team-labels:
     runs-on: ubuntu-latest
@@ -20,6 +25,8 @@ jobs:
           private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply
+          permission-issues: write
+          permission-members: read
 
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/get_team_assign_label_milestone.yaml
+++ b/.github/workflows/get_team_assign_label_milestone.yaml
@@ -7,11 +7,20 @@ on:
 jobs:
   assign-team-labels:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      contents: read
 
     steps:
+      # The script reads org team membership, which GITHUB_TOKEN can't do —
+      # mint a token from the tmf-ci-bot GitHub App (org Members: read,
+      # plus issues write on this repo).
+      - name: Mint tmf-ci-bot token
+        uses: actions/create-github-app-token@v3
+        id: bot-token
+        with:
+          client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
+          owner: msupply-foundation
+          repositories: open-msupply
+
       - name: Checkout repository
         uses: actions/checkout@v5
 
@@ -27,6 +36,6 @@ jobs:
       - name: Run team label assignment script
         run: python .github/scripts/get_team_assign_label_milestone.py
         env:
-          GITHUB_TOKEN: ${{ secrets.ASSIGN_TEAM_LABEL_AND_MILESTONE }}
+          GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/integrate-rc-to-develop.yaml
+++ b/.github/workflows/integrate-rc-to-develop.yaml
@@ -8,14 +8,22 @@ on:
 jobs:
   integrate-rc-to-develop:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
+      # Branches pushed / PRs opened with the workflow's own GITHUB_TOKEN
+      # would not trigger CI on the resulting PR, so use an app-minted token.
+      - name: Mint tmf-ci-bot token
+        uses: actions/create-github-app-token@v3
+        id: bot-token
+        with:
+          client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
+          owner: msupply-foundation
+          repositories: open-msupply
+
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.NIGHTLY_BUILD_GITHUB_PAT }}
+          token: ${{ steps.bot-token.outputs.token }}
 
       - name: Configure Git
         run: |
@@ -24,5 +32,5 @@ jobs:
 
       - name: Integrate RC to Develop
         env:
-          GITHUB_TOKEN: ${{ secrets.NIGHTLY_BUILD_GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
         run: bash .github/scripts/integrate-rc-to-develop.sh

--- a/.github/workflows/integrate-rc-to-develop.yaml
+++ b/.github/workflows/integrate-rc-to-develop.yaml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: "0 8 * * *" # Every day at 08:00 AM UTC - equivalent to 08:00 PM NZST (or 09:00 PM NZDT)
 
+# Privileged work (pushing branches, opening the PR) uses the tmf-ci-bot
+# token minted below; GITHUB_TOKEN needs nothing beyond read.
+permissions:
+  contents: read
+
 jobs:
   integrate-rc-to-develop:
     runs-on: ubuntu-latest
@@ -19,6 +24,8 @@ jobs:
           private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/nightly-automated-builds.yaml
+++ b/.github/workflows/nightly-automated-builds.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "30 6 * * *" # Every day at 06:30 AM UTC - equivalent to 06:30 PM NZST (or 07:30 PM NZDT)
 
+# Privileged work (pushing tags) uses the tmf-ci-bot token minted below;
+# GITHUB_TOKEN only ever needs to read this repo for checkout.
+permissions:
+  contents: read
+
 jobs:
   create-tags:
     runs-on: ubuntu-latest
@@ -22,6 +27,7 @@ jobs:
           private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply
+          permission-contents: write
 
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/nightly-automated-builds.yaml
+++ b/.github/workflows/nightly-automated-builds.yaml
@@ -7,17 +7,26 @@ on:
 jobs:
   create-tags:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     outputs:
       CREATED_TAGS: ${{ steps.create_tags.outputs.CREATED_TAGS }}
       AFFECTED_BRANCHES: ${{ steps.create_tags.outputs.AFFECTED_BRANCHES }}
       HAS_TAGS: ${{ steps.create_tags.outputs.HAS_TAGS }}
     steps:
+      # Tags pushed with the workflow's own GITHUB_TOKEN would not trigger
+      # the tag-driven build workflows, so push with an app-minted token.
+      - name: Mint tmf-ci-bot token
+        uses: actions/create-github-app-token@v3
+        id: bot-token
+        with:
+          client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
+          owner: msupply-foundation
+          repositories: open-msupply
+
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.NIGHTLY_BUILD_GITHUB_PAT }}
+          token: ${{ steps.bot-token.outputs.token }}
 
       - name: Configure Git
         run: |

--- a/.github/workflows/server-build.yaml
+++ b/.github/workflows/server-build.yaml
@@ -20,8 +20,8 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: fe-token
         with:
-          client-id: ${{ vars.FE_APP_ID }}
-          private-key: ${{ secrets.FE_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply-frontend
       - name: Build

--- a/.github/workflows/server-build.yaml
+++ b/.github/workflows/server-build.yaml
@@ -24,6 +24,7 @@ jobs:
           private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: open-msupply-frontend
+          permission-contents: read
       - name: Build
         run: ./build/mac/build.sh
         env:

--- a/.github/workflows/trigger-plugin-tests.yaml
+++ b/.github/workflows/trigger-plugin-tests.yaml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
     secrets:
-      ORG_WORKFLOW_TOKEN:
+      TMF_CI_BOT_PRIVATE_KEY:
         required: true
   workflow_dispatch:
     inputs:
@@ -21,6 +21,18 @@ jobs:
   trigger-tests:
     runs-on: ubuntu-latest
     steps:
+      # Dispatching workflows in other repos is beyond GITHUB_TOKEN's scope,
+      # so mint a token from the tmf-ci-bot GitHub App (needs actions write
+      # on the target repos). Keep `repositories` in sync with REPOS below.
+      - name: Mint tmf-ci-bot token
+        uses: actions/create-github-app-token@v3
+        id: bot-token
+        with:
+          client-id: ${{ vars.TMF_CI_BOT_APP_ID }}
+          private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
+          owner: msupply-foundation
+          repositories: sao-tome-plugins
+
       - name: Trigger tests in plugin repositories
         run: |
           # List of repositories to trigger tests in
@@ -34,7 +46,7 @@ jobs:
             
             curl -X POST \
               -H "Accept: application/vnd.github.v3+json" \
-              -H "Authorization: token ${{ secrets.ORG_WORKFLOW_TOKEN }}" \
+              -H "Authorization: token ${{ steps.bot-token.outputs.token }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/$repo/actions/workflows/test.yml/dispatches \
               -d '{

--- a/.github/workflows/trigger-plugin-tests.yaml
+++ b/.github/workflows/trigger-plugin-tests.yaml
@@ -32,31 +32,32 @@ jobs:
           private-key: ${{ secrets.TMF_CI_BOT_PRIVATE_KEY }}
           owner: msupply-foundation
           repositories: sao-tome-plugins
+          permission-actions: write
 
       - name: Trigger tests in plugin repositories
+        env:
+          BOT_TOKEN: ${{ steps.bot-token.outputs.token }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
           # List of repositories to trigger tests in
           REPOS=(
             "msupply-foundation/sao-tome-plugins"
             # Add more repositories as needed
           )
-          
+
           for repo in "${REPOS[@]}"; do
-            echo "Triggering test workflow in $repo with image tag: ${{ inputs.image_tag }}"
-            
-            curl -X POST \
+            echo "Triggering test workflow in $repo with image tag: $IMAGE_TAG"
+
+            # --fail-with-body so a repo the token can't reach (404) fails the
+            # step instead of passing silently — see the `repositories` note above.
+            curl --fail-with-body -sS -X POST \
               -H "Accept: application/vnd.github.v3+json" \
-              -H "Authorization: token ${{ steps.bot-token.outputs.token }}" \
+              -H "Authorization: Bearer $BOT_TOKEN" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/$repo/actions/workflows/test.yml/dispatches \
-              -d '{
-                "ref": "main",
-                "inputs": {
-                  "image_tag": "${{ inputs.image_tag }}",
-                  "branch": "Tests"
-                }
-              }'
-            
+              "https://api.github.com/repos/$repo/actions/workflows/test.yml/dispatches" \
+              -d "$(jq -n --arg image_tag "$IMAGE_TAG" \
+                    '{ref: "main", inputs: {image_tag: $image_tag, branch: "Tests"}}')"
+
             # Add a small delay between requests to avoid rate limiting
             sleep 2
           done

--- a/docs/content/docker/_index.md
+++ b/docs/content/docker/_index.md
@@ -124,7 +124,7 @@ Run `bash .github/scripts/cleanup-docker-tags.sh --help` for all options.
 ### Requirements
 
 - Docker Hub credentials must be configured as repository secrets: `DOCKER_USERNAME` and `DOCKER_TOKEN`
-- The `ORG_WORKFLOW_TOKEN` secret is needed for triggering downstream plugin tests
+- The tmf-ci-bot GitHub App credentials (`TMF_CI_BOT_APP_ID` variable and `TMF_CI_BOT_PRIVATE_KEY` secret) are needed for triggering downstream plugin tests
 
 ### Testing the workflow
 

--- a/server/README.md
+++ b/server/README.md
@@ -39,10 +39,10 @@ packaged bundle serves both UIs out of the box.
 - **Private-repo token:** the fetch needs `FRONTEND_FETCH_TOKEN` (or `GITHUB_TOKEN`) with
   read access to the FE repo's release assets — it is sent as an `Authorization: token …`
   header to github.com and dropped when GitHub redirects to its signed asset CDN. GitHub
-  Actions workflows (Docker image, transition APK, mac builds) mint a short-lived token
-  per run from the same GitHub App the e2e workflow uses to read the FE repo
-  (`vars.FE_APP_ID` / `secrets.FE_APP_PRIVATE_KEY`) — nothing to configure beyond the
-  app. The Jenkins/Windows box cannot mint app tokens: set
+  Actions workflows (Docker image, transition APK, mac builds) mint a short-lived,
+  read-only token per run from the tmf-ci-bot GitHub App
+  (`vars.TMF_CI_BOT_APP_ID` / `secrets.TMF_CI_BOT_PRIVATE_KEY`) — nothing to configure
+  beyond the app. The Jenkins/Windows box cannot mint app tokens: set
   `FRONTEND_DIST_BASE_URL=https://f002.backblazeb2.com/file/msupply-releases` once —
   the FE release workflow mirrors every dist there (public bucket, layout
   `<tag>/frontend-dist-<tag>.zip`), the script derives the URL from the pin's tag, and


### PR DESCRIPTION
> [!NOTE]
> No linked issue — this came out of an auth review of the workflows.

# 👩🏻‍💻 What does this PR do?

Removes all four personal access tokens from GitHub Actions and replaces them with short-lived tokens minted from the **tmf-ci-bot** GitHub App (the former frontend-fetch app, renamed and given wider permissions). App tokens keep the behaviours the PATs were covering — pushed tags/PRs still trigger downstream workflows, cross-repo access still works, and the branch-protection bypass moves from a personal account to the app — with nothing to expire, rotate, or tie to an individual's account.

PATs removed and what replaces them:

| Old PAT | Workflows | App token scope |
|---|---|---|
| `NIGHTLY_BUILD_GITHUB_PAT` | nightly-automated-builds, integrate-rc-to-develop, bump-frontend-pin | this repo (bump also reads the FE repo) |
| `DATABASE_SCHEMA_REPO_TOKEN` | generate-database-schema | open-msupply-database-schema |
| `ORG_WORKFLOW_TOKEN` | trigger-plugin-tests (called from dockerise) | sao-tome-plugins |
| `ASSIGN_TEAM_LABEL_AND_MILESTONE` | get_team_assign_label_milestone | this repo + org Members: read |

Because tmf-ci-bot is the renamed FE app, the five FE-dist-fetch workflows (dockerise, build-android-apk, build-mac-demo, build-windows-installers, server-build) also move from `FE_APP_ID`/`FE_APP_PRIVATE_KEY` to the renamed `TMF_CI_BOT_APP_ID` variable / `TMF_CI_BOT_PRIVATE_KEY` secret — same app, same key, one name everywhere. bump-frontend-pin previously minted two tokens from what is now one app; it still mints two, but both from tmf-ci-bot — one read-only on the FE repo, one with write on this repo.

## 💌 Any notes for the reviewer?

- **Rollout is sequenced for zero downtime**: the new-name variable/secret already exist alongside the old names, tmf-ci-bot is on develop's required-PR bypass list, and the app installation already covers all target repos (`open-msupply-database-schema`, `sao-tome-plugins`). The old `FE_APP_*` names and the four PATs stay in place until this merges and each workflow is verified, then get deleted.
- Remaining ops steps after merge (not in this diff): verify each workflow, then delete the four PATs and the old `FE_APP_*` names.
- `trigger-plugin-tests.yaml` now takes `TMF_CI_BOT_PRIVATE_KEY` as its `workflow_call` secret and mints its own token; the `repositories:` list on the mint step must be kept in sync with the `REPOS` array when plugin repos are added (commented in the file).
- The `fe-token` step ids in the packaging workflows are unchanged — that step is still "the token that fetches the FE dist", just minted from the renamed app.
- Also updated the secrets note in `docs/content/docker/_index.md`; the [Github Actions wiki page](https://github.com/msupply-foundation/open-msupply/wiki/Github-Actions) will need a matching edit.
- **Every mint step is permission-scoped.** `repositories:` narrows which repos a token covers, not which permissions it carries, so each `create-github-app-token` step passes explicit `permission-*` inputs — the five FE dist fetches get `contents: read`, and nothing else gets more than it uses. A consequence worth knowing: if the app is missing a permission a step asks for, the mint now fails loudly at that step rather than silently over-granting.
- **`trigger-plugin-tests` now fails loudly on an unreachable repo.** The dispatch loop's `curl` gained `--fail-with-body`, so the documented `repositories:`/`REPOS` drift becomes a failed step instead of a silently-ignored 404. Adding a plugin repo to `REPOS` without adding it to `repositories:` will break `dockerise`.
- The three workflows that lost their `permissions:` blocks got them back as `contents: read` at workflow level. Removing a block doesn't zero `GITHUB_TOKEN` — it falls back to the repo default, which is read-write-all unless the org restricts it.

# 🧪 Tested

- All 11 edited workflow files pass YAML parsing.
- Verified no references to the four PAT secret names or `FE_APP_*` remain anywhere in the repo (the first sweep was scoped to `.github/` and `docs/` and missed `server/README.md`, now fixed).
- Not yet executed — every touched workflow with `workflow_dispatch` (nightly-automated-builds, integrate-rc-to-develop, bump-frontend-pin, generate-database-schema, trigger-plugin-tests) can be dispatched against this branch from the Actions tab to verify token minting before/after merge; the tag-triggered packaging workflows get exercised by the next nightly.

# 📃 Documentation

- [ ] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [x] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  - `docs/content/docker/_index.md` secrets requirement and `server/README.md`'s private-repo-token note updated in this PR; wiki page to follow.


