### PR TITLE
e2e harness: pin the server role instead of inheriting it from local.yaml

### DIFF
--- a/client/playwright/scripts/run-e2e.sh
+++ b/client/playwright/scripts/run-e2e.sh
@@ -35,11 +35,29 @@ DB_NAME=e2e_playwright # -> server/e2e_playwright.sqlite (gitignored)
 # server can't try to re-authenticate this throwaway site against a real
 # central on startup (which would panic or overwrite the restored settings).
 # All four must be set together or settings validation rejects the block.
+#
+# The server-role override is pinned for the same reason: it must NOT be
+# inherited from local.yaml. Left unpinned, the stack's sync topology depends
+# on whether the developer happens to set `server.override_is_central_server`
+# — and the two settings behave very differently:
+#
+#   pinned true (here)  the site is its own central, so a sync run is a local
+#                       no-op that SUCCEEDS instantly. Status, phase list,
+#                       last-successful notice and Sync-now are all exercised.
+#   unpinned in CI      settings are "not configured", so the synchroniser
+#                       logs "Sync is disabled, skipping" and NO run is ever
+#                       recorded — every trigger silently does nothing, and
+#                       isCentralServer flips to false (which changes the
+#                       phase-visibility row the modal displays).
+#
+# The sync-modal suite asserts triggering, so it needs runs to happen; every
+# other suite is indifferent. Pin it so local and CI agree.
 SYNC_OFF=(
   APP__SYNC__URL=
   APP__SYNC__USERNAME=
   APP__SYNC__PASSWORD_SHA256=
   APP__SYNC__INTERVAL_SECONDS=0
+  APP__SERVER__OVERRIDE_IS_CENTRAL_SERVER=true
 )
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
One line in `SYNC_OFF`, for the same reason the sync credentials are already
neutralised there: **the hermetic stack's shape should come from the harness,
not from an untracked file.**

Today the stack's sync topology is whatever the developer happens to have in
the gitignored `server/configuration/local.yaml`. The two modes are not
interchangeable:

| `server.override_is_central_server` | what the stack does |
| --- | --- |
| `true` (most dev machines) | the site is its own central — a sync run is a local no-op that **succeeds instantly** |
| unset (**CI**, fresh checkout) | settings read as "not configured": the synchroniser logs `Sync is disabled, skipping`, **no run is ever recorded** (`manualSync` returns `"Sync triggered"` and does nothing), and `isCentralServer` flips to **false**, changing which phase row the sync modal displays |

So a suite that asserts sync triggering can pass on a developer's machine and
fail in CI for a reason nothing in the repo explains. Measured on the reference
datafile, both ways:

```
pinned true   isCentralServer: true,  a successful run on record after a fresh restore
unpinned      isCentralServer: false, "Sync is disabled, skipping" — summary.started never advances
```

The sync-modal regression suite
([open-msupply-frontend#810](https://github.com/msupply-foundation/open-msupply-frontend/pull/810))
is the first to depend on this; every other suite is indifferent, so this is
inert for them. open-msupply-frontend's mirror of this script gets the same
pin in that PR.

Verified: the suite runs **14/14** against this app on the hermetic stack with
the pin, including with `local.yaml` moved aside to reproduce a fresh checkout.

Separate from (and independent of) the test-id PR
[#12596](https://github.com/msupply-foundation/open-msupply/pull/12596).