### PR TITLE
Reconcile user data on login instead of delete-all-then-reinsert (#12612)

### DIFF
--- a/server/repository/src/db_diesel/user_store_join_row.rs
+++ b/server/repository/src/db_diesel/user_store_join_row.rs
@@ -94,12 +94,6 @@ impl<'a> UserStoreJoinRowRepository<'a> {
             .load(self.connection.lock().connection())?)
     }
 
-    pub fn delete_by_user_id(&self, id: &str) -> Result<(), RepositoryError> {
-        diesel::delete(user_store_join::table.filter(user_store_join::user_id.eq(id)))
-            .execute(self.connection.lock().connection())?;
-        Ok(())
-    }
-
     pub fn find_many_by_user_id(
         &self,
         user_id: &str,

--- a/server/repository/src/db_diesel/user_store_join_row.rs
+++ b/server/repository/src/db_diesel/user_store_join_row.rs
@@ -99,6 +99,15 @@ impl<'a> UserStoreJoinRowRepository<'a> {
             .execute(self.connection.lock().connection())?;
         Ok(())
     }
+
+    pub fn find_many_by_user_id(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<UserStoreJoinRow>, RepositoryError> {
+        Ok(user_store_join::table
+            .filter(user_store_join::user_id.eq(user_id))
+            .load(self.connection.lock().connection())?)
+    }
 }
 
 impl Upsert for UserStoreJoinRow {

--- a/server/service/src/login.rs
+++ b/server/service/src/login.rs
@@ -438,12 +438,28 @@ impl LoginService {
         password: &str,
         user_info: LoginUserInfoV4,
     ) -> Result<(), UpdateUserError> {
+        // Keep the stored hash while the password is unchanged: bcrypt salts
+        // every hash, so re-hashing per login would make the user row always
+        // look changed and defeat upsert_user's delta detection (#12612).
+        // Central has already accepted `password` at this point.
+        let hashed_password = UserAccountRowRepository::new(&service_ctx.connection)
+            .find_one_by_id(&user_info.user.id)
+            .map_err(UpdateUserError::DatabaseError)?
+            .filter(|existing| {
+                bcrypt::verify(password, &existing.hashed_password).unwrap_or(false)
+            })
+            .map(|existing| existing.hashed_password);
+        let hashed_password = match hashed_password {
+            Some(existing_hash) => existing_hash,
+            None => UserAccountService::hash_password(password)
+                .map_err(UpdateUserError::PasswordHashError)?,
+        };
+
         // convert user_info to internal format
         let user = UserAccountRow {
             id: user_info.user.id,
             username: user_info.user.name.to_string(),
-            hashed_password: UserAccountService::hash_password(password)
-                .map_err(UpdateUserError::PasswordHashError)?,
+            hashed_password,
             email: user_info.user.e_mail,
             language: match user_info.user.language {
                 0 => LanguageType::English,

--- a/server/service/src/user_account.rs
+++ b/server/service/src/user_account.rs
@@ -8,6 +8,7 @@ use util::uuid::uuid;
 
 use bcrypt::{hash, verify, BcryptError, DEFAULT_COST};
 use log::{error, warn};
+use std::collections::{HashMap, HashSet};
 
 pub struct CreateUserAccount {
     pub username: String,
@@ -55,7 +56,14 @@ impl<'a> UserAccountService<'a> {
         UserAccountService { connection }
     }
 
-    /// Deletes existing user and replaces the user with the provided data
+    /// Reconciles the user's account row, store joins and (non-context)
+    /// permissions with the provided data, writing only deltas: new or changed
+    /// rows are upserted, rows absent from the input are deleted, identical
+    /// rows are left untouched so no changelog row is written. The previous
+    /// delete-all-then-reinsert wrote ~2 changelog rows per permission on
+    /// every login even when nothing changed, and — because permission ids are
+    /// deterministic — manufactured the stale delete → re-create changelog
+    /// pairs behind #12610 (see #12612).
     pub fn upsert_user(
         &self,
         user: UserAccountRow,
@@ -67,26 +75,88 @@ impl<'a> UserAccountService<'a> {
                 let user_store_repo = UserStoreJoinRowRepository::new(con);
                 let permission_repo = UserPermissionRowRepository::new(con);
 
-                let permissions_to_delete = UserPermissionRepository::new(con).query_by_filter(
-                    UserPermissionFilter::new()
-                        .user_id(EqualFilter::equal_to(user.id.to_string()))
-                        .has_context(false),
-                )?;
-                for permission in permissions_to_delete {
-                    permission_repo.delete(&permission.id)?;
+                // Context permissions are managed by sync, not the login flow —
+                // left untouched, as before (has_context(false)).
+                let existing_permissions: HashMap<String, UserPermissionRow> =
+                    UserPermissionRepository::new(con)
+                        .query_by_filter(
+                            UserPermissionFilter::new()
+                                .user_id(EqualFilter::equal_to(user.id.to_string()))
+                                .has_context(false),
+                        )?
+                        .into_iter()
+                        .map(|p| (p.id.clone(), p))
+                        .collect();
+                let incoming_permission_ids: HashSet<&str> = stores_permissions
+                    .iter()
+                    .flat_map(|s| &s.permissions)
+                    .map(|p| p.id.as_str())
+                    .collect();
+                for id in existing_permissions
+                    .keys()
+                    .filter(|id| !incoming_permission_ids.contains(id.as_str()))
+                {
+                    // A genuine revocation — the Delete changelog must sync.
+                    permission_repo.delete(id)?;
                 }
-                user_store_repo.delete_by_user_id(&user.id)?;
-                user_repo.upsert_one(&user)?;
+
+                // Store joins absent from the input are removed. Like the
+                // previous wholesale delete this writes no changelog — store
+                // join removals don't sync (tracked in #12612).
+                let existing_joins: HashMap<String, UserStoreJoinRow> = user_store_repo
+                    .find_many_by_user_id(&user.id)?
+                    .into_iter()
+                    .map(|j| (j.id.clone(), j))
+                    .collect();
+                let incoming_join_ids: HashSet<&str> = stores_permissions
+                    .iter()
+                    .map(|s| s.user_store_join.id.as_str())
+                    .collect();
+                for id in existing_joins
+                    .keys()
+                    .filter(|id| !incoming_join_ids.contains(id.as_str()))
+                {
+                    user_store_repo.delete_by_id(id)?;
+                }
+
+                // The user row is rewritten only on material change.
+                // `last_successful_sync` is stamped by the caller on every
+                // login and is local bookkeeping only, so it is excluded from
+                // the comparison; the caller keeps `hashed_password` stable
+                // while the password is unchanged (see `update_user`).
+                let existing_user = user_repo.find_one_by_id(&user.id)?;
+                let user_unchanged = existing_user.as_ref().is_some_and(|existing| {
+                    UserAccountRow {
+                        last_successful_sync: existing.last_successful_sync,
+                        ..user.clone()
+                    } == *existing
+                });
+                if !user_unchanged {
+                    user_repo.upsert_one(&user)?;
+                }
 
                 for store in stores_permissions {
+                    let join_changed = existing_joins.get(&store.user_store_join.id)
+                        != Some(&store.user_store_join);
+                    let changed_permissions: Vec<&UserPermissionRow> = store
+                        .permissions
+                        .iter()
+                        .filter(|p| existing_permissions.get(&p.id) != Some(*p))
+                        .collect();
+                    if !join_changed && changed_permissions.is_empty() {
+                        continue;
+                    }
+
                     // The list may contain stores we don't know about; try to insert the store
                     // in a sub-transaction and ignore the store when there is an error
                     // Note: Postgres requires this to run in a sub-transaction because it aborts
                     // the whole tx when encounter an error.
                     let sub_result = con.transaction_sync_etc(
                         |_| {
-                            user_store_repo.upsert_one(&store.user_store_join)?;
-                            for permission in &store.permissions {
+                            if join_changed {
+                                user_store_repo.upsert_one(&store.user_store_join)?;
+                            }
+                            for permission in &changed_permissions {
                                 permission_repo.upsert_one(permission)?;
                             }
                             Ok(())
@@ -368,5 +438,204 @@ mod user_account_test {
             result,
             Err(VerifyPasswordError::UsernameDoesNotExist)
         ));
+    }
+
+    // ---- upsert_user reconciliation (#12612) ----
+
+    use repository::{
+        ChangelogCondition, ChangelogRepository, ChangelogRow, ChangelogTableName, CursorAndLimit,
+        RowActionType,
+    };
+
+    fn reconcile_user() -> UserAccountRow {
+        UserAccountRow {
+            id: "reconcile_user".to_string(),
+            username: "reconcile_user".to_string(),
+            // Stable across calls, as update_user keeps the stored hash while
+            // the password is unchanged.
+            hashed_password: "stable_hash".to_string(),
+            email: None,
+            language: Default::default(),
+            first_name: None,
+            last_name: None,
+            phone_number: None,
+            job_title: None,
+            // Stamped fresh on every login by update_user — excluded from
+            // upsert_user's change detection.
+            last_successful_sync: Some(chrono::Utc::now().naive_utc()),
+            is_active: true,
+        }
+    }
+
+    fn permission(id: &str, permission: PermissionType) -> UserPermissionRow {
+        UserPermissionRow {
+            id: id.to_string(),
+            user_id: reconcile_user().id,
+            store_id: Some("store_a".to_string()),
+            permission,
+            context_id: None,
+        }
+    }
+
+    fn store_a_permissions(permissions: Vec<UserPermissionRow>) -> Vec<StorePermissions> {
+        vec![StorePermissions {
+            user_store_join: UserStoreJoinRow {
+                id: "reconcile_join_a".to_string(),
+                user_id: reconcile_user().id,
+                store_id: "store_a".to_string(),
+                is_default: true,
+            },
+            permissions,
+        }]
+    }
+
+    fn both_permissions() -> Vec<UserPermissionRow> {
+        vec![
+            permission("reconcile_p1", PermissionType::StoreAccess),
+            permission("reconcile_p2", PermissionType::InboundShipmentMutate),
+        ]
+    }
+
+    /// Changelog rows written after `mark`.
+    fn changelogs_after(connection: &StorageConnection, mark: u64) -> Vec<ChangelogRow> {
+        ChangelogRepository::new(connection)
+            .query(
+                ChangelogCondition::True(),
+                CursorAndLimit {
+                    cursor: mark as i64,
+                    limit: 1000,
+                },
+            )
+            .unwrap()
+            .rows
+    }
+
+    #[actix_rt::test]
+    async fn upsert_user_idempotent_writes_no_changelog() {
+        let (_, connection, _, _) = setup_all(
+            "upsert_user_idempotent_writes_no_changelog",
+            MockDataInserts::none().names().stores(),
+        )
+        .await;
+        let service = UserAccountService::new(&connection);
+
+        service
+            .upsert_user(reconcile_user(), store_a_permissions(both_permissions()))
+            .unwrap();
+        let mark = ChangelogRepository::new(&connection).max_cursor().unwrap();
+
+        // Same data again (fresh last_successful_sync, as every login stamps).
+        service
+            .upsert_user(reconcile_user(), store_a_permissions(both_permissions()))
+            .unwrap();
+
+        assert_eq!(
+            changelogs_after(&connection, mark),
+            vec![],
+            "an unchanged login must write no changelog rows"
+        );
+    }
+
+    #[actix_rt::test]
+    async fn upsert_user_deletes_only_removed_permissions() {
+        let (_, connection, _, _) = setup_all(
+            "upsert_user_deletes_only_removed_permissions",
+            MockDataInserts::none().names().stores(),
+        )
+        .await;
+        let service = UserAccountService::new(&connection);
+
+        service
+            .upsert_user(reconcile_user(), store_a_permissions(both_permissions()))
+            .unwrap();
+        let mark = ChangelogRepository::new(&connection).max_cursor().unwrap();
+
+        // p2 revoked.
+        service
+            .upsert_user(
+                reconcile_user(),
+                store_a_permissions(vec![permission("reconcile_p1", PermissionType::StoreAccess)]),
+            )
+            .unwrap();
+
+        let new_rows = changelogs_after(&connection, mark);
+        assert_eq!(new_rows.len(), 1);
+        assert_eq!(new_rows[0].table_name, ChangelogTableName::UserPermission);
+        assert_eq!(new_rows[0].record_id, "reconcile_p2");
+        assert_eq!(new_rows[0].row_action, RowActionType::Delete);
+
+        let remaining = UserPermissionRepository::new(&connection)
+            .query_by_filter(
+                UserPermissionFilter::new()
+                    .user_id(EqualFilter::equal_to(reconcile_user().id)),
+            )
+            .unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].id, "reconcile_p1");
+    }
+
+    #[actix_rt::test]
+    async fn upsert_user_upserts_only_changed_rows() {
+        let (_, connection, _, _) = setup_all(
+            "upsert_user_upserts_only_changed_rows",
+            MockDataInserts::none().names().stores(),
+        )
+        .await;
+        let service = UserAccountService::new(&connection);
+
+        service
+            .upsert_user(reconcile_user(), store_a_permissions(both_permissions()))
+            .unwrap();
+        let mark = ChangelogRepository::new(&connection).max_cursor().unwrap();
+
+        // The join flips is_default and p1 changes permission; p2 and the user
+        // row are untouched.
+        let mut changed = store_a_permissions(vec![
+            permission("reconcile_p1", PermissionType::OutboundShipmentMutate),
+            permission("reconcile_p2", PermissionType::InboundShipmentMutate),
+        ]);
+        changed[0].user_store_join.is_default = false;
+        service.upsert_user(reconcile_user(), changed).unwrap();
+
+        let mut new_rows = changelogs_after(&connection, mark);
+        new_rows.sort_by_key(|r| r.record_id.clone());
+        assert_eq!(new_rows.len(), 2);
+        assert_eq!(new_rows[0].table_name, ChangelogTableName::UserStoreJoin);
+        assert_eq!(new_rows[0].record_id, "reconcile_join_a");
+        assert_eq!(new_rows[0].row_action, RowActionType::Upsert);
+        assert_eq!(new_rows[1].table_name, ChangelogTableName::UserPermission);
+        assert_eq!(new_rows[1].record_id, "reconcile_p1");
+        assert_eq!(new_rows[1].row_action, RowActionType::Upsert);
+    }
+
+    #[actix_rt::test]
+    async fn upsert_user_writes_user_row_only_when_changed() {
+        let (_, connection, _, _) = setup_all(
+            "upsert_user_writes_user_row_only_when_changed",
+            MockDataInserts::none().names().stores(),
+        )
+        .await;
+        let service = UserAccountService::new(&connection);
+
+        service
+            .upsert_user(reconcile_user(), store_a_permissions(both_permissions()))
+            .unwrap();
+        let mark = ChangelogRepository::new(&connection).max_cursor().unwrap();
+
+        service
+            .upsert_user(
+                UserAccountRow {
+                    email: Some("changed@example.com".to_string()),
+                    ..reconcile_user()
+                },
+                store_a_permissions(both_permissions()),
+            )
+            .unwrap();
+
+        let new_rows = changelogs_after(&connection, mark);
+        assert_eq!(new_rows.len(), 1);
+        assert_eq!(new_rows[0].table_name, ChangelogTableName::UserAccount);
+        assert_eq!(new_rows[0].record_id, "reconcile_user");
+        assert_eq!(new_rows[0].row_action, RowActionType::Upsert);
     }
 }


### PR DESCRIPTION
Fixes #12612

# 👩🏻‍💻 What does this PR do?

Stops every V5V6 login from churning the changelog. `upsert_user` previously replaced the user's data wholesale on each login: it hard-deleted **all** non-context permissions and re-inserted them (2 changelog rows per permission, with the same deterministic UUIDv5 ids — the systematic producer of the stale delete → re-create pairs behind #12610), rewrote every store join, and re-upserted the user row with a freshly salted password hash — even when nothing had changed. ~2N+M+1 changelog rows per login, per user.

Now `upsert_user` **reconciles**:
- permissions absent from the input are deleted (a genuine revocation — the Delete changelog must sync); new/changed ones are upserted; identical ones are untouched
- store joins likewise (removals still write no changelog, matching previous behaviour — that latent "join removals never sync" gap is tracked in #12612's notes)
- the user row is rewritten only on material change: `update_user` keeps the stored password hash while the entered password still `bcrypt::verify`s against it (re-hashing per login would always differ due to fresh salt), and the locally-stamped `last_successful_sync` is excluded from the comparison

Net effect: **an unchanged login writes zero changelog rows**; a permission grant/revoke writes exactly the delta.

## 💌 Any notes for the reviewer?

- Semantics change for `user_account.last_successful_sync`: it now updates only when a login materially changes the user's data, rather than on every login. It isn't exposed via GraphQL and is only read by the v5 user sync translator (which preserves the local value), so this looked safe — flag if you know a consumer I missed.
- The per-store sub-transaction + FK-violation tolerance for unknown stores is preserved verbatim; unchanged stores now skip the sub-transaction entirely.
- Context permissions (`context_id` set) remain untouched by the login flow, as before — locked in by the pre-existing `test_user_upsert`.
- `update_user`'s hash-stability branch has no direct unit test (`LoginUserInfoV4` has no test fixture); its effect is exercised by the `upsert_user` tests, which rely on a stable hash producing zero writes.
- Related to #12613 (the #12610 sync fix): that PR makes the delete/re-create pairs harmless; this one stops manufacturing them.

# 🧪 Testing

Automated (`cargo nextest run`):
- `upsert_user_idempotent_writes_no_changelog` — identical second login writes zero changelog rows
- `upsert_user_deletes_only_removed_permissions` — revoking one permission writes exactly one `user_permission` Delete
- `upsert_user_upserts_only_changed_rows` — one changed join + one changed permission → exactly those two Upserts
- `upsert_user_writes_user_row_only_when_changed` — email change → exactly one `user_account` Upsert
- pre-existing `test_user_upsert` (replacement semantics for changed data, context-permission preservation, other-user isolation) unchanged and passing

Manual:
- [ ] Log into a V5V6 remote site twice with the same user; `SELECT count(*) FROM changelog WHERE table_name IN ('user_permission','user_store_join','user_account')` is unchanged after the second login
- [ ] Revoke a permission for the user in legacy mSupply, log in again → exactly one `user_permission` delete changelog row; permission removed locally

# 📃 Documentation

- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)
