### PR TITLE
Frontend sync: KDDs and spec

### DIFF
--- a/decisions/2026-08-03_frontend_sync_transport.md
+++ b/decisions/2026-08-03_frontend_sync_transport.md
@@ -1,0 +1,244 @@
+# Frontend sync — how the bundle reaches a remote site
+
+- _Date_: 2026-08-03
+- _Deciders_: James Brunskill
+- _Status_: PROPOSED
+- _Outcome_: Option 3 — metadata over normal sync, bytes over file sync
+
+## Context
+
+The new front end lives in its own repo
+([open-msupply-frontend](https://github.com/msupply-foundation/open-msupply-frontend)) and is
+shipped as a checksum-verified dist zip. This repo records which one it ships in the **pin file**
+`frontend-version.json` (tag + sha256); packaging runs `build/fetch-frontend.js` to download,
+verify and unpack it into the directory the server serves from (`server.frontend_dir`,
+[serve_frontend.rs](../server/server/src/serve_frontend.rs)). On Android the app shell copies the
+APK-bundled build into `<filesDir>/frontend` instead
+([FrontendAssets.java](../client/packages/android/app/src/main/java/org/openmsupply/client/FrontendAssets.java)).
+
+Today the only way a site gets new front-end code is a new installer or APK. That is slow — a full
+release and a per-site upgrade for what may be a one-line UI fix
+([#12622](https://github.com/msupply-foundation/open-msupply/issues/12622)). We want to deliver a
+new front end the way we already deliver reports and plugins: publish once on central, and let sync
+carry it to every compatible site.
+
+This KDD decides **how the bundle's bytes travel**. Which bundle a site is allowed to run is
+[Frontend and plugin version compatibility](./2026-08-03_frontend_version_compatibility.md).
+
+### What the reference implementations do
+
+**Reports** are embedded in the server binary (`rust_embed` over `standard_reports/generated`) and
+upserted at startup by
+[`StandardReports::load_reports`](../server/service/src/standard_reports.rs). Many versions of the
+same `code` coexist in the `report` table; the newest compatible one is chosen at query time
+([`report_filter_method`](../server/service/src/report/report_service.rs)). Reports sync as ordinary
+records.
+
+**Frontend plugins** already do the thing this KDD is weighing up: `frontend_plugin.files` is a JSON
+array of `{file_name, file_content_base64}` — the entire JS bundle base64-encoded inside a single
+sync record ([frontend_plugin_row.rs](../server/repository/src/db_diesel/frontend_plugin_row.rs)).
+The server decodes it on load, keeps the newest compatible version per `code` in an in-memory cache,
+sha256s the bytes into a hash token, and serves the files at `/frontend_plugins/{code}/{file}` with
+`immutable, max-age=1y`; the client cache-busts with `?v=<hash>`.
+
+**File sync** ([2024-02-28_file_sync.md](./2024-02-28_file_sync.md)) syncs a `sync_file_reference`
+row through the normal sync process and moves the bytes out of band over HTTP. Two things about the
+current implementation matter here:
+
+- The [`FileSyncDriver`](../server/service/src/sync/file_sync_driver.rs) loop only **uploads**
+  (`find_all_to_upload`). There is no background download.
+- Downloads are on demand only: a user opening an attachment hits
+  `GET /sync_files/{table}/{record}/{file}`, and if the bytes are not on disk the request falls
+  through to `FileSynchroniser::download_file_from_central`
+  ([static_files.rs](../server/server/src/static_files.rs)). It is a single whole-file GET with no
+  range, no resume and no retry schedule — uploads get tus chunking, pause and exponential backoff;
+  downloads get none of it.
+
+### Sizes
+
+Measured against the current `open-msupply-frontend` dist (excluding the component showcase, which
+is not part of a deployment): **269 files, 3.3 MB on disk, ~945 KB zipped.** The old `client` dist,
+for comparison, is 8.5 MB on disk. The new front end is deliberately small, but ~1 MB zipped today
+and growing is the number to design against.
+
+### Requirements
+
+1. A remote site can run a newer front end than its installer shipped, without reinstalling.
+2. The bundle must survive an APK/installer upgrade sensibly (see the Android clobber, below).
+3. A site must only download bundles it can actually run — not every bundle ever published.
+4. Transferring a bundle must not block or noticeably degrade normal sync.
+5. A partially transferred bundle must never be served.
+6. The bytes must be verifiable end to end (we already have a sha256 per dist).
+7. Offline-first: once downloaded, a site serves its front end with no connection to central.
+8. v7 sites only, open-mSupply central only. No 4D involvement.
+
+## Options
+
+### Option 1 — Base64 the bundle into a normal sync record (the `frontend_plugin` pattern)
+
+Add a `frontend_bundle` table shaped like `frontend_plugin`: the whole dist as a JSON array of
+base64 files, or a single base64 zip, in a text column.
+
+_Pros:_
+
+- Zero new infrastructure. The pattern is proven, the sync style is a copy-paste, and it works on
+  every transport we already have.
+- Atomic by construction: the record either integrates or it doesn't.
+
+_Cons:_
+
+- ~1.3 MB of base64 in one changelog row today (base64 of the zip; base64 of the unpacked files
+  would be ~4.4 MB). `batch_size` is a **record count**, not a byte budget, so a batch that happens
+  to contain a bundle is one multi-megabyte HTTP body with no resume — on a bad link it retries from
+  zero, forever. This is precisely the failure mode
+  [the file sync KDD](./2024-02-28_file_sync.md) rejected Option 2 for.
+- Every site pays the transfer, including sites that will reject the bundle as incompatible
+  (requirement 3) — the record is the payload, so there is no way to see it before receiving it.
+- The bytes land in the database. A handful of retained versions is tens of MB of `changelog` and
+  table data on every site, and it is all in the backup.
+- It gets worse monotonically as the front end grows.
+
+### Option 2 — `sync_file_reference` alone, with no owning record
+
+Publish only a file reference; put the version and compatibility information in `file_name` or in a
+convention over `record_id`.
+
+_Pros:_
+
+- Nothing new in the schema at all.
+
+_Cons:_
+
+- `sync_file_reference` is explicitly a *reference* — it carries `table_name` + `record_id` naming
+  the record it belongs to, and every consumer assumes that record exists. A dangling reference is a
+  new special case in code that currently has none.
+- Metadata-in-a-filename is not queryable, not typed, not migratable, and has nowhere to put an
+  `is_active` flag or a compatibility range.
+
+### Option 3 — Metadata over normal sync, bytes over file sync (chosen)
+
+A new `frontend_bundle` table syncs as an ordinary record — a few hundred bytes carrying the
+version, the compatibility information, the sha256 and an active flag. It owns a
+`sync_file_reference` whose bytes are the dist zip, moved by file sync.
+
+The site then decides **locally** whether to download: it compares the bundle record's declared
+compatibility against its own app version and only queues the file if it could actually run it. This
+is what makes requirement 3 work without central-side targeting — and it has to work that way,
+because `changelog` has no `site_id` column and distribution is keyed on store/patient
+([changelog filter](../docs/content/docs/sync/changelog-filter/)). `Central` distribution means a
+keyless row goes to every site; the *decision* is what's local, not the routing.
+
+_Pros:_
+
+- Sync batches stay small and predictable; the megabytes move on the file-sync path, which already
+  pauses while normal sync runs.
+- A site sees the compatibility metadata *before* it commits to a download.
+- Bytes live in the static file store, not the database or the backup.
+- Reuses the existing static-file layout, retry/backoff bookkeeping and status/error columns; a
+  progress UI later gets bundles for free alongside every other synced file.
+
+_Cons:_
+
+- Requires a **background download** mechanism, which does not exist yet (see below).
+- Two-phase state: a record can exist while its bytes are still in flight, so "is this bundle
+  usable?" is a real question the serving path has to answer.
+- Whole-file download with no resume is a poor fit for ~1 MB over a bad link — worth fixing as part
+  of this work (requirement 4 and the tablet case).
+
+### Option 4 — Central hosts the front end; sites fetch it over HTTP on demand
+
+_Cons:_ breaks offline-first (requirement 7). Rejected for the same reason
+[the file sync KDD](./2024-02-28_file_sync.md) rejected its Option 4.
+
+### Option 5 — Each site fetches the dist straight from the B2 mirror / GitHub release
+
+The pin mechanism already knows how to do this, and `fetch-frontend.js` already verifies a sha256.
+
+_Cons:_ requires every remote site to have internet access to a third-party host — many do not, and
+sync to central is the only connectivity we can assume. It also puts release distribution outside
+the system that already knows which sites exist and what they run.
+
+## Decision
+
+**Option 3 — metadata over normal sync, bytes over file sync.**
+
+Rationale:
+
+- The size trajectory makes Option 1 a slow-motion version of the problem
+  [the file sync KDD](./2024-02-28_file_sync.md) already solved: ~1 MB today is survivable, but the
+  reason we built file sync was to stop large payloads from riding the sync path at all.
+- Only Option 3 lets a site read the compatibility metadata before spending the bandwidth
+  (requirement 3).
+- The pieces that don't exist yet — background download, resumable download — are things we want
+  regardless. Reports and plugins are on the same trajectory, and the same queue would let us move
+  them off the sync path later.
+
+Trade-offs accepted:
+
+- We build a background download mechanism now rather than reusing an existing one.
+- A bundle record can be present without its bytes; the serving path must treat "downloaded and
+  verified" as a distinct state from "known about".
+
+### Sub-decision: how downloads get triggered
+
+Downloads today are user-driven. Rather than special-casing the front end, extend the file-sync
+machinery generically:
+
+- A **processor** decides *what* to download and enqueues it — for the front end, "the newest
+  compatible bundle this site does not yet hold". Processors already run off sync integration
+  ([`processors/`](../server/service/src/processors/)), which is exactly when new bundle records
+  arrive, and the `LoadPlugin` processor is the direct precedent.
+- The **`FileSyncDriver`** grows a download side alongside its upload side, draining a queue of
+  `sync_file_reference` rows marked for download and reusing the existing status / retries /
+  `retry_at` / error columns.
+
+This keeps "which files are worth having" (a domain question, per feature) separate from "move the
+bytes" (a transport concern, shared). Reports and plugins can register their own predicate later
+without touching the driver.
+
+### Sub-decision: publishing on central
+
+Two paths, mirroring how reports work:
+
+- **Bundled with central** — the normal path. Central publishes the dist that its own packaging
+  pinned and verified, on startup, the way `StandardReports::load_reports` upserts embedded reports.
+  Note `fetch-frontend.js` currently deletes the zip after unpacking, so packaging must retain it
+  (or the sha256-verified bytes) for central to publish. Upgrading central is therefore what
+  releases a new front end to the fleet.
+- **Manual upload** — an admin uploads a dist zip on central, the way plugins are installed today
+  (`install_uploaded_plugin`). This is the hotfix path and the "customer-specific build" path.
+
+## Consequences
+
+- **New table** `frontend_bundle`, a new sync style (Central authoring, Central distribution, v7
+  only), a translator and a migration. Exact columns are settled in the
+  [compatibility KDD](./2026-08-03_frontend_version_compatibility.md) and the
+  [spec](../server/spec/sync/frontend-sync.md).
+- **`FileSyncDriver` gains a download path**, and downloads should become resumable (HTTP range or
+  the tus-style approach uploads already use). A ~1 MB restart-from-zero loop on a poor link is a
+  realistic way for this feature to silently never work.
+- **The Android clobber is a hard constraint.** `FrontendAssets.sync()` deletes
+  `<filesDir>/frontend` and re-copies from the APK whenever the app version changes. A synced bundle
+  stored there would be destroyed by every APK upgrade. Synced bundles must unpack somewhere else
+  (under `base_dir`), with `frontend_dir` remaining the installer-shipped baseline and the fallback.
+- **Verification before activation.** The record carries the sha256; the downloaded zip is verified
+  against it before unpacking, and a bundle is only activated after a complete, verified unpack —
+  stage-then-swap, which is already the pattern in both `fetch-frontend.js` and `FrontendAssets`.
+- **Retention interacts with in-flight clients.** Assets are served `immutable, max-age=1y` with
+  content-hashed filenames, so an open tab holding old URLs keeps working *only if the old version's
+  files are still on disk. Deleting the previous version immediately is what turns a swap into a
+  broken tab. See the spec for the retention rule.
+- **Storage.** Each retained version is the zip plus ~3.3 MB unpacked. On a tablet this is small but
+  not free; retention must be bounded.
+- **Not in scope, deliberately** (each worth its own issue):
+  - Signing. sha256 from a record that arrived over authenticated sync is the MVP trust model; a
+    real signature over the bundle is a follow-up, and we already have cert/signature machinery from
+    the old plugin system ([manifest.rs](../server/service/src/plugin/manifest.rs)) to build on.
+  - Rate limiting / staggering the fleet. File sync already yields to normal sync, which should be
+    enough at current sizes.
+  - A file-sync progress and error UI. Wanted, but a follow-up.
+  - Delta or shared-chunk transfer (not re-sending unchanged vendor code).
+  - Targeting which bundle a site receives. Every site gets every bundle record and narrows it
+    locally by compatibility alone. The eventual shape is likely a selector over site/store
+    attributes rather than a release-channel label, so the compatibility KDD deliberately
+    provisions nothing for it.

--- a/decisions/2026-08-03_frontend_version_compatibility.md
+++ b/decisions/2026-08-03_frontend_version_compatibility.md
@@ -1,0 +1,236 @@
+# Frontend and plugin version compatibility
+
+- _Date_: 2026-08-03
+- _Deciders_: James Brunskill
+- _Status_: PROPOSED
+- _Outcome_: Option 1 for the front end (reuse the existing "newest compatible wins" rule, with an
+  explicit server-version field), Option 2b for plugins (additive plugin-API column, gated
+  server-side)
+
+## Context
+
+Once the front end can arrive by sync
+([transport KDD](./2026-08-03_frontend_sync_transport.md)), a site can hold several front-end
+bundles and must decide which one it is allowed to run. Separately, frontend plugins are built
+against a *host* front end as well as against a server, so "is this plugin compatible?" is now two
+questions, not one.
+
+### What we have today
+
+`Version` ([version.rs](../server/repository/src/migrations/version.rs)) is a `major.minor.patch`
+plus an ignored pre-release suffix, with one compatibility predicate:
+
+```rust
+// self is compatible with app_version if self is not "newer" by (major, minor)
+pub fn is_compatible_by_major_and_minor(&self, app_version: &Version) -> bool {
+    if self.major != app_version.major { return self.major < app_version.major; }
+    self.minor <= app_version.minor
+}
+```
+
+There is deliberately **no upper bound**: an old report or plugin stays compatible forever, on the
+theory that you fix an incompatibility by shipping a newer artefact, not by expiring the old one.
+`app_version` comes from the repo-root `package.json`, embedded in the binary.
+
+Both consumers pair that predicate with "newest wins":
+
+- Reports: [`report_filter_method`](../server/service/src/report/report_service.rs) filters to
+  compatible versions, groups by `code`, prefers `is_custom`, then takes the highest version.
+- Frontend plugins:
+  [`bind_frontend_plugin`](../server/service/src/plugin/mod.rs) skips incompatible versions and
+  keeps the highest version per `code` in the serving cache.
+
+The central server also already records, per remote site, its `app_name`, `app_version` and
+`sync_version` ([site_row.rs](../server/repository/src/db_diesel/site_row.rs)) — so central knows
+what the fleet is running, even though nothing uses that for distribution today.
+
+### What changed
+
+**The front end now has its own version line.** It is released from its own repo as `v0.0.231`
+(heading for `1.0.0`) while the server is on `3.x`. That breaks an assumption baked into the rule
+above: `is_compatible_by_major_and_minor` compares `self` against `app_version` **on the same
+number line**. A report version of `2.8.3` means "for server 2.8". A front-end version of `1.2.0`
+means nothing at all about which server it needs.
+
+**The front end already gates plugins itself.** The new front end ships a plugin API contract —
+`PLUGIN_API_VERSION` and `PLUGIN_API_MIN_SUPPORTED`, two integers, checked by the loader against
+the integer a plugin bundle declares
+(`src/plugin-sdk/apiVersion.ts`, `src/plugins/validate.ts`, `spec/plugins/rules.md § compatibility
+gates` in the front-end repo). A plugin built against a newer API than the host, or older than the
+host's floor, is refused and named. That gate exists, works, and is specified — deliberately an
+integer pair, never a semver range.
+
+So the three axes are:
+
+| Axis | Question | Status |
+| --- | --- | --- |
+| Front end ↔ backend | can this server serve this bundle? | new, this KDD |
+| Plugin ↔ backend | can this server serve this plugin? | exists (`frontend_plugin.version`) |
+| Plugin ↔ front end | can this host load this plugin? | exists client-side; not visible to the server |
+
+### Requirements
+
+1. A site serves the newest front end it can run, with no manual intervention.
+2. A site never serves a front end its server cannot support.
+3. The front end's version line stays independent of the server's.
+4. A site can decide compatibility **from the record alone**, before downloading ~1 MB of bytes
+   ([transport KDD](./2026-08-03_frontend_sync_transport.md), requirement 3).
+5. A broken bundle can be withdrawn, and a site can get back to a working UI without a working UI.
+6. Any sync wire-format change must be backwards compatible with sites that predate it.
+7. Targeting a bundle at a subset of sites is out of scope, and its design is deliberately left
+   open — this work must not bake in a shape that presumes the answer.
+
+## Options — front end ↔ backend
+
+### Option 1 — Reuse the existing rule, with an explicit server-version field (chosen)
+
+The bundle record carries **two** versions:
+
+- `version` — the front end's own version (`1.2.0`). Identity, and the ordering used to pick the
+  newest.
+- `server_version` — the server version the bundle was built against (`3.2.0`), i.e. a value on the
+  *server's* number line, which is what `is_compatible_by_major_and_minor` needs.
+
+A bundle is servable when `server_version.is_compatible_by_major_and_minor(app_version)`. Among
+servable, active, fully-downloaded bundles, the highest `version` wins.
+
+Who sets `server_version`: for the bundled path, central stamps its own app version at publish time
+— central packaging pinned that dist for that release, so it is true by construction, and needs no
+change in the front-end repo. For the manual-upload path it is supplied at upload (or read from a
+manifest in the zip, if the front-end repo adds one).
+
+_Pros:_
+
+- Identical semantics to reports and plugins — one rule to understand, one to test.
+- "Compatible forever" holds up here better than it does for reports: a server 4.0 release ships a
+  4.0-compatible front end, so the newest-compatible bundle is always the right one. The old bundle
+  staying nominally compatible is harmless because it is never the newest.
+- Satisfies requirement 4 with two short strings on the record.
+
+_Cons:_
+
+- Two version fields is a thing to explain; getting `server_version` wrong on a manual upload
+  produces a bundle that is offered and then fails at runtime.
+- No upper bound means a front end is never *excluded* by a server upgrade — correctness depends on
+  a newer bundle existing. The `is_active` flag (below) is the manual override when it does not.
+
+### Option 2 — An explicit `[min_server, max_server)` range on the bundle
+
+_Pros:_ genuinely expresses "this front end needs server ≥ 3.2 and is untested above 4.0", and would
+let a server upgrade correctly *stop* serving a bundle.
+
+_Cons:_ a second compatibility model alongside the one reports and plugins use; someone must
+maintain an upper bound per release, and an upper bound set too tight strands sites on an old UI
+with no automatic way forward. Defer until the "compatible forever" rule actually bites.
+
+### Option 3 — Central decides per site, using the `site.app_version` it already records
+
+Central knows every site's version; it could publish per-site rows.
+
+_Cons:_ `changelog` has no `site_id`, so per-site routing does not exist
+([changelog filter](../docs/content/docs/sync/changelog-filter/)); building it is a much larger
+change. It also moves the decision away from the only party that knows the *truth* about a
+multi-device site, where several devices share one site id and can run different binaries.
+
+## Options — plugin ↔ front end
+
+### Option 2a — Leave it entirely client-side (status quo)
+
+The front-end loader already refuses an incompatible plugin, names it, and carries on. Nothing to
+build.
+
+_Cons:_ the refusal happens after the bundle has been fetched and evaluated, and the server keeps
+advertising a plugin no client can use. There is no server-side view of "this plugin will not work
+here", which is what an administrator actually needs.
+
+### Option 2b — Add the plugin-API version to `frontend_plugin` and gate server-side too (chosen)
+
+A new **nullable integer** column on `frontend_plugin` — the plugin API version the bundle was built
+against, the same integer the loader already checks. `frontend_plugin.version` keeps its current
+meaning (the *server* compatibility axis), unchanged.
+
+The server can then leave the plugin out of discovery when the active front end cannot load it —
+provided it knows the active bundle's API pair, which means the dist must declare
+`plugin_api_version` / `plugin_api_min_supported` somewhere the server can read after unpacking
+(`VERSION.txt` already exists and is served at `/VERSION.txt`; a small `manifest.json` would be
+cleaner). That is a cross-repo dependency on open-msupply-frontend.
+
+_Pros:_
+
+- Nullable and `#[serde(default)]` on the wire, so older sites and existing rows are unaffected
+  (requirement 6).
+- An integer matches the contract the front end already enforces; inventing a parallel semver would
+  mean two answers to the same question.
+- Server-side gating makes incompatibility visible in admin surfaces rather than only in a browser
+  console.
+
+_Cons:_ needs the front-end dist to declare its API pair before the server-side gate can be
+switched on. Until then the column is carried but only the client-side gate is live — an acceptable
+staging.
+
+### Option 2c — Encode the second axis inside the existing `version` string
+
+_Cons:_ unparseable by `Version`, unqueryable, and invisible in every existing tool.
+
+## Decision
+
+**Front end ↔ backend: Option 1.** Keep `is_compatible_by_major_and_minor` and "newest compatible
+wins", and give the bundle record an explicit `server_version` alongside its own `version` so the
+existing rule has something on the right number line to compare.
+
+**Plugin ↔ front end: Option 2b.** `frontend_plugin.version` keeps meaning server compatibility; add
+a nullable plugin-API integer column for front-end compatibility, backwards compatible on the wire,
+with the server-side gate enabled once the dist declares its API pair.
+
+Trade-offs accepted:
+
+- No upper bound on front-end compatibility. If a server upgrade breaks an older bundle, the fix is
+  to publish a newer bundle or deactivate the old one — not an automatic exclusion.
+- Two version fields on the bundle record, and a manual-upload path where `server_version` can be
+  entered wrongly.
+- The plugin-API column ships before the gate that consumes it.
+
+## Consequences
+
+- **Selection rule** (server-side, on startup and after every sync integration and activation):
+  among `frontend_bundle` rows that are `is_active`, whose `server_version` is compatible with this
+  server's app version, and whose bytes are downloaded and sha256-verified, serve the highest
+  `version`. If none qualify, serve the installer-shipped baseline in `frontend_dir`. This mirrors
+  `report_filter_method` and `bind_frontend_plugin` closely enough that the logic should be
+  recognisably the same shape.
+- **Withdrawal, not just publication.** `is_active` on the bundle record is the withdrawal
+  mechanism (as on `report`): central clears it, the flag syncs, sites fall back to the next best
+  bundle — which may be the baseline. Deleting the record works too and should also reclaim disk.
+  Neither helps if the site cannot reach central, hence the escape hatch below.
+- **The escape hatch stays.** `/old-ui/` is served from `frontend_dir/old-ui` by convention and is
+  never touched by sync ([serve_frontend.rs](../server/server/src/serve_frontend.rs)). It remains
+  the way a site with a broken front end reaches a working UI. Worth confirming it is reachable
+  without the new front end booting at all, and worth considering a companion route that forces the
+  baseline new-UI bundle.
+- **Upgrades do not clobber a newer synced bundle.** After a server upgrade, the selection rule runs
+  again: if the synced bundle is still compatible and still the highest `version`, it keeps serving,
+  even though the installer shipped a different baseline. The baseline only wins when it is newer or
+  the synced bundle stops qualifying. This is a consequence worth stating explicitly because it is
+  surprising the first time.
+- **Targeting is left entirely open** (requirement 7). Every site receives every bundle record, and
+  the only thing narrowing what it runs is its own compatibility check. Wanting different sites to
+  get different bundles is real — canary rollouts, customer-specific builds, a reduced UI for
+  multi-device sites — and the same need exists for reports ("show this report only to stores with a
+  dispensary"). But a single label such as a release channel is the wrong shape for that: the need
+  is a **selector** over site and store attributes (tags, capabilities, store preferences), possibly
+  extending to a customer-supplied compatibility check shipped as a plugin. Because that design is
+  not settled, **nothing is provisioned for it here** — no column, no wire-format placeholder. We
+  knowingly accept that adding it later may require a wire-format change, in exchange for not
+  committing to a shape we would have to unpick. It is a separate action, and an approach should be
+  proposed before this work ships.
+- **Multi-device sites.** Several devices share a site id, each running their own binary at
+  potentially different versions. Because the decision is local, each device independently picks the
+  bundle it can run. The cost is that each downloads its own copy from central. Accepted.
+- **Front-end version semantics.** `v0.0.x` is not yet semver-meaningful; this design assumes it
+  becomes so at `1.0.0`. Until then, ordering by `version` still works (it is monotonic per release)
+  but "major/minor" carries no promise — which is fine, because the compatibility check is on
+  `server_version`, not on `version`.
+- **Translations need no special handling.** The front end's dictionary cache is keyed on a
+  `LANG_VERSION` token minted per production build (`vite.config.ts`), so a new bundle busts the
+  localStorage cache and new keys appear on first load. Server-supplied `custom-translations` are
+  fetched live and unaffected. Worth a test rather than a mechanism.

--- a/server/spec/README.md
+++ b/server/spec/README.md
@@ -1,0 +1,8 @@
+## open-mSupply Server Specifications
+
+Specifications for the open-mSupply (server) are contained in this folder.
+Specifications are to added as new functionality is added, creating an code independent and human readable understanding of designed behavior for the system.
+
+This spec is the source of truth: when spec and implementation disagree, the spec wins or gets fixed — generating code from it is the ideal we work towards, not a claim about today.
+
+Where spec is missing, we rely on code as our source of truth, but check with the develop if it's possible and a good idea to create specifications as we write the code.

--- a/server/spec/sync/frontend-sync.md
+++ b/server/spec/sync/frontend-sync.md
@@ -1,0 +1,24 @@
+# Frontend Sync
+
+## Overview
+
+We want to be able to quickly deliver updates to our frontend to our remote servers (without an upgrade e.g. installing a new version of the application via APK or windows installer)
+
+For this to work, we can leverage our sync system to update the frontend code in place after it's downloaded via sync.
+
+## Reference implementations
+
+_Built in reports_
+These are built and commited to git, the distributed as part of the binary. They are versioned so that a new install on central server gets distributed out to remote sites that are compatible.
+
+_plugins_
+Plugins aren't bundled with the binary, they are synced to remote sites and are loaded if they are compatible.
+
+## Compatibility Versioning requirements
+
+Frontend Plugins need to have 2 compatibility versions.
+
+1. Are they compatible with backend server infrastructure, e.g. Requries backend > 3.0.0
+2. Are they compatible with the frontend code e.g. Requires frontend 3.1.3
+
+The frontend code itself needs to be compatible with the backend version.

--- a/server/spec/sync/frontend-sync.md
+++ b/server/spec/sync/frontend-sync.md
@@ -22,3 +22,174 @@ Frontend Plugins need to have 2 compatibility versions.
 2. Are they compatible with the frontend code e.g. Requires frontend 3.1.3
 
 The frontend code itself needs to be compatible with the backend version.
+
+## Key decisions
+
+The reasoning behind the design below, and the options rejected along the way, are in two KDDs:
+
+- [Frontend sync — how the bundle reaches a remote site](../../../decisions/2026-08-03_frontend_sync_transport.md)
+  — metadata over normal sync, bytes over file sync; how downloads get triggered; how bundles get
+  onto central.
+- [Frontend and plugin version compatibility](../../../decisions/2026-08-03_frontend_version_compatibility.md)
+  — the two version lines, the selection rule, and the plugin compatibility axes.
+
+## Scope
+
+- **v7 sites only**, syncing against an open-mSupply central server. No 4D involvement.
+- The **new** front end (served at `/`) only. The old UI at `/old-ui/` is built from this repo and
+  ships with the installer; it is not synced.
+
+## Data model
+
+### `frontend_bundle`
+
+A new synced table. One row per published front-end bundle; several rows coexist on a site the same
+way several versions of a report do.
+
+| Column | Notes |
+| --- | --- |
+| `id` | uuid |
+| `version` | the front end's own version, e.g. `1.2.0`. Identity and ordering. |
+| `server_version` | the server version this bundle was built against, e.g. `3.2.0`. The value the compatibility check uses — it is on the *server's* number line, `version` is not. |
+| `sha256` | of the dist zip. Verified after download, before unpacking. |
+| `is_active` | withdrawal flag, as on `report`. Central clears it to retire a bundle. |
+| `description` / `created_datetime` | provenance for the admin surface. |
+
+Every site that syncs receives every bundle record. Nothing here targets a bundle at a subset of
+sites — see [future work](#future-work).
+
+Sync style: authored on **Central**, distribution **Central**, **v7 only**. The record reaches every
+site; the site decides what to do with it.
+
+The bundle's bytes are a `sync_file_reference` owned by the row (`table_name = "frontend_bundle"`,
+`record_id = <bundle id>`), carrying the dist zip.
+
+### `frontend_plugin`
+
+One new **nullable integer** column: the plugin API version the bundle was built against — the same
+integer the front-end loader already checks against its `PLUGIN_API_VERSION` /
+`PLUGIN_API_MIN_SUPPORTED` pair.
+
+`frontend_plugin.version` is unchanged and keeps its current meaning: compatibility with the
+*server*. Nullable, and defaulted on the wire, so sites and rows that predate this column are
+unaffected.
+
+## Publishing on central
+
+Two paths:
+
+1. **Bundled with central** — the normal path, mirroring standard reports. On startup central
+   publishes the dist that its own packaging pinned and verified, stamping `server_version` with its
+   own app version. Upgrading central is what releases a new front end to the fleet.
+2. **Manual upload** — an admin uploads a dist zip, as plugins are installed today. `server_version`
+   is supplied at upload. This is the hotfix and customer-specific-build path.
+
+Publishing writes the `frontend_bundle` row, stores the zip in the static file store, and creates
+the owning `sync_file_reference`.
+
+## Distribution and download on a remote site
+
+1. The `frontend_bundle` record arrives by normal sync, along with its `sync_file_reference`.
+2. A **processor** evaluates the site's bundles after integration and enqueues a download for the
+   newest bundle that is `is_active`, whose `server_version` is compatible with this server's app
+   version, and whose bytes are not already held. A site never downloads a bundle it could not run.
+3. The **file sync driver** drains the download queue in the background, reusing the existing
+   status / `retries` / `retry_at` / `error` bookkeeping on `sync_file_reference`. Downloads yield
+   to normal sync the same way uploads do.
+4. On completion the zip is verified against the record's `sha256`, then unpacked
+   **stage-then-swap** into a per-version directory under `base_dir` — never into `frontend_dir`.
+
+> `frontend_dir` is off limits for synced bundles: on Android the app shell deletes and re-copies
+> `<filesDir>/frontend` from the APK whenever the app version changes, so anything stored there is
+> destroyed by the next upgrade.
+
+A bundle whose bytes are absent, unverified, or incompletely unpacked is never a candidate for
+serving.
+
+## Selection and serving
+
+Evaluated at startup, after sync integration, and after a bundle is activated:
+
+> Among `frontend_bundle` rows that are `is_active`, whose `server_version` is compatible with this
+> server's app version by major and minor, and whose bytes are downloaded, verified and unpacked —
+> serve the highest `version`. If none qualify, serve the baseline in `frontend_dir`.
+
+Compatibility uses the existing `Version::is_compatible_by_major_and_minor`, the same predicate
+reports and plugins use. Consequences worth stating explicitly:
+
+- A server upgrade does **not** clobber a newer synced bundle. If the synced bundle still qualifies
+  and is still the highest version, it keeps serving even though the installer shipped a different
+  baseline.
+- There is no upper compatibility bound. A server 4.0 release is expected to ship a 4.0-compatible
+  front end, so the newest compatible bundle is the right one; `is_active` is the manual override
+  when it is not.
+
+Serving behaviour is otherwise unchanged: `index.html` and `locales/` are `no-cache`, everything
+else is `immutable, max-age=1y` over content-hashed filenames.
+
+## Updating a client that is already running
+
+Swapping the served bundle must never discard a user's in-progress work.
+
+- A reload is **user-triggered**. The client surfaces that a new version is available and the user
+  chooses when to take it; nothing reloads underneath them mid-task.
+- The front end already detects a stale bundle reactively: a content-hashed chunk that 404s raises
+  `vite:preloadError`, which triggers one reload and, if it recurs, a "new version available"
+  message (`src/staleBundle.ts` in the front-end repo). That is a safety net for a bundle that has
+  gone away — it is not proactive notification, and it only fires if the old chunks have actually
+  been removed.
+- Because previous versions are retained on disk (below), old chunks keep resolving, so the stale
+  detector will usually *not* fire. Proactive notification is therefore required, not optional:
+  the client needs to learn the active bundle version has changed. `/VERSION.txt` is already served
+  from the dist and is the obvious source.
+- A reload re-fetches plugins along with the host, which resolves the module-federation shared-scope
+  problem: a swapped host and a plugin loaded against the previous host never coexist.
+- Translations need no special handling: the dictionary cache is keyed on a per-build `LANG_VERSION`
+  token, so new keys appear on the first load of a new bundle. Server-supplied custom translations
+  are fetched live.
+
+An Android tablet acting as a server swaps for every LAN client attached to it at once; each client
+takes the update on its own reload.
+
+## Withdrawal, rollback and escape hatches
+
+- **Withdraw**: central clears `is_active`. The flag syncs and sites fall back to the next
+  qualifying bundle, or the baseline.
+- **Delete**: removing the record retires the bundle and reclaims its disk.
+- **Escape hatch**: `/old-ui/` is served from `frontend_dir/old-ui`, is never touched by sync, and
+  remains reachable when the new front end is broken.
+
+## Retention
+
+Bundles are retained for a bounded number of versions, not deleted on swap: an open tab holds
+content-hashed asset URLs from the version it loaded, and those files must still exist for it to
+keep working. The baseline in `frontend_dir` is always retained.
+
+## Future work
+
+Deliberately out of scope, each worth its own issue:
+
+- **Signing.** The MVP trust model is a sha256 on a record that arrived over authenticated sync.
+- **Targeting which sites get which bundle.** A real need — canary rollouts, customer-specific
+  builds, a reduced UI for multi-device sites — and the same need exists for reports ("show this
+  report only to stores with a dispensary"). A single label such as a release channel is too blunt
+  for that; the shape is more likely a **selector** evaluated against site and store attributes
+  (tags, capabilities, store preferences), and possibly a customer-supplied compatibility check
+  shipped as a plugin. That deserves its own design, covering bundles and reports together, so
+  **nothing is provisioned for it here** — no column, no wire-format placeholder — rather than
+  baking in a shape that presumes the answer. Tracked as a separate action; an approach should be proposed
+  before this ships, accepting that adding it may mean a wire-format change.
+- **File sync progress and error UI.** Wanted; would serve every synced file, not just bundles.
+- **Delta / shared-chunk transfer**, so unchanged vendor code is not re-sent every release.
+- **Moving reports and plugins onto the same download queue**, to take their payloads off the normal
+  sync path.
+- **Rate limiting** central when the whole fleet pulls a new bundle at once.
+
+## Open questions
+
+- Does the server-side plugin gate need the dist to declare its `plugin_api_version` /
+  `plugin_api_min_supported` (in `VERSION.txt` or a manifest)? Until it does, only the existing
+  client-side gate is live.
+- Packaging currently discards the dist zip after unpacking (`build/fetch-frontend.js`). Central
+  needs the zip to publish it — retain it during packaging, or reconstruct it?
+- How many previous versions to retain, and what triggers the cleanup?


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Part of #12622 — the design, ahead of the code. Docs only; no behaviour change.

Two KDDs and an expanded spec for delivering front-end updates over sync, instead of via an installer/APK upgrade:

- **[Transport KDD](decisions/2026-08-03_frontend_sync_transport.md)** — metadata over normal sync, bytes over file sync. The measured dist is 269 files / 3.3 MB unpacked / **~945 KB zipped** and growing, so base64ing it into a changelog row (the `frontend_plugin` pattern) would put a multi-megabyte non-resumable body on the sync path *and* make every site pay for bundles it cannot run. A small `frontend_bundle` record carries the metadata; the zip rides file sync.
- **[Version compatibility KDD](decisions/2026-08-03_frontend_version_compatibility.md)** — keep `is_compatible_by_major_and_minor` and "newest compatible wins". The wrinkle: that predicate compares against `app_version` *on the same number line*, and the front end now has its own line (`v1.x` vs server `3.x`). So a bundle carries both `version` (front-end line, ordering) and `server_version` (server line, the compatibility check).
- **[Spec](server/spec/sync/frontend-sync.md)** — data model, publishing, download, selection/serving, client update, rollback, retention, future work, open questions. Appended below the hand-written sections, which are untouched.

## 💌 Any notes for the reviewer?

**This is the base of a 5-PR stack** and should merge first. The others target it in turn: table+sync → publishing → download → serving.

The KDDs are where the arguing should happen — the code PRs implement these decisions fairly literally, so a disagreement here is much cheaper than one downstream. In particular:

- **Two version fields on the bundle** is the load-bearing decision. If you'd rather have an explicit `[min_server, max_server)` range, say so now (it's Option 2 in the compatibility KDD, rejected for consistency with reports/plugins).
- **No targeting mechanism**, deliberately: every site receives every bundle record and narrows locally. Wanting per-site bundles is real (canary, customer builds, a reduced UI for multi-device sites) but the right shape is likely a *selector* over site/store attributes, not a release-channel label — so nothing is provisioned for it, and we knowingly accept that adding it later may need a wire-format change.
- Regenerating the sync-styles doc surfaced **pre-existing staleness** unrelated to this feature: the `CustomField` family was missing entirely, a per-cell note called `StockRelocation` v6 where the code says v7-only, and the transport-flag table had no `v7-only` row despite the main table using that value. Fixed here since I was in those sections — happy to split out if you'd prefer.

# 🧪 Tested

- Docs only — nothing to run.
- Every claim about current behaviour was read out of the code rather than assumed; the size figures come from measuring the actual `open-msupply-frontend` dist.

# 📃 Documentation

- [x] **Part of an epic** — documentation will be completed for the feature as a whole