### PR TITLE
#2490 Locale-independent postgres database auto-create

### DIFF
--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -141,37 +141,51 @@ impl diesel::r2d2::CustomizeConnection<diesel::SqliteConnection, diesel::r2d2::E
 #[cfg(feature = "postgres")]
 pub fn get_storage_connection_manager(settings: &DatabaseSettings) -> StorageConnectionManager {
     use crate::diesel::r2d2::ManageConnection;
+    use crate::diesel_helper_types::Count;
+    use diesel::{sql_query, sql_types::Text, RunQueryDsl};
+
     let connection_manager =
-        ConnectionManager::<DBBackendConnection>::new(&settings.connection_string());
+        ConnectionManager::<DBBackendConnection>::new(settings.connection_string());
 
     // Check the database connection, and attempt to create the database if required
     // Note: the build() call isn't failing when you have an incorrect server or database name
     // so we need to explicitly call connect() to test the connection
-    if let Err(e) = connection_manager.connect() {
-        if e.to_string()
-            .contains(format!("database \"{}\" does not exist", &settings.database_name).as_str())
-        {
-            info!(
-                "Database {} does not exist. Attempting to create it.",
-                &settings.database_name
-            );
-            let root_connection_manager = ConnectionManager::<DBBackendConnection>::new(
-                &settings.connection_string_without_db(),
-            );
+    if let Err(connect_error) = connection_manager.connect() {
+        // The connect error text is localised by the postgres server (lc_messages), so it
+        // can't be used to detect a missing database. Connect to the base database and
+        // check pg_database instead.
+        let root_connection_manager =
+            ConnectionManager::<DBBackendConnection>::new(settings.connection_string_without_db());
 
-            match root_connection_manager.connect() {
-                Ok(mut root_connection) => {
-                    root_connection
-                        .batch_execute(&format!("CREATE DATABASE \"{}\";", &settings.database_name))
-                        .expect("Failed to create database");
-                }
-                Err(e) => {
-                    panic!("Failed to connect to postgres root: {}", e);
-                }
+        let mut root_connection = match root_connection_manager.connect() {
+            Ok(connection) => connection,
+            Err(root_error) => {
+                panic!(
+                    "Failed to connect to database: {} (also failed to connect to the base database to check whether it exists: {})",
+                    connect_error, root_error
+                );
             }
-        } else {
-            panic!("Failed to connect to database: {}", e);
+        };
+
+        let count =
+            sql_query("SELECT count(*)::bigint AS count FROM pg_database WHERE datname = $1")
+                .bind::<Text, _>(&settings.database_name)
+                .get_result::<Count>(&mut root_connection)
+                .expect("Failed to check whether database exists")
+                .count;
+
+        if count > 0 {
+            // Database exists, the original connection failure was something else
+            panic!("Failed to connect to database: {}", connect_error);
         }
+
+        info!(
+            "Database {} does not exist. Attempting to create it.",
+            &settings.database_name
+        );
+        root_connection
+            .batch_execute(&format!("CREATE DATABASE \"{}\";", &settings.database_name))
+            .expect("Failed to create database");
     }
     info!("Connecting to database '{}'", settings.database_name);
     let pool = Pool::builder()
@@ -258,6 +272,41 @@ mod database_setting_test {
             settings.connection_string(),
             "postgres://user:pass@localhost:5432/testdb?application_name=open-msupply"
         );
+    }
+
+    // feature postgres
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn test_creates_missing_database() {
+        use crate::database_settings::get_storage_connection_manager;
+        use crate::test_db::get_test_db_settings;
+        use diesel::r2d2::ManageConnection;
+        use diesel::{r2d2::ConnectionManager, sql_query, PgConnection, RunQueryDsl};
+
+        let settings = get_test_db_settings("auto_create_db_test");
+
+        let root_connection_manager =
+            ConnectionManager::<PgConnection>::new(settings.connection_string_without_db());
+        let mut root_connection = root_connection_manager
+            .connect()
+            .expect("Failed to connect to base database");
+
+        sql_query(format!(
+            "DROP DATABASE IF EXISTS \"{}\";",
+            settings.database_name
+        ))
+        .execute(&mut root_connection)
+        .unwrap();
+
+        // Database is missing, so this should create it rather than panic
+        let connection_manager = get_storage_connection_manager(&settings);
+        connection_manager
+            .connection()
+            .expect("Failed to connect to the newly created database");
+
+        // Best-effort cleanup (fails while the pool above holds connections open, which is fine)
+        let _ = sql_query(format!("DROP DATABASE \"{}\";", settings.database_name))
+            .execute(&mut root_connection);
     }
 
     // feature sqlite


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #2490

On server startup, the postgres flavour of `get_storage_connection_manager` decided whether to auto-create the configured database by string-matching the connect error against the **English** libpq text `database "<name>" does not exist`. Postgres localises error text according to the server's `lc_messages`, so on a French (or any non-English) Postgres the match never fired and startup panicked with `Failed to connect to database: … FATAL: la base de données « … » n'existe pas` instead of creating the database — exactly the panic in the issue (and re-reported by Alain during a fresh install last week).

This PR removes the message-text parsing entirely. On connect failure the server now:

1. Connects to the base database via the existing `connection_string_without_db()`.
2. Runs a bound catalog query — `SELECT count(*) FROM pg_database WHERE datname = $1` (reusing the existing `Count` helper from `diesel_helper_types.rs`) — which is locale-independent.
3. Creates the database only if the catalog says it's missing; otherwise re-raises the original connection error, since the failure must be something else (privileges, credentials, etc.).

Error reporting is also slightly improved: if the base-database connection fails too, the panic now includes both errors instead of replacing the original with the root-connection one.

## 💌 Any notes for the reviewer?

- Only this one call site had the localisation bug. The other `CREATE DATABASE` paths (`test_db/postgres.rs`, `cli/src/backup/restore.rs`) are unconditional drop-then-create and never inspect error text.
- The panic message keeps the `Failed to connect to database:` prefix so existing log greps / support knowledge still match.
- `connection_string_without_db()` is unchanged: libpq still falls back to a maintenance DB named after the user (fine for the default `postgres` user, same behaviour as before).
- The existing postgres test suite never exercised the create-if-missing branch (test setup always pre-creates the DB), so the new test is the first coverage of it.

# 🧪 Tested

- Added `test_creates_missing_database` (postgres-gated): drops the DB via a root connection, calls `get_storage_connection_manager`, and asserts a connection to the newly created database succeeds.
- `cargo nextest run -p repository --features postgres database_setting` — both tests pass against a live Postgres 18.
- `cargo check -p repository` (sqlite default) and `--features postgres` both build; clippy clean in the touched file.
- Attempted an end-to-end French repro by setting `lc_messages = 'fr_FR.UTF-8'` locally, but Postgres.app is compiled without NLS so it emits English errors regardless. Since the fix no longer reads error text at all, locale can no longer influence the branch decision — the new test covers the create path directly.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
