### PR TITLE
#12606 Add frontend interaction-performance harness

### DIFF
--- a/.github/workflows/client-bundle-size-diff.yaml
+++ b/.github/workflows/client-bundle-size-diff.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - 'client/**'
+      # client/perf is the perf harness: not a workspace, not imported by product
+      # code, and excluded from tsc, jest and eslint. No check here covers it, so
+      # harness-only changes should not trigger client CI.
+      - '!client/perf/**'
   merge_group:
     branches:
       - develop

--- a/.github/workflows/client-code-checks.yaml
+++ b/.github/workflows/client-code-checks.yaml
@@ -2,6 +2,10 @@ on:
   pull_request:
     paths:
       - 'client/**'
+      # client/perf is the perf harness: not a workspace, not imported by product
+      # code, and excluded from tsc, jest and eslint. No check here covers it, so
+      # harness-only changes should not trigger client CI.
+      - '!client/perf/**'
   merge_group:
     branches:
       - develop

--- a/.github/workflows/client-tests.yaml
+++ b/.github/workflows/client-tests.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - 'client/**'
+      # client/perf is the perf harness: not a workspace, not imported by product
+      # code, and excluded from tsc, jest and eslint. No check here covers it, so
+      # harness-only changes should not trigger client CI.
+      - '!client/perf/**'
   merge_group:
     branches:
       - develop

--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,8 @@
     "test": "jest --config ./jest.config.js --maxWorkers=50% --env=jsdom --testPathIgnorePatterns codegen.test.ts --testPathIgnorePatterns playwright",
     "test:codegen": "jest --config ./jest.config.js codegen.test.ts",
     "e2e": "npx playwright test --config playwright/playwright.config.ts",
+    "perf": "npx playwright test --config perf/perf.config.ts",
+    "perf:baseline": "PERF_BASELINE=1 npx playwright test --config perf/perf.config.ts",
     "translate": "node translate_locale"
   },
   "workspaces": {

--- a/client/perf/.gitignore
+++ b/client/perf/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/client/perf/CHARTER.md
+++ b/client/perf/CHARTER.md
@@ -1,0 +1,174 @@
+# Frontend performance charter
+
+Scope: the **legacy `client/`** app. Goal is shippable wins, not evidence for a rewrite. Pilot
+vertical is **Outbound Shipment**; once strategies are proven there they fan out to the other
+verticals.
+
+The pilot that produced these numbers and the constraints below is issue **#12606** — read it for
+the specific findings and the open follow-ups. This file is the standing agreement; the issue is
+the point-in-time story.
+
+---
+
+## 1. The one number this effort is judged on
+
+**Interaction latency p95** — for a named user interaction, the time from the input event to the
+next paint that reflects the work the interaction triggered, measured under **6× CPU throttle**.
+
+Everything else in §2 exists to *explain* that number, not to replace it.
+
+Why this one: startup bytes are already owned by #12494 / PR #12497, and route-transition time
+mixes in server query cost. Interaction latency is what "the app feels slow" actually is, and
+nothing in this repo currently measures it.
+
+### Deliberately rejected metrics
+
+| Rejected | Why |
+|---|---|
+| why-did-you-render render counts | Counts render-phase invocations, not committed renders. Already produced a false "win" on `perf/stock-search` that the running app contradicted. |
+| Lighthouse score | Composite, weights network heavily. Our deployments are tablet + **local** server, so network is not the constraint. |
+| Average frame rate | An average hides the single 600 ms stall that is the actual complaint. |
+| Bundle size (as *this* effort's goal) | In flight elsewhere (#12494). Tracked here only as a non-regression guard. |
+
+---
+
+## 2. The metric set
+
+Recorded per scenario, per run, by `client/perf` (see `README.md`).
+
+| ID | Metric | Definition | Role |
+|---|---|---|---|
+| **M1** | **Interaction latency** | Event Timing API `duration` for the triggering event (input → next paint). Reported median + p95. | **Headline / gate** |
+| M2 | Settle time | Click → the DOM state that means the user can proceed (rows present, modal fields populated). Includes network. | Separates client render cost from server cost |
+| M3 | Blocking time | Σ (longtask.duration − 50 ms) over the interaction window. | Predicts jank on the real device |
+| M4 | Startup JS (gzip) | Entry + eager chunks from `build-stats`. | Non-regression guard only |
+| M5 | GraphQL round trips | Request count + max serial depth per scenario. | Usually explains a bad M2 |
+
+M1 vs M2 is the important pair. M1 bad + M2 fine ⇒ our render cost. M2 bad + M1 fine ⇒ the
+server or the waterfall (→ file it, don't fix it here; see constraint C8).
+
+---
+
+## 3. Measurement protocol
+
+Non-negotiable, because the numbers are worthless if they drift between runs.
+
+- **Device proxy:** 6× CPU throttle via CDP `Emulation.setCPUThrottlingRate`. **No network
+  throttling** — deployments are tablets against a local server.
+- **Build:** iterate against the **dev** build; every *recorded or reported* number comes from a
+  **production** build. **Never compare a dev number to a prod number** — they are different
+  units. Measured ratio: the same sort was **1832 ms dev vs 472 ms prod**, so dev runs ~3–4×
+  slower.
+  - Dev-mode React plus the WDYR `createElement` patch in `packages/host/src/bootstrap.tsx`
+    inflate render cost, so dev overstates the payoff of render-side fixes. Dev is for
+    *direction*, prod is for *magnitude*.
+  - **Serve the production build from the Rust server on `:8000`**, not `yarn serve` on `:3003`.
+    A production build resolves the API to same-origin (`packages/config/src/config.ts`), so a
+    static server on a different port than the API cannot reach it and the app hangs on
+    "Server startup in progress".
+- **Data:** the seeded `perf-*` fixture only (`client/perf/seed.sh`). Store `GEN` by
+  default, user `Admin`/`pass`. A number taken against unseeded data is not a number, and
+  two numbers taken with different fixture parameters are not comparable — record any
+  override with the result.
+- **Runs:** 7 iterations per scenario, first discarded as warm-up, report median and p95 of 6.
+- **Serial:** 1 worker, no parallel tests — parallel runs contend for CPU and poison the numbers.
+- **Quiet machine, or don't bother.** The same suite run while the developer was working (VS
+  Code, a browser, a VM) came out **2–3× worse across the board** than on an idle machine —
+  `list-sort` p95 936 → 2176 ms. Under a 6× throttle the harness has only a sixth of a core to
+  play with, so anything else running shows up directly.
+  - **The tell is the control scenarios.** If interactions the change cannot possibly affect
+    (opening a column menu, typing in a line-edit field) also move, and the median-to-p95 spread
+    widens, it is contention — not a regression. Re-run when idle rather than believing it.
+- **Noise:** dev run-to-run variance is **±15%**, which sits uncomfortably close to the ≥20%
+  merge gate in C5. Decide borderline changes on a production build, or raise `PERF_RUNS`.
+- **Provenance:** every perf claim in a PR cites a committed baseline JSON. No claim without a run.
+
+### Two traps that have already produced wrong answers here
+
+- **Trace *durations* are not evidence; trace *stacks* are.** Chrome DevTools attributed 1310 ms
+  to MRT's `measureElement` and 1290 ms to style recalculation. Implementing the first produced
+  **no measurable win** (+4%, inside the noise band) and was reverted. Tracing overhead inflates
+  exactly the operations traces are best at naming. Attribute with a trace, decide with the harness.
+- **M1 under-reports debounced interactions.** A filter keystroke is cheap (local state); the
+  expensive URL write happens in a `setTimeout` afterwards, so the Event Timing entry never sees
+  it. Judge those scenarios on M3 (blocking) and M2 (settle) instead.
+
+---
+
+## 4. Budgets and goals
+
+Budgets are the **absolute UX thresholds** (RAIL), applied at 6× throttle — legitimate because the
+throttled machine *is* the device proxy, not a handicap on top of one.
+
+| Class | Budget (M1 p95) | Interactions |
+|---|---|---|
+| Instant | **< 100 ms** | column sort, tab switch, typing in a cell, row select, checkbox |
+| Responsive | **< 500 ms** | open a modal, page a list, apply a filter |
+| Navigational | **< 1000 ms** (M2) | route change including data fetch |
+
+Assigning the class is a judgement call and part of the work, and getting it wrong manufactures
+fake violations. The pilot classed the Details→Log tab switch as `instant`, which made a 352 ms
+result look like a 3.5× breach; but that interaction unmounts a 150-row table, mounts a different
+table and fetches its data. That is a view transition, not a widget toggle. The budget was wrong,
+not the app.
+
+Goals for the pilot, in priority order:
+
+1. **No scenario over 2 s p95.** Anything there is treated as a bug, not a budget miss.
+2. **−50 % M1 p95** on every scenario that starts above its budget class.
+3. **Budget compliance** where reachable without breaking constraint C2/C3.
+4. **M4 not regressed** by any change made here.
+
+### Recorded baselines
+
+| file | what it is |
+|---|---|
+| `baseline/prod.json` | pre-pilot production state (`main` @ bb036d77) |
+| `baseline/prod-after-fixes.json` | after the two fixes in #12606 / PR #12607 |
+| `baseline/dev*.json` | the dev-build equivalents — **3–4× slower**, never quote them as results |
+
+Worst offenders at the production baseline were `detail-sort-lines` 616 ms, `list-page-next`
+488 ms and `list-sort` 472 ms. After the fixes every scenario sits inside its budget class.
+
+---
+
+## 5. Constraints
+
+| # | Constraint |
+|---|---|
+| C1 | **Measurement discipline** exactly as §3. Dev to iterate, prod to claim, never mixed. |
+| C2 | **No dependency swaps.** material-react-table, MUI, react-query, webpack Module Federation all stay. |
+| C3 | **Behaviour-preserving.** No UX changes to buy speed (no swapping pagination for virtualization, no dropping features). If a fix needs a UX change it becomes its own issue. |
+| C4 | **Shared `packages/common` is fair game** — that is where the cost lives — but any change there must be validated by the harness on **≥ 2 verticals** before merge. |
+| C5 | **Merge gate:** a change lands only if it moves a recorded metric by **≥ 20 %** on at least one scenario, or is pure prerequisite work (harness, instrumentation, fixtures). No speculative `useMemo`. |
+| C6 | **No new runtime dependencies.** devDependencies for measurement only. |
+| C7 | **Pilot is Outbound Shipment only** (list, detail, line edit, save). Fan-out starts only after the pilot produces written strategy cards (§6). |
+| C8 | **Not the server.** If M2/M5 show the cost is a slow GraphQL query, file it (cf. #12054) and move on. |
+| C9 | **Two-attempt rule.** If a scenario resists two genuine attempts, document it as an architectural ceiling and stop. Those ceilings are the honest input to the client-next decision — but chasing them is out of scope here. |
+| C10 | Existing `yarn test` and the Playwright e2e suite stay green. |
+
+---
+
+## 6. Fan-out (after the pilot)
+
+Each confirmed fix becomes a **strategy card** in this format:
+
+```text
+pattern:    what the slow shape looks like
+detection:  a grep / lint rule / AST signal that finds it elsewhere
+recipe:     the fix, concretely
+expected:   which metric moves, by roughly how much
+risk:       what it can break
+verify:     which scenario proves it
+```
+
+**The cards themselves live in [README.md](./README.md)** — they are working instructions, kept
+next to the harness that verifies them. This section only fixes the format.
+
+Only then does the workflow phase run: one agent per vertical, each doing
+detect → fix → **harness-verify on its own vertical**, reporting a before/after number. The
+harness is what makes that fan-out safe — an agent cannot claim a win it did not measure.
+
+Fan-out queue: inbound shipment · prescriptions · request requisition · response requisition ·
+stocktake · stock list · item catalogue · customer/supplier returns · patients · dashboard ·
+coldchain monitoring.

--- a/client/perf/README.md
+++ b/client/perf/README.md
@@ -1,0 +1,215 @@
+# `client/perf` — frontend interaction-performance harness
+
+Measures what the app *feels* like: how long an interaction takes to respond,
+under a 6× CPU throttle standing in for a low-end Android tablet. Goals, budgets
+and constraints live in [CHARTER.md](./CHARTER.md).
+
+This is not the e2e suite. It asserts almost nothing about behaviour; it produces
+numbers, and refuses to produce misleading ones.
+
+## Running it
+
+```fish
+# 1. With Postgres running, seed the fixture (once per DB). Connection details
+#    come from server/configuration (base.yaml, overridden by local.yaml); any
+#    PG* env var you set wins. The target store defaults to GEN.
+client/perf/seed.sh
+
+# 2. Bring the app up. `yarn start` at the repo ROOT runs the Rust server and the
+#    webpack dev server (`cargo run & yarn start-local`); from client/ it starts
+#    just the client. Either blocks — leave it running and use a second shell.
+yarn start
+
+# 3. Dev, to iterate on a fix
+cd client
+yarn perf                      # or PERF_RUNS=2 yarn perf for a quick pass
+
+# 4. Production, for ANY number you intend to report. Build the client; the Rust
+#    server already serves it on :8000 with the API on the same origin.
+yarn build
+BASE_URL=http://localhost:8000 PERF_BUILD=prod yarn perf
+
+# Record the current numbers as the comparison point
+BASE_URL=http://localhost:8000 PERF_BUILD=prod yarn perf:baseline
+```
+
+> Do **not** serve the production build with `yarn serve` on :3003. A production
+> build resolves the API to same-origin (`packages/config/src/config.ts`), so on
+> :3003 it cannot reach the server on :8000 and the app just shows
+> "Server startup in progress".
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `PERF_RUNS` | `7` | Iterations per scenario. The first is discarded as warm-up. |
+| `PERF_BASELINE` | unset | Also write `baseline/<build>.json`, the file future runs diff against. |
+| `PERF_BUILD` | unset | Assert the build being measured (`dev`/`prod`). Mismatch = hard failure. |
+| `PERF_HEADED` | unset | Run headed, for watching a scenario misbehave. |
+| `PERF_DIAG` / `PERF_PROFILE` | unset | Run the diagnostics in `scenarios/diag.perf.ts` (see below). |
+| `BASE_URL` | `http://localhost:3003` | Point at `:8000` for production runs. |
+
+The fixture itself is parameterised — `seed.sh` passes extra args to `psql`:
+
+```fish
+client/perf/seed.sh -v fat_lines=400     # bigger detail-view fixture
+client/perf/seed.sh -v store_code=HUF    # seed into a different store
+PGDATABASE=my-db client/perf/seed.sh     # different database
+client/perf/seed.sh --clean              # remove it all again
+```
+
+Numbers are only comparable against the same fixture parameters, so record any
+override alongside the result.
+
+Results land in `results/<build>-<timestamp>.json`; baselines in
+`baseline/<build>.json`. Both are gitignored except the baselines, which are the
+provenance for any perf claim.
+
+## What it reports
+
+| | Metric | Meaning |
+|---|---|---|
+| **M1** | interaction latency | Event Timing `duration` — input event to the next paint. **The headline.** |
+| M2 | settle | interaction → first frame the scenario's settle predicate holds. Includes network. |
+| M3 | blocking | Σ (longtask − 50 ms) in the window. |
+| M5 | gql | requests / serial waves in the window. |
+
+Read M1 against M2. **M1 high** is our render cost. **M1 fine but M2 high** is the
+server or a request waterfall — file it, don't fix it here.
+
+`p95` at the default run count is the nearest-rank p95 of 6 samples, i.e. the
+worst observed run. That is deliberate: 6 points cannot support a smoother
+percentile, and pretending otherwise would be false precision.
+
+## Guards against lying to ourselves
+
+The harness is built around the failure modes that have produced bogus perf
+claims in this repo before:
+
+- **Build mode is detected, not trusted.** Every report records the actual JS byte
+  count and labels the build from it (dev ships ~27 MiB, prod ~5 MiB); if
+  `PERF_BUILD` disagrees, the run fails rather than recording a mislabelled
+  number. Mixing a dev number with a prod one is a ~4× error, so this is worth
+  a hard failure.
+- **A scenario that measures nothing fails.** Before each interaction the settle
+  predicate is asserted false. Without this, a wrong predicate silently reports
+  ~0 ms and looks like a win.
+- **Fixed fixture.** Numbers are only comparable against `seed.sql` data. The
+  seeder also sets several columns that are nullable in Postgres but non-`Option`
+  in the Rust row structs — leaving them NULL makes the server fail the entire
+  invoice query with `DIESEL_DESERIALIZATION_ERROR`, taking out real rows too.
+- **Real Chrome, one worker.** `channel: 'chrome'` (Event Timing is defined
+  against a real paint; the bundled headless shell has no proper compositor), and
+  no parallelism, because concurrent runs contend for CPU.
+- **Throttle only around the interaction.** Getting back to the pre-state runs
+  unthrottled — it is setup, not the measurement.
+- Runs are quiesced (wait for a 250 ms longtask-free gap) so one run cannot bleed
+  into the next.
+
+Both M1 and M2 are paint-quantised and so carry up to one frame of error. That is
+inherent to "when could the user see it", not a defect.
+
+## Adding a scenario
+
+```ts
+{
+  name: 'stocktake-open-line',      // stable — it is the baseline key
+  budget: 'responsive',             // instant <100ms · responsive <500ms · navigational <1000ms
+  reset: async page => { … },       // back to the pre-state; runs unthrottled
+  ready: `<js expr>`,               // true once reset has landed
+  token: `<js expr>`,               // optional: value captured pre-act, readable as __perf.token
+  act: async page => { … },         // the interaction — must be real Playwright input
+  settle: `<js expr>`,              // true once the user could proceed
+}
+```
+
+`act` must use real Playwright input: Event Timing only sees trusted events, so a
+`dispatchEvent` shim would report `null` for M1.
+
+Beware positional selectors. These views carry very few `data-testid`s, so some
+selectors are index-based (the line-edit modal's Issue input) and guarded with an
+assertion that fails loudly when the DOM shifts. Prefer a testid when one exists.
+
+Two UI facts worth knowing before writing a scenario for a table page:
+
+- **Sorting is two clicks, not one.** `useTableDisplayOptions` deliberately replaces
+  the column-actions button with a full-width invisible one, so clicking anywhere in
+  a header opens the column menu; the sort is applied from a *menu item*
+  ("Sort by X ascending"). Both clicks are worth measuring, separately.
+- **A settle predicate based on row order can never become true on a small table**
+  that is already in the target order. Settle on the URL param instead, or use a
+  larger fixture.
+
+---
+
+## Diagnosing a new slowness
+
+The sequence below is what found the app-shell re-render bug. Each step is cheap and
+rules out a whole class, so run them in order rather than reaching for a profiler
+first.
+
+1. **Scale test.** Run the same interaction against a large and a tiny dataset
+   (`diag.perf.ts` does this). If the cost barely changes, it is *fixed overhead*,
+   not per-row work — which stops you optimising rows when the shell is the problem.
+2. **No-op location change.** `history.pushState` + a synthetic `popstate` with a
+   param nothing reads: react-router adopts a new location, nothing refetches, no DOM
+   needs to differ. Any cost measured this way is *pure waste*, with no legitimate
+   work mixed in.
+3. **Profiler regions.** Temporarily wrap shell regions in `React.Profiler` and log
+   `{id, phase, actualDuration}` per commit. **Commit count matters as much as
+   duration** — a `nested-update` is a second render scheduled during commit, so it
+   blocks the paint.
+4. **Table-free route.** Repeat on a page with no table (e.g. `/dashboard`) to
+   separate shell cost from table-layer cost.
+5. **Confirm with the harness, on a production build.** A trace attribution is a
+   hypothesis; only a harness delta is a result.
+
+`scenarios/diag.perf.ts` holds steps 1, 2 and 3 behind `PERF_DIAG=1` / `PERF_PROFILE=1`.
+Step 3 needs temporary `React.Profiler` wrappers added to `host/src/Site.tsx` — it is
+a diagnostic, not a standing test.
+
+---
+
+## Strategy cards
+
+Patterns proven on the Outbound Shipment pilot (#12606), with detection signals, so
+they can be applied to other verticals. Format is defined in
+[CHARTER.md](./CHARTER.md) §6.
+
+### Card 1 — Whole-store zustand subscription
+
+```text
+pattern:    const { x } = useSomeStore()        // no selector
+            + setters written set(s => ({ ...s, x }))
+            ⇒ any write to any field re-renders every consumer
+detection:  grep -rn "= use[A-Z][A-Za-z]*\(Context\|Store\)()" packages --include=*.tsx
+recipe:     const x = useSomeStore(s => s.x)    // one call per field
+            Select fields individually. A selector returning a new object
+            (s => ({a, b})) needs `useShallow`, or it defeats the point.
+expected:   proportional to how much of the tree consumes the store. For the
+            app-shell store: −14% to −43% on mount-heavy interactions.
+risk:       Low — it only narrows a subscription.
+verify:     any scenario that mounts portals (open a detail view, open a modal)
+```
+
+`useHostContext` was fixed in PR #12607. **Still unfixed**, detected but not yet
+measured: `useDrawer` (9 sites, incl. every `AppNavLink`), `useKeyboard` (4 sites,
+incl. every `Autocomplete` and every modal via `useDialog` — tablet-relevant, since
+the on-screen keyboard opening re-renders them all), `useDetailPanelStore` (5 sites),
+`useAppBarRectStore` (1). Their triggering interactions are not in the scenario set
+yet, so per C5 they must not be fixed blind — adding a drawer-toggle and a
+keyboard/autocomplete scenario is the prerequisite.
+
+### Card 2 — A fresh object in a dependency array
+
+```text
+pattern:    useEffect(..., [location, ...])  where only location.pathname is used
+            ⇒ the effect re-runs on search-param-only changes; if it setStates,
+              the subtree re-renders again as a `nested-update`
+detection:  grep -rn "\[location" packages --include=*.tsx
+            plus any dep array holding a router/query object rather than a
+            primitive derived from it
+recipe:     depend on the primitive (pathname, or the derived string), not the object
+expected:   removes one full re-render pass per URL change: −31% to −49% here
+risk:       Low, but confirm the effect still fires when it must — here, on real
+            title changes and on mount
+verify:     any sort / paginate / filter / tab-switch scenario
+```

--- a/client/perf/baseline/dev-after-fixes.json
+++ b/client/perf/baseline/dev-after-fixes.json
@@ -1,0 +1,1188 @@
+{
+  "build": "dev",
+  "buildEvidence": {
+    "scriptBytes": 28599757,
+    "scriptCount": 6
+  },
+  "throttle": 6,
+  "baseUrl": "http://localhost:3003",
+  "createdAt": "2026-07-30T12:40:27.828Z",
+  "scenarios": [
+    {
+      "name": "list-header-menu",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 124,
+      "interactionP95": 128,
+      "settleMedian": 186.25000005960464,
+      "settleP95": 193.80000007152557,
+      "blockingMedian": 38,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [],
+      "samples": [
+        {
+          "interactionMs": 128,
+          "settleMs": 186.40000009536743,
+          "blockingMs": 39,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 120,
+          "settleMs": 193.70000004768372,
+          "blockingMs": 37,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 128,
+          "settleMs": 177.79999995231628,
+          "blockingMs": 39,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 128,
+          "settleMs": 193.80000007152557,
+          "blockingMs": 38,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 120,
+          "settleMs": 182.10000002384186,
+          "blockingMs": 34,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 120,
+          "settleMs": 186.10000002384186,
+          "blockingMs": 38,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "list-sort",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 916,
+      "interactionP95": 936,
+      "settleMedian": 1749.1000000238419,
+      "settleP95": 1798,
+      "blockingMedian": 1480.5,
+      "gqlCount": 3,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 84,
+      "gqlOps": [
+        "invoices",
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 888,
+          "settleMs": 1705.3999999761581,
+          "blockingMs": 1434,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 80.29999995231628,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 920,
+          "settleMs": 1763.5,
+          "blockingMs": 1487,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 89.10000002384186,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 920,
+          "settleMs": 1737.1000000238419,
+          "blockingMs": 1474,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 79.69999992847443,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 936,
+          "settleMs": 1761.1000000238419,
+          "blockingMs": 1489,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 88.5,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 912,
+          "settleMs": 1733.1000000238419,
+          "blockingMs": 1468,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 77.90000009536743,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 912,
+          "settleMs": 1798,
+          "blockingMs": 1501,
+          "longTasks": 3,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 97.10000002384186,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-filter-open",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 112,
+      "interactionP95": 120,
+      "settleMedian": 166.60000002384186,
+      "settleP95": 177.29999995231628,
+      "blockingMedian": 28.5,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [],
+      "samples": [
+        {
+          "interactionMs": 120,
+          "settleMs": 177.29999995231628,
+          "blockingMs": 32,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 112,
+          "settleMs": 162.5,
+          "blockingMs": 27,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 104,
+          "settleMs": 162.30000007152557,
+          "blockingMs": 25,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 112,
+          "settleMs": 176.60000002384186,
+          "blockingMs": 31,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 112,
+          "settleMs": 161.60000002384186,
+          "blockingMs": 28,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 112,
+          "settleMs": 170.70000004768372,
+          "blockingMs": 29,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "list-filter-keystroke",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 64,
+      "interactionP95": 64,
+      "settleMedian": 54.450000047683716,
+      "settleP95": 62.60000002384186,
+      "blockingMedian": 0,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 64,
+          "settleMs": 58.700000047683716,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 47.299999952316284,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 56,
+          "settleMs": 60.200000047683716,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 29.90000009536743,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 56,
+          "settleMs": 50.10000002384186,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 32.89999997615814,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 64,
+          "settleMs": 50.200000047683716,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 64,
+          "settleMs": 62.60000002384186,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "list-filter-apply",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 56,
+      "interactionP95": 64,
+      "settleMedian": 1266.5499999523163,
+      "settleP95": 1311.1000000238419,
+      "blockingMedian": 916.5,
+      "gqlCount": 3,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 43,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync",
+        "invoices"
+      ],
+      "samples": [
+        {
+          "interactionMs": 48,
+          "settleMs": 1274.6000000238419,
+          "blockingMs": 927,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 43.60000002384186,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 64,
+          "settleMs": 1269.6999999284744,
+          "blockingMs": 918,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 42.799999952316284,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 56,
+          "settleMs": 1263.3999999761581,
+          "blockingMs": 915,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 41.89999997615814,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 64,
+          "settleMs": 1311.1000000238419,
+          "blockingMs": 960,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 56.299999952316284,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 56,
+          "settleMs": 1236.2000000476837,
+          "blockingMs": 886,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 42.5,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 56,
+          "settleMs": 1249.3999999761581,
+          "blockingMs": 899,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 44.39999997615814,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoices"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-page-next",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 908,
+      "interactionP95": 936,
+      "settleMedian": 1700.1500000357628,
+      "settleP95": 1722.0999999046326,
+      "blockingMedian": 1455.5,
+      "gqlCount": 3,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 63,
+      "gqlOps": [
+        "invoices",
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 912,
+          "settleMs": 1713.9000000953674,
+          "blockingMs": 1469,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 63.5,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 904,
+          "settleMs": 1709.3000000715256,
+          "blockingMs": 1467,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 63.299999952316284,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 520,
+          "settleMs": 1320.5,
+          "blockingMs": 1080,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 61.5,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 936,
+          "settleMs": 1722.0999999046326,
+          "blockingMs": 1482,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 61.10000002384186,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 880,
+          "settleMs": 1665.3999999761581,
+          "blockingMs": 1422,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 62.5,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 912,
+          "settleMs": 1691,
+          "blockingMs": 1444,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 63.200000047683716,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-open-detail",
+      "budget": "navigational",
+      "budgetMs": 1000,
+      "runs": 6,
+      "interactionMedian": 348,
+      "interactionP95": 352,
+      "settleMedian": 1539.9999999403954,
+      "settleP95": 1575.2999999523163,
+      "blockingMedian": 1363,
+      "gqlCount": 4,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 950,
+      "gqlOps": [
+        "invoice",
+        "initialisationStatus",
+        "reports",
+        "names",
+        "shippingMethods"
+      ],
+      "samples": [
+        {
+          "interactionMs": 352,
+          "settleMs": 1572.5,
+          "blockingMs": 1394,
+          "longTasks": 2,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 979.5,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 224,
+          "settleMs": 1188.0999999046326,
+          "blockingMs": 1010,
+          "longTasks": 2,
+          "gqlCount": 5,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 817.8000000715256,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus",
+            "reports",
+            "names",
+            "shippingMethods"
+          ]
+        },
+        {
+          "interactionMs": 232,
+          "settleMs": 1221.5,
+          "blockingMs": 1033,
+          "longTasks": 2,
+          "gqlCount": 5,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 834.6000000238419,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus",
+            "reports",
+            "names",
+            "shippingMethods"
+          ]
+        },
+        {
+          "interactionMs": 352,
+          "settleMs": 1532.5999999046326,
+          "blockingMs": 1356,
+          "longTasks": 2,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 946.6000000238419,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 344,
+          "settleMs": 1547.3999999761581,
+          "blockingMs": 1370,
+          "longTasks": 2,
+          "gqlCount": 5,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 954.2000000476837,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus",
+            "reports",
+            "names",
+            "shippingMethods"
+          ]
+        },
+        {
+          "interactionMs": 352,
+          "settleMs": 1575.2999999523163,
+          "blockingMs": 1374,
+          "longTasks": 2,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 956.1000000238419,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "detail-sort-lines",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 956,
+      "interactionP95": 984,
+      "settleMedian": 1036.0000000596046,
+      "settleP95": 1056.3999999761581,
+      "blockingMedian": 832,
+      "gqlCount": 2,
+      "gqlWaves": 1,
+      "gqlSlowestMs": 11,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 944,
+          "settleMs": 1018.3000000715256,
+          "blockingMs": 832,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 10.199999928474426,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 952,
+          "settleMs": 1035.7000000476837,
+          "blockingMs": 832,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 8.5,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 936,
+          "settleMs": 1014.2999999523163,
+          "blockingMs": 819,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 12.600000023841858,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 984,
+          "settleMs": 1056.3999999761581,
+          "blockingMs": 857,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 11.100000023841858,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 960,
+          "settleMs": 1039.8999999761581,
+          "blockingMs": 839,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 8,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 960,
+          "settleMs": 1036.3000000715256,
+          "blockingMs": 832,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 18,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "detail-tab-log",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 956,
+      "interactionP95": 984,
+      "settleMedian": 1064.0000000596046,
+      "settleP95": 1087,
+      "blockingMedian": 880,
+      "gqlCount": 4,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 615,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync",
+        "activityLogs",
+        "initialisationStatus"
+      ],
+      "samples": [
+        {
+          "interactionMs": 944,
+          "settleMs": 1054.8000000715256,
+          "blockingMs": 876,
+          "longTasks": 1,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 603.2999999523163,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 960,
+          "settleMs": 1073.2000000476837,
+          "blockingMs": 896,
+          "longTasks": 1,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 621.7999999523163,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 984,
+          "settleMs": 1087,
+          "blockingMs": 906,
+          "longTasks": 1,
+          "gqlCount": 4,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 966.6000000238419,
+          "gqlOps": [
+            "syncInfo",
+            "activityLogs",
+            "initialisationStatus",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 960,
+          "settleMs": 1059.8999999761581,
+          "blockingMs": 881,
+          "longTasks": 1,
+          "gqlCount": 4,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 616.6999999284744,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 952,
+          "settleMs": 1067.6000000238419,
+          "blockingMs": 879,
+          "longTasks": 1,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 608.1999999284744,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 952,
+          "settleMs": 1060.4000000953674,
+          "blockingMs": 879,
+          "longTasks": 1,
+          "gqlCount": 4,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 614.2000000476837,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "line-edit-open",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 448,
+      "interactionP95": 456,
+      "settleMedian": 2707.050000011921,
+      "settleP95": 2730.6999999284744,
+      "blockingMedian": 2332.5,
+      "gqlCount": 7,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 1417,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync",
+        "itemStockOnHand",
+        "itemById",
+        "initialisationStatus",
+        "getOutboundEditLines"
+      ],
+      "samples": [
+        {
+          "interactionMs": 440,
+          "settleMs": 2690.5999999046326,
+          "blockingMs": 2306,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1421.2000000476837,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines"
+          ]
+        },
+        {
+          "interactionMs": 448,
+          "settleMs": 2712.600000023842,
+          "blockingMs": 2341,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1423.3000000715256,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 448,
+          "settleMs": 2688.3000000715256,
+          "blockingMs": 2319,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1410.2000000476837,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 456,
+          "settleMs": 2712.2999999523163,
+          "blockingMs": 2333,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1413.2000000476837,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 440,
+          "settleMs": 2701.8000000715256,
+          "blockingMs": 2332,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1403.5,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 448,
+          "settleMs": 2730.6999999284744,
+          "blockingMs": 2361,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1468.5,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "line-edit-type",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 56,
+      "interactionP95": 56,
+      "settleMedian": 48.89999997615814,
+      "settleP95": 53,
+      "blockingMedian": 0,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [],
+      "samples": [
+        {
+          "interactionMs": null,
+          "settleMs": 48.10000002384186,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 50.699999928474426,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 44.60000002384186,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 37.300000071525574,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 49.699999928474426,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 56,
+          "settleMs": 53,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "line-edit-save",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 80,
+      "interactionP95": 88,
+      "settleMedian": 1308.949999988079,
+      "settleP95": 1362.2999999523163,
+      "blockingMedian": 1038,
+      "gqlCount": 2,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 1012,
+      "gqlOps": [
+        "saveOutboundShipmentItemLines",
+        "invoice"
+      ],
+      "samples": [
+        {
+          "interactionMs": 72,
+          "settleMs": 1306.1000000238419,
+          "blockingMs": 1026,
+          "longTasks": 4,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1010.8999999761581,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 88,
+          "settleMs": 1362.2999999523163,
+          "blockingMs": 1099,
+          "longTasks": 5,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1020,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 1309.2999999523163,
+          "blockingMs": 1050,
+          "longTasks": 5,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 987.2000000476837,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 1347.3999999761581,
+          "blockingMs": 1064,
+          "longTasks": 5,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1012.3999999761581,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 1308.6000000238419,
+          "blockingMs": 1025,
+          "longTasks": 4,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1012.3999999761581,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 72,
+          "settleMs": 1265.5,
+          "blockingMs": 1016,
+          "longTasks": 3,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 984.0999999046326,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "invoice"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/client/perf/baseline/dev.json
+++ b/client/perf/baseline/dev.json
@@ -1,0 +1,1176 @@
+{
+  "build": "dev",
+  "buildEvidence": {
+    "scriptBytes": 28598768,
+    "scriptCount": 6
+  },
+  "throttle": 6,
+  "baseUrl": "http://localhost:3003",
+  "createdAt": "2026-07-30T11:56:56.420Z",
+  "scenarios": [
+    {
+      "name": "list-header-menu",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 128,
+      "interactionP95": 128,
+      "settleMedian": 180.70000004768372,
+      "settleP95": 187.09999990463257,
+      "blockingMedian": 40.5,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [],
+      "samples": [
+        {
+          "interactionMs": null,
+          "settleMs": 153.30000007152557,
+          "blockingMs": 16,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 128,
+          "settleMs": 186.30000007152557,
+          "blockingMs": 40,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 128,
+          "settleMs": 180.60000002384186,
+          "blockingMs": 42,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 128,
+          "settleMs": 168.59999990463257,
+          "blockingMs": 38,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 128,
+          "settleMs": 180.80000007152557,
+          "blockingMs": 44,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 128,
+          "settleMs": 187.09999990463257,
+          "blockingMs": 41,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "list-sort",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 1776,
+      "interactionP95": 1832,
+      "settleMedian": 2263.850000023842,
+      "settleP95": 2318.5,
+      "blockingMedian": 2033,
+      "gqlCount": 3,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 910,
+      "gqlOps": [
+        "invoices",
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 1736,
+          "settleMs": 2232.5,
+          "blockingMs": 2002,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 897.5,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 1728,
+          "settleMs": 2213.5999999046326,
+          "blockingMs": 1983,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 886,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 1832,
+          "settleMs": 2318.5,
+          "blockingMs": 2087,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 931.3999999761581,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 1776,
+          "settleMs": 2264.2000000476837,
+          "blockingMs": 2034,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 915.1000000238419,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 1792,
+          "settleMs": 2284.399999976158,
+          "blockingMs": 2049,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 910.7000000476837,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 1776,
+          "settleMs": 2263.5,
+          "blockingMs": 2032,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 908.5,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-filter-open",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 112,
+      "interactionP95": 112,
+      "settleMedian": 167.10000002384186,
+      "settleP95": 172.39999997615814,
+      "blockingMedian": 26.5,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [],
+      "samples": [
+        {
+          "interactionMs": 112,
+          "settleMs": 169.80000007152557,
+          "blockingMs": 27,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 112,
+          "settleMs": 170.30000007152557,
+          "blockingMs": 30,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 112,
+          "settleMs": 164.20000004768372,
+          "blockingMs": 26,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 104,
+          "settleMs": 172.39999997615814,
+          "blockingMs": 25,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 112,
+          "settleMs": 164.39999997615814,
+          "blockingMs": 30,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 96,
+          "settleMs": 143.70000004768372,
+          "blockingMs": 11,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "list-filter-keystroke",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 72,
+      "interactionP95": 88,
+      "settleMedian": 69.35000002384186,
+      "settleP95": 85.40000009536743,
+      "blockingMedian": 0,
+      "gqlCount": 1,
+      "gqlWaves": 1,
+      "gqlSlowestMs": 2,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 64,
+          "settleMs": 56.90000009536743,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 56,
+          "settleMs": 48.5,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 81.79999995231628,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 4.100000023841858,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 88,
+          "settleMs": 82.60000002384186,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 4.5,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 64,
+          "settleMs": 55.5,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 88,
+          "settleMs": 85.40000009536743,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 5.700000047683716,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-filter-apply",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 56,
+      "interactionP95": 56,
+      "settleMedian": 2451.3000000715256,
+      "settleP95": 2476.899999976158,
+      "blockingMedian": 2090,
+      "gqlCount": 5,
+      "gqlWaves": 3,
+      "gqlSlowestMs": 1242,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync",
+        "invoices"
+      ],
+      "samples": [
+        {
+          "interactionMs": 56,
+          "settleMs": 2438.2999999523163,
+          "blockingMs": 2080,
+          "longTasks": 2,
+          "gqlCount": 5,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1236.3999999761581,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 56,
+          "settleMs": 2434.399999976158,
+          "blockingMs": 2073,
+          "longTasks": 2,
+          "gqlCount": 5,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1235,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 56,
+          "settleMs": 2471,
+          "blockingMs": 2114,
+          "longTasks": 2,
+          "gqlCount": 5,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1259.2000000476837,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 48,
+          "settleMs": 2476.899999976158,
+          "blockingMs": 2111,
+          "longTasks": 2,
+          "gqlCount": 5,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1260,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 48,
+          "settleMs": 2442.4000000953674,
+          "blockingMs": 2079,
+          "longTasks": 2,
+          "gqlCount": 5,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1236.1000000238419,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 56,
+          "settleMs": 2460.2000000476837,
+          "blockingMs": 2100,
+          "longTasks": 2,
+          "gqlCount": 5,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1248.0999999046326,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoices"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-page-next",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 1744,
+      "interactionP95": 1776,
+      "settleMedian": 2245.650000035763,
+      "settleP95": 2261.399999976158,
+      "blockingMedian": 2030,
+      "gqlCount": 3,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 888,
+      "gqlOps": [
+        "invoices",
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 1744,
+          "settleMs": 2249.600000023842,
+          "blockingMs": 2043,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 890.7999999523163,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 1776,
+          "settleMs": 2261.399999976158,
+          "blockingMs": 2050,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 896.6999999284744,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 1744,
+          "settleMs": 2210.4000000953674,
+          "blockingMs": 2000,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 885.7999999523163,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 1768,
+          "settleMs": 2251.899999976158,
+          "blockingMs": 2038,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 892.5,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 1736,
+          "settleMs": 2241.7000000476837,
+          "blockingMs": 2022,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 872.2000000476837,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 1728,
+          "settleMs": 2211.600000023842,
+          "blockingMs": 1998,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 875.3000000715256,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-open-detail",
+      "budget": "navigational",
+      "budgetMs": 1000,
+      "runs": 6,
+      "interactionMedian": 608,
+      "interactionP95": 616,
+      "settleMedian": 2280.050000011921,
+      "settleP95": 2353,
+      "blockingMedian": 2096.5,
+      "gqlCount": 4,
+      "gqlWaves": 3,
+      "gqlSlowestMs": 1454,
+      "gqlOps": [
+        "invoice",
+        "syncInfo",
+        "lastSuccessfulUserSync",
+        "initialisationStatus"
+      ],
+      "samples": [
+        {
+          "interactionMs": 616,
+          "settleMs": 2353,
+          "blockingMs": 2163,
+          "longTasks": 2,
+          "gqlCount": 4,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1508.7999999523163,
+          "gqlOps": [
+            "invoice",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 608,
+          "settleMs": 2274.4000000953674,
+          "blockingMs": 2093,
+          "longTasks": 2,
+          "gqlCount": 4,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1451.6000000238419,
+          "gqlOps": [
+            "invoice",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 608,
+          "settleMs": 2264.2000000476837,
+          "blockingMs": 2089,
+          "longTasks": 2,
+          "gqlCount": 4,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1448.3000000715256,
+          "gqlOps": [
+            "invoice",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 616,
+          "settleMs": 2330,
+          "blockingMs": 2135,
+          "longTasks": 2,
+          "gqlCount": 4,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1472.6000000238419,
+          "gqlOps": [
+            "invoice",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 600,
+          "settleMs": 2282,
+          "blockingMs": 2100,
+          "longTasks": 2,
+          "gqlCount": 4,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1446.6000000238419,
+          "gqlOps": [
+            "invoice",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 608,
+          "settleMs": 2278.100000023842,
+          "blockingMs": 2092,
+          "longTasks": 2,
+          "gqlCount": 4,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1457.2000000476837,
+          "gqlOps": [
+            "invoice",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "initialisationStatus"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "detail-sort-lines",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 1840,
+      "interactionP95": 1920,
+      "settleMedian": 1903.300000011921,
+      "settleP95": 1991.1999999284744,
+      "blockingMedian": 1718,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 1832,
+          "settleMs": 1902.3999999761581,
+          "blockingMs": 1708,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 1920,
+          "settleMs": 1991.1999999284744,
+          "blockingMs": 1799,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 28.200000047683716,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 1824,
+          "settleMs": 1871.2000000476837,
+          "blockingMs": 1702,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 1824,
+          "settleMs": 1870.3000000715256,
+          "blockingMs": 1699,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 1856,
+          "settleMs": 1925.3999999761581,
+          "blockingMs": 1728,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 1848,
+          "settleMs": 1904.2000000476837,
+          "blockingMs": 1768,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "detail-tab-log",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 964,
+      "interactionP95": 1024,
+      "settleMedian": 1077.2499999403954,
+      "settleP95": 1108.1000000238419,
+      "blockingMedian": 891,
+      "gqlCount": 4,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 617,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync",
+        "activityLogs",
+        "initialisationStatus"
+      ],
+      "samples": [
+        {
+          "interactionMs": 952,
+          "settleMs": 1062,
+          "blockingMs": 871,
+          "longTasks": 1,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 604.1999999284744,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 944,
+          "settleMs": 1043.8999999761581,
+          "blockingMs": 871,
+          "longTasks": 1,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 612.6000000238419,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 968,
+          "settleMs": 1071.6999999284744,
+          "blockingMs": 890,
+          "longTasks": 1,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 614.3000000715256,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 1024,
+          "settleMs": 1108.1000000238419,
+          "blockingMs": 959,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 654.6999999284744,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 960,
+          "settleMs": 1082.7999999523163,
+          "blockingMs": 892,
+          "longTasks": 1,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 659.7000000476837,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 976,
+          "settleMs": 1086.2999999523163,
+          "blockingMs": 902,
+          "longTasks": 1,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 619.8999999761581,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "line-edit-open",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 776,
+      "interactionP95": 800,
+      "settleMedian": 2734.400000035763,
+      "settleP95": 3098.2999999523163,
+      "blockingMedian": 2346,
+      "gqlCount": 7,
+      "gqlWaves": 3,
+      "gqlSlowestMs": 1452,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync",
+        "itemStockOnHand",
+        "itemById",
+        "initialisationStatus",
+        "getOutboundEditLines"
+      ],
+      "samples": [
+        {
+          "interactionMs": 464,
+          "settleMs": 2778.5,
+          "blockingMs": 2395,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1471.7999999523163,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines"
+          ]
+        },
+        {
+          "interactionMs": 768,
+          "settleMs": 2731.7000000476837,
+          "blockingMs": 2343,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1455.3999999761581,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines"
+          ]
+        },
+        {
+          "interactionMs": 784,
+          "settleMs": 3098.2999999523163,
+          "blockingMs": 2695,
+          "longTasks": 4,
+          "gqlCount": 8,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1237.6999999284744,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines"
+          ]
+        },
+        {
+          "interactionMs": 776,
+          "settleMs": 2716.4000000953674,
+          "blockingMs": 2334,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1449.6000000238419,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines"
+          ]
+        },
+        {
+          "interactionMs": 776,
+          "settleMs": 2692.2999999523163,
+          "blockingMs": 2296,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1454.6999999284744,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines"
+          ]
+        },
+        {
+          "interactionMs": 800,
+          "settleMs": 2737.100000023842,
+          "blockingMs": 2349,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 3,
+          "gqlSlowestMs": 1437.5,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "line-edit-type",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 48,
+      "interactionP95": 48,
+      "settleMedian": 44.44999998807907,
+      "settleP95": 48.199999928474426,
+      "blockingMedian": 0,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [],
+      "samples": [
+        {
+          "interactionMs": null,
+          "settleMs": 48.199999928474426,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 39.89999997615814,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 48,
+          "settleMs": 45.10000002384186,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 48,
+          "settleMs": 44.5,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 48,
+          "settleMs": 43.40000009536743,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 48,
+          "settleMs": 44.39999997615814,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "line-edit-save",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 80,
+      "interactionP95": 80,
+      "settleMedian": 1327.449999988079,
+      "settleP95": 1343.1000000238419,
+      "blockingMedian": 1065.5,
+      "gqlCount": 2,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 1011,
+      "gqlOps": [
+        "saveOutboundShipmentItemLines",
+        "invoice"
+      ],
+      "samples": [
+        {
+          "interactionMs": 80,
+          "settleMs": 1343.1000000238419,
+          "blockingMs": 1083,
+          "longTasks": 5,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1025.2000000476837,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 1339.2999999523163,
+          "blockingMs": 1073,
+          "longTasks": 5,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1008.8000000715256,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 1312.3999999761581,
+          "blockingMs": 1049,
+          "longTasks": 5,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1001.3999999761581,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 1329.3999999761581,
+          "blockingMs": 1048,
+          "longTasks": 4,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1019.2999999523163,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 1302.5,
+          "blockingMs": 1058,
+          "longTasks": 5,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 997.2999999523163,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 1325.5,
+          "blockingMs": 1217,
+          "longTasks": 4,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 1012.2999999523163,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "invoice"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/client/perf/baseline/prod-after-fixes.json
+++ b/client/perf/baseline/prod-after-fixes.json
@@ -1,0 +1,1151 @@
+{
+  "build": "prod",
+  "buildEvidence": {
+    "scriptBytes": 5571992,
+    "scriptCount": 24
+  },
+  "throttle": 6,
+  "baseUrl": "http://localhost:8000",
+  "createdAt": "2026-07-30T13:01:00.570Z",
+  "scenarios": [
+    {
+      "name": "list-header-menu",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 88,
+      "interactionP95": 96,
+      "settleMedian": 121.75,
+      "settleP95": 138.10000002384186,
+      "blockingMedian": 12.5,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [],
+      "samples": [
+        {
+          "interactionMs": 96,
+          "settleMs": 138.10000002384186,
+          "blockingMs": 20,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 96,
+          "settleMs": 131.30000007152557,
+          "blockingMs": 21,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 121.39999997615814,
+          "blockingMs": 9,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 88,
+          "settleMs": 120.10000002384186,
+          "blockingMs": 12,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 120.10000002384186,
+          "blockingMs": 10,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 88,
+          "settleMs": 122.10000002384186,
+          "blockingMs": 13,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "list-sort",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 280,
+      "interactionP95": 288,
+      "settleMedian": 497.49999994039536,
+      "settleP95": 498.60000002384186,
+      "blockingMedian": 303,
+      "gqlCount": 3,
+      "gqlWaves": 1,
+      "gqlSlowestMs": 34,
+      "gqlOps": [
+        "invoices",
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 256,
+          "settleMs": 472.89999997615814,
+          "blockingMs": 284,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 31.700000047683716,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 288,
+          "settleMs": 496.6999999284744,
+          "blockingMs": 303,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 35,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 280,
+          "settleMs": 498.2999999523163,
+          "blockingMs": 305,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 33.200000047683716,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 280,
+          "settleMs": 498.5,
+          "blockingMs": 303,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 35.60000002384186,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 288,
+          "settleMs": 498.60000002384186,
+          "blockingMs": 312,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 32.5,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 280,
+          "settleMs": 493.1999999284744,
+          "blockingMs": 301,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 34.199999928474426,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-filter-open",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 80,
+      "interactionP95": 80,
+      "settleMedian": 108.94999998807907,
+      "settleP95": 119.60000002384186,
+      "blockingMedian": 3.5,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [],
+      "samples": [
+        {
+          "interactionMs": 80,
+          "settleMs": 105.19999992847443,
+          "blockingMs": 1,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 119.09999990463257,
+          "blockingMs": 4,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 111,
+          "blockingMs": 5,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 106.5,
+          "blockingMs": 3,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 106.89999997615814,
+          "blockingMs": 3,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 119.60000002384186,
+          "blockingMs": 4,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "list-filter-keystroke",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 40,
+      "interactionP95": 40,
+      "settleMedian": 33.10000002384186,
+      "settleP95": 36.5,
+      "blockingMedian": 0,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [],
+      "samples": [
+        {
+          "interactionMs": null,
+          "settleMs": 31.90000009536743,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 30,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 29.299999952316284,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 40,
+          "settleMs": 34.299999952316284,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 35.199999928474426,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 36.5,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "list-filter-apply",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 40,
+      "interactionP95": 48,
+      "settleMedian": 516.9499999880791,
+      "settleP95": 523.1000000238419,
+      "blockingMedian": 182,
+      "gqlCount": 1,
+      "gqlWaves": 1,
+      "gqlSlowestMs": 17,
+      "gqlOps": [
+        "invoices"
+      ],
+      "samples": [
+        {
+          "interactionMs": 40,
+          "settleMs": 512.3999999761581,
+          "blockingMs": 178,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 16.5,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 40,
+          "settleMs": 512.2999999523163,
+          "blockingMs": 179,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 16.700000047683716,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 40,
+          "settleMs": 523.1000000238419,
+          "blockingMs": 184,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 16,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 40,
+          "settleMs": 517.8000000715256,
+          "blockingMs": 186,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 18.200000047683716,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 48,
+          "settleMs": 516.0999999046326,
+          "blockingMs": 180,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 17.399999976158142,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 40,
+          "settleMs": 520.8999999761581,
+          "blockingMs": 188,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 17.5,
+          "gqlOps": [
+            "invoices"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-page-next",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 288,
+      "interactionP95": 296,
+      "settleMedian": 516.9999999403954,
+      "settleP95": 522.3000000715256,
+      "blockingMedian": 330,
+      "gqlCount": 1,
+      "gqlWaves": 1,
+      "gqlSlowestMs": 27,
+      "gqlOps": [
+        "invoices"
+      ],
+      "samples": [
+        {
+          "interactionMs": 288,
+          "settleMs": 515.5999999046326,
+          "blockingMs": 328,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 26.799999952316284,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 296,
+          "settleMs": 522.3000000715256,
+          "blockingMs": 339,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 26.399999976158142,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 288,
+          "settleMs": 518.3999999761581,
+          "blockingMs": 332,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 25.299999952316284,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 296,
+          "settleMs": 521.5,
+          "blockingMs": 341,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 27,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 264,
+          "settleMs": 462.1999999284744,
+          "blockingMs": 293,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 17.200000047683716,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 288,
+          "settleMs": 507.2000000476837,
+          "blockingMs": 324,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 26.799999952316284,
+          "gqlOps": [
+            "invoices"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-open-detail",
+      "budget": "navigational",
+      "budgetMs": 1000,
+      "runs": 6,
+      "interactionMedian": 144,
+      "interactionP95": 152,
+      "settleMedian": 668.4000000357628,
+      "settleP95": 680.5,
+      "blockingMedian": 479.5,
+      "gqlCount": 2,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 397,
+      "gqlOps": [
+        "invoice",
+        "initialisationStatus"
+      ],
+      "samples": [
+        {
+          "interactionMs": 144,
+          "settleMs": 672.3999999761581,
+          "blockingMs": 480,
+          "longTasks": 2,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 397.10000002384186,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 144,
+          "settleMs": 662.2000000476837,
+          "blockingMs": 479,
+          "longTasks": 2,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 395,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 144,
+          "settleMs": 648.6000000238419,
+          "blockingMs": 481,
+          "longTasks": 2,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 398.2999999523163,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 152,
+          "settleMs": 664.8000000715256,
+          "blockingMs": 469,
+          "longTasks": 2,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 387.39999997615814,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 144,
+          "settleMs": 680.5,
+          "blockingMs": 480,
+          "longTasks": 2,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 397.3000000715256,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 136,
+          "settleMs": 672,
+          "blockingMs": 476,
+          "longTasks": 2,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 397.60000002384186,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "detail-sort-lines",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 408,
+      "interactionP95": 424,
+      "settleMedian": 448.4500000476837,
+      "settleP95": 465.40000009536743,
+      "blockingMedian": 316.5,
+      "gqlCount": 2,
+      "gqlWaves": 1,
+      "gqlSlowestMs": 12,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 408,
+          "settleMs": 446.40000009536743,
+          "blockingMs": 317,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 18.799999952316284,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 408,
+          "settleMs": 443.7999999523163,
+          "blockingMs": 309,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 5.5,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 452.5,
+          "blockingMs": 317,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 5.699999928474426,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 424,
+          "settleMs": 465.40000009536743,
+          "blockingMs": 336,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 17.699999928474426,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 445.7000000476837,
+          "blockingMs": 316,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 5.300000071525574,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 400,
+          "settleMs": 450.5,
+          "blockingMs": 310,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 18.100000023841858,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "detail-tab-log",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 344,
+      "interactionP95": 352,
+      "settleMedian": 411.25000005960464,
+      "settleP95": 419.5,
+      "blockingMedian": 273.5,
+      "gqlCount": 2,
+      "gqlWaves": 1,
+      "gqlSlowestMs": 141,
+      "gqlOps": [
+        "activityLogs",
+        "initialisationStatus"
+      ],
+      "samples": [
+        {
+          "interactionMs": 344,
+          "settleMs": 406.1999999284744,
+          "blockingMs": 270,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 141.60000002384186,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 352,
+          "settleMs": 419.5,
+          "blockingMs": 278,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 141.70000004768372,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 344,
+          "settleMs": 413.5,
+          "blockingMs": 274,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 142,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 344,
+          "settleMs": 409.5,
+          "blockingMs": 272,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 140.79999995231628,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 344,
+          "settleMs": 411.3000000715256,
+          "blockingMs": 273,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 136.80000007152557,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 352,
+          "settleMs": 411.2000000476837,
+          "blockingMs": 274,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 138.5,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "line-edit-open",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 216,
+      "interactionP95": 224,
+      "settleMedian": 920.3500000238419,
+      "settleP95": 939.1999999284744,
+      "blockingMedian": 587,
+      "gqlCount": 6,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 332,
+      "gqlOps": [
+        "itemStockOnHand",
+        "itemById",
+        "initialisationStatus",
+        "getOutboundEditLines",
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 224,
+          "settleMs": 939.1999999284744,
+          "blockingMs": 607,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 478.59999990463257,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 208,
+          "settleMs": 921.8999999761581,
+          "blockingMs": 586,
+          "longTasks": 4,
+          "gqlCount": 6,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 337.8000000715256,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 208,
+          "settleMs": 915.1000000238419,
+          "blockingMs": 583,
+          "longTasks": 4,
+          "gqlCount": 6,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 328,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 216,
+          "settleMs": 902.6999999284744,
+          "blockingMs": 573,
+          "longTasks": 4,
+          "gqlCount": 6,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 328.2000000476837,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 216,
+          "settleMs": 918.8000000715256,
+          "blockingMs": 588,
+          "longTasks": 4,
+          "gqlCount": 6,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 329.60000002384186,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 216,
+          "settleMs": 924.7999999523163,
+          "blockingMs": 592,
+          "longTasks": 4,
+          "gqlCount": 6,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 335.10000002384186,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "line-edit-type",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": null,
+      "interactionP95": null,
+      "settleMedian": 33.39999997615814,
+      "settleP95": 38.40000009536743,
+      "blockingMedian": 0,
+      "gqlCount": 1,
+      "gqlWaves": 1,
+      "gqlSlowestMs": 4,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": null,
+          "settleMs": 26.300000071525574,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 28.100000023841858,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 38.40000009536743,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 8.200000047683716,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 31.399999976158142,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 36.799999952316284,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 8.400000095367432,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 35.39999997615814,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 8.200000047683716,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "line-edit-save",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 84,
+      "interactionP95": 88,
+      "settleMedian": 419.69999998807907,
+      "settleP95": 446.89999997615814,
+      "blockingMedian": 198,
+      "gqlCount": 4,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 270,
+      "gqlOps": [
+        "saveOutboundShipmentItemLines",
+        "syncInfo",
+        "lastSuccessfulUserSync",
+        "invoice"
+      ],
+      "samples": [
+        {
+          "interactionMs": 88,
+          "settleMs": 442.5,
+          "blockingMs": 206,
+          "longTasks": 3,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 275.2000000476837,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 88,
+          "settleMs": 416.89999997615814,
+          "blockingMs": 196,
+          "longTasks": 3,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 271.7000000476837,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 419.60000002384186,
+          "blockingMs": 196,
+          "longTasks": 3,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 264.7000000476837,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 419.7999999523163,
+          "blockingMs": 200,
+          "longTasks": 3,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 267.7000000476837,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 446.89999997615814,
+          "blockingMs": 211,
+          "longTasks": 3,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 278.7999999523163,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 88,
+          "settleMs": 413.39999997615814,
+          "blockingMs": 190,
+          "longTasks": 3,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 260.10000002384186,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoice"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/client/perf/baseline/prod.json
+++ b/client/perf/baseline/prod.json
@@ -1,0 +1,1157 @@
+{
+  "build": "prod",
+  "buildEvidence": {
+    "scriptBytes": 5571915,
+    "scriptCount": 24
+  },
+  "throttle": 6,
+  "baseUrl": "http://localhost:8000",
+  "createdAt": "2026-07-30T12:50:02.280Z",
+  "scenarios": [
+    {
+      "name": "list-header-menu",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 96,
+      "interactionP95": 96,
+      "settleMedian": 130.55000001192093,
+      "settleP95": 140,
+      "blockingMedian": 19.5,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [],
+      "samples": [
+        {
+          "interactionMs": 96,
+          "settleMs": 138,
+          "blockingMs": 21,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 96,
+          "settleMs": 140,
+          "blockingMs": 20,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 88,
+          "settleMs": 125.70000004768372,
+          "blockingMs": 15,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 122.60000002384186,
+          "blockingMs": 19,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 88,
+          "settleMs": 124.39999997615814,
+          "blockingMs": 14,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 96,
+          "settleMs": 135.39999997615814,
+          "blockingMs": 23,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "list-sort",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 468,
+      "interactionP95": 472,
+      "settleMedian": 663.3999999761581,
+      "settleP95": 673.5,
+      "blockingMedian": 486.5,
+      "gqlCount": 3,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 207,
+      "gqlOps": [
+        "invoices",
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 440,
+          "settleMs": 639.7999999523163,
+          "blockingMs": 462,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 207.80000007152557,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 464,
+          "settleMs": 665.3999999761581,
+          "blockingMs": 487,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 206.20000004768372,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 472,
+          "settleMs": 661.3999999761581,
+          "blockingMs": 486,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 204.20000004768372,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 472,
+          "settleMs": 673.5,
+          "blockingMs": 492,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 204.60000002384186,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 472,
+          "settleMs": 671.3999999761581,
+          "blockingMs": 493,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 209.70000004768372,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 456,
+          "settleMs": 657.1999999284744,
+          "blockingMs": 477,
+          "longTasks": 2,
+          "gqlCount": 3,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 208.5,
+          "gqlOps": [
+            "invoices",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-filter-open",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 72,
+      "interactionP95": 80,
+      "settleMedian": 103.69999998807907,
+      "settleP95": 110.10000002384186,
+      "blockingMedian": 0,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [],
+      "samples": [
+        {
+          "interactionMs": null,
+          "settleMs": 103,
+          "blockingMs": 2,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 72,
+          "settleMs": 90,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 104.39999997615814,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 93.89999997615814,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 110.10000002384186,
+          "blockingMs": 5,
+          "longTasks": 1,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 72,
+          "settleMs": 107.19999992847443,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "list-filter-keystroke",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 40,
+      "interactionP95": 40,
+      "settleMedian": 31.149999976158142,
+      "settleP95": 34.800000071525574,
+      "blockingMedian": 0,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [],
+      "samples": [
+        {
+          "interactionMs": null,
+          "settleMs": 28.800000071525574,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 31.399999976158142,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 30.700000047683716,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 33.700000047683716,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 30.899999976158142,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": 40,
+          "settleMs": 34.800000071525574,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "list-filter-apply",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 40,
+      "interactionP95": 40,
+      "settleMedian": 701.1999999880791,
+      "settleP95": 703,
+      "blockingMedian": 364.5,
+      "gqlCount": 1,
+      "gqlWaves": 1,
+      "gqlSlowestMs": 209,
+      "gqlOps": [
+        "invoices"
+      ],
+      "samples": [
+        {
+          "interactionMs": 40,
+          "settleMs": 686.1000000238419,
+          "blockingMs": 353,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 205.5,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 40,
+          "settleMs": 701.1999999284744,
+          "blockingMs": 368,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 216.39999997615814,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 40,
+          "settleMs": 696.5,
+          "blockingMs": 363,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 210.89999997615814,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 40,
+          "settleMs": 701.2999999523163,
+          "blockingMs": 366,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 206.79999995231628,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 40,
+          "settleMs": 703,
+          "blockingMs": 369,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 213.70000004768372,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 40,
+          "settleMs": 701.2000000476837,
+          "blockingMs": 361,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 206.10000002384186,
+          "gqlOps": [
+            "invoices"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-page-next",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 476,
+      "interactionP95": 488,
+      "settleMedian": 687.1499999761581,
+      "settleP95": 700,
+      "blockingMedian": 511.5,
+      "gqlCount": 1,
+      "gqlWaves": 1,
+      "gqlSlowestMs": 201,
+      "gqlOps": [
+        "invoices"
+      ],
+      "samples": [
+        {
+          "interactionMs": 472,
+          "settleMs": 690,
+          "blockingMs": 510,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 195.69999992847443,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 488,
+          "settleMs": 700,
+          "blockingMs": 521,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 202.69999992847443,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 472,
+          "settleMs": 683.2000000476837,
+          "blockingMs": 512,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 204.09999990463257,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 480,
+          "settleMs": 674.2000000476837,
+          "blockingMs": 507,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 196.29999995231628,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 472,
+          "settleMs": 684.2999999523163,
+          "blockingMs": 511,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 203.20000004768372,
+          "gqlOps": [
+            "invoices"
+          ]
+        },
+        {
+          "interactionMs": 480,
+          "settleMs": 690.6999999284744,
+          "blockingMs": 512,
+          "longTasks": 2,
+          "gqlCount": 1,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 200.20000004768372,
+          "gqlOps": [
+            "invoices"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "list-open-detail",
+      "budget": "navigational",
+      "budgetMs": 1000,
+      "runs": 6,
+      "interactionMedian": 176,
+      "interactionP95": 176,
+      "settleMedian": 778.5499999523163,
+      "settleP95": 784.6000000238419,
+      "blockingMedian": 605,
+      "gqlCount": 4,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 502,
+      "gqlOps": [
+        "invoice",
+        "initialisationStatus",
+        "reports",
+        "names",
+        "shippingMethods"
+      ],
+      "samples": [
+        {
+          "interactionMs": 176,
+          "settleMs": 775.1000000238419,
+          "blockingMs": 607,
+          "longTasks": 2,
+          "gqlCount": 5,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 502.10000002384186,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus",
+            "reports",
+            "names",
+            "shippingMethods"
+          ]
+        },
+        {
+          "interactionMs": 152,
+          "settleMs": 756.7000000476837,
+          "blockingMs": 579,
+          "longTasks": 2,
+          "gqlCount": 5,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 488.8000000715256,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus",
+            "reports",
+            "names",
+            "shippingMethods"
+          ]
+        },
+        {
+          "interactionMs": 168,
+          "settleMs": 777.2999999523163,
+          "blockingMs": 603,
+          "longTasks": 2,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 502.8000000715256,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 176,
+          "settleMs": 781.8999999761581,
+          "blockingMs": 609,
+          "longTasks": 2,
+          "gqlCount": 5,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 501.60000002384186,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus",
+            "reports",
+            "names",
+            "shippingMethods"
+          ]
+        },
+        {
+          "interactionMs": 176,
+          "settleMs": 784.6000000238419,
+          "blockingMs": 613,
+          "longTasks": 2,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 503.09999990463257,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 176,
+          "settleMs": 779.7999999523163,
+          "blockingMs": 603,
+          "longTasks": 2,
+          "gqlCount": 2,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 501.10000002384186,
+          "gqlOps": [
+            "invoice",
+            "initialisationStatus"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "detail-sort-lines",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 612,
+      "interactionP95": 616,
+      "settleMedian": 659.1999999880791,
+      "settleP95": 667.2000000476837,
+      "blockingMedian": 517.5,
+      "gqlCount": 2,
+      "gqlWaves": 1,
+      "gqlSlowestMs": 18,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 616,
+          "settleMs": 666.6999999284744,
+          "blockingMs": 524,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 20.199999928474426,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 616,
+          "settleMs": 664,
+          "blockingMs": 521,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 18.5,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 608,
+          "settleMs": 654.3999999761581,
+          "blockingMs": 510,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 19,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 608,
+          "settleMs": 639.6999999284744,
+          "blockingMs": 514,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 7.399999976158142,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 608,
+          "settleMs": 630.6999999284744,
+          "blockingMs": 510,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 6.299999952316284,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 616,
+          "settleMs": 667.2000000476837,
+          "blockingMs": 522,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 17.299999952316284,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "detail-tab-log",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": 348,
+      "interactionP95": 352,
+      "settleMedian": 411.5,
+      "settleP95": 419.7000000476837,
+      "blockingMedian": 273.5,
+      "gqlCount": 2,
+      "gqlWaves": 1,
+      "gqlSlowestMs": 143,
+      "gqlOps": [
+        "activityLogs",
+        "initialisationStatus"
+      ],
+      "samples": [
+        {
+          "interactionMs": 352,
+          "settleMs": 412.60000002384186,
+          "blockingMs": 276,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 145.60000002384186,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 352,
+          "settleMs": 407.10000002384186,
+          "blockingMs": 270,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 144,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 344,
+          "settleMs": 401.2000000476837,
+          "blockingMs": 265,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 140.5,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 344,
+          "settleMs": 414.60000002384186,
+          "blockingMs": 274,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 147.39999997615814,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 344,
+          "settleMs": 419.7000000476837,
+          "blockingMs": 275,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 140.19999992847443,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        },
+        {
+          "interactionMs": 352,
+          "settleMs": 410.39999997615814,
+          "blockingMs": 273,
+          "longTasks": 1,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 142.89999997615814,
+          "gqlOps": [
+            "activityLogs",
+            "initialisationStatus"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "line-edit-open",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 212,
+      "interactionP95": 216,
+      "settleMedian": 903.4999999403954,
+      "settleP95": 920.2999999523163,
+      "blockingMedian": 571.5,
+      "gqlCount": 6,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 329,
+      "gqlOps": [
+        "itemStockOnHand",
+        "itemById",
+        "initialisationStatus",
+        "getOutboundEditLines",
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": 216,
+          "settleMs": 909.1000000238419,
+          "blockingMs": 574,
+          "longTasks": 4,
+          "gqlCount": 6,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 329.8000000715256,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 216,
+          "settleMs": 893.2000000476837,
+          "blockingMs": 565,
+          "longTasks": 4,
+          "gqlCount": 6,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 313.5,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 208,
+          "settleMs": 902.1999999284744,
+          "blockingMs": 569,
+          "longTasks": 4,
+          "gqlCount": 6,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 317.6999999284744,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 208,
+          "settleMs": 904.7999999523163,
+          "blockingMs": 583,
+          "longTasks": 4,
+          "gqlCount": 6,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 327.39999997615814,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 216,
+          "settleMs": 898.6000000238419,
+          "blockingMs": 565,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 480.5,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": 208,
+          "settleMs": 920.2999999523163,
+          "blockingMs": 589,
+          "longTasks": 4,
+          "gqlCount": 7,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 463.5,
+          "gqlOps": [
+            "itemStockOnHand",
+            "itemById",
+            "initialisationStatus",
+            "getOutboundEditLines",
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "line-edit-type",
+      "budget": "instant",
+      "budgetMs": 100,
+      "runs": 6,
+      "interactionMedian": null,
+      "interactionP95": null,
+      "settleMedian": 30.44999998807907,
+      "settleP95": 37.40000009536743,
+      "blockingMedian": 0,
+      "gqlCount": 0,
+      "gqlWaves": 0,
+      "gqlSlowestMs": 0,
+      "gqlOps": [
+        "syncInfo",
+        "lastSuccessfulUserSync"
+      ],
+      "samples": [
+        {
+          "interactionMs": null,
+          "settleMs": 37.40000009536743,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 2,
+          "gqlWaves": 1,
+          "gqlSlowestMs": 17.100000023841858,
+          "gqlOps": [
+            "syncInfo",
+            "lastSuccessfulUserSync"
+          ]
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 30.09999990463257,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 34.700000047683716,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 30.399999976158142,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 29.799999952316284,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        },
+        {
+          "interactionMs": null,
+          "settleMs": 30.5,
+          "blockingMs": 0,
+          "longTasks": 0,
+          "gqlCount": 0,
+          "gqlWaves": 0,
+          "gqlSlowestMs": 0,
+          "gqlOps": []
+        }
+      ]
+    },
+    {
+      "name": "line-edit-save",
+      "budget": "responsive",
+      "budgetMs": 500,
+      "runs": 6,
+      "interactionMedian": 80,
+      "interactionP95": 88,
+      "settleMedian": 411.75,
+      "settleP95": 440.39999997615814,
+      "blockingMedian": 191.5,
+      "gqlCount": 4,
+      "gqlWaves": 2,
+      "gqlSlowestMs": 268,
+      "gqlOps": [
+        "saveOutboundShipmentItemLines",
+        "syncInfo",
+        "lastSuccessfulUserSync",
+        "invoice"
+      ],
+      "samples": [
+        {
+          "interactionMs": 80,
+          "settleMs": 407.39999997615814,
+          "blockingMs": 189,
+          "longTasks": 3,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 252.69999992847443,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 416.10000002384186,
+          "blockingMs": 194,
+          "longTasks": 3,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 269.10000002384186,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 428.7999999523163,
+          "blockingMs": 196,
+          "longTasks": 3,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 277.1999999284744,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 440.39999997615814,
+          "blockingMs": 199,
+          "longTasks": 3,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 273.8000000715256,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 80,
+          "settleMs": 403.2000000476837,
+          "blockingMs": 184,
+          "longTasks": 3,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 265.7000000476837,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoice"
+          ]
+        },
+        {
+          "interactionMs": 88,
+          "settleMs": 396.39999997615814,
+          "blockingMs": 186,
+          "longTasks": 3,
+          "gqlCount": 4,
+          "gqlWaves": 2,
+          "gqlSlowestMs": 266.7999999523163,
+          "gqlOps": [
+            "saveOutboundShipmentItemLines",
+            "syncInfo",
+            "lastSuccessfulUserSync",
+            "invoice"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/client/perf/lib/measure.ts
+++ b/client/perf/lib/measure.ts
@@ -1,0 +1,372 @@
+/**
+ * Measurement core for the frontend perf harness. See ../CHARTER.md §2–3.
+ *
+ * Metrics, per run:
+ *   M1 interactionMs — Event Timing `duration` (input → next paint) for the
+ *                      interaction. This is the headline number.
+ *   M2 settleMs      — interaction start → first animation frame on which the
+ *                      scenario's settle predicate holds. Includes network.
+ *   M3 blockingMs    — Σ (longtask − 50 ms) inside the interaction window.
+ *   M5 gql           — GraphQL requests in the window, plus a serial-depth
+ *                      ("waves") estimate.
+ *
+ * Both M1 and M2 are paint-quantised, so both carry up to one frame of error.
+ * That is inherent to measuring "when could the user see it", not a defect.
+ */
+import fs from 'fs';
+import path from 'path';
+import { BrowserContext, CDPSession, Page, expect } from '@playwright/test';
+
+export const THROTTLE_RATE = 6;
+
+export interface Sample {
+  interactionMs: number | null;
+  settleMs: number;
+  blockingMs: number;
+  longTasks: number;
+  gqlCount: number;
+  gqlWaves: number;
+  gqlSlowestMs: number;
+  gqlOps: string[];
+}
+
+export interface Scenario {
+  /** Stable id — used as the key in baseline JSON. */
+  name: string;
+  /** Budget class from CHARTER.md §4. */
+  budget: 'instant' | 'responsive' | 'navigational';
+  /**
+   * Return the page to the pre-interaction state. Runs unthrottled, and is
+   * re-run before every iteration.
+   */
+  reset: (page: Page, run: number) => Promise<void>;
+  /** JS expression, evaluated in-page, that is true once `reset` has landed. */
+  ready: string;
+  /**
+   * Optional JS expression evaluated just before the interaction; its value is
+   * exposed to `settle` as `__perf.token`. Use it when "done" means "changed
+   * from what was there before" (e.g. a re-sort).
+   */
+  token?: string;
+  /** The interaction itself. Must be real Playwright input for Event Timing to see it. */
+  act: (page: Page, run: number) => Promise<void>;
+  /** JS expression, evaluated in-page, true once the user could proceed. */
+  settle: string;
+}
+
+declare global {
+  interface Window {
+    __perf: {
+      t0: number;
+      settleAt: number | null;
+      token: unknown;
+      events: { name: string; duration: number; startTime: number }[];
+      longTasks: { start: number; duration: number }[];
+      gql: { op: string; start: number; end: number }[];
+      observers: PerformanceObserver[];
+      begin(): void;
+      markSettled(): void;
+      end(): Omit<Sample, never>;
+    };
+  }
+}
+
+/**
+ * Installed before any app code runs. The fetch wrapper has to be in place from
+ * the start (the app captures no reference we could patch later), so it is on
+ * for every run — a constant cost, not a per-run variable.
+ */
+export async function installProbe(context: BrowserContext) {
+  await context.addInitScript(() => {
+    const perf: Window['__perf'] = {
+      t0: 0,
+      settleAt: null,
+      token: undefined,
+      events: [],
+      longTasks: [],
+      gql: [],
+      observers: [],
+
+      begin() {
+        this.observers.forEach(o => o.disconnect());
+        this.observers = [];
+        this.events = [];
+        this.longTasks = [];
+        this.gql = [];
+        this.settleAt = null;
+
+        const evObs = new PerformanceObserver(list => {
+          for (const e of list.getEntries()) {
+            this.events.push({
+              name: e.name,
+              duration: e.duration,
+              startTime: e.startTime,
+            });
+          }
+        });
+        // 16 ms is the floor the spec allows; the 104 ms default would hide
+        // everything inside our "instant" budget class.
+        evObs.observe({
+          type: 'event',
+          buffered: true,
+          durationThreshold: 16,
+        } as PerformanceObserverInit);
+        this.observers.push(evObs);
+
+        const ltObs = new PerformanceObserver(list => {
+          for (const e of list.getEntries()) {
+            this.longTasks.push({ start: e.startTime, duration: e.duration });
+          }
+        });
+        ltObs.observe({ type: 'longtask', buffered: true });
+        this.observers.push(ltObs);
+
+        this.t0 = performance.now();
+      },
+
+      markSettled() {
+        if (this.settleAt === null) this.settleAt = performance.now();
+      },
+
+      end() {
+        this.observers.forEach(o => o.disconnect());
+        this.observers = [];
+
+        const t0 = this.t0;
+        const settleAt = this.settleAt ?? performance.now();
+        // One frame of slack: Event Timing startTime is the hardware event
+        // timestamp, which can predate our t0 by a hair.
+        const from = t0 - 20;
+
+        const INPUT = [
+          'click',
+          'pointerdown',
+          'pointerup',
+          'mousedown',
+          'mouseup',
+          'keydown',
+          'keyup',
+          'keypress',
+          'input',
+          'change',
+        ];
+        const relevant = this.events.filter(
+          e => e.startTime >= from && INPUT.includes(e.name)
+        );
+        const interactionMs = relevant.length
+          ? Math.max(...relevant.map(e => e.duration))
+          : null;
+
+        const blockingMs = this.longTasks
+          .filter(l => l.start + l.duration >= t0 && l.start <= settleAt)
+          .reduce((sum, l) => sum + Math.max(0, l.duration - 50), 0);
+        const longTasks = this.longTasks.filter(
+          l => l.start + l.duration >= t0 && l.start <= settleAt
+        ).length;
+
+        const gql = this.gql
+          .filter(g => g.start >= from && g.start <= settleAt)
+          .sort((a, b) => a.start - b.start);
+
+        // Serial depth: a new wave begins when a request starts after every
+        // earlier request in the current wave has already finished.
+        let waves = 0;
+        let waveEnd = -Infinity;
+        for (const g of gql) {
+          if (g.start >= waveEnd) {
+            waves++;
+            waveEnd = g.end;
+          } else {
+            waveEnd = Math.max(waveEnd, g.end);
+          }
+        }
+
+        return {
+          interactionMs,
+          settleMs: settleAt - t0,
+          blockingMs,
+          longTasks,
+          gqlCount: gql.length,
+          gqlWaves: waves,
+          gqlSlowestMs: gql.length
+            ? Math.max(...gql.map(g => g.end - g.start))
+            : 0,
+          gqlOps: [...new Set(gql.map(g => g.op))],
+        };
+      },
+    };
+
+    window.__perf = perf;
+
+    const nativeFetch = window.fetch;
+    window.fetch = async function (...args: Parameters<typeof fetch>) {
+      const [input, init] = args;
+      const url = typeof input === 'string' ? input : (input as Request)?.url;
+      if (!url || !url.includes('graphql')) return nativeFetch.apply(this, args);
+
+      let op = 'unknown';
+      try {
+        const body = init?.body ?? (input as Request)?.body;
+        if (typeof body === 'string') {
+          op = JSON.parse(body).operationName ?? 'anonymous';
+        }
+      } catch {
+        // Body is not the JSON we expected; the timing is still worth keeping.
+      }
+
+      const start = performance.now();
+      try {
+        return await nativeFetch.apply(this, args);
+      } finally {
+        perf.gql.push({ op, start, end: performance.now() });
+      }
+    };
+  });
+}
+
+export async function setThrottle(cdp: CDPSession, rate: number) {
+  await cdp.send('Emulation.setCPUThrottlingRate', { rate });
+}
+
+/** Wait for the main thread to go quiet, so one run cannot bleed into the next. */
+async function waitForQuiet(page: Page, quietMs = 250, timeoutMs = 15_000) {
+  await page.evaluate(
+    async ([quiet, timeout]) => {
+      await new Promise<void>(resolve => {
+        let last = performance.now();
+        const obs = new PerformanceObserver(() => {
+          last = performance.now();
+        });
+        obs.observe({ type: 'longtask', buffered: false });
+        const deadline = performance.now() + timeout;
+        const tick = () => {
+          if (performance.now() - last >= quiet || performance.now() > deadline) {
+            obs.disconnect();
+            resolve();
+            return;
+          }
+          requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+      });
+    },
+    [quietMs, timeoutMs] as const
+  );
+}
+
+/**
+ * Stamp the settle time from inside the page, on the first animation frame the
+ * predicate holds — no round-trip, so no round-trip error.
+ */
+async function waitForSettle(page: Page, expr: string, timeout: number) {
+  await page.waitForFunction(
+    src => {
+      // eslint-disable-next-line no-new-func
+      const ok = new Function('return (' + src + ')')();
+      if (!ok) return false;
+      window.__perf.markSettled();
+      return true;
+    },
+    expr,
+    { polling: 'raf', timeout }
+  );
+}
+
+/**
+ * Progress goes to a file as well as stdout: Playwright's reporter buffers a
+ * test's stdout until the test ends, so a suite that hangs mid-run tells you
+ * nothing about where. `tail -f perf/results/progress.log` to watch.
+ */
+export function progress(msg: string) {
+  const line = `${new Date().toISOString()} ${msg}\n`;
+  const dir = path.join(__dirname, '..', 'results');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(path.join(dir, 'progress.log'), line);
+  process.stdout.write(line);
+}
+
+export async function runScenario(
+  page: Page,
+  cdp: CDPSession,
+  scenario: Scenario,
+  { runs, settleTimeout = 30_000 }: { runs: number; settleTimeout?: number }
+): Promise<Sample[]> {
+  const samples: Sample[] = [];
+
+  for (let run = 0; run < runs; run++) {
+    progress(`${scenario.name} run ${run + 1}/${runs} — reset`);
+    // Reset unthrottled: getting back to the pre-state is setup, not the thing
+    // being measured, and 6× makes it needlessly slow.
+    await setThrottle(cdp, 1);
+    await scenario.reset(page, run);
+    await page.waitForFunction(
+      src => new Function('return (' + src + ')')(),
+      scenario.ready,
+      { polling: 'raf', timeout: settleTimeout }
+    );
+    await waitForQuiet(page);
+
+    await setThrottle(cdp, THROTTLE_RATE);
+
+    if (scenario.token) {
+      await page.evaluate(
+        src => {
+          window.__perf.token = new Function('return (' + src + ')')();
+        },
+        scenario.token
+      );
+    }
+
+    await page.evaluate(() => window.__perf.begin());
+
+    // Guard against the whole class of bogus 0 ms results: if the settle
+    // predicate is already satisfied before we act, the scenario is measuring
+    // nothing and the number would be a lie.
+    const alreadySettled = await page.evaluate(
+      src => !!new Function('return (' + src + ')')(),
+      scenario.settle
+    );
+    expect(
+      alreadySettled,
+      `[${scenario.name}] settle predicate was already true before the interaction — ` +
+        `this scenario would measure nothing. Fix the predicate or the reset.`
+    ).toBe(false);
+
+    progress(`${scenario.name} run ${run + 1}/${runs} — act`);
+    await scenario.act(page, run);
+    try {
+      await waitForSettle(page, scenario.settle, settleTimeout);
+    } catch (err) {
+      // Report where it stalled rather than dying with a bare Playwright
+      // timeout; a settle predicate that never becomes true is a scenario bug,
+      // and the page state is what tells you which one.
+      const state = await page
+        .evaluate(() => ({
+          url: location.href,
+          rows: document.querySelectorAll('table tbody tr').length,
+          dialog: !!document.querySelector('[role="dialog"]'),
+          menu: !!document.querySelector('[role="menu"]'),
+          text: (document.body.innerText ?? '').replace(/\n+/g, ' | ').slice(0, 400),
+        }))
+        .catch(() => null);
+      progress(
+        `${scenario.name} run ${run + 1} STALLED. settle=\`${scenario.settle}\`\n` +
+          `  page: ${JSON.stringify(state)}`
+      );
+      await setThrottle(cdp, 1);
+      throw err;
+    }
+
+    const sample = await page.evaluate(() => window.__perf.end());
+    await setThrottle(cdp, 1);
+    progress(
+      `${scenario.name} run ${run + 1}/${runs} — M1=${
+        sample.interactionMs ?? '—'
+      }ms M2=${Math.round(sample.settleMs)}ms`
+    );
+
+    samples.push(sample);
+  }
+
+  return samples;
+}

--- a/client/perf/lib/report.ts
+++ b/client/perf/lib/report.ts
@@ -1,0 +1,214 @@
+/**
+ * Aggregation, build-mode detection, and baseline comparison. See ../CHARTER.md.
+ */
+import fs from 'fs';
+import path from 'path';
+import { Page } from '@playwright/test';
+import { Sample, Scenario } from './measure';
+
+export const BUDGETS = {
+  instant: 100,
+  responsive: 500,
+  navigational: 1000,
+} as const;
+
+export interface Aggregate {
+  name: string;
+  budget: Scenario['budget'];
+  budgetMs: number;
+  runs: number;
+  /** M1 */
+  interactionMedian: number | null;
+  interactionP95: number | null;
+  /** M2 */
+  settleMedian: number;
+  settleP95: number;
+  /** M3 */
+  blockingMedian: number;
+  /** M5 */
+  gqlCount: number;
+  gqlWaves: number;
+  gqlSlowestMs: number;
+  gqlOps: string[];
+  samples: Sample[];
+}
+
+export interface Report {
+  build: 'dev' | 'prod';
+  buildEvidence: { scriptBytes: number; scriptCount: number };
+  throttle: number;
+  baseUrl: string;
+  createdAt: string;
+  scenarios: Aggregate[];
+}
+
+const median = (xs: number[]) => {
+  if (!xs.length) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m]! : (s[m - 1]! + s[m]!) / 2;
+};
+
+/**
+ * Nearest-rank p95. At our run counts (6 measured) this is the maximum by
+ * definition — deliberately so: the worst observed run is the honest tail here,
+ * and pretending to a smoother percentile from 6 points would be false
+ * precision. Raise `runs` if a real p95 is ever needed.
+ */
+const p95 = (xs: number[]) => {
+  if (!xs.length) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.ceil(0.95 * s.length) - 1]!;
+};
+
+export function aggregate(scenario: Scenario, samples: Sample[]): Aggregate {
+  // Drop the warm-up run (module chunks, query cache, JIT).
+  const measured = samples.length > 1 ? samples.slice(1) : samples;
+  const interactions = measured
+    .map(s => s.interactionMs)
+    .filter((n): n is number => n !== null);
+
+  return {
+    name: scenario.name,
+    budget: scenario.budget,
+    budgetMs: BUDGETS[scenario.budget],
+    runs: measured.length,
+    interactionMedian: interactions.length ? median(interactions) : null,
+    interactionP95: interactions.length ? p95(interactions) : null,
+    settleMedian: median(measured.map(s => s.settleMs)),
+    settleP95: p95(measured.map(s => s.settleMs)),
+    blockingMedian: median(measured.map(s => s.blockingMs)),
+    gqlCount: Math.round(median(measured.map(s => s.gqlCount))),
+    gqlWaves: Math.round(median(measured.map(s => s.gqlWaves))),
+    gqlSlowestMs: Math.round(median(measured.map(s => s.gqlSlowestMs))),
+    gqlOps: [...new Set(measured.flatMap(s => s.gqlOps))],
+    samples: measured,
+  };
+}
+
+/**
+ * Which build is actually loaded, decided from evidence rather than from what
+ * the operator believes. Dev and prod are served on the same port by different
+ * commands, and mistaking one for the other invalidates every number — this has
+ * bitten before, so it is measured, not asserted.
+ *
+ * The webpack dev build ships ~28 MiB of unminified JS; the production build is
+ * a couple of MiB. There is no ambiguity in between.
+ */
+export async function detectBuild(page: Page): Promise<{
+  build: 'dev' | 'prod';
+  evidence: { scriptBytes: number; scriptCount: number };
+}> {
+  const evidence = await page.evaluate(() => {
+    const scripts = performance
+      .getEntriesByType('resource')
+      .filter((r): r is PerformanceResourceTiming => {
+        const rt = r as PerformanceResourceTiming;
+        return rt.initiatorType === 'script' || /\.js(\?|$)/.test(rt.name);
+      });
+    return {
+      scriptBytes: scripts.reduce(
+        (sum, r) => sum + (r.decodedBodySize || r.transferSize || 0),
+        0
+      ),
+      scriptCount: scripts.length,
+    };
+  });
+
+  return {
+    build: evidence.scriptBytes > 8_000_000 ? 'dev' : 'prod',
+    evidence,
+  };
+}
+
+const RESULTS_DIR = path.join(__dirname, '..', 'results');
+const BASELINE_DIR = path.join(__dirname, '..', 'baseline');
+
+export function writeReport(report: Report): string {
+  fs.mkdirSync(RESULTS_DIR, { recursive: true });
+  const stamp = report.createdAt.replace(/[:.]/g, '-');
+  const file = path.join(RESULTS_DIR, `${report.build}-${stamp}.json`);
+  fs.writeFileSync(file, JSON.stringify(report, null, 2));
+
+  if (process.env.PERF_BASELINE) {
+    fs.mkdirSync(BASELINE_DIR, { recursive: true });
+    fs.writeFileSync(
+      path.join(BASELINE_DIR, `${report.build}.json`),
+      JSON.stringify(report, null, 2)
+    );
+  }
+  return file;
+}
+
+export function readBaseline(build: 'dev' | 'prod'): Report | null {
+  const file = path.join(BASELINE_DIR, `${build}.json`);
+  if (!fs.existsSync(file)) return null;
+  return JSON.parse(fs.readFileSync(file, 'utf8')) as Report;
+}
+
+const pad = (s: string, n: number) => s.padEnd(n);
+/** `—` means no Event Timing entry cleared the 16 ms observer floor, i.e. the
+ *  interaction was faster than 16 ms — a good result, not a missing one. */
+const num = (n: number | null, n2 = 6) =>
+  (n === null ? '<16' : Math.round(n).toString()).padStart(n2);
+
+export function printSummary(report: Report) {
+  const baseline = readBaseline(report.build);
+  const lines: string[] = [];
+
+  lines.push('');
+  lines.push(
+    `Perf report — build=${report.build} (${(
+      report.buildEvidence.scriptBytes /
+      1024 /
+      1024
+    ).toFixed(1)} MiB JS, ${report.buildEvidence.scriptCount} scripts), ` +
+      `CPU throttle ${report.throttle}×, ${report.baseUrl}`
+  );
+  if (baseline) {
+    lines.push(`Comparing against baseline/${report.build}.json`);
+  } else {
+    lines.push(
+      `No baseline/${report.build}.json — run with PERF_BASELINE=1 to record one.`
+    );
+  }
+  lines.push('');
+  lines.push(
+    `${pad('scenario', 26)}${pad('class', 14)}` +
+      `${pad('M1 med', 8)}${pad('M1 p95', 8)}${pad('budget', 8)}` +
+      `${pad('M2 med', 8)}${pad('M3 blk', 8)}${pad('gql', 10)}${pad('Δ M1 p95', 12)}`
+  );
+  lines.push('-'.repeat(108));
+
+  for (const s of report.scenarios) {
+    const base = baseline?.scenarios.find(b => b.name === s.name);
+    let delta = '';
+    if (base?.interactionP95 && s.interactionP95) {
+      const pct = ((s.interactionP95 - base.interactionP95) / base.interactionP95) * 100;
+      delta = `${pct >= 0 ? '+' : ''}${pct.toFixed(0)}%`;
+    }
+    const over =
+      s.interactionP95 !== null && s.interactionP95 > s.budgetMs
+        ? `${(s.interactionP95 / s.budgetMs).toFixed(1)}× over`
+        : 'ok';
+
+    lines.push(
+      `${pad(s.name, 26)}${pad(s.budget, 14)}` +
+        `${num(s.interactionMedian)}  ${num(s.interactionP95)}  ` +
+        `${pad(over, 8)}` +
+        `${num(s.settleMedian)}  ${num(s.blockingMedian)}  ` +
+        `${pad(`${s.gqlCount}/${s.gqlWaves}w`, 10)}${pad(delta, 12)}`
+    );
+  }
+
+  lines.push('');
+  lines.push(
+    'M1 interaction latency (input→paint) · M2 settle (incl. network) · ' +
+      'M3 blocking · gql = requests/serial waves. All ms, median of ' +
+      `${report.scenarios[0]?.runs ?? 0} runs.`
+  );
+  lines.push('');
+
+  // eslint-disable-next-line no-console
+  console.log(lines.join('\n'));
+}

--- a/client/perf/perf.config.ts
+++ b/client/perf/perf.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Perf harness config. Deliberately NOT the e2e config:
+ *  - one worker, no parallelism — concurrent tests contend for CPU and the
+ *    numbers stop meaning anything (CHARTER.md §3)
+ *  - no retries — a retried perf run is a different run, not the same one
+ *  - long timeouts, because 6× CPU throttle is the point
+ */
+export default defineConfig({
+  testDir: './scenarios',
+  testMatch: /.*\.perf\.ts/,
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 60 * 60 * 1000,
+  // Without this, Playwright actions wait forever: a selector that never
+  // becomes clickable hangs the whole suite with no output instead of failing.
+  expect: { timeout: 30_000 },
+  reporter: [['list']],
+  // Keep Playwright's failure artifacts inside the already-ignored results/ dir
+  // rather than creating an untracked client/test-results/ next to the packages.
+  outputDir: './results/test-artifacts',
+  use: {
+    actionTimeout: 30_000,
+    baseURL: process.env.BASE_URL ?? 'http://localhost:3003',
+    // A fixed viewport keeps row counts (and therefore render cost) constant
+    // between runs. Tablet-ish landscape, matching the deployment target.
+    viewport: { width: 1280, height: 900 },
+    trace: 'off',
+    video: 'off',
+  },
+  projects: [
+    {
+      name: 'perf',
+      use: {
+        ...devices['Desktop Chrome'],
+        // Real Chrome, not the bundled chromium-headless-shell: the shell has no
+        // proper compositor, and Event Timing `duration` is defined against an
+        // actual paint. Also decouples us from Playwright's browser-build pinning.
+        // The version is recorded in each report for provenance.
+        channel: 'chrome',
+        headless: !process.env.PERF_HEADED,
+      },
+    },
+  ],
+});

--- a/client/perf/scenarios/diag.perf.ts
+++ b/client/perf/scenarios/diag.perf.ts
@@ -1,0 +1,273 @@
+/**
+ * Diagnostic bisection, not part of the baseline. Run with PERF_DIAG=1.
+ *
+ * Question: is the ~1.8 s cost of a URL search-param write proportional to how
+ * much table is on screen, or is it fixed overhead paid regardless?
+ *
+ * Same interaction (column sort → URL write) against three very different
+ * tables, in one run so conditions are identical:
+ *   - 2-line shipment detail   (2 rows × 15 cols)
+ *   - 150-line shipment detail (19 rows in DOM × 15 cols, virtualized)
+ *   - outbound list            (20 rows × 8 cols, not virtualized)
+ *
+ * Flat across all three ⇒ fixed overhead (app shell / MRT setup / emotion).
+ * Scaling with rows ⇒ per-row render cost.
+ */
+import { test, CDPSession } from '@playwright/test';
+import { login } from '../../playwright/helpers/login';
+import {
+  Scenario,
+  installProbe,
+  runScenario,
+  setThrottle,
+  progress,
+} from '../lib/measure';
+import { aggregate } from '../lib/report';
+
+const RUNS = Number(process.env.PERF_RUNS ?? 7);
+const ROWS = `document.querySelectorAll('table tbody tr').length`;
+const FIRST_ROW = `document.querySelector('table tbody tr')?.textContent`;
+
+/**
+ * Settles on the URL search param rather than on the first row changing: a
+ * 2-row table may already be in the target order, so a row-order predicate can
+ * never become true and the scenario would stall.
+ *
+ * M1 is unaffected by this choice — Event Timing measures the click through to
+ * the next paint, which is precisely the re-render cost under test. M2/M3 are
+ * truncated here (the param lands before the render finishes) and should be
+ * ignored for this diagnostic.
+ */
+const sortScenario = (
+  name: string,
+  url: string,
+  header: string,
+  sortKey: string,
+  minRows: number
+): Scenario => ({
+  name,
+  budget: 'responsive',
+  reset: async page => {
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('table tbody tr');
+    await page.locator('table thead th', { hasText: header }).first().click();
+    await page.waitForSelector('[role="menu"]', { timeout: 30_000 });
+  },
+  ready: `!!document.querySelector('[role="menu"]') && ${ROWS} >= ${minRows}`,
+  token: FIRST_ROW,
+  act: async page => {
+    await page
+      .locator('li', { hasText: `Sort by ${header} ascending` })
+      .first()
+      .click();
+  },
+  settle: `location.search.includes('sort=${sortKey}&dir=asc') && ${ROWS} >= ${minRows}`,
+});
+
+const scenarios: Scenario[] = [
+  sortScenario(
+    'diag-sort-detail-2line',
+    '/distribution/outbound-shipment/perf-outbound-list-0001',
+    'Batch',
+    'batch',
+    1
+  ),
+  sortScenario(
+    'diag-sort-detail-150line',
+    '/distribution/outbound-shipment/perf-outbound-fat',
+    'Batch',
+    'batch',
+    10
+  ),
+  sortScenario(
+    'diag-sort-list-20rows',
+    '/distribution/outbound-shipment?sort=invoiceNumber&dir=desc',
+    'Number',
+    'invoiceNumber',
+    20
+  ),
+];
+
+/**
+ * Pure re-render probe. `history.pushState` + a synthetic `popstate` makes
+ * react-router adopt a new location without any user-visible change and without
+ * touching any query the page actually reads — so nothing refetches and nothing
+ * in the DOM needs to differ. Whatever main-thread time that costs IS the cost
+ * of a location change alone.
+ *
+ * Measured as blocking time inside a fixed window (there is no DOM change to
+ * settle on, and popstate is not an input event so Event Timing sees nothing).
+ */
+const POPSTATE_WINDOW_MS = 2500;
+
+async function popstateCost(
+  page: import('@playwright/test').Page,
+  url: string,
+  readySelector: string,
+  runs: number
+) {
+  const samples: number[] = [];
+  for (let run = 0; run < runs; run++) {
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector(readySelector, { timeout: 60_000 });
+    await page.waitForTimeout(1200);
+
+    await page.evaluate(() => window.__perf.begin());
+    const blocking = await page.evaluate(
+      async ([windowMs, seq]) => {
+        const search = new URLSearchParams(location.search);
+        search.set('perfProbe', String(seq));
+        history.pushState({}, '', `${location.pathname}?${search}`);
+        window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
+        await new Promise(r => setTimeout(r, windowMs));
+        window.__perf.markSettled();
+        return window.__perf.end().blockingMs;
+      },
+      [POPSTATE_WINDOW_MS, run] as const
+    );
+    // Discard the warm-up run.
+    if (run > 0) samples.push(blocking);
+  }
+  const sorted = samples.sort((a, b) => a - b);
+  return {
+    median: sorted[Math.floor(sorted.length / 2)] ?? 0,
+    all: sorted,
+  };
+}
+
+test.describe('diagnostics', () => {
+  test('cost of a location change alone', async ({ page, context }) => {
+    test.skip(!process.env.PERF_DIAG, 'set PERF_DIAG=1 to run diagnostics');
+    test.setTimeout(60 * 60 * 1000);
+
+    await installProbe(context);
+    await login(page, { username: 'admin', password: 'pass' });
+    const cdp: CDPSession = await context.newCDPSession(page);
+    await setThrottle(cdp, 6);
+
+    const pages: [string, string, string][] = [
+      ['list-20rows', '/distribution/outbound-shipment', 'table tbody tr'],
+      [
+        'detail-2line',
+        '/distribution/outbound-shipment/perf-outbound-list-0001',
+        'table tbody tr',
+      ],
+      [
+        'detail-150line',
+        '/distribution/outbound-shipment/perf-outbound-fat',
+        'table tbody tr',
+      ],
+      ['no-table-help', '/help', 'text=Help'],
+    ];
+
+    for (const [label, url, ready] of pages) {
+      try {
+        const { median, all } = await popstateCost(page, url, ready, 5);
+        progress(`POPSTATE ${label}: blocking median=${median}ms all=[${all}]`);
+      } catch (err) {
+        progress(`POPSTATE ${label}: FAILED ${(err as Error).message.slice(0, 120)}`);
+      }
+    }
+    await setThrottle(cdp, 1);
+  });
+
+  /**
+   * Attributes the cost of a location change across the app-shell regions, per
+   * commit — which is how the double render (a `nested-update` blocking the paint)
+   * was found.
+   *
+   * This one is NOT self-contained: it needs temporary `React.Profiler` wrappers
+   * added to `host/src/Site.tsx`, pushing `{id, phase, actualDuration}` onto
+   * `window.__profile`. That instrumentation is deliberately not committed — it is
+   * a diagnostic, not a standing test. Wrap the regions you want to attribute:
+   *
+   *   const onProfilerRender = (id, phase, actualDuration) => {
+   *     (window.__profile ??= []).push({ id, phase, actualDuration });
+   *   };
+   *   const P = ({ id, children }) => (
+   *     <React.Profiler id={id} onRender={onProfilerRender}>{children}</React.Profiler>
+   *   );
+   *
+   * …then wrap AppDrawer / AppBar / Routes / Footer / DetailPanel in `<P id="…">`.
+   */
+  test('profiler attribution of a location change', async ({ page, context }) => {
+    test.skip(!process.env.PERF_PROFILE, 'set PERF_PROFILE=1 to run');
+    test.setTimeout(60 * 60 * 1000);
+
+    await installProbe(context);
+    await login(page, { username: 'admin', password: 'pass' });
+    const cdp: CDPSession = await context.newCDPSession(page);
+    await setThrottle(cdp, 6);
+
+    for (const [label, url, ready] of [
+      ['list-20rows', '/distribution/outbound-shipment', 'table tbody tr'],
+      [
+        'detail-2line',
+        '/distribution/outbound-shipment/perf-outbound-list-0001',
+        'table tbody tr',
+      ],
+      [
+        'detail-150line',
+        '/distribution/outbound-shipment/perf-outbound-fat',
+        'table tbody tr',
+      ],
+      // No MRT table on this route: if the nested-update still happens here it
+      // comes from the shell/providers, not from the table layer.
+      ['dashboard-no-table', '/dashboard', 'body'],
+    ] as const) {
+      await page.goto(url, { waitUntil: 'domcontentloaded' });
+      await page.waitForSelector(ready, { timeout: 60_000 });
+      await page.waitForTimeout(2500);
+
+      const tally = await page.evaluate(async () => {
+        const w = window as unknown as {
+          __profile?: { id: string; phase: string; actualDuration: number }[];
+        };
+        // Fail loudly rather than reporting an empty tally that reads as "nothing
+        // re-rendered" when the truth is "the instrumentation isn't there".
+        if (!Array.isArray(w.__profile)) {
+          throw new Error(
+            'window.__profile is missing — add the temporary React.Profiler ' +
+              'wrappers to host/src/Site.tsx (see this test\'s doc comment).'
+          );
+        }
+        w.__profile = [];
+        const search = new URLSearchParams(location.search);
+        search.set('perfProbe', String(Math.floor(performance.now())));
+        history.pushState({}, '', `${location.pathname}?${search}`);
+        window.dispatchEvent(new PopStateEvent('popstate', { state: {} }));
+        await new Promise(r => setTimeout(r, 2500));
+
+        // Per-commit detail, in order, so a render→effect→setState cascade is
+        // visible as separate commits rather than hidden in a total.
+        return (w.__profile ?? []).map(
+          e => `${e.id}:${e.phase}:${Math.round(e.actualDuration)}ms`
+        );
+      });
+      progress(`PROFILE ${label}: ${tally.join('  ')}`);
+    }
+    await setThrottle(cdp, 1);
+  });
+
+  test('url-write cost vs table size', async ({ page, context }) => {
+    test.skip(!process.env.PERF_DIAG, 'set PERF_DIAG=1 to run diagnostics');
+    test.setTimeout(60 * 60 * 1000);
+
+    await installProbe(context);
+    await login(page, { username: 'admin', password: 'pass' });
+    const cdp: CDPSession = await context.newCDPSession(page);
+    await setThrottle(cdp, 1);
+
+    for (const scenario of scenarios) {
+      const samples = await runScenario(page, cdp, scenario, { runs: RUNS });
+      const agg = aggregate(scenario, samples);
+      progress(
+        `RESULT ${agg.name}: M1 med=${agg.interactionMedian} p95=${agg.interactionP95} ` +
+          `M2 med=${Math.round(agg.settleMedian)} M3 blk=${Math.round(agg.blockingMedian)} ` +
+          `rows-in-dom=${await page.evaluate(
+            () => document.querySelectorAll('table tbody tr').length
+          )}`
+      );
+    }
+  });
+});

--- a/client/perf/scenarios/outbound.perf.ts
+++ b/client/perf/scenarios/outbound.perf.ts
@@ -1,0 +1,298 @@
+/**
+ * Outbound Shipment — the pilot vertical (CHARTER.md §5 C7).
+ *
+ * Selectors are DOM-shape based because these views carry almost no
+ * `data-testid`s. Where a selector is positional it is called out; the e2e
+ * testid work landing on other branches should let these tighten up later.
+ */
+import { test, expect, CDPSession, Page } from '@playwright/test';
+import { login } from '../../playwright/helpers/login';
+import { Scenario, installProbe, runScenario, setThrottle, THROTTLE_RATE } from '../lib/measure';
+import { aggregate, detectBuild, printSummary, writeReport, Report } from '../lib/report';
+
+const RUNS = Number(process.env.PERF_RUNS ?? 7);
+
+const LIST_URL = '/distribution/outbound-shipment?sort=invoiceNumber&dir=desc';
+const FAT_URL = '/distribution/outbound-shipment/perf-outbound-fat';
+
+/** First data row's text — the change token for sort/paging scenarios. */
+const FIRST_ROW = `document.querySelector('table tbody tr')?.textContent`;
+const ROWS = `document.querySelectorAll('table tbody tr').length`;
+const DIALOG = `document.querySelector('[role="dialog"]')`;
+
+/** The line-edit modal's "Issue" input: index 1 of the dialog's inputs (0 is the
+ *  item selector, 2+ are the per-batch allocation inputs). Positional — see the
+ *  guard in `openLineEdit`. */
+const ISSUE_INPUT = '[role="dialog"] input';
+const ISSUE_INDEX = 1;
+const OK_BUTTON = '[role="dialog"] button[aria-label="OK"]';
+
+async function gotoList(page: Page) {
+  await page.goto(LIST_URL, { waitUntil: 'domcontentloaded' });
+}
+
+async function gotoFat(page: Page) {
+  await page.goto(FAT_URL, { waitUntil: 'domcontentloaded' });
+}
+
+/** Rows vary per run so we never re-measure an already-cached item's stock lines. */
+const rowForRun = (run: number) => run % 8;
+
+async function openLineEdit(page: Page, run: number) {
+  await page.locator('table tbody tr').nth(rowForRun(run)).click();
+  await page.waitForSelector('[role="dialog"] table tbody tr', { timeout: 60_000 });
+  const issue = page.locator(ISSUE_INPUT).nth(ISSUE_INDEX);
+  await expect(
+    issue,
+    'positional Issue-input selector no longer points at a numeric field — re-probe the modal'
+  ).toHaveValue(/^[\d,.]*$/);
+}
+
+/**
+ * Sorting is a two-click flow here, not a header click: `useTableDisplayOptions`
+ * deliberately replaces the column-actions button with a full-width invisible
+ * one, so clicking anywhere in a header opens the column menu and the sort is
+ * applied from a menu item. Both clicks are measured, separately.
+ */
+const FILTERS_COMBOBOX =
+  'div[role="combobox"][aria-labelledby="action-drop-down-label-Filters"]';
+const NAME_FILTER_INPUT = 'input[placeholder="Search by name"]';
+
+/** The Name text filter is not mounted until it is picked from the Filters menu. */
+async function addNameFilter(page: Page) {
+  await page.locator(FILTERS_COMBOBOX).click();
+  await page.locator('[role="listbox"] li', { hasText: 'Name' }).first().click();
+  await page.waitForSelector(NAME_FILTER_INPUT, { timeout: 30_000 });
+}
+
+async function openHeaderMenu(page: Page, header: string) {
+  await page.locator('table thead th', { hasText: header }).first().click();
+  await page.waitForSelector('[role="menu"]', { timeout: 30_000 });
+}
+
+const scenarios: Scenario[] = [
+  {
+    name: 'list-header-menu',
+    budget: 'instant',
+    reset: gotoList,
+    ready: `${ROWS} >= 20 && !document.querySelector('[role="menu"]')`,
+    act: async page => {
+      await page.locator('table thead th', { hasText: 'Number' }).first().click();
+    },
+    settle: `!!document.querySelector('[role="menu"]')`,
+  },
+  {
+    name: 'list-sort',
+    budget: 'responsive',
+    reset: async page => {
+      await gotoList(page);
+      await page.waitForSelector('table tbody tr');
+      await openHeaderMenu(page, 'Number');
+    },
+    ready: `!!document.querySelector('[role="menu"]') && ${ROWS} >= 20`,
+    token: FIRST_ROW,
+    act: async page => {
+      await page.locator('li', { hasText: 'Sort by Number ascending' }).first().click();
+    },
+    settle: `${FIRST_ROW} !== window.__perf.token && ${ROWS} >= 20`,
+  },
+  {
+    name: 'list-filter-open',
+    budget: 'instant',
+    reset: gotoList,
+    ready: `${ROWS} >= 20 && !document.querySelector('[role="listbox"]')`,
+    act: async page => {
+      await page.locator(FILTERS_COMBOBOX).click();
+    },
+    settle: `!!document.querySelector('[role="listbox"]')`,
+  },
+  {
+    // The immediate echo of a keystroke. TextFilter holds the value in local
+    // state and debounces the URL write by 200 ms, so this should be cheap —
+    // only the input ought to re-render.
+    name: 'list-filter-keystroke',
+    budget: 'instant',
+    reset: async page => {
+      await gotoList(page);
+      await page.waitForSelector('table tbody tr');
+      await addNameFilter(page);
+      await page.locator(NAME_FILTER_INPUT).focus();
+    },
+    ready: `!!document.querySelector('${NAME_FILTER_INPUT}')`,
+    token: `document.querySelector('${NAME_FILTER_INPUT}').value`,
+    act: async page => {
+      await page.keyboard.press('Z');
+    },
+    settle: `document.querySelector('${NAME_FILTER_INPUT}').value !== window.__perf.token`,
+  },
+  {
+    // Same keystroke, followed through to the filtered result. The costly part —
+    // the debounced URL write and whatever re-renders because of it — happens in
+    // a timer, NOT inside the input event, so it lands in M2/M3 and is invisible
+    // to M1. Read this row on blocking time, not interaction latency.
+    name: 'list-filter-apply',
+    budget: 'responsive',
+    reset: async page => {
+      await gotoList(page);
+      await page.waitForSelector('table tbody tr');
+      await addNameFilter(page);
+      await page.locator(NAME_FILTER_INPUT).focus();
+    },
+    ready: `!!document.querySelector('${NAME_FILTER_INPUT}') && ${ROWS} >= 20`,
+    token: ROWS,
+    act: async page => {
+      await page.keyboard.press('Z');
+    },
+    settle: `location.search.includes('otherPartyName') && ${ROWS} !== window.__perf.token`,
+  },
+  {
+    name: 'list-page-next',
+    budget: 'responsive',
+    reset: gotoList,
+    ready: `${ROWS} >= 20`,
+    token: FIRST_ROW,
+    act: async page => {
+      await page.locator('button:has([data-testid="NavigateNextIcon"])').first().click();
+    },
+    settle: `${FIRST_ROW} !== window.__perf.token && ${ROWS} >= 20`,
+  },
+  {
+    name: 'list-open-detail',
+    budget: 'navigational',
+    reset: gotoList,
+    ready: `${ROWS} >= 20`,
+    act: async page => {
+      await page.locator('table tbody tr').first().click();
+    },
+    settle: `location.pathname.split('/').length > 3 && document.body.innerText.includes('Add item') && ${ROWS} > 0`,
+  },
+  {
+    name: 'detail-sort-lines',
+    budget: 'responsive',
+    reset: async page => {
+      await gotoFat(page);
+      await page.waitForSelector('table tbody tr');
+      await openHeaderMenu(page, 'Batch');
+    },
+    ready: `!!document.querySelector('[role="menu"]') && ${ROWS} >= 10`,
+    token: FIRST_ROW,
+    act: async page => {
+      await page.locator('li', { hasText: 'Sort by Batch ascending' }).first().click();
+    },
+    settle: `${FIRST_ROW} !== window.__perf.token && ${ROWS} >= 10`,
+  },
+  {
+    name: 'detail-tab-log',
+    // `responsive`, not `instant`: this swaps the whole tab body — unmounting the
+    // 150-line lines table, mounting the activity-log table, and fetching its
+    // data. That is a view transition, not a widget toggle. It was originally
+    // classed `instant` and looked like a 3.5× budget violation; the budget was
+    // wrong, not the app.
+    budget: 'responsive',
+    reset: gotoFat,
+    ready: `${ROWS} >= 10 && document.body.innerText.includes('Unit sell price')`,
+    act: async page => {
+      await page.getByRole('tab', { name: 'Log' }).click();
+    },
+    // The lines table's columns are gone once the Log tab owns the view.
+    settle: `!document.body.innerText.includes('Unit sell price')`,
+  },
+  {
+    name: 'line-edit-open',
+    budget: 'responsive',
+    reset: gotoFat,
+    ready: `${ROWS} >= 10`,
+    act: async (page, run) => {
+      await page.locator('table tbody tr').nth(rowForRun(run)).click();
+    },
+    settle: `!!${DIALOG} && ${DIALOG}.querySelectorAll('table tbody tr').length > 0`,
+  },
+  {
+    name: 'line-edit-type',
+    budget: 'instant',
+    reset: async (page, run) => {
+      await gotoFat(page);
+      await page.waitForSelector('table tbody tr');
+      await openLineEdit(page, run);
+      await page.locator(ISSUE_INPUT).nth(ISSUE_INDEX).fill('1');
+      await page.locator(ISSUE_INPUT).nth(ISSUE_INDEX).focus();
+    },
+    ready: `!!${DIALOG} && ${DIALOG}.querySelectorAll('table tbody tr').length > 0`,
+    token: `${DIALOG}.querySelectorAll('input')[${ISSUE_INDEX}].value`,
+    act: async page => {
+      await page.keyboard.press('5');
+    },
+    settle: `${DIALOG}.querySelectorAll('input')[${ISSUE_INDEX}].value !== window.__perf.token`,
+  },
+  {
+    name: 'line-edit-save',
+    budget: 'responsive',
+    reset: async (page, run) => {
+      await gotoFat(page);
+      await page.waitForSelector('table tbody tr');
+      await openLineEdit(page, run);
+      // OK is disabled until the form is dirty, so the value written must differ
+      // from what is already there — otherwise the click waits on a disabled
+      // button forever. Alternating 2/3 keeps it dirty without the value drifting
+      // across suite runs.
+      const issue = page.locator(ISSUE_INPUT).nth(ISSUE_INDEX);
+      await issue.fill((await issue.inputValue()) === '2' ? '3' : '2');
+      await expect(
+        page.locator(OK_BUTTON),
+        'OK stayed disabled after editing the issue quantity — the form did not go dirty'
+      ).toBeEnabled();
+    },
+    ready: `!!${DIALOG} && ${DIALOG}.querySelectorAll('table tbody tr').length > 0`,
+    act: async page => {
+      await page.locator(OK_BUTTON).click();
+    },
+    settle: `!${DIALOG}`,
+  },
+];
+
+test.describe('outbound shipment', () => {
+  test('perf suite', async ({ page, context, baseURL }) => {
+    test.setTimeout(60 * 60 * 1000);
+
+    await installProbe(context);
+    await login(page, { username: 'admin', password: 'pass' });
+
+    const cdp: CDPSession = await context.newCDPSession(page);
+    await setThrottle(cdp, 1);
+
+    // Warm the route chunks and detect which build we are actually measuring,
+    // rather than trusting what the operator thinks is being served.
+    await gotoFat(page);
+    await page.waitForSelector('table tbody tr', { timeout: 120_000 });
+    const { build, evidence } = await detectBuild(page);
+    const claimed = process.env.PERF_BUILD;
+    if (claimed && claimed !== build) {
+      throw new Error(
+        `PERF_BUILD=${claimed} but the page loaded ${(
+          evidence.scriptBytes / 1024 / 1024
+        ).toFixed(1)} MiB of JS, which is a ${build} build. Refusing to record a mislabelled run.`
+      );
+    }
+
+    const report: Report = {
+      build,
+      buildEvidence: evidence,
+      throttle: THROTTLE_RATE,
+      baseUrl: baseURL ?? '',
+      createdAt: new Date().toISOString(),
+      scenarios: [],
+    };
+
+    for (const scenario of scenarios) {
+      const samples = await runScenario(page, cdp, scenario, { runs: RUNS });
+      report.scenarios.push(aggregate(scenario, samples));
+      // eslint-disable-next-line no-console
+      console.log(`  ✓ ${scenario.name}`);
+    }
+
+    const file = writeReport(report);
+    printSummary(report);
+    // eslint-disable-next-line no-console
+    console.log(`written: ${file}\n`);
+  });
+});

--- a/client/perf/seed.sh
+++ b/client/perf/seed.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Seed (or remove) the perf harness fixture.
+#
+#   ./seed.sh                      # seed with defaults
+#   ./seed.sh --clean              # remove everything the seeder created
+#   ./seed.sh -v fat_lines=400     # override a fixture size
+#   ./seed.sh -v store_code=HUF    # seed into a different store
+#
+# Connection details are resolved the same way the server resolves them:
+# server/configuration/base.yaml, overridden by local.yaml when it exists. Any
+# PG* variable already set in the environment wins over both, so CI or a
+# non-standard setup needs no config file at all.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+conf_dir="$here/../../server/configuration"
+
+# Read one key from the `database:` block. base.yaml first, then local.yaml, so
+# the later file wins — mirroring how the server layers its own config.
+yaml_db_value() {
+  local key="$1" found="" file value
+  for file in "$conf_dir/base.yaml" "$conf_dir/local.yaml"; do
+    [ -f "$file" ] || continue
+    value="$(
+      awk -v k="$key" '
+        /^database:/ { inblock = 1; next }
+        /^[^[:space:]#]/ { inblock = 0 }
+        inblock && $1 == k ":" {
+          $1 = ""
+          sub(/^[[:space:]]+/, "")
+          gsub(/"/, "")
+          sub(/[[:space:]]*#.*$/, "")
+          print
+        }
+      ' "$file" | tail -n 1
+    )"
+    [ -n "$value" ] && found="$value"
+  done
+  printf '%s' "$found"
+}
+
+# Env wins, then config, then the base.yaml defaults as a last resort.
+export PGHOST="${PGHOST:-$(yaml_db_value host)}"
+export PGPORT="${PGPORT:-$(yaml_db_value port)}"
+export PGUSER="${PGUSER:-$(yaml_db_value username)}"
+export PGPASSWORD="${PGPASSWORD:-$(yaml_db_value password)}"
+export PGDATABASE="${PGDATABASE:-$(yaml_db_value database_name)}"
+
+: "${PGHOST:=localhost}"
+: "${PGPORT:=5432}"
+: "${PGUSER:=postgres}"
+: "${PGDATABASE:=omsupply-database}"
+
+script="seed.sql"
+if [ "${1:-}" = "--clean" ]; then
+  script="unseed.sql"
+  shift
+fi
+
+echo "perf fixture: ${script} -> ${PGUSER}@${PGHOST}:${PGPORT}/${PGDATABASE}"
+
+exec psql -v ON_ERROR_STOP=1 "$@" -f "$here/$script"

--- a/client/perf/seed.sql
+++ b/client/perf/seed.sql
@@ -1,0 +1,256 @@
+-- Deterministic fixture data for the frontend perf harness.
+--
+-- Everything created here is id-prefixed `perf-` so `unseed.sql` can remove it
+-- cleanly. Re-running is safe (delete-then-insert).
+--
+-- Run it via ./seed.sh, which resolves the database connection from the server
+-- config (see that script). Overrides pass straight through:
+--
+--   ./seed.sh                       -- defaults: 150 fat lines, 300 shipments
+--   ./seed.sh -v fat_lines=400      -- bigger detail-view fixture
+--   ./seed.sh -v store_code=HUF     -- seed into a different store
+--
+-- Logs in as Admin/pass in the app.
+
+\set ON_ERROR_STOP on
+
+-- Defaults, only applied when not passed with -v
+\if :{?fat_lines} \else \set fat_lines 150 \endif
+\if :{?list_shipments} \else \set list_shipments 300 \endif
+\if :{?items} \else \set items 400 \endif
+\if :{?stock_per_item} \else \set stock_per_item 6 \endif
+\if :{?store_code} \else \set store_code 'GEN' \endif
+
+-- Resolve the target store by CODE, not by id: store ids differ between
+-- datafiles, and `invoice.store_id` / `stock_line.store_id` are FK-constrained,
+-- so a pinned id from one machine fails ~200 lines in with a constraint
+-- violation. Fail here instead, with something readable.
+-- Guard in SQL rather than with \if / \quit: psql's \quit ignores an exit code
+-- (so a caller could not detect the failure), and \warn does not interpolate
+-- variables inside a quoted string. RAISE + ON_ERROR_STOP gives both a readable
+-- message and a non-zero exit.
+-- The code is handed to the server as a setting rather than interpolated into the
+-- DO body: psql does not substitute :'var' inside a dollar-quoted string, so the
+-- `:` would reach the server as literal SQL and fail to parse.
+SELECT set_config('perf.store_code', :'store_code', false);
+
+DO $guard$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM store WHERE code = current_setting('perf.store_code')
+  ) THEN
+    RAISE EXCEPTION
+      'perf fixture: no store with code "%" in this database. Pass -v store_code=XXX (default GEN).',
+      current_setting('perf.store_code');
+  END IF;
+END $guard$;
+
+SELECT id AS store_id FROM store WHERE code = :'store_code' \gset
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Teardown (children first)
+--
+-- Deleting by `perf-` prefix alone is not enough: once the app has been driven
+-- against the fixture, it has written its OWN rows against it with generated
+-- UUIDs — saving a line-edit adds `invoice_line`s to a perf invoice. So scope
+-- child rows by relationship as well as by prefix.
+--
+-- Deliberately NOT deleted: `invoice_line`s that live on a NON-perf invoice but
+-- reference perf stock. Those belong to someone's real shipment, and quietly
+-- removing them would damage real data. If any exist, the `stock_line` delete
+-- below fails on its FK — which is the correct outcome; resolve it by hand.
+-- ---------------------------------------------------------------------------
+DELETE FROM vvm_status_log
+ WHERE stock_line_id LIKE 'perf-%'
+    OR invoice_line_id IN (
+         SELECT id FROM invoice_line WHERE invoice_id LIKE 'perf-%'
+       );
+DELETE FROM invoice_line WHERE invoice_id LIKE 'perf-%' OR id LIKE 'perf-%';
+DELETE FROM invoice      WHERE id LIKE 'perf-%';
+DELETE FROM stock_line   WHERE id LIKE 'perf-%';
+DELETE FROM item_link    WHERE id LIKE 'perf-%';
+DELETE FROM item         WHERE id LIKE 'perf-%';
+DELETE FROM name_link    WHERE id LIKE 'perf-%';
+DELETE FROM name         WHERE id LIKE 'perf-%';
+
+-- ---------------------------------------------------------------------------
+-- Customer to ship to
+-- ---------------------------------------------------------------------------
+-- NOTE: several columns are nullable in the DB but non-Option in the Rust row
+-- structs (name: is_manufacturer/is_donor/on_hold; item: is_vaccine/
+-- vaccine_doses/volume_per_pack; stock_line: total_volume/volume_per_pack).
+-- Leaving them NULL makes the server fail the whole query with
+-- DIESEL_DESERIALIZATION_ERROR (UnexpectedNullError) — which takes out the real
+-- rows too, not just the fixture. Every such column is set explicitly below.
+INSERT INTO name (
+  id, name, code, type, is_customer, is_supplier,
+  is_manufacturer, is_donor, on_hold, is_deceased, is_sync_update,
+  margin, freight_factor
+)
+VALUES (
+  'perf-customer', 'Perf Test Customer', 'PERFCUST', 'FACILITY', true, false,
+  false, false, false, false, false, 0, 1
+);
+
+INSERT INTO name_link (id, name_id) VALUES ('perf-customer-link', 'perf-customer');
+
+-- ---------------------------------------------------------------------------
+-- Items. Names are shuffled (not id-ordered) so sorting does real work rather
+-- than confirming an already-sorted list.
+-- ---------------------------------------------------------------------------
+INSERT INTO item (
+  id, name, code, type, default_pack_size, legacy_record, is_active,
+  is_vaccine, vaccine_doses, volume_per_pack, unit_id
+)
+SELECT
+  'perf-item-' || lpad(n::text, 5, '0'),
+  (ARRAY['Amoxicillin','Paracetamol','Ibuprofen','Metformin','Ceftriaxone',
+         'Oxytocin','Gentamicin','Ringer Lactate','Zinc Sulfate','Albendazole',
+         'Artemether','Salbutamol','Omeprazole','Furosemide','Diazepam',
+         'Hydralazine','Misoprostol','Nifedipine','Tranexamic Acid','Vitamin A'
+        ])[1 + (n * 7) % 20]
+    || ' ' || (50 + (n * 13) % 950)::text || 'mg'
+    || ' (' || lpad(n::text, 4, '0') || ')',
+  'PERF' || lpad(n::text, 5, '0'),
+  'STOCK',
+  (ARRAY[1, 10, 20, 50, 100])[1 + n % 5],
+  '',
+  true,
+  false,
+  0,
+  0.0,
+  (SELECT id FROM unit ORDER BY "index" LIMIT 1)
+FROM generate_series(1, :items) AS n;
+
+INSERT INTO item_link (id, item_id)
+SELECT id, id FROM item WHERE id LIKE 'perf-item-%';
+
+-- ---------------------------------------------------------------------------
+-- Stock lines. `stock_per_item` batches each, with staggered expiries — this is
+-- what the OutboundLineEdit allocation table iterates over, so it is a direct
+-- driver of that modal's cost.
+-- ---------------------------------------------------------------------------
+INSERT INTO stock_line (
+  id, store_id, item_link_id, batch, expiry_date,
+  cost_price_per_pack, sell_price_per_pack,
+  available_number_of_packs, total_number_of_packs, pack_size, on_hold,
+  total_volume, volume_per_pack
+)
+SELECT
+  'perf-stock-' || lpad(n::text, 5, '0') || '-' || b,
+  :'store_id',
+  'perf-item-' || lpad(n::text, 5, '0'),
+  'B' || lpad(n::text, 5, '0') || '-' || b,
+  (DATE '2027-01-01' + ((n * 17 + b * 31) % 900))::date,
+  round((2 + (n % 40) * 0.35)::numeric, 2),
+  round((5 + (n % 40) * 0.55)::numeric, 2),
+  500 + (n * 7 + b * 11) % 4500,
+  500 + (n * 7 + b * 11) % 4500,
+  (ARRAY[1, 10, 20, 50, 100])[1 + n % 5],
+  false,
+  0.0,
+  0.0
+FROM generate_series(1, :items) AS n,
+     generate_series(1, :stock_per_item) AS b;
+
+-- ---------------------------------------------------------------------------
+-- The fat shipment: status NEW so lines are editable. This is the detail-view
+-- and line-edit scenario under test.
+-- ---------------------------------------------------------------------------
+INSERT INTO invoice (
+  id, store_id, name_link_id, invoice_number, type, status,
+  on_hold, created_datetime, currency_rate, comment, their_reference
+)
+VALUES (
+  'perf-outbound-fat', :'store_id', 'perf-customer-link', 990001,
+  'OUTBOUND_SHIPMENT', 'NEW', false, now(), 1.0,
+  'perf fixture: fat shipment', 'PERF-FAT'
+);
+
+INSERT INTO invoice_line (
+  id, invoice_id, item_link_id, item_name, item_code, stock_line_id,
+  batch, expiry_date, cost_price_per_pack, sell_price_per_pack,
+  total_before_tax, total_after_tax, type, number_of_packs, pack_size,
+  volume_per_pack
+)
+SELECT
+  'perf-fatline-' || lpad(n::text, 5, '0'),
+  'perf-outbound-fat',
+  i.id,
+  i.name,
+  i.code,
+  s.id,
+  s.batch,
+  s.expiry_date,
+  s.cost_price_per_pack,
+  s.sell_price_per_pack,
+  round((s.sell_price_per_pack * (1 + n % 9))::numeric, 2),
+  round((s.sell_price_per_pack * (1 + n % 9))::numeric, 2),
+  'STOCK_OUT',
+  1 + n % 9,
+  s.pack_size,
+  0.0
+FROM generate_series(1, :fat_lines) AS n
+JOIN item i ON i.id = 'perf-item-' || lpad(n::text, 5, '0')
+-- first batch of each item
+JOIN stock_line s ON s.id = 'perf-stock-' || lpad(n::text, 5, '0') || '-1';
+
+-- ---------------------------------------------------------------------------
+-- List-view volume: many small shipments across mixed statuses, so the list
+-- page's sort / page / count paths see a realistic row count.
+-- ---------------------------------------------------------------------------
+INSERT INTO invoice (
+  id, store_id, name_link_id, invoice_number, type, status,
+  on_hold, created_datetime, allocated_datetime, picked_datetime,
+  currency_rate, comment, their_reference
+)
+SELECT
+  'perf-outbound-list-' || lpad(n::text, 4, '0'),
+  :'store_id',
+  'perf-customer-link',
+  991000 + n,
+  'OUTBOUND_SHIPMENT',
+  (ARRAY['NEW','ALLOCATED','PICKED','SHIPPED','VERIFIED']::invoice_status[])[1 + n % 5],
+  false,
+  now() - (n || ' hours')::interval,
+  CASE WHEN n % 5 > 0 THEN now() - (n || ' hours')::interval END,
+  CASE WHEN n % 5 > 1 THEN now() - (n || ' hours')::interval END,
+  1.0,
+  'perf fixture ' || n,
+  'PERF-' || lpad(n::text, 4, '0')
+FROM generate_series(1, :list_shipments) AS n;
+
+INSERT INTO invoice_line (
+  id, invoice_id, item_link_id, item_name, item_code, stock_line_id,
+  batch, expiry_date, cost_price_per_pack, sell_price_per_pack,
+  total_before_tax, total_after_tax, type, number_of_packs, pack_size,
+  volume_per_pack
+)
+SELECT
+  'perf-listline-' || lpad(n::text, 4, '0') || '-' || k,
+  'perf-outbound-list-' || lpad(n::text, 4, '0'),
+  i.id, i.name, i.code, s.id, s.batch, s.expiry_date,
+  s.cost_price_per_pack, s.sell_price_per_pack,
+  round(s.sell_price_per_pack::numeric, 2),
+  round(s.sell_price_per_pack::numeric, 2),
+  'STOCK_OUT', 1 + k, s.pack_size, 0.0
+-- Explicit CROSS JOIN (not a comma) so the later ON clauses may reference n/k:
+-- comma binds looser than JOIN and would make those references invalid.
+FROM generate_series(1, :list_shipments) AS n
+CROSS JOIN generate_series(1, 2) AS k
+JOIN item i
+  ON i.id = 'perf-item-' || lpad((1 + (n * 3 + k) % :items)::text, 5, '0')
+JOIN stock_line s
+  ON s.id = 'perf-stock-' || lpad((1 + (n * 3 + k) % :items)::text, 5, '0') || '-2';
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- Report
+-- ---------------------------------------------------------------------------
+SELECT 'items'          AS fixture, count(*) FROM item       WHERE id LIKE 'perf-%'
+UNION ALL SELECT 'stock lines',     count(*) FROM stock_line WHERE id LIKE 'perf-%'
+UNION ALL SELECT 'shipments',       count(*) FROM invoice    WHERE id LIKE 'perf-%'
+UNION ALL SELECT 'fat shipment lines', count(*) FROM invoice_line WHERE invoice_id = 'perf-outbound-fat';

--- a/client/perf/unseed.sql
+++ b/client/perf/unseed.sql
@@ -1,0 +1,36 @@
+-- Remove everything seed.sql created. Children first.
+-- Run via `./seed.sh --clean`, which resolves the DB connection for you.
+--
+-- Deleting by `perf-` prefix alone is not enough: once the app has been driven
+-- against the fixture, it has written its OWN rows against it with generated
+-- UUIDs — saving a line-edit adds `invoice_line`s to a perf invoice. So child
+-- rows are scoped by relationship as well as by prefix.
+--
+-- Deliberately NOT deleted: `invoice_line`s on a NON-perf invoice that reference
+-- perf stock. Those belong to someone's real shipment, and quietly removing them
+-- would damage real data. If any exist the `stock_line` delete fails on its FK,
+-- which is the correct outcome — resolve it by hand.
+\set ON_ERROR_STOP on
+
+BEGIN;
+DELETE FROM vvm_status_log
+ WHERE stock_line_id LIKE 'perf-%'
+    OR invoice_line_id IN (
+         SELECT id FROM invoice_line WHERE invoice_id LIKE 'perf-%'
+       );
+DELETE FROM invoice_line WHERE invoice_id LIKE 'perf-%' OR id LIKE 'perf-%';
+DELETE FROM invoice      WHERE id LIKE 'perf-%';
+DELETE FROM stock_line   WHERE id LIKE 'perf-%';
+DELETE FROM item_link    WHERE id LIKE 'perf-%';
+DELETE FROM item         WHERE id LIKE 'perf-%';
+DELETE FROM name_link    WHERE id LIKE 'perf-%';
+DELETE FROM name         WHERE id LIKE 'perf-%';
+COMMIT;
+
+SELECT 'remaining perf rows' AS check, (
+  (SELECT count(*) FROM invoice_line WHERE id LIKE 'perf-%' OR invoice_id LIKE 'perf-%') +
+  (SELECT count(*) FROM invoice      WHERE id LIKE 'perf-%') +
+  (SELECT count(*) FROM stock_line   WHERE id LIKE 'perf-%') +
+  (SELECT count(*) FROM item         WHERE id LIKE 'perf-%') +
+  (SELECT count(*) FROM name         WHERE id LIKE 'perf-%')
+) AS count;


### PR DESCRIPTION
Refs #12606

# 👩🏻‍💻 What does this PR do?

We had no way to measure what "the app feels slow" actually is. Bundle size is
tracked in CI and route timing mixes in server cost, but nothing measured **how long
an interaction takes to respond** — which is the complaint users actually report from
tablets.

This adds `client/perf`: a harness that drives real Chrome over CDP at **6× CPU
throttle** (no network throttling — deployments are tablet + local server, so network
isn't the constraint), against a deterministic fixture, over 12 Outbound Shipment
scenarios. Per scenario it records:

| | metric | meaning |
|---|---|---|
| **M1** | interaction latency | Event Timing API: input event → next paint. **The headline.** |
| M2 | settle | interaction → the DOM state that means the user can proceed. Includes network. |
| M3 | blocking | Σ (longtask − 50 ms) over the interaction window |
| M5 | GraphQL | request count + serial wave depth |

Read M1 against M2: **M1 high** is our render cost; **M1 fine but M2 high** is the
server or a request waterfall, which the charter says to file rather than fix.

It diffs every run against a committed baseline and prints a delta table.

**This is the harness that produced the numbers in #12607.** It's separate so that PR
stays a reviewable 11-file diff.

### It's built to refuse misleading numbers

Every guard here exists because of a specific way perf work has gone wrong in this
repo, or went wrong during the pilot:

- **Build mode is detected, not trusted.** Each report records actual JS byte count
  and labels the build from it (dev ~27 MiB, prod ~5 MiB); if `PERF_BUILD` disagrees,
  the run **fails**. Mixing a dev number with a prod one is a ~4× error.
- **A scenario that measures nothing fails.** Each settle predicate is asserted
  *false* before the interaction. Without it, a wrong predicate silently reports ~0 ms
  and looks like a win — this caught a real bug during the pilot.
- **Real Chrome, one worker.** `channel: 'chrome'` because Event Timing is defined
  against an actual paint and the bundled headless shell has no proper compositor; no
  parallelism, because concurrent runs contend for CPU.
- **Throttle only around the interaction** — returning to the pre-state is setup, not
  measurement — and each run waits for a 250 ms longtask-free gap so runs can't bleed.
- The charter records the traps that already produced wrong answers, including that
  **DevTools trace durations are inflated by tracing overhead** (a 1310 ms attribution
  led to a fix that measured no improvement and was reverted) and that a **busy machine
  costs 2–3×**, with the tell being control scenarios moving too.

### The fixture is portable, not pinned to one machine

- `seed.sh` resolves the Postgres connection the way the server does —
  `configuration/base.yaml` overridden by `local.yaml` — with any `PG*` env var
  winning, so CI or a non-standard setup needs no config file.
- `seed.sql` resolves the target store **by code** (default `GEN`, override with
  `-v store_code=…`) instead of an id that only exists in one datafile.
  `invoice.store_id` and `stock_line.store_id` are FK-constrained, so a pinned id
  aborts ~200 lines in with a constraint violation; there's now a readable guard that
  fails immediately with a non-zero exit.
- Teardown scopes child rows **by relationship**, not just the `perf-` prefix: driving
  the app against the fixture makes it write its own rows with generated UUIDs (saving
  a line-edit adds `invoice_line`s to a fixture invoice), which previously made
  `--clean` fail on an FK.
- The seeder sets the columns that are nullable in Postgres but non-`Option` in the
  Rust row structs (`name.is_manufacturer`, `item.is_vaccine`,
  `stock_line.total_volume`, …). Leaving them NULL makes the server fail the *entire*
  invoice query with `DIESEL_DESERIALIZATION_ERROR`, taking out real rows too.

`CHARTER.md` is the standing agreement (metrics, RAIL budget classes, constraints
C1–C10 including a ≥20% merge gate and "no dependency swaps"). `README.md` covers how
to run it, the 5-step **diagnosis protocol**, and the **strategy cards** for applying
findings to other verticals.

### CI: `client/perf` is excluded from the three client workflows

`client-code-checks`, `client-tests` and `client-bundle-size-diff` all trigger on
`paths: 'client/**'`. None actually covers the harness — it isn't a workspace, no
product code imports it, and `tsc`, `jest` and `eslint` all skip it (verified with
`--listFiles` / `--listTests`). So harness-only changes were triggering checks that
test nothing, including **two full production webpack builds** for the bundle-size
diff. Added `- '!client/perf/**'` after the existing pattern in each.

## 💌 Any notes for the reviewer?

- **No product source changes.** Outside `client/perf/`, this touches only three
  workflow path filters and two added `client/package.json` scripts (`perf`,
  `perf:baseline`). Nothing reaches a bundle.
- **Independent of #12607** — both branch from `main` and touch disjoint files, so they
  can merge in either order.
- **The committed baselines were measured on `main` @ bb036d77.** `prod.json` is the
  pre-fix state and `prod-after-fixes.json` is with #12607 applied, so the pair is the
  provenance for that PR's numbers. `dev*.json` are the dev-build equivalents and run
  3–4× slower — the charter says never to quote them as results.
- **The store-by-code change is provably fixture-identical**: on this datafile the
  lookup resolves to `D77F67339BF8400886D009178F4962E1`, exactly the id that was
  previously hardcoded, with unchanged row counts (400 items / 2400 stock lines / 301
  shipments / 150 fat lines). So the committed baselines remain valid.
- **One test is not self-contained.** `diag.perf.ts`'s `profiler attribution` case
  (behind `PERF_PROFILE=1`) needs temporary `React.Profiler` wrappers in `Site.tsx`.
  That instrumentation is deliberately uncommitted — it's a diagnostic, not a standing
  test — and the test throws a clear message if it's missing rather than reporting an
  empty tally. Its doc comment has the snippet to paste in.
- **Some selectors are positional**, because these views carry very few
  `data-testid`s — e.g. the line-edit modal's Issue input is `input` index 1. Those are
  guarded by assertions that fail loudly when the DOM shifts. The e2e testid work on
  other branches should let them tighten up.
- **Baselines are ~128 KB of JSON** because they retain per-run samples. Deliberate —
  it's the provenance — but say the word if you'd rather they were aggregate-only.
- Worth knowing when reading `outbound.perf.ts`: **sorting in this app is two clicks.**
  `useTableDisplayOptions` replaces the column-actions button with a full-width
  invisible one, so clicking a header opens the column menu and the sort is applied
  from a menu item. Both clicks are measured separately.

# 🧪 Testing

```fish
# 1. Seed the fixture. Connection is resolved from server/configuration
#    (base.yaml, overridden by local.yaml); the store defaults to GEN.
client/perf/seed.sh

# 2. Bring the app up. `yarn start` at the repo root runs the Rust server AND the
#    webpack dev server; from client/ it starts just the client. Either blocks, so
#    leave it running and use a second shell for step 3.
yarn start

# 3. Dev build — quick pass while iterating
cd client
PERF_RUNS=2 yarn perf

# 4. Production — required for any number you intend to report. Build the client;
#    the Rust server already serves it on :8000 with the API on the same origin,
#    which is both the real deployment shape and the only one that works (a prod
#    build resolves the API same-origin, so `yarn serve` on :3003 can't reach it).
yarn build
BASE_URL=http://localhost:8000 PERF_BUILD=prod yarn perf

# 5. Tear the fixture back down
./perf/seed.sh --clean
```

- [x] 12 scenarios pass on a dev build and on a production build
- [x] Report prints and a JSON result is written; deltas vs `baseline/prod.json`
      reproduce #12607's numbers (−39/−39/−31%)
- [x] Fixture round-trips: `--clean` leaves 0 perf rows, reseed restores the same
      counts, and it lands in the `GEN` store
- [x] `seed.sh` overrides work: `PGDATABASE=…` retargets, `-v fat_lines=200` and
      `-v store_code=…` pass through, and an unknown store code aborts with a readable
      message and exit 3
- [x] Confirmed the harness is outside every existing check:
      `tsc -p packages/host --listFiles` → 0 perf files; `jest --listTests` → 0 perf
      files; `yarn eslint` covers `packages/*` only
- [x] `yarn test` still 86 suites / 592 tests (harness adds none)
- [ ] Reviewer: run `client/perf/seed.sh` on **your** datafile — the point of the
      portability work is that it should just work, or tell you exactly which store
      code to pass
- [ ] Reviewer: confirm the CI path filters behave — a PR touching only
      `client/perf/**` should show no client checks, while one touching
      `client/packages/**` still runs all three

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: developer tooling, no user-facing change. It
      documents itself in `client/perf/README.md` and `client/perf/CHARTER.md`.
- [ ] **These areas should be updated or checked**:
  1.
  2.
