### PR TITLE
#12568 Close the inbound shipment backend validation gaps

### DIFF
--- a/server/graphql/invoice/src/mutations/inbound_shipment/update.rs
+++ b/server/graphql/invoice/src/mutations/inbound_shipment/update.rs
@@ -233,6 +233,7 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         | ServiceError::CannotMoveReceivedDateForward
         | ServiceError::ExceedsMaximumBackdatingDays
         | ServiceError::CannotSetShippedStatusOnManualInboundShipment
+        | ServiceError::CannotReceiveWithNoLines
         | ServiceError::CurrencyRateMustBePositive
         | ServiceError::UnknownPropertyKey(_) => BadUserInput(formatted_error),
         ServiceError::PreferenceError(_) => InternalError(formatted_error),
@@ -497,6 +498,18 @@ mod test {
 
         //OtherPartyDoesNotExist
         let test_service = TestService(Box::new(|_| Err(ServiceError::OtherPartyDoesNotExist)));
+        let expected_message = "Bad user input";
+        assert_standard_graphql_error!(
+            &settings,
+            &mutation,
+            &Some(empty_variables()),
+            &expected_message,
+            None,
+            Some(service_provider(test_service, &connection_manager))
+        );
+
+        //CannotReceiveWithNoLines
+        let test_service = TestService(Box::new(|_| Err(ServiceError::CannotReceiveWithNoLines)));
         let expected_message = "Bad user input";
         assert_standard_graphql_error!(
             &settings,

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
@@ -194,6 +194,8 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         | ServiceError::LineAlreadyExists
         | ServiceError::NotAStockIn
         | ServiceError::NumberOfPacksBelowZero
+        | ServiceError::SellPricePerPackBelowZero
+        | ServiceError::CostPricePerPackBelowZero
         | ServiceError::PackSizeBelowOne
         | ServiceError::LocationDoesNotExist
         | ServiceError::ItemVariantDoesNotExist

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
@@ -237,6 +237,8 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         ServiceError::NotThisStoreInvoice
         | ServiceError::NotAStockIn
         | ServiceError::NumberOfPacksBelowZero
+        | ServiceError::SellPricePerPackBelowZero
+        | ServiceError::CostPricePerPackBelowZero
         | ServiceError::NotThisInvoiceLine(_)
         | ServiceError::PackSizeBelowOne
         | ServiceError::LocationDoesNotExist

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -1478,6 +1478,31 @@ mod test {
             }
         }
 
+        fn transferred_invoice() -> InvoiceRow {
+            InvoiceRow {
+                id: "delivered_transferred_invoice".to_string(),
+                linked_invoice_id: Some(mock_outbound_shipment_e().id),
+                ..empty_invoice()
+            }
+        }
+
+        /// A line that came over from the sending store's outbound shipment. Even with nothing
+        /// shipped and nothing received it exempts the invoice from the empty check, mirroring
+        /// `validateEmptyInvoice` on the client — the store still needs to close out the transfer.
+        fn transferred_line() -> InvoiceLineRow {
+            InvoiceLineRow {
+                id: "transferred_line".to_string(),
+                invoice_id: transferred_invoice().id,
+                item_id: mock_item_a().id,
+                r#type: InvoiceLineType::StockIn,
+                pack_size: 1.0,
+                number_of_packs: 0.0,
+                shipped_number_of_packs: None,
+                linked_invoice_id: Some(mock_outbound_shipment_e().id),
+                ..Default::default()
+            }
+        }
+
         fn service_line() -> InvoiceLineRow {
             InvoiceLineRow {
                 id: "freight_charge_line".to_string(),
@@ -1499,8 +1524,14 @@ mod test {
                     placeholder_invoice(),
                     nothing_received_invoice(),
                     service_line_invoice(),
+                    transferred_invoice(),
                 ],
-                invoice_lines: vec![placeholder_line(), nothing_received_line(), service_line()],
+                invoice_lines: vec![
+                    placeholder_line(),
+                    nothing_received_line(),
+                    service_line(),
+                    transferred_line(),
+                ],
                 ..Default::default()
             },
         )
@@ -1568,6 +1599,16 @@ mod test {
             .update_inbound_shipment(
                 &context,
                 receive(service_line_invoice().id),
+                InboundShipmentType::InboundShipment,
+            )
+            .is_ok());
+
+        // A transfer can be received even when every line is zero, receiving nothing is how the
+        // store closes out a transfer where nothing arrived
+        assert!(service
+            .update_inbound_shipment(
+                &context,
+                receive(transferred_invoice().id),
                 InboundShipmentType::InboundShipment,
             )
             .is_ok());

--- a/server/service/src/invoice/inbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/inbound_shipment/update/mod.rs
@@ -230,6 +230,7 @@ pub enum UpdateInboundShipmentError {
     CannotMoveReceivedDateForward,
     ExceedsMaximumBackdatingDays,
     CannotReceiveWithPendingLines,
+    CannotReceiveWithNoLines,
     CannotSetShippedStatusOnManualInboundShipment,
     CurrencyRateMustBePositive,
     /// A customFields patch key is not a visible inbound shipment property.
@@ -1412,6 +1413,164 @@ mod test {
             ),
             Err(ServiceError::CannotReceiveWithPendingLines)
         );
+    }
+
+    #[actix_rt::test]
+    async fn update_inbound_shipment_cannot_receive_with_no_lines() {
+        fn empty_invoice() -> InvoiceRow {
+            InvoiceRow {
+                id: "delivered_invoice_with_no_lines".to_string(),
+                name_id: mock_name_a().id,
+                store_id: mock_store_a().id,
+                r#type: InvoiceType::InboundShipment,
+                status: InvoiceStatus::Delivered,
+                ..Default::default()
+            }
+        }
+
+        fn placeholder_invoice() -> InvoiceRow {
+            InvoiceRow {
+                id: "delivered_invoice_with_placeholders".to_string(),
+                ..empty_invoice()
+            }
+        }
+
+        /// Nothing received and nothing shipped, this line receives no stock
+        fn placeholder_line() -> InvoiceLineRow {
+            InvoiceLineRow {
+                id: "placeholder_line".to_string(),
+                invoice_id: placeholder_invoice().id,
+                item_id: mock_item_a().id,
+                r#type: InvoiceLineType::StockIn,
+                pack_size: 1.0,
+                number_of_packs: 0.0,
+                shipped_number_of_packs: None,
+                ..Default::default()
+            }
+        }
+
+        fn nothing_received_invoice() -> InvoiceRow {
+            InvoiceRow {
+                id: "delivered_invoice_nothing_received".to_string(),
+                ..empty_invoice()
+            }
+        }
+
+        /// The supplier said they sent 5 packs but none arrived, this is a real record of a
+        /// discrepancy and must still be receivable
+        fn nothing_received_line() -> InvoiceLineRow {
+            InvoiceLineRow {
+                id: "nothing_received_line".to_string(),
+                invoice_id: nothing_received_invoice().id,
+                item_id: mock_item_a().id,
+                r#type: InvoiceLineType::StockIn,
+                pack_size: 1.0,
+                number_of_packs: 0.0,
+                shipped_number_of_packs: Some(5.0),
+                ..Default::default()
+            }
+        }
+
+        fn service_line_invoice() -> InvoiceRow {
+            InvoiceRow {
+                id: "delivered_invoice_service_line".to_string(),
+                ..empty_invoice()
+            }
+        }
+
+        fn service_line() -> InvoiceLineRow {
+            InvoiceLineRow {
+                id: "freight_charge_line".to_string(),
+                invoice_id: service_line_invoice().id,
+                item_id: mock_item_a().id,
+                r#type: InvoiceLineType::Service,
+                total_before_tax: 10.0,
+                total_after_tax: 10.0,
+                ..Default::default()
+            }
+        }
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "update_inbound_cannot_receive_no_lines",
+            MockDataInserts::all(),
+            MockData {
+                invoices: vec![
+                    empty_invoice(),
+                    placeholder_invoice(),
+                    nothing_received_invoice(),
+                    service_line_invoice(),
+                ],
+                invoice_lines: vec![placeholder_line(), nothing_received_line(), service_line()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+        let service = &service_provider.invoice_service;
+
+        fn receive(id: String) -> UpdateInboundShipment {
+            UpdateInboundShipment {
+                id,
+                status: Some(UpdateInboundShipmentStatus::Received),
+                ..Default::default()
+            }
+        }
+
+        // An invoice with no lines at all can't be received
+        assert_eq!(
+            service.update_inbound_shipment(
+                &context,
+                receive(empty_invoice().id),
+                InboundShipmentType::InboundShipment,
+            ),
+            Err(ServiceError::CannotReceiveWithNoLines)
+        );
+
+        // Nor can it be verified
+        assert_eq!(
+            service.update_inbound_shipment(
+                &context,
+                UpdateInboundShipment {
+                    id: empty_invoice().id,
+                    status: Some(UpdateInboundShipmentStatus::Verified),
+                    ..Default::default()
+                },
+                InboundShipmentType::InboundShipment,
+            ),
+            Err(ServiceError::CannotReceiveWithNoLines)
+        );
+
+        // An invoice whose only lines are placeholders receives no stock, so it's empty too
+        assert_eq!(
+            service.update_inbound_shipment(
+                &context,
+                receive(placeholder_invoice().id),
+                InboundShipmentType::InboundShipment,
+            ),
+            Err(ServiceError::CannotReceiveWithNoLines)
+        );
+
+        // Recording that nothing arrived of what was shipped is a valid receipt
+        assert!(service
+            .update_inbound_shipment(
+                &context,
+                receive(nothing_received_invoice().id),
+                InboundShipmentType::InboundShipment,
+            )
+            .is_ok());
+
+        // A shipment of only service lines (freight and the like) is valid
+        assert!(service
+            .update_inbound_shipment(
+                &context,
+                receive(service_line_invoice().id),
+                InboundShipmentType::InboundShipment,
+            )
+            .is_ok());
     }
 
     #[actix_rt::test]

--- a/server/service/src/invoice/inbound_shipment/update/validate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/validate.rs
@@ -10,8 +10,8 @@ use crate::validate::{
 };
 use chrono::{Duration, Utc};
 use repository::{
-    InvoiceLineRowRepository, InvoiceLineStatus, InvoiceRow, InvoiceStatus, InvoiceType, Name,
-    StorageConnection,
+    InvoiceLineRow, InvoiceLineRowRepository, InvoiceLineStatus, InvoiceLineType, InvoiceRow,
+    InvoiceStatus, InvoiceType, Name, StorageConnection,
 };
 
 use super::{super::InboundShipmentType, UpdateInboundShipment, UpdateInboundShipmentError};
@@ -70,12 +70,9 @@ pub fn validate(
             return Err(CannotSetShippedStatusOnManualInboundShipment);
         }
 
-        // All pending lines must be resolved (accepted or rejected) before the invoice can be
-        // received or verified, otherwise stock would be created for lines that haven't been
-        // reviewed yet.
         use UpdateInboundShipmentStatus::*;
         if matches!(patch.status, Some(Received | Verified)) {
-            check_no_pending_lines(&invoice.id, connection)?;
+            check_lines_can_be_received(&invoice.id, connection)?;
         }
     }
 
@@ -149,18 +146,41 @@ pub fn validate(
     Ok((invoice, Some(other_party), status_changed))
 }
 
-fn check_no_pending_lines(
+/// Checks that the lines of an invoice are in a fit state to be received or verified:
+///
+/// * All pending lines must be resolved (accepted or rejected), otherwise stock would be created
+///   for lines that haven't been reviewed yet.
+/// * The invoice must not be empty. An invoice with no lines at all, or one whose only lines are
+///   placeholders (nothing received and nothing shipped), receives no stock, so confirming it
+///   would produce a finalised but empty shipment.
+fn check_lines_can_be_received(
     invoice_id: &str,
     connection: &StorageConnection,
 ) -> Result<(), UpdateInboundShipmentError> {
     let invoice_lines =
         InvoiceLineRowRepository::new(connection).find_many_by_invoice_id(invoice_id)?;
 
-    for invoice_line in invoice_lines {
+    for invoice_line in &invoice_lines {
         if invoice_line.status == Some(InvoiceLineStatus::Pending) {
             return Err(UpdateInboundShipmentError::CannotReceiveWithPendingLines);
         }
     }
 
+    if invoice_lines.iter().all(is_placeholder_line) {
+        return Err(UpdateInboundShipmentError::CannotReceiveWithNoLines);
+    }
+
     Ok(())
+}
+
+/// A stock in line with nothing received and nothing shipped. It's valid to record "the supplier
+/// said they sent 5 packs but I received 0", which is why shipped packs are checked too. These
+/// are the same lines that `empty_lines_to_trim` deletes when the invoice leaves New status.
+///
+/// Mirrors `validateEmptyInvoice` on the client. Note service lines (freight charges and the
+/// like) are not placeholders, so an invoice of only service lines can still be received.
+fn is_placeholder_line(line: &InvoiceLineRow) -> bool {
+    line.r#type == InvoiceLineType::StockIn
+        && line.number_of_packs == 0.0
+        && line.shipped_number_of_packs.unwrap_or(0.0) == 0.0
 }

--- a/server/service/src/invoice/inbound_shipment/update/validate.rs
+++ b/server/service/src/invoice/inbound_shipment/update/validate.rs
@@ -151,8 +151,12 @@ pub fn validate(
 /// * All pending lines must be resolved (accepted or rejected), otherwise stock would be created
 ///   for lines that haven't been reviewed yet.
 /// * The invoice must not be empty. An invoice with no lines at all, or one whose only lines are
-///   placeholders (nothing received and nothing shipped), receives no stock, so confirming it
-///   would produce a finalised but empty shipment.
+///   manually added placeholders (nothing received and nothing shipped), receives no stock, so
+///   confirming it would produce a finalised but empty shipment. Lines that came from another
+///   store's transfer (`linked_invoice_id` is set) are exempt: receiving zero of everything is a
+///   valid receipt, the store still needs to close out the transfer.
+///
+/// This deliberately mirrors `validateEmptyInvoice` on the client.
 fn check_lines_can_be_received(
     invoice_id: &str,
     connection: &StorageConnection,
@@ -166,7 +170,10 @@ fn check_lines_can_be_received(
         }
     }
 
-    if invoice_lines.iter().all(is_placeholder_line) {
+    if invoice_lines
+        .iter()
+        .all(|line| line.linked_invoice_id.is_none() && is_placeholder_line(line))
+    {
         return Err(UpdateInboundShipmentError::CannotReceiveWithNoLines);
     }
 
@@ -177,7 +184,7 @@ fn check_lines_can_be_received(
 /// said they sent 5 packs but I received 0", which is why shipped packs are checked too. These
 /// are the same lines that `empty_lines_to_trim` deletes when the invoice leaves New status.
 ///
-/// Mirrors `validateEmptyInvoice` on the client. Note service lines (freight charges and the
+/// Mirrors `isInboundPlaceholderRow` on the client. Note service lines (freight charges and the
 /// like) are not placeholders, so an invoice of only service lines can still be received.
 fn is_placeholder_line(line: &InvoiceLineRow) -> bool {
     line.r#type == InvoiceLineType::StockIn

--- a/server/service/src/invoice/validate.rs
+++ b/server/service/src/invoice/validate.rs
@@ -86,6 +86,29 @@ pub fn check_invoice_is_editable(invoice: &InvoiceRow) -> bool {
     false
 }
 
+/// Stricter than [`check_invoice_is_editable`], for editing invoice *lines* rather than the
+/// invoice itself.
+///
+/// Transfer-created inbound shipments and customer returns arrive already in Shipped status and
+/// must still accept status changes (so the receiving store can move them to Delivered), but
+/// their lines are the sending store's record of what was despatched and must not be edited
+/// until the goods are delivered.
+///
+/// Externally-sourced (purchase order) inbounds have no linked invoice and stay editable at
+/// Shipped, so the user can record what the supplier despatched.
+pub fn check_invoice_lines_are_editable(invoice: &InvoiceRow) -> bool {
+    if !check_invoice_is_editable(invoice) {
+        return false;
+    }
+
+    match &invoice.r#type {
+        InvoiceType::InboundShipment | InvoiceType::CustomerReturn => {
+            !(invoice.status == InvoiceStatus::Shipped && invoice.linked_invoice_id.is_some())
+        }
+        _ => true,
+    }
+}
+
 pub enum InvoiceRowStatusError {
     CannotChangeStatusOfInvoiceOnHold,
     CannotReverseInvoiceStatus,
@@ -123,11 +146,31 @@ pub fn check_invoice_exists(
 mod test {
     use repository::{InvoiceRow, InvoiceStatus, InvoiceType};
 
-    use super::check_invoice_is_editable;
+    use super::{check_invoice_is_editable, check_invoice_lines_are_editable};
 
     fn outbound(status: InvoiceStatus) -> InvoiceRow {
         InvoiceRow {
             r#type: InvoiceType::OutboundShipment,
+            status,
+            ..Default::default()
+        }
+    }
+
+    /// An inbound shipment created by a transfer from another store's outbound shipment
+    fn transferred_inbound(status: InvoiceStatus) -> InvoiceRow {
+        InvoiceRow {
+            r#type: InvoiceType::InboundShipment,
+            linked_invoice_id: Some("outbound_shipment_id".to_string()),
+            status,
+            ..Default::default()
+        }
+    }
+
+    /// An inbound shipment raised against a purchase order to an external supplier
+    fn external_inbound(status: InvoiceStatus) -> InvoiceRow {
+        InvoiceRow {
+            r#type: InvoiceType::InboundShipment,
+            purchase_order_id: Some("purchase_order_id".to_string()),
             status,
             ..Default::default()
         }
@@ -152,6 +195,80 @@ mod test {
             assert!(
                 !check_invoice_is_editable(&outbound(status.clone())),
                 "outbound should not be editable at status {:?}",
+                status
+            );
+        }
+    }
+
+    #[test]
+    fn transferred_inbound_lines_are_locked_while_shipped() {
+        // The invoice itself stays editable at Shipped, otherwise the receiving store could
+        // never move the transfer on to Delivered
+        assert!(check_invoice_is_editable(&transferred_inbound(
+            InvoiceStatus::Shipped
+        )));
+        assert!(!check_invoice_lines_are_editable(&transferred_inbound(
+            InvoiceStatus::Shipped
+        )));
+
+        for status in [
+            InvoiceStatus::New,
+            InvoiceStatus::Delivered,
+            InvoiceStatus::Received,
+        ] {
+            assert!(
+                check_invoice_lines_are_editable(&transferred_inbound(status.clone())),
+                "transferred inbound lines should be editable at status {:?}",
+                status
+            );
+        }
+
+        for status in [InvoiceStatus::Verified, InvoiceStatus::Cancelled] {
+            assert!(
+                !check_invoice_lines_are_editable(&transferred_inbound(status.clone())),
+                "transferred inbound lines should not be editable at status {:?}",
+                status
+            );
+        }
+    }
+
+    #[test]
+    fn external_inbound_lines_stay_editable_while_shipped() {
+        // An external inbound has no linked invoice, the user records what the supplier
+        // despatched while the goods are in transit
+        for status in [
+            InvoiceStatus::New,
+            InvoiceStatus::Shipped,
+            InvoiceStatus::Delivered,
+            InvoiceStatus::Received,
+        ] {
+            assert!(
+                check_invoice_lines_are_editable(&external_inbound(status.clone())),
+                "external inbound lines should be editable at status {:?}",
+                status
+            );
+        }
+
+        assert!(!check_invoice_lines_are_editable(&external_inbound(
+            InvoiceStatus::Verified
+        )));
+    }
+
+    #[test]
+    fn outbound_line_editability_matches_invoice_editability() {
+        // The extra Shipped rule is inbound only, outbound is unchanged
+        for status in [
+            InvoiceStatus::New,
+            InvoiceStatus::Allocated,
+            InvoiceStatus::Picked,
+            InvoiceStatus::Shipped,
+            InvoiceStatus::Verified,
+        ] {
+            let invoice = outbound(status.clone());
+            assert_eq!(
+                check_invoice_lines_are_editable(&invoice),
+                check_invoice_is_editable(&invoice),
+                "outbound line editability should match invoice editability at status {:?}",
                 status
             );
         }

--- a/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/generate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/generate.rs
@@ -1,6 +1,6 @@
 use crate::{
     invoice::common::generate_invoice_user_id_update,
-    invoice_line::stock_in_line::{generate_batch, StockLineInput},
+    invoice_line::stock_in_line::{generate_batch, should_update_stock, StockLineInput},
 };
 use repository::{
     InvoiceLineRow, InvoiceLineType, InvoiceRow, ItemRow, RepositoryError, RequisitionLineRow,
@@ -11,7 +11,7 @@ use util::uuid::uuid;
 pub struct GenerateResult {
     pub invoice: Option<InvoiceRow>,
     pub invoice_line: InvoiceLineRow,
-    pub stock_line: StockLineRow,
+    pub stock_line: Option<StockLineRow>,
 }
 
 pub fn generate(
@@ -23,20 +23,25 @@ pub fn generate(
 ) -> Result<GenerateResult, RepositoryError> {
     let mut invoice_line = generate_line(requisition_row, item_row, existing_invoice_row.clone());
 
-    let stock_line = generate_batch(
-        connection,
-        invoice_line.clone(),
-        StockLineInput {
-            stock_line_id: None,
-            store_id: existing_invoice_row.store_id.clone(),
-            supplier_id: existing_invoice_row.name_id.clone(),
-            on_hold: false,
-            barcode_id: None,
-            overwrite_stock_levels: true,
-        },
-    )?;
-    // If a new stock line has been created, update the stock_line_id on the invoice line
-    invoice_line.stock_line_id = Some(stock_line.id.clone());
+    let stock_line = if should_update_stock(&existing_invoice_row) {
+        let batch = generate_batch(
+            connection,
+            invoice_line.clone(),
+            StockLineInput {
+                stock_line_id: None,
+                store_id: existing_invoice_row.store_id.clone(),
+                supplier_id: existing_invoice_row.name_id.clone(),
+                on_hold: false,
+                barcode_id: None,
+                overwrite_stock_levels: true,
+            },
+        )?;
+        // If a new stock line has been created, update the stock_line_id on the invoice line
+        invoice_line.stock_line_id = Some(batch.id.clone());
+        Some(batch)
+    } else {
+        None
+    };
 
     Ok(GenerateResult {
         invoice: generate_invoice_user_id_update(user_id, existing_invoice_row),

--- a/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/mod.rs
+++ b/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/mod.rs
@@ -57,7 +57,9 @@ pub fn insert_from_internal_order_line(
                 requisition_line,
             )?;
 
-            StockLineRowRepository::new(connection).upsert_one(&stock_line)?;
+            if let Some(stock_line) = stock_line {
+                StockLineRowRepository::new(connection).upsert_one(&stock_line)?;
+            }
             InvoiceLineRowRepository::new(connection).upsert_one(&invoice_line)?;
 
             if let Some(invoice_row) = invoice {
@@ -87,7 +89,8 @@ mod test {
         },
         test_db::setup_all_with_data,
         EqualFilter, InvoiceLine, InvoiceLineFilter, InvoiceLineRepository, InvoiceRow,
-        InvoiceStatus, InvoiceType, RequisitionLineRow, RequisitionRow, StorePreferenceRow,
+        InvoiceStatus, InvoiceType, RequisitionLineRow, RequisitionRow, StockLineRowRepository,
+        StorePreferenceRow,
     };
 
     use crate::{
@@ -161,6 +164,15 @@ mod test {
             }
         }
 
+        fn transferred_shipped_invoice() -> InvoiceRow {
+            InvoiceRow {
+                id: "transferred_shipped_invoice".to_string(),
+                status: InvoiceStatus::Shipped,
+                linked_invoice_id: Some(mock_outbound_shipment_e().id),
+                ..invoice_linked_to_requisition()
+            }
+        }
+
         fn requisition_not_linked_to_invoice() -> RequisitionRow {
             RequisitionRow {
                 id: "requisition_not_linked_to_invoice".to_string(),
@@ -194,6 +206,7 @@ mod test {
                 invoices: vec![
                     invoice_linked_to_requisition(),
                     finalised_invoice_linked_to_requisition(),
+                    transferred_shipped_invoice(),
                 ],
                 ..Default::default()
             },
@@ -243,6 +256,19 @@ mod test {
             Err(ServiceError::CannotEditFinalised)
         );
 
+        // CannotEditFinalised: a transferred inbound's lines are the sending store's record of
+        // what was despatched, they are locked while the shipment is Shipped
+        assert_eq!(
+            insert_from_internal_order_line(
+                &context,
+                InsertFromInternalOrderLine {
+                    invoice_id: transferred_shipped_invoice().id,
+                    requisition_line_id: requisition_line_test().id,
+                }
+            ),
+            Err(ServiceError::CannotEditFinalised)
+        );
+
         // NotAnInboundShipment
         assert_eq!(
             insert_from_internal_order_line(
@@ -282,6 +308,14 @@ mod test {
 
     #[actix_rt::test]
     async fn insert_from_internal_order_line_success() {
+        fn received_invoice_linked_to_requisition() -> InvoiceRow {
+            InvoiceRow {
+                id: "received_invoice_linked_to_requisition".to_string(),
+                status: InvoiceStatus::Received,
+                ..invoice_linked_to_requisition()
+            }
+        }
+
         let (_, connection, connection_manager, _) = setup_all_with_data(
             "insert_from_internal_order_line",
             MockDataInserts::all(),
@@ -289,7 +323,10 @@ mod test {
                 store_preferences: vec![store_pref()],
                 requisitions: vec![requisition_test()],
                 requisition_lines: vec![requisition_line_test()],
-                invoices: vec![invoice_linked_to_requisition()],
+                invoices: vec![
+                    invoice_linked_to_requisition(),
+                    received_invoice_linked_to_requisition(),
+                ],
                 ..Default::default()
             },
         )
@@ -322,5 +359,28 @@ mod test {
             .unwrap();
 
         assert_eq!(result.invoice_line_row, inbound_line);
+        // The invoice is still New, the goods have not arrived, so no stock is created yet.
+        // Stock is created when the invoice transitions to Received.
+        assert_eq!(inbound_line.stock_line_id, None);
+
+        // On an invoice that has already been received, the new line introduces stock immediately
+        let result = insert_from_internal_order_line(
+            &context,
+            InsertFromInternalOrderLine {
+                invoice_id: received_invoice_linked_to_requisition().id,
+                requisition_line_id: requisition_line_test().id,
+            },
+        )
+        .unwrap();
+
+        let stock_line_id = result.invoice_line_row.stock_line_id.expect(
+            "a line added to a received invoice should be linked to a newly created stock line",
+        );
+        let stock_line = StockLineRowRepository::new(&connection)
+            .find_one_by_id(&stock_line_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(stock_line.total_number_of_packs, 5.0);
+        assert_eq!(stock_line.available_number_of_packs, 5.0);
     }
 }

--- a/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/validate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_from_internal_order_lines/validate.rs
@@ -1,7 +1,7 @@
 use repository::{InvoiceRow, InvoiceType, ItemRow, RequisitionLineRow, StorageConnection};
 
 use crate::{
-    invoice::{check_invoice_exists, check_invoice_is_editable, check_store},
+    invoice::{check_invoice_exists, check_invoice_lines_are_editable, check_store},
     invoice_line::validate::check_item_exists,
     requisition_line::common::check_requisition_line_exists,
     validate::check_other_party_store_is_disabled,
@@ -33,7 +33,7 @@ pub fn validate(
         return Err(NotAnInboundShipment);
     }
 
-    if !check_invoice_is_editable(&invoice) {
+    if !check_invoice_lines_are_editable(&invoice) {
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {

--- a/server/service/src/invoice_line/inbound_shipment_service_line/delete/validate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/delete/validate.rs
@@ -1,6 +1,6 @@
 use crate::{
     invoice::{
-        check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store,
+        check_invoice_exists, check_invoice_lines_are_editable, check_invoice_type, check_store,
         inbound_shipment::InboundShipmentType,
     },
     invoice_line::{
@@ -35,7 +35,7 @@ pub fn validate(
             return Err(WrongInboundShipmentType);
         }
     }
-    if !check_invoice_is_editable(&invoice) {
+    if !check_invoice_lines_are_editable(&invoice) {
         return Err(CannotEditInvoice);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {

--- a/server/service/src/invoice_line/inbound_shipment_service_line/insert/validate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/insert/validate.rs
@@ -6,7 +6,7 @@ use util::constants::DEFAULT_SERVICE_ITEM_CODE;
 
 use crate::{
     invoice::{
-        check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store,
+        check_invoice_exists, check_invoice_lines_are_editable, check_invoice_type, check_store,
         inbound_shipment::InboundShipmentType,
     },
     invoice_line::validate::{check_item_exists, check_line_exists},
@@ -53,7 +53,7 @@ pub fn validate(
             return Err(OutError::WrongInboundShipmentType);
         }
     }
-    if !check_invoice_is_editable(&invoice) {
+    if !check_invoice_lines_are_editable(&invoice) {
         return Err(OutError::CannotEditInvoice);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {

--- a/server/service/src/invoice_line/inbound_shipment_service_line/update/validate.rs
+++ b/server/service/src/invoice_line/inbound_shipment_service_line/update/validate.rs
@@ -2,7 +2,7 @@ use repository::{InvoiceLine, InvoiceRow, InvoiceType, ItemRow, ItemType, Storag
 
 use crate::{
     invoice::{
-        check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store,
+        check_invoice_exists, check_invoice_lines_are_editable, check_invoice_type, check_store,
         inbound_shipment::InboundShipmentType,
     },
     invoice_line::validate::{check_item_exists, check_line_belongs_to_invoice, check_line_exists},
@@ -43,7 +43,7 @@ pub fn validate(
             return Err(WrongInboundShipmentType);
         }
     }
-    if !check_invoice_is_editable(&invoice) {
+    if !check_invoice_lines_are_editable(&invoice) {
         return Err(CannotEditInvoice);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {

--- a/server/service/src/invoice_line/stock_in_line/delete/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/delete/validate.rs
@@ -1,6 +1,8 @@
 use crate::invoice::inbound_shipment::InboundShipmentType;
 use crate::{
-    invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
+    invoice::{
+        check_invoice_exists, check_invoice_lines_are_editable, check_invoice_type, check_store,
+    },
     invoice_line::{
         stock_in_line::{check_batch, check_lines_locked_by_authorisation},
         validate::{
@@ -36,7 +38,7 @@ pub fn validate(
             return Err(WrongInboundShipmentType);
         }
     }
-    if !check_invoice_is_editable(&invoice) {
+    if !check_invoice_lines_are_editable(&invoice) {
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -117,6 +117,8 @@ pub enum InsertStockInLineError {
     ItemNotFound,
     PackSizeBelowOne,
     NumberOfPacksBelowZero,
+    SellPricePerPackBelowZero,
+    CostPricePerPackBelowZero,
     NewlyCreatedLineDoesNotExist,
     ManufacturerDoesNotExist,
     ManufacturerNotVisible,
@@ -249,6 +251,38 @@ mod test {
                 None
             ),
             Err(ServiceError::NumberOfPacksBelowZero)
+        );
+
+        // SellPricePerPackBelowZero
+        assert_eq!(
+            insert_stock_in_line(
+                &context,
+                InsertStockInLine {
+                    id: "new invoice line id".to_string(),
+                    pack_size: 1.0,
+                    number_of_packs: 1.0,
+                    sell_price_per_pack: -1.0,
+                    ..Default::default()
+                },
+                None
+            ),
+            Err(ServiceError::SellPricePerPackBelowZero)
+        );
+
+        // CostPricePerPackBelowZero
+        assert_eq!(
+            insert_stock_in_line(
+                &context,
+                InsertStockInLine {
+                    id: "new invoice line id".to_string(),
+                    pack_size: 1.0,
+                    number_of_packs: 1.0,
+                    cost_price_per_pack: -1.0,
+                    ..Default::default()
+                },
+                None
+            ),
+            Err(ServiceError::CostPricePerPackBelowZero)
         );
 
         // ItemNotFound
@@ -941,5 +975,90 @@ mod test {
             line.reason_option_id,
             Some(mock_shipment_variance_reason_option().id)
         );
+    }
+    #[actix_rt::test]
+    async fn insert_stock_in_line_shipped_inbound_shipment() {
+        /// A transfer from another store, its lines are the sending store's record
+        fn transferred_shipment() -> InvoiceRow {
+            InvoiceRow {
+                id: "shipped_transferred_shipment".to_string(),
+                status: InvoiceStatus::Shipped,
+                store_id: mock_store_a().id,
+                name_id: mock_name_store_b().id,
+                r#type: InvoiceType::InboundShipment,
+                linked_invoice_id: Some(mock_outbound_shipment_e().id),
+                ..Default::default()
+            }
+        }
+
+        /// Raised against a purchase order, the user records what the supplier despatched
+        fn external_shipment() -> InvoiceRow {
+            InvoiceRow {
+                id: "shipped_external_shipment".to_string(),
+                status: InvoiceStatus::Shipped,
+                store_id: mock_store_a().id,
+                name_id: mock_name_store_b().id,
+                r#type: InvoiceType::InboundShipment,
+                purchase_order_id: Some(mock_purchase_order_a().id),
+                ..Default::default()
+            }
+        }
+
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "insert_stock_in_line_shipped_inbound_shipment",
+            MockDataInserts::all(),
+            MockData {
+                invoices: vec![transferred_shipment(), external_shipment()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, mock_user_account_a().id)
+            .unwrap();
+
+        // Lines of a transferred shipment are locked while it is in transit
+        assert_eq!(
+            insert_stock_in_line(
+                &context,
+                InsertStockInLine {
+                    id: "line_on_transferred_shipment".to_string(),
+                    invoice_id: transferred_shipment().id,
+                    item_id: mock_item_a().id,
+                    pack_size: 1.0,
+                    number_of_packs: 5.0,
+                    r#type: StockInType::InboundShipment,
+                    ..Default::default()
+                },
+                None
+            ),
+            Err(ServiceError::CannotEditFinalised)
+        );
+
+        // An external shipment stays editable while in transit
+        insert_stock_in_line(
+            &context,
+            InsertStockInLine {
+                id: "line_on_external_shipment".to_string(),
+                invoice_id: external_shipment().id,
+                item_id: mock_item_a().id,
+                pack_size: 1.0,
+                number_of_packs: 5.0,
+                r#type: StockInType::InboundShipment,
+                purchase_order_line_id: Some(mock_purchase_order_a_line_1().id),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+
+        // ...but the goods are still in transit, so no stock is created for it yet
+        let line = InvoiceLineRowRepository::new(&connection)
+            .find_one_by_id("line_on_external_shipment")
+            .unwrap()
+            .unwrap();
+        assert_eq!(line.stock_line_id, None);
     }
 }

--- a/server/service/src/invoice_line/stock_in_line/insert/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/validate.rs
@@ -3,10 +3,15 @@ use crate::invoice::inbound_shipment::InboundShipmentType;
 use crate::{
     check_item_variant_exists, check_location_exists, check_location_type_is_valid,
     check_vvm_status_exists,
-    invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
+    invoice::{
+        check_invoice_exists, check_invoice_lines_are_editable, check_invoice_type, check_store,
+    },
     invoice_line::{
         stock_in_line::{check_lines_locked_by_authorisation, check_pack_size},
-        validate::{check_item_exists, check_line_exists, check_number_of_packs},
+        validate::{
+            check_item_exists, check_line_exists, check_number_of_packs,
+            check_price_is_not_negative,
+        },
     },
     validate::{
         check_date_is_not_in_future, check_other_party, check_other_party_store_is_disabled,
@@ -33,6 +38,12 @@ pub fn validate(
     }
     if !check_number_of_packs(Some(input.number_of_packs)) {
         return Err(NumberOfPacksBelowZero);
+    }
+    if !check_price_is_not_negative(Some(input.sell_price_per_pack)) {
+        return Err(SellPricePerPackBelowZero);
+    }
+    if !check_price_is_not_negative(Some(input.cost_price_per_pack)) {
+        return Err(CostPricePerPackBelowZero);
     }
 
     if let Some(manufacture_date) = &input.manufacture_date {
@@ -84,7 +95,7 @@ pub fn validate(
             return Err(WrongInboundShipmentType);
         }
     }
-    if !check_invoice_is_editable(&invoice) {
+    if !check_invoice_lines_are_editable(&invoice) {
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {

--- a/server/service/src/invoice_line/stock_in_line/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/mod.rs
@@ -61,10 +61,12 @@ pub fn check_lines_locked_by_authorisation(
 
 pub fn should_update_stock(invoice: &InvoiceRow) -> bool {
     match invoice.status {
-        InvoiceStatus::New | InvoiceStatus::Delivered => false,
+        // Shipped means the goods are still in transit, so they must not exist as stock yet.
+        // Stock is created when the invoice transitions to Received or Verified, see
+        // `crate::invoice::stock_effect::stock_effects`.
+        InvoiceStatus::New | InvoiceStatus::Shipped | InvoiceStatus::Delivered => false,
         InvoiceStatus::Allocated
         | InvoiceStatus::Picked
-        | InvoiceStatus::Shipped
         | InvoiceStatus::Cancelled
         | InvoiceStatus::Received
         | InvoiceStatus::Verified => true,

--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -123,6 +123,8 @@ pub enum UpdateStockInLineError {
     ItemNotFound,
     PackSizeBelowOne,
     NumberOfPacksBelowZero,
+    SellPricePerPackBelowZero,
+    CostPricePerPackBelowZero,
     BatchIsReserved,
     UpdatedLineDoesNotExist,
     NotThisInvoiceLine(String),
@@ -312,6 +314,47 @@ mod test {
             ),
             Err(ServiceError::NumberOfPacksBelowZero)
         );
+
+        // SellPricePerPackBelowZero
+        assert_eq!(
+            update_stock_in_line(
+                &context,
+                UpdateStockInLine {
+                    id: mock_customer_return_a_invoice_line_a().id,
+                    sell_price_per_pack: Some(-1.0),
+                    ..Default::default()
+                },
+                None
+            ),
+            Err(ServiceError::SellPricePerPackBelowZero)
+        );
+
+        // CostPricePerPackBelowZero
+        assert_eq!(
+            update_stock_in_line(
+                &context,
+                UpdateStockInLine {
+                    id: mock_customer_return_a_invoice_line_a().id,
+                    cost_price_per_pack: Some(-1.0),
+                    ..Default::default()
+                },
+                None
+            ),
+            Err(ServiceError::CostPricePerPackBelowZero)
+        );
+
+        // Zero is allowed, donated and free of charge stock has no price
+        assert!(update_stock_in_line(
+            &context,
+            UpdateStockInLine {
+                id: mock_customer_return_a_invoice_line_a().id,
+                sell_price_per_pack: Some(0.0),
+                cost_price_per_pack: Some(0.0),
+                ..Default::default()
+            },
+            None
+        )
+        .is_ok());
 
         // ItemNotFound
         assert_eq!(

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -4,12 +4,14 @@ use crate::{
     campaign::check_campaign_exists_including_deleted,
     check_item_variant_exists, check_location_exists, check_location_type_is_valid,
     check_vvm_status_exists,
-    invoice::{check_invoice_exists, check_invoice_is_editable, check_invoice_type, check_store},
+    invoice::{
+        check_invoice_exists, check_invoice_lines_are_editable, check_invoice_type, check_store,
+    },
     invoice_line::{
         stock_in_line::{check_batch, check_pack_size},
         validate::{
             check_item_exists, check_line_belongs_to_invoice, check_line_exists,
-            check_number_of_packs,
+            check_number_of_packs, check_price_is_not_negative,
         },
     },
     validate::{
@@ -44,6 +46,12 @@ pub fn validate(
     if !check_number_of_packs(input.number_of_packs) {
         return Err(NumberOfPacksBelowZero);
     }
+    if !check_price_is_not_negative(input.sell_price_per_pack) {
+        return Err(SellPricePerPackBelowZero);
+    }
+    if !check_price_is_not_negative(input.cost_price_per_pack) {
+        return Err(CostPricePerPackBelowZero);
+    }
 
     if let Some(NullableUpdate {
         value: Some(manufacture_date),
@@ -67,7 +75,7 @@ pub fn validate(
             return Err(WrongInboundShipmentType);
         }
     }
-    if !check_invoice_is_editable(&invoice) {
+    if !check_invoice_lines_are_editable(&invoice) {
         return Err(CannotEditFinalised);
     }
     if check_other_party_store_is_disabled(connection, store_id, &invoice.name_id)? {
@@ -186,7 +194,7 @@ pub fn validate(
         .is_some_and(|s| s.value != line_row.status)
     {
         use repository::InvoiceStatus::*;
-        // Verified is already excluded by check_invoice_is_editable (invoice is no longer editable once verified).
+        // Verified is already excluded by check_invoice_lines_are_editable (invoice is no longer editable once verified).
         // Can't change line status once invoice is received as stock lines may have already been allocated so rejecting a line at that point could cause issues with stock management.
         if invoice.status == Received {
             return Err(CannotChangeLineStatusOfReceivedInvoice);

--- a/server/service/src/invoice_line/validate.rs
+++ b/server/service/src/invoice_line/validate.rs
@@ -14,6 +14,11 @@ pub fn check_number_of_packs(number_of_packs_option: Option<f64>) -> bool {
     true
 }
 
+pub fn check_price_is_not_negative(price_option: Option<f64>) -> bool {
+    // Zero is valid, donated and free of charge stock has no price
+    !matches!(price_option, Some(price) if price < 0.0)
+}
+
 pub fn check_item_exists(
     connection: &StorageConnection,
     id: &str,

--- a/server/service/src/processors/transfer/invoice/common.rs
+++ b/server/service/src/processors/transfer/invoice/common.rs
@@ -9,7 +9,7 @@ use util::uuid::uuid;
 use crate::invoice::common::calculate_total_after_tax;
 use crate::invoice::inbound_shipment::{
     update_inbound_shipment, InboundShipmentType, UpdateInboundShipment,
-    UpdateInboundShipmentStatus,
+    UpdateInboundShipmentError, UpdateInboundShipmentStatus,
 };
 use crate::preference::{InboundShipmentAutoVerify, ItemMarginOverridesSupplierMargin, Preference};
 use crate::service_provider::ServiceContext;
@@ -220,7 +220,7 @@ pub(crate) fn auto_verify_if_store_preference(
         })?;
 
     if should_auto_verify {
-        update_inbound_shipment(
+        let result = update_inbound_shipment(
             ctx,
             UpdateInboundShipment {
                 id: inbound_shipment.id.to_string(),
@@ -229,11 +229,27 @@ pub(crate) fn auto_verify_if_store_preference(
             },
             Some(&inbound_shipment.store_id),
             InboundShipmentType::InboundShipment,
-        )
-        .map_err(|e| {
-            log::error!("{e:?}");
-            RepositoryError::as_db_error("Error attempting to verify inbound shipment", e)
-        })?;
+        );
+
+        match result {
+            Ok(_) => (),
+            // An empty shipment can't be verified, and there is nothing for the processor to
+            // retry, so leave it where it is for someone to deal with by hand rather than
+            // failing the transfer and blocking every record behind it.
+            Err(UpdateInboundShipmentError::CannotReceiveWithNoLines) => {
+                log::warn!(
+                    "Not auto verifying inbound shipment {}, it has no lines to receive",
+                    inbound_shipment.id
+                );
+            }
+            Err(e) => {
+                log::error!("{e:?}");
+                return Err(RepositoryError::as_db_error(
+                    "Error attempting to verify inbound shipment",
+                    e,
+                ));
+            }
+        }
     }
     Ok(())
 }

--- a/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/create_inbound_invoice.rs
@@ -304,9 +304,13 @@ mod test {
     use crate::{preference::PrefKey, service_provider::ServiceProvider};
     use chrono::NaiveDate;
     use repository::{
-        mock::{mock_name_b, mock_outbound_shipment_a, mock_store_b, MockData, MockDataInserts},
+        mock::{
+            mock_item_a, mock_name_b, mock_outbound_shipment_a, mock_store_b, MockData,
+            MockDataInserts,
+        },
         test_db::setup_all_with_data,
-        InvoiceFilter, InvoiceRepository, PreferenceRow, SyncLogV5V6Row,
+        InvoiceFilter, InvoiceLineRow, InvoiceLineType, InvoiceRepository, PreferenceRow,
+        SyncLogV5V6Row,
     };
 
     #[actix_rt::test]
@@ -481,10 +485,36 @@ mod test {
             InvoiceType::SupplierReturn,
         );
 
+        // Shipments need lines, an empty shipment can't be received or verified
+        fn outbound_line(invoice_id: &str) -> InvoiceLineRow {
+            InvoiceLineRow {
+                id: format!("{invoice_id}_line"),
+                invoice_id: invoice_id.to_string(),
+                item_id: mock_item_a().id,
+                item_name: mock_item_a().name,
+                item_code: mock_item_a().code,
+                r#type: InvoiceLineType::StockOut,
+                pack_size: 1.0,
+                number_of_packs: 10.0,
+                ..Default::default()
+            }
+        }
+        let lines_with_supplier_return = vec![
+            outbound_line(&new_invoice_row.id),
+            outbound_line(&picked_invoice_row.id),
+            outbound_line(&shipped_invoice_row.id),
+            outbound_line(&supplier_return_row.id),
+        ];
+        let lines_without_supplier_return = vec![
+            outbound_line(&new_invoice_row.id),
+            outbound_line(&picked_invoice_row.id),
+            outbound_line(&shipped_invoice_row.id),
+        ];
+
         // First test without preference
         let (_, _, connection_manager, _) = setup_all_with_data(
             "test_create_inbound_invoice_auto_finalise_off",
-            MockDataInserts::none().stores(),
+            MockDataInserts::none().names().stores().units().items(),
             MockData {
                 invoices: vec![
                     new_invoice_row.clone(),
@@ -492,6 +522,7 @@ mod test {
                     shipped_invoice_row.clone(),
                     supplier_return_row.clone(),
                 ],
+                invoice_lines: lines_with_supplier_return,
                 ..Default::default()
             },
         )
@@ -553,13 +584,14 @@ mod test {
 
         let (_, _, connection_manager, _) = setup_all_with_data(
             "test_create_inbound_invoice_auto_finalise_on",
-            MockDataInserts::none().stores(),
+            MockDataInserts::none().names().stores().units().items(),
             MockData {
                 invoices: vec![
                     new_invoice_row.clone(),
                     picked_invoice_row.clone(),
                     shipped_invoice_row.clone(),
                 ],
+                invoice_lines: lines_without_supplier_return,
                 preferences: vec![preference],
                 ..Default::default()
             },

--- a/server/service/src/processors/transfer/invoice/update_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/update_inbound_invoice.rs
@@ -178,11 +178,12 @@ mod test {
     use chrono::Utc;
     use repository::{
         mock::{
-            mock_name_a, mock_name_b, mock_outbound_shipment_a, mock_store_a, mock_store_b,
-            MockData, MockDataInserts,
+            mock_item_a, mock_name_a, mock_name_b, mock_outbound_shipment_a, mock_store_a,
+            mock_store_b, MockData, MockDataInserts,
         },
         test_db::setup_all_with_data,
-        EqualFilter, Invoice, InvoiceFilter, InvoiceRepository, PreferenceRow, StorageConnection,
+        EqualFilter, Invoice, InvoiceFilter, InvoiceLineRow, InvoiceLineType, InvoiceRepository,
+        PreferenceRow, StorageConnection,
     };
 
     #[actix_rt::test]
@@ -220,6 +221,19 @@ mod test {
             store_row: mock_store_a(),
             clinician_row: None,
         };
+        // Shipments need lines, an empty shipment can't be received or verified
+        let outbound_line = InvoiceLineRow {
+            id: "picked_first_half_line".to_string(),
+            invoice_id: first_half_row.id.clone(),
+            item_id: mock_item_a().id,
+            item_name: mock_item_a().name,
+            item_code: mock_item_a().code,
+            r#type: InvoiceLineType::StockOut,
+            pack_size: 1.0,
+            number_of_packs: 10.0,
+            ..Default::default()
+        };
+
         let mut processor_input = InvoiceTransferProcessorRecord {
             operation: Operation::Upsert {
                 invoice: first_half.clone(),
@@ -233,9 +247,10 @@ mod test {
         // First test without preference
         let (_, _, connection_manager, _) = setup_all_with_data(
             "test_update_inbound_invoice_auto_finalise_off",
-            MockDataInserts::none().stores(),
+            MockDataInserts::none().names().stores().units().items(),
             MockData {
                 invoices: vec![first_half_row.clone(), second_half_row.clone()],
+                invoice_lines: vec![outbound_line.clone()],
                 ..Default::default()
             },
         )
@@ -291,9 +306,10 @@ mod test {
 
         let (_, _, connection_manager, _) = setup_all_with_data(
             "test_update_inbound_invoice_auto_finalise_on",
-            MockDataInserts::none().stores(),
+            MockDataInserts::none().names().stores().units().items(),
             MockData {
                 invoices: vec![first_half_row.clone(), second_half_row.clone()],
+                invoice_lines: vec![outbound_line.clone()],
                 preferences: vec![preference],
                 ..Default::default()
             },

--- a/server/service/src/processors/transfer/invoice/update_inbound_invoice.rs
+++ b/server/service/src/processors/transfer/invoice/update_inbound_invoice.rs
@@ -348,4 +348,90 @@ mod test {
             "The transfer should be auto verified if the first half is shipped and the auto verify preference is on"
         );
     }
+
+    /// An empty shipment can't be verified (`CannotReceiveWithNoLines`), and there is nothing
+    /// for the processor to retry, so auto verify must log and leave the shipment at Shipped
+    /// rather than failing the transfer and blocking every record queued behind it.
+    #[actix_rt::test]
+    async fn test_update_inbound_invoice_auto_verify_empty_shipment() {
+        let outbound_row = InvoiceRow {
+            id: "empty_shipped_outbound".to_string(),
+            status: InvoiceStatus::Shipped,
+            created_datetime: Utc::now().naive_utc(),
+            ..mock_outbound_shipment_a()
+        };
+        let outbound = Invoice {
+            invoice_row: outbound_row.clone(),
+            name_row: mock_name_b(),
+            store_row: mock_store_b(),
+            clinician_row: None,
+        };
+        let inbound_row = InvoiceRow {
+            id: "empty_picked_inbound".to_string(),
+            name_id: mock_name_a().id,
+            store_id: mock_store_a().id,
+            r#type: InvoiceType::InboundShipment,
+            status: InvoiceStatus::Picked,
+            ..outbound_row.clone()
+        };
+        let inbound = Invoice {
+            invoice_row: inbound_row.clone(),
+            name_row: mock_name_a(),
+            store_row: mock_store_a(),
+            clinician_row: None,
+        };
+
+        let processor_input = InvoiceTransferProcessorRecord {
+            operation: Operation::Upsert {
+                invoice: outbound,
+                linked_invoice: Some(inbound),
+                linked_shipment_requisition: None,
+                linked_original_shipment: None,
+            },
+            other_party_store_id: mock_store_a().id,
+        };
+
+        let preference = PreferenceRow {
+            id: "preference_on".to_string(),
+            key: PrefKey::InboundShipmentAutoVerify.to_string(),
+            value: "true".to_string(),
+            store_id: Some(mock_store_a().id),
+        };
+
+        // Neither invoice has any lines
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "test_update_inbound_invoice_auto_verify_empty_shipment",
+            MockDataInserts::none().names().stores(),
+            MockData {
+                invoices: vec![outbound_row, inbound_row.clone()],
+                preferences: vec![preference],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let ctx = &ServiceProvider::new(connection_manager)
+            .basic_context()
+            .unwrap();
+
+        let result = UpdateInboundInvoiceProcessor {}
+            .try_process_record(ctx, &processor_input)
+            .unwrap();
+        assert!(
+            matches!(result, InvoiceTransferOutput::Processed(_)),
+            "an empty shipment should still be processed, got {result:?}"
+        );
+
+        let invoice = InvoiceRepository::new(&ctx.connection)
+            .query_one(InvoiceFilter::new().id(EqualFilter::equal_to(inbound_row.id)))
+            .unwrap()
+            .unwrap()
+            .invoice_row;
+        assert_eq!(
+            invoice.status,
+            InvoiceStatus::Shipped,
+            "an empty shipment can't be verified, auto verify should leave it at Shipped"
+        );
+        assert_eq!(invoice.verified_datetime, None);
+    }
 }


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12568

The front end already blocked all four of these, but the API didn't — so anything talking straight to GraphQL (a script, an integration, or a future front end) could push an inbound shipment into a state the rest of the system doesn't expect. This adds the matching server-side validation.

**1. An empty shipment could be received or verified.** `check_no_pending_lines` in [validate.rs](server/service/src/invoice/inbound_shipment/update/validate.rs) becomes `check_lines_can_be_received` and now also rejects a shipment whose lines would receive no stock, with a new `CannotReceiveWithNoLines` error. "Empty" means no lines at all, or only placeholder lines — a stock-in line with nothing received *and* nothing shipped. This deliberately mirrors `validateEmptyInvoice` in [StatusChangeButton.tsx](client/packages/invoices/src/InboundShipment/DetailView/Footer/StatusChangeButton.tsx), and matches the lines `empty_lines_to_trim` already deletes when an invoice leaves New. Two cases stay valid: recording a discrepancy ("supplier says they sent 5, none arrived" — shipped 5, received 0), and a shipment of only service lines such as a freight charge.

**2. Lines could be edited while the shipment was Shipped.** New `check_invoice_lines_are_editable` in [invoice/validate.rs](server/service/src/invoice/validate.rs) — a stricter variant of `check_invoice_is_editable` for editing invoice *lines* rather than the invoice itself. All six inbound line validators (stock-in and service line, insert/update/delete) switch to it. The invoice itself must stay editable at Shipped, otherwise the receiving store could never move a transfer on to Delivered — it's specifically the lines that need locking, because on a transfer they're the sending store's record of what was despatched.

**3. Negative sell and cost prices.** New `check_price_is_not_negative` in [invoice_line/validate.rs](server/service/src/invoice_line/validate.rs), wired into stock-in line insert and update with `SellPricePerPackBelowZero` / `CostPricePerPackBelowZero`, alongside the existing `check_number_of_packs`. Zero is still allowed — donated and free-of-charge stock has no price.

**4. Editing a line on a Shipped shipment created stock lines.** `should_update_stock` in [stock_in_line/mod.rs](server/service/src/invoice_line/stock_in_line/mod.rs) returned `true` for Shipped, so a line edit created stock for goods still in transit — no other path does that. Now `false`, consistent with `stock_effects`, which only creates stock on the transition to Received or Verified.

## 💌 Any notes for the reviewer?

**Two deliberate divergences from the issue.** Both are in item 2, which asks for "Shipped invoices should be read only":

- **The invoice itself stays editable at Shipped, only its lines are locked.** A transfer-created inbound arrives already in Shipped status; if the whole invoice were frozen the receiving store could never progress it to Delivered. Locking the lines is what actually protects the sending store's record.
- **Externally sourced (purchase order) inbounds stay line-editable at Shipped.** They have no `linked_invoice_id`, and Shipped there means "the supplier has despatched, I'm recording what's coming" — that's exactly when the user needs to enter lines. So the new rule is narrow: inbound shipment or customer return, *and* status is Shipped, *and* `linked_invoice_id` is set.

**Fix 1 needed a change to the transfer processor.** `auto_verify_if_store_preference` in [transfer/invoice/common.rs](server/service/src/processors/transfer/invoice/common.rs) can now hit `CannotReceiveWithNoLines`. Previously any error there was escalated to a DB error, which fails the transfer and blocks every record queued behind it. There's nothing for the processor to retry on an empty shipment, so it now logs a warning and leaves the shipment where it is for someone to sort out by hand.

Worth a look: whether the placeholder definition in `is_placeholder_line` should also treat a zero-quantity line with a *non-zero* shipped quantity from a **manual** (non-transfer) inbound as empty. Right now it's receivable, on the grounds that it's a real record of a discrepancy.

# 🧪 Tested

- Added `update_inbound_shipment_cannot_receive_with_no_lines` covering all four cases: no lines at all (rejected for both Received and Verified), placeholder-only (rejected), shipped-but-nothing-received (allowed), service-lines-only (allowed)
- Added three tests in [invoice/validate.rs](server/service/src/invoice/validate.rs) pinning the new line-editability rule: transferred inbound lines locked at Shipped while the invoice stays editable, external inbound lines editable at Shipped, and outbound line editability unchanged from invoice editability
- Added `insert_stock_in_line_shipped_inbound_shipment`, which also asserts that a line inserted on a Shipped external inbound gets `stock_line_id: None` — covering fix 4
- Extended the existing `insert_stock_in_line_errors` / `update_stock_in_line_errors` cases with negative sell and cost price, plus an explicit check that zero is accepted
- Updated the four transfer-processor auto-finalise tests to give their outbound shipments lines — they were relying on empty shipments being verifiable
- Added the `CannotReceiveWithNoLines` case to the GraphQL `update.rs` error-mapping test

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)

The front end already prevented all four of these, so there's no change a user can see. It only closes the gap for API clients.
