### PR TITLE
#12606 Stop URL search-param writes re-rendering the whole app shell

### DIFF
--- a/client/packages/common/src/hooks/useHostContext/FullScreen.tsx
+++ b/client/packages/common/src/hooks/useHostContext/FullScreen.tsx
@@ -7,7 +7,8 @@ import { useNotification } from '../useNotification';
 
 export const FullScreenButton = () => {
   const t = useTranslation();
-  const { fullScreen, setFullScreen } = useHostContext();
+  const fullScreen = useHostContext(s => s.fullScreen);
+  const setFullScreen = useHostContext(s => s.setFullScreen);
   const { success } = useNotification();
 
   const exitFullScreen = (e: KeyboardEvent) => {

--- a/client/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
+++ b/client/packages/common/src/ui/components/navigation/Breadcrumbs/Breadcrumbs.tsx
@@ -24,7 +24,7 @@ export const Breadcrumbs = ({
   topLevelPaths?: string[];
 }) => {
   const t = useTranslation();
-  const { fullScreen } = useHostContext();
+  const fullScreen = useHostContext(s => s.fullScreen);
   const { plugins } = usePluginProvider();
 
   // Plugin category-root pages live at `/<categoryKey>` (no second segment),

--- a/client/packages/common/src/ui/components/portals/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/common/src/ui/components/portals/AppBarButtons/AppBarButtons.tsx
@@ -3,7 +3,7 @@ import React, { FC, useEffect, useRef } from 'react';
 import { useHostContext, useIsExtraSmallScreen } from '@common/hooks';
 
 export const AppBarButtons: FC = () => {
-  const { setAppBarButtonsRef } = useHostContext();
+  const setAppBarButtonsRef = useHostContext(s => s.setAppBarButtonsRef);
   const ref = useRef(null);
   const isExtraSmallScreen = useIsExtraSmallScreen();
 
@@ -24,7 +24,7 @@ export const AppBarButtons: FC = () => {
 };
 
 export const AppBarButtonsPortal: FC<BoxProps> = props => {
-  const { appBarButtonsRef } = useHostContext();
+  const appBarButtonsRef = useHostContext(s => s.appBarButtonsRef);
 
   if (!appBarButtonsRef?.current) return null;
 

--- a/client/packages/common/src/ui/components/portals/AppBarContent/AppBarContent.tsx
+++ b/client/packages/common/src/ui/components/portals/AppBarContent/AppBarContent.tsx
@@ -19,7 +19,7 @@ const MobileContainer = styled('div')({});
 // mounted at any one time as mounting this in multiple locations would cause
 // some pretty weird behaviour
 export const AppBarContent: FC = () => {
-  const { setAppBarContentRef } = useHostContext();
+  const setAppBarContentRef = useHostContext(s => s.setAppBarContentRef);
   const ref = useRef(null);
   const isExtraSmallScreen = useIsExtraSmallScreen();
 
@@ -35,7 +35,7 @@ export const AppBarContent: FC = () => {
 };
 
 export const AppBarContentPortal: FC<BoxProps> = props => {
-  const { appBarContentRef } = useHostContext();
+  const appBarContentRef = useHostContext(s => s.appBarContentRef);
 
   if (!appBarContentRef?.current) return null;
 

--- a/client/packages/common/src/ui/components/portals/AppBarTabs/AppBarTabs.tsx
+++ b/client/packages/common/src/ui/components/portals/AppBarTabs/AppBarTabs.tsx
@@ -10,7 +10,7 @@ const Container = styled('div')({
 });
 
 export const AppBarTabs: FC = () => {
-  const { setAppBarTabsRef } = useHostContext();
+  const setAppBarTabsRef = useHostContext(s => s.setAppBarTabsRef);
   const ref = useRef(null);
 
   useEffect(() => {
@@ -21,7 +21,7 @@ export const AppBarTabs: FC = () => {
 };
 
 export const AppBarTabsPortal: FC<BoxProps> = props => {
-  const { appBarTabsRef } = useHostContext();
+  const appBarTabsRef = useHostContext(s => s.appBarTabsRef);
 
   if (!appBarTabsRef?.current) return null;
 

--- a/client/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
+++ b/client/packages/common/src/ui/components/portals/DetailPanel/DetailPanel.tsx
@@ -55,7 +55,7 @@ const StyledDrawer = styled(Box, {
 }));
 
 export const DetailPanel: FC = () => {
-  const { setDetailPanelRef } = useHostContext();
+  const setDetailPanelRef = useHostContext(s => s.setDetailPanelRef);
   const { isOpen } = useDetailPanelStore();
   const ref = useRef(null);
 
@@ -72,7 +72,7 @@ export const DetailPanelPortal: FC<
   const t = useTranslation();
   const theme = useAppTheme();
   const isLargeScreen = useMediaQuery(theme.breakpoints.down(Breakpoints.xl));
-  const { detailPanelRef } = useHostContext();
+  const detailPanelRef = useHostContext(s => s.detailPanelRef);
   const { hasUserSet, isOpen, close } = useDetailPanelStore();
 
   const setIsOpen = (isOpen: boolean) =>

--- a/client/packages/host/src/Site.tsx
+++ b/client/packages/host/src/Site.tsx
@@ -82,7 +82,7 @@ const isModifierKey = (e: KeyboardEvent) => {
 export const Site: FC = () => {
   const location = useLocation();
   const getPageTitle = useGetPageTitle();
-  const { setPageTitle } = useHostContext();
+  const setPageTitle = useHostContext(s => s.setPageTitle);
   const pageTitle = getPageTitle(location.pathname);
   const isExtraSmallScreen = useIsExtraSmallScreen();
   const rootNavigationPath = useRootNavigationPath();
@@ -94,7 +94,15 @@ export const Site: FC = () => {
 
   useEffect(() => {
     setPageTitle(pageTitle);
-  }, [location, pageTitle, setPageTitle]);
+    // Deliberately NOT keyed on `location`: it is a new object on every location
+    // change, including a search-param-only change (sort, filter, pagination,
+    // tab) that cannot alter the title. Re-running then called setPageTitle with
+    // an identical string, and because every `useHostContext()` consumer
+    // subscribes to the whole zustand store, that wrote a fresh state object and
+    // re-rendered the entire app shell a SECOND time before paint. `pageTitle`
+    // is a string, so keying on it runs the effect exactly when the title
+    // really changes.
+  }, [pageTitle, setPageTitle]);
 
   // Listen for modifier keys to show keyboard shortcut hints in the UI
   useEffect(() => {

--- a/client/packages/host/src/components/AppBar/AppBar.tsx
+++ b/client/packages/host/src/components/AppBar/AppBar.tsx
@@ -35,7 +35,8 @@ export const AppBar: React.FC = () => {
   const { ref } = useAppBarRect();
   const isDashboard = useMatch(AppRoute.Dashboard);
   const { store } = useAuthContext();
-  const { fullScreen, setFullScreen } = useHostContext();
+  const fullScreen = useHostContext(s => s.fullScreen);
+  const setFullScreen = useHostContext(s => s.setFullScreen);
   const hasVaccineModule = store?.preferences.vaccineModule ?? false;
   const containerStyle = isDashboard
     ? { borderBottom: 0, minHeight: '10px' }

--- a/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
+++ b/client/packages/host/src/components/AppDrawer/AppDrawer.tsx
@@ -146,7 +146,7 @@ export const AppDrawer: React.FC = () => {
   const isMediumScreen = useMediaQuery(theme.breakpoints.down(Breakpoints.lg));
   const drawer = useDrawer();
   const { store } = useAuthContext();
-  const { fullScreen } = useHostContext();
+  const fullScreen = useHostContext(s => s.fullScreen);
   const pluginCategories = usePluginNewCategories();
 
   React.useEffect(() => {

--- a/client/packages/host/src/components/Initialise/Initialise.tsx
+++ b/client/packages/host/src/components/Initialise/Initialise.tsx
@@ -21,7 +21,7 @@ import { mapSyncError } from 'packages/system/src';
 
 export const Initialise = () => {
   const t = useTranslation();
-  const { setPageTitle } = useHostContext();
+  const setPageTitle = useHostContext(s => s.setPageTitle);
   const nativeClient = useNativeClient();
   const exportLog = useExportLog();
   const { warning } = useNotification();

--- a/client/packages/host/src/components/Login/Login.tsx
+++ b/client/packages/host/src/components/Login/Login.tsx
@@ -19,7 +19,7 @@ import { useHost } from '../../api';
 
 export const Login = ({ fullSize = true }: { fullSize?: boolean }) => {
   const t = useTranslation();
-  const { setPageTitle } = useHostContext();
+  const setPageTitle = useHostContext(s => s.setPageTitle);
   const { logout } = useAuthContext();
   const hashInput = {
     logo: LocalStorage.getItem('/theme/logohash') ?? '',


### PR DESCRIPTION
Fixes #12606

# 👩🏻‍💻 What does this PR do?

Sort, filter, pagination and tab switches are all implemented as URL search
parameters. **Every one of those writes was re-rendering the entire app shell two
to three times** — AppDrawer, AppBar, Breadcrumbs, all four portals, DetailPanel
and the whole route subtree — costing **~1.3 s of main-thread blocking at 6× CPU
throttle**, even when nothing visible changed and nothing refetched.

This is the "editing a table filter re-renders the whole app" symptom. On a
low-end tablet the UI freezes for over a second each time a filter keystroke
settles.

There were two independent causes, both around the `useHostContext` zustand store:

1. **`Site.tsx` keyed its page-title effect on `location`**, which is a new object
   on every location change. So the effect re-ran on search-param-only changes and
   called `setPageTitle` with an *identical string*.
2. **Every `useHostContext()` call site subscribed to the whole store** (no
   selector), and every setter is written `set(state => ({ ...state, x }))` — a
   brand-new state object each time. So *any* write to *any* field re-rendered
   *every* consumer, which is the entire app shell.

Together: location change → `setPageTitle` → new store object → whole shell
re-renders a second time, before paint (a React `nested-update`).

Cause 2 also fired on mount, which is why opening a detail view was slow: it mounts
AppBarButtons + AppBarContent + DetailPanel portals, and each ref registration
re-rendered the whole shell.

**The fix is small and mechanical** — 11 files, +26/−16:

- Key the page-title effect on the `pageTitle` string rather than `location`. The
  title still updates exactly when it changes (and on mount).
- Convert 11 `const { x } = useHostContext()` call sites to
  `useHostContext(s => s.x)`. This matches the pattern `AppFooter.tsx` in the same
  directory already used, so it makes the codebase consistent rather than
  introducing anything new.

### Measured results

Production build, 6× CPU throttle, no network throttling (deployments are tablet +
local server), against a seeded fixture of 400 items / 327 outbound shipments /
one 150-line shipment. Median of 6 runs after a discarded warm-up.

| interaction | before | after | Δ | blocking time |
|---|---:|---:|---:|---|
| sort outbound list | 472 ms | **288 ms** | **−39%** | 487 → 303 ms |
| next page of list | 488 ms | **296 ms** | **−39%** | 512 → 330 ms |
| sort 150 shipment lines | 616 ms | **424 ms** | **−31%** | 518 → 317 ms |
| open a shipment detail | 176 ms | 152 ms | **−14%** | 605 → 480 ms |
| filter keystroke → result | — | — | — | **365 → 182 ms (−50%)** |

"Before/after" is interaction latency: the Event Timing API's input-event-to-next-paint
duration. Control interactions (opening a column menu, opening the filter dropdown,
typing in a line-edit field) moved ±0%, which is what makes the wins attributable
rather than noise.

## 💌 Any notes for the reviewer?

- **This targets `main`, not `develop`.** Worth a conscious decision: `main` is
  currently 1565 commits behind `develop`, and **both defects are present verbatim
  on `develop`** (same `[location, pageTitle, setPageTitle]` deps, same
  whole-store subscriptions). Unless `main` is merged forward, `develop` keeps the
  bug — so this may need porting or a forward-merge.
- **The measurements were taken on exactly this base** (`main` @ bb036d77), so the
  numbers correspond to the diff rather than to a different tree.
- **The harness that produced these numbers is not in this PR.** It lives locally at
  `client/perf/` (Playwright + CDP at 6× throttle, a deterministic SQL fixture, 12
  Outbound Shipment scenarios, committed baselines). Landing it is worth a separate
  decision — without it nobody can reproduce these numbers or safely extend the work
  to other pages. Happy to raise it as its own PR.
- **Scope was deliberately kept to what is measured.** #12606 lists four further
  findings that are diagnosed but *not* fixed here, the most significant being that
  `AppNavLink` uses `useMatch()` so all ~20 nav links re-render on every
  search-param write (~170 ms dev per write). That one needs `Site` to stop
  subscribing to `location` *and* a memoised pathname context — and an earlier
  attempt at it (`perf/stock-search`, June) added machinery, was never validated, and
  left the app feeling worse. It should land separately, with numbers attached.
- **One thing I tried and reverted, worth knowing about:** Chrome DevTools' trace
  confidently attributed 1310 ms to MRT's `measureElement` (row-height measurement
  forcing synchronous layout per row per render). I implemented the fix and it
  produced **no measurable improvement** (+4%, inside the ±15% dev noise band), so it
  was reverted and is not in this PR. Trace *durations* are inflated by tracing
  overhead; the *stacks* are still trustworthy. Same caveat now applies to the
  1290 ms style-recalculation figure.
- `eslint` reports 7 `react-hooks/exhaustive-deps` warnings on the touched files.
  These are **pre-existing** — the diff only changes hook *call* lines, no dependency
  arrays (other than `Site.tsx`, which is the fix itself).
- The `useHostContext` store is now clean, but `useDrawer` (9 sites, including every
  `AppNavLink`), `useKeyboard` (4 sites, including every `Autocomplete` and every
  modal via `useDialog` — tablet-relevant, since the on-screen keyboard opening
  re-renders them all) and `useDetailPanelStore` (5 sites) have the identical
  whole-store pattern. Detected but not measured, so not touched here; tracked in
  #12606.

# 🧪 Testing

Automated, on this branch:

- [x] `yarn test` — 86 suites / 592 tests pass
- [x] `tsc --noEmit` (host project, covers all workspaces) — clean
- [x] `yarn eslint` on the touched files — 0 errors

Manual — the behaviour to confirm is that **nothing changed functionally**:

- [ ] Page title (browser tab) still updates when navigating between pages, and on
      first load
- [ ] Full-screen toggle still works (AppBar button and the keyboard shortcut/exit
      notification)
- [ ] App bar content, app bar buttons, tabs and the detail side panel all still
      render on a detail view (these are the four portals whose ref registration
      changed) — e.g. open an Outbound Shipment, check the toolbar filters, the
      "Add item" buttons, the Details/Log tabs, and the side panel open/close
- [ ] Breadcrumbs still render and collapse in full-screen mode
- [ ] Login and Initialise screens still set their page titles

Manual — confirming the improvement (no harness needed):

- [ ] Open an Outbound Shipment list with a decent number of rows, open React
      DevTools → Profiler, record, then sort a column via the header menu. Before
      this change you see **two commits** for the one interaction, the second flagged
      as a nested update; after, you see **one**.
- [ ] With DevTools Performance set to 6× CPU throttling, sort a column and compare
      the blocking time — roughly halved.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.
