### PR TITLE
#12602 Add HTG (Haitian Gourde) currency

### DIFF
--- a/client/packages/common/src/intl/currency/currency.test.tsx
+++ b/client/packages/common/src/intl/currency/currency.test.tsx
@@ -77,3 +77,26 @@ describe('currency formatting - eur for en', () => {
     expect(f1).toBe('€111.00');
   });
 });
+
+describe('currency formatting - htg for en', () => {
+  it('trails the amount with the currency code', () => {
+    const { result } = renderHookWithProvider(() => useCurrency('HTG'));
+
+    const f1 = result.current.c(1_234.56).format();
+    expect(f1).toBe('1,234.56 HTG');
+  });
+
+  it('formats negative amounts with the code trailing', () => {
+    const { result } = renderHookWithProvider(() => useCurrency('HTG'));
+
+    const f1 = result.current.c(-1_234.56).format();
+    expect(f1).toBe('-1,234.56 HTG');
+  });
+
+  it('formats to two decimal places', () => {
+    const { result } = renderHookWithProvider(() => useCurrency('HTG'));
+
+    const f1 = result.current.c(111).format();
+    expect(f1).toBe('111.00 HTG');
+  });
+});

--- a/client/packages/common/src/intl/currency/currency.ts
+++ b/client/packages/common/src/intl/currency/currency.ts
@@ -113,7 +113,8 @@ export type Currencies =
   | 'XAF'
   | 'XOF'
   | 'STN'
-  | 'AFN';
+  | 'AFN'
+  | 'HTG';
 
 export const currencyOptions = (locale: string, code?: Currencies) => {
   switch (code) {
@@ -251,6 +252,19 @@ export const currencyOptions = (locale: string, code?: Currencies) => {
         ...getSeparatorAndDecimal(locale),
         ...getPatterns(locale),
         symbol: '؋',
+        precision: 2,
+        format,
+      };
+    }
+    case 'HTG': {
+      return {
+        // separator: "," decimal = "."
+        ...getSeparatorAndDecimal(locale),
+        // The Gourde is always written with the code trailing the amount
+        // (1,234.56 HTG), regardless of the UI language.
+        pattern: '# !',
+        negativePattern: '-# !',
+        symbol: 'HTG',
         precision: 2,
         format,
       };


### PR DESCRIPTION
Fixes #12602

# 👩🏻‍💻 What does this PR do?

<img height="200" alt="Screenshot 2026-07-31 at 11 46 43 am" src="https://github.com/user-attachments/assets/64ddc968-a510-4458-943d-bad1b6141ad3" />
<img height="200" alt="Screenshot 2026-07-31 at 11 47 03 am" src="https://github.com/user-attachments/assets/7620571e-8a25-49dc-85ba-327a924a7f87" />


Adds `HTG` to the client's currency formatting map so Haitian Gourde amounts render as `1,234.56 HTG`.

Currency records sync down from central without any code-level filtering — `CurrencyTranslation` in `server/service/src/sync/translations/currency.rs` passes `code` through verbatim, so no server change is needed. The gap was entirely client-side: `currencyOptions` in `client/packages/common/src/intl/currency/currency.ts` is a hardcoded switch, and any code not listed falls through to the `default` case, which is US dollars. HTG amounts on the Haiti site were therefore displaying as `$1,234.56`.

Two changes in `currency.ts`:

1. `'HTG'` added to the `Currencies` union.
2. A new `HTG` case — symbol `HTG`, precision 2, group separator and decimal taken from the active locale via the existing `getSeparatorAndDecimal` helper.

Plus three unit tests in `currency.test.tsx` covering the format from the issue, negative amounts, and the two-decimal minimum.

## 💌 Any notes for the reviewer?

**One deliberate deviation from the surrounding cases.** Every other currency spreads `getPatterns(locale)`, which places the symbol *before* the amount in all locales except `fr` / `fr-DJ` / `ru`. For an English-language user that would render `HTG1,234.56`. The issue specifies `1,234.56 HTG`, so the HTG case pins the trailing-symbol pattern directly instead of inheriting it from the locale — commented inline. Separators still follow the locale, so French renders `1 234,56 HTG`. Shout if you'd rather it stayed locale-driven for consistency, but then the format only comes out right for French/Russian users.

# 🧪 Testing

- [ ] Central server with a `currency` record for `HTG` (rate set), synced to an OMS remote site running this PR
- [ ] Set the store's home currency to HTG — or leave home currency as-is and pick HTG as the foreign currency on a purchase order / inbound shipment
- [ ] Open an inbound shipment → **Pricing** side panel and the **Currency** / **Financial** tabs → amounts render as `1,234.56 HTG`, not `$1,234.56`
- [ ] Same check on a purchase order detail view (pricing section and line columns)
- [ ] Enter a negative/credit amount → renders `-1,234.56 HTG`
- [ ] Switch the UI language to French → renders `1 234,56 HTG` (locale separators, code still trailing)
- [ ] Regression: switch a store back to USD/EUR and confirm existing currencies are unchanged
