### PR TITLE
Frontend sync: publish front-end bundles from central

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -9615,6 +9615,7 @@ dependencies = [
  "util",
  "walkdir",
  "x509-parser",
+ "zip",
 ]
 
 [[package]]

--- a/server/graphql/general/src/lib.rs
+++ b/server/graphql/general/src/lib.rs
@@ -408,6 +408,16 @@ impl GeneralQueries {
         frontend_plugin_metadata(ctx)
     }
 
+    /// Front-end bundles this site knows about. Available on remotes as well as
+    /// central: an administrator wants to see which bundles reached this site and
+    /// which is active, not only what central published.
+    pub async fn frontend_bundles(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Vec<queries::frontend_bundle::FrontendBundleNode>> {
+        queries::frontend_bundle::frontend_bundles(ctx)
+    }
+
     pub async fn currencies(
         &self,
         ctx: &Context<'_>,
@@ -763,5 +773,31 @@ impl CentralGeneralMutations {
         input: Vec<ConfigureNamePropertyInput>,
     ) -> Result<ConfigureNamePropertiesResponse> {
         configure_name_properties(ctx, input)
+    }
+
+    /// Publish a front-end bundle from a zip uploaded via `POST /upload`. The hotfix
+    /// path — normally central publishes the dist it is serving, on startup.
+    ///
+    /// `server_version` says which server version the bundle was built against; an
+    /// uploaded zip carries no such claim, and it is what sites compare against their
+    /// own version. Defaults to this server's version.
+    pub async fn install_uploaded_frontend_bundle(
+        &self,
+        ctx: &Context<'_>,
+        file_id: String,
+        server_version: Option<String>,
+    ) -> Result<queries::frontend_bundle::PublishFrontendBundleNode> {
+        queries::frontend_bundle::install_uploaded_frontend_bundle(ctx, file_id, server_version)
+    }
+
+    /// Withdraw (or restore) a bundle. Withdrawing syncs to every site, which then
+    /// falls back to the next qualifying bundle or the installer-shipped baseline.
+    pub async fn set_frontend_bundle_active(
+        &self,
+        ctx: &Context<'_>,
+        id: String,
+        is_active: bool,
+    ) -> Result<queries::frontend_bundle::FrontendBundleNode> {
+        queries::frontend_bundle::set_frontend_bundle_active(ctx, id, is_active)
     }
 }

--- a/server/graphql/general/src/queries/frontend_bundle.rs
+++ b/server/graphql/general/src/queries/frontend_bundle.rs
@@ -1,0 +1,127 @@
+use async_graphql::*;
+use graphql_core::{
+    standard_graphql_error::{validate_auth, StandardGraphqlError},
+    ContextExt,
+};
+use repository::FrontendBundleRow;
+use service::{
+    auth::{Resource, ResourceAccessRequest},
+    frontend_bundle::{self, PublishOutcome},
+    UploadedFile,
+};
+use util::format_error;
+
+/// A published front-end bundle, as the central admin surface sees it.
+#[derive(SimpleObject)]
+pub struct FrontendBundleNode {
+    pub id: String,
+    /// The front end's own version — identity and ordering.
+    pub version: String,
+    /// The server version this bundle was built against. Sites compare this against
+    /// their own app version to decide whether they can run the bundle.
+    pub server_version: String,
+    pub sha256: String,
+    /// Cleared to withdraw a bundle from circulation.
+    pub is_active: bool,
+    pub description: Option<String>,
+    pub created_datetime: chrono::NaiveDateTime,
+}
+
+impl FrontendBundleNode {
+    fn from_domain(row: FrontendBundleRow) -> Self {
+        let FrontendBundleRow {
+            id,
+            version,
+            server_version,
+            sha256,
+            is_active,
+            description,
+            created_datetime,
+        } = row;
+        Self {
+            id,
+            version,
+            server_version,
+            sha256,
+            is_active,
+            description,
+            created_datetime,
+        }
+    }
+}
+
+/// Result of publishing, so the caller can tell a fresh publish from a no-op
+/// (re-uploading an already-published version).
+#[derive(SimpleObject)]
+pub struct PublishFrontendBundleNode {
+    pub bundle: FrontendBundleNode,
+    /// False when this version was already published and nothing changed.
+    pub published: bool,
+}
+
+/// Installing a front-end bundle means shipping executable code to every compatible
+/// site, so it is gated on the same server-admin permission as installing a plugin.
+fn validate_configure_auth(ctx: &Context<'_>) -> Result<()> {
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::ConfigurePlugin,
+            store_id: None,
+            require_central_standalone: false,
+        },
+    )?;
+    Ok(())
+}
+
+pub fn frontend_bundles(ctx: &Context<'_>) -> Result<Vec<FrontendBundleNode>> {
+    validate_configure_auth(ctx)?;
+
+    let service_provider = ctx.service_provider();
+    let context = service_provider.basic_context()?;
+
+    Ok(frontend_bundle::all_bundles(&context)?
+        .into_iter()
+        .map(FrontendBundleNode::from_domain)
+        .collect())
+}
+
+pub fn install_uploaded_frontend_bundle(
+    ctx: &Context<'_>,
+    file_id: String,
+    server_version: Option<String>,
+) -> Result<PublishFrontendBundleNode> {
+    validate_configure_auth(ctx)?;
+
+    let service_provider = ctx.service_provider();
+    let context = service_provider.basic_context()?;
+    let settings = ctx.get_settings();
+
+    let outcome = frontend_bundle::install_uploaded_bundle(
+        &context,
+        settings,
+        UploadedFile { file_id },
+        server_version,
+    )
+    .map_err(|e| StandardGraphqlError::InternalError(format_error(&e)).extend())?;
+
+    let published = matches!(outcome, PublishOutcome::Published(_));
+    Ok(PublishFrontendBundleNode {
+        bundle: FrontendBundleNode::from_domain(outcome.row().clone()),
+        published,
+    })
+}
+
+pub fn set_frontend_bundle_active(
+    ctx: &Context<'_>,
+    id: String,
+    is_active: bool,
+) -> Result<FrontendBundleNode> {
+    validate_configure_auth(ctx)?;
+
+    let service_provider = ctx.service_provider();
+    let context = service_provider.basic_context()?;
+
+    frontend_bundle::set_active(&context, &id, is_active)
+        .map_err(|e| StandardGraphqlError::InternalError(format_error(&e)).extend())
+        .map(FrontendBundleNode::from_domain)
+}

--- a/server/graphql/general/src/queries/mod.rs
+++ b/server/graphql/general/src/queries/mod.rs
@@ -1,3 +1,4 @@
+pub mod frontend_bundle;
 pub mod login;
 mod plugin;
 

--- a/server/repository/src/db_diesel/sync_file_reference_row.rs
+++ b/server/repository/src/db_diesel/sync_file_reference_row.rs
@@ -216,6 +216,19 @@ impl<'a> SyncFileReferenceRowRepository<'a> {
         Ok(())
     }
 
+    /// Every live reference belonging to one owning record — e.g. a front-end bundle's
+    /// dist zip, or an invoice's attachments. Excludes soft-deleted rows.
+    pub fn find_all_by_record_id(
+        &self,
+        owning_record_id: &str,
+    ) -> Result<Vec<SyncFileReferenceRow>, RepositoryError> {
+        let result = sync_file_reference
+            .filter(deleted_datetime.is_null())
+            .filter(record_id.eq(owning_record_id))
+            .load(self.connection.lock().connection())?;
+        Ok(result)
+    }
+
     pub fn find_all_to_upload(&self) -> Result<Vec<SyncFileReferenceRow>, RepositoryError> {
         // NOTE: InProgress status here as the behaviour is a bit undefined. We should either upload a whole file or get an error.
         // It's included here in case the server is restarted with an Inprogress file, it will be re-tried.

--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -41,6 +41,7 @@ use service::{
     },
     auth_data::AuthData,
     boajs::context::BoaJsContext,
+    frontend_bundle,
     ledger_fix::ledger_fix_driver::LedgerFixDriver,
     plugin::validation::ValidatedPluginBucket,
     processors::Processors,
@@ -440,6 +441,25 @@ pub async fn start_server(
     }
 
     StandardReports::load_reports(&connection_manager.connection().unwrap(), false).unwrap();
+
+    // Publish the front-end bundle this server is serving, so remote sites can pick it
+    // up over sync (#12622). Central only — central is where bundles originate. Cheap
+    // and idempotent when the version hasn't changed, and deliberately non-fatal: a
+    // server that can't publish a bundle should still start and serve its own.
+    if CentralServerConfig::is_central_server() {
+        match frontend_bundle::publish_from_frontend_dir(&service_context, &settings) {
+            Ok(frontend_bundle::PublishOutcome::Published(row)) => {
+                info!("Published front-end bundle {} for sync", row.version)
+            }
+            Ok(frontend_bundle::PublishOutcome::AlreadyPublished(row)) => {
+                info!("Front-end bundle {} already published", row.version)
+            }
+            Err(e) => log::error!(
+                "Could not publish the front-end bundle for sync: {}",
+                format_error(&e)
+            ),
+        }
+    }
 
     // Log the server starting message with the startup timestamp
     let status_log = StatusLog(&connection);

--- a/server/service/Cargo.toml
+++ b/server/service/Cargo.toml
@@ -70,6 +70,8 @@ lettre = { version = "0.11.19", default-features = false, features = [
     "builder",
 ] }
 nanohtml2text = "0.2.1"
+# Front-end bundles are published and transferred as zips (frontend_bundle)
+zip = { version = "2.4.2", default-features = false, features = ["deflate"] }
 
 
 [dev-dependencies]

--- a/server/service/src/frontend_bundle/dist.rs
+++ b/server/service/src/frontend_bundle/dist.rs
@@ -1,0 +1,298 @@
+use std::io::{Read, Seek, Write};
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+use walkdir::WalkDir;
+
+/// The version marker the front-end release workflow writes into every dist zip.
+/// It is unpacked alongside `index.html`, so the server also serves it at
+/// `/VERSION.txt` — deployed versions stay inspectable.
+pub(crate) const VERSION_FILE: &str = "VERSION.txt";
+
+/// The old UI lives in a subdirectory of the front-end dir by convention and is built
+/// from *this* repo, not the front-end repo. It ships with the installer and is the
+/// escape hatch when a synced bundle is broken, so it is never part of a published
+/// bundle.
+const OLD_UI_DIR: &str = "old-ui";
+
+/// Read the bundle version out of a dist directory's `VERSION.txt`.
+///
+/// The file is `key: value` lines (`version`, `package`, `commit`); we want `version`.
+/// A dist without a readable version cannot be published — we would have no way to
+/// order it against other bundles, and ordering is how a site picks which to run.
+pub(crate) fn read_version(dist_dir: &Path) -> anyhow::Result<String> {
+    let path = dist_dir.join(VERSION_FILE);
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", path.display()))?;
+
+    parse_version(&contents)
+        .ok_or_else(|| anyhow::anyhow!("no `version:` line in {}", path.display()))
+}
+
+fn parse_version(contents: &str) -> Option<String> {
+    contents.lines().find_map(|line| {
+        let (key, value) = line.split_once(':')?;
+        (key.trim() == "version").then(|| value.trim().to_string())
+    })
+}
+
+/// Files that make up a publishable bundle: everything under `dist_dir` except the
+/// old UI, as (path-relative-to-root, absolute path) pairs sorted by relative path.
+///
+/// Sorting matters: it makes the zip — and therefore its sha256 — reproducible for
+/// unchanged input, so republishing the same dist twice does not produce two bundles
+/// that differ only by file ordering.
+fn bundle_files(dist_dir: &Path) -> anyhow::Result<Vec<(String, PathBuf)>> {
+    let mut files = Vec::new();
+
+    for entry in WalkDir::new(dist_dir).sort_by_file_name() {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let relative = entry.path().strip_prefix(dist_dir)?;
+        // `Path::starts_with` matches whole components, so this excludes the old-ui
+        // directory without also excluding a file merely named `old-ui-something`.
+        if relative.starts_with(OLD_UI_DIR) {
+            continue;
+        }
+        // Zip entry names are '/'-separated regardless of the host platform, so a
+        // bundle zipped on Windows unpacks correctly everywhere.
+        let name = relative
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+        files.push((name, entry.path().to_path_buf()));
+    }
+
+    files.sort_by(|(a, _), (b, _)| a.cmp(b));
+    Ok(files)
+}
+
+/// Zip a dist directory into `writer`, returning the hex sha256 of the bytes written.
+///
+/// The bundle sits at the zip's top level (`index.html` at the root), matching the
+/// layout the front-end release workflow publishes and `build/fetch-frontend.js`
+/// expects — so a bundle central produces here and one downloaded from the FE release
+/// unpack identically.
+///
+/// `writer` must be readable as well as writable (a read-write `File`, or a `Cursor`):
+/// the hash is taken over the finished archive, so we read back what we wrote rather
+/// than hashing a running guess — zip seeks back to write its central directory, so
+/// hashing during the write would not describe the final bytes.
+pub(crate) fn zip_dist<W: Write + Seek + Read>(
+    dist_dir: &Path,
+    writer: W,
+) -> anyhow::Result<String> {
+    if !dist_dir.join("index.html").exists() {
+        return Err(anyhow::anyhow!(
+            "{} has no index.html — not a front-end dist",
+            dist_dir.display()
+        ));
+    }
+
+    let files = bundle_files(dist_dir)?;
+    if files.is_empty() {
+        return Err(anyhow::anyhow!("{} is empty", dist_dir.display()));
+    }
+
+    let mut zip = zip::ZipWriter::new(writer);
+    let options: zip::write::FileOptions<'_, ()> =
+        zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+    let mut buffer = Vec::new();
+    for (name, path) in files {
+        zip.start_file(name, options)?;
+        buffer.clear();
+        std::fs::File::open(&path)?.read_to_end(&mut buffer)?;
+        zip.write_all(&buffer)?;
+    }
+
+    let mut writer = zip.finish()?;
+    writer.flush()?;
+
+    Ok(sha256_of_reader(&mut writer)?)
+}
+
+fn sha256_of_reader<R: Read + Seek>(reader: &mut R) -> std::io::Result<String> {
+    reader.rewind()?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0u8; 64 * 1024];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Hex sha256 of a file on disk. Used to hash an uploaded zip, and (in the download
+/// path) to verify received bytes against the sha256 the bundle record carries.
+pub fn sha256_of_file(path: &Path) -> anyhow::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    Ok(sha256_of_reader(&mut file)?)
+}
+
+/// Read the version out of an already-built zip, without unpacking it. Used by the
+/// manual-upload path, which has a zip rather than a directory.
+pub(crate) fn read_version_from_zip(path: &Path) -> anyhow::Result<String> {
+    let file = std::fs::File::open(path)?;
+    let mut archive = zip::ZipArchive::new(file)?;
+
+    if archive.by_name("index.html").is_err() {
+        return Err(anyhow::anyhow!(
+            "zip has no index.html at its root — wrong layout?"
+        ));
+    }
+
+    let mut version_file = archive
+        .by_name(VERSION_FILE)
+        .map_err(|_| anyhow::anyhow!("zip has no {VERSION_FILE}"))?;
+    let mut contents = String::new();
+    version_file.read_to_string(&mut contents)?;
+
+    parse_version(&contents).ok_or_else(|| anyhow::anyhow!("no `version:` line in {VERSION_FILE}"))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::io::Cursor;
+
+    fn write(path: &Path, contents: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    /// A minimal dist: index.html, a hashed asset, VERSION.txt, and an old UI that
+    /// must not be included.
+    fn dist(dir: &Path) {
+        write(&dir.join("index.html"), "<html>app</html>");
+        write(&dir.join("assets/app-abc123.js"), "console.log(1)");
+        write(
+            &dir.join(VERSION_FILE),
+            "version: v1.2.3\npackage: 0.0.1\ncommit: deadbeef\n",
+        );
+        write(&dir.join("old-ui/index.html"), "<html>old</html>");
+    }
+
+    #[test]
+    fn reads_version_from_version_file() {
+        let temp = tempfile::tempdir().unwrap();
+        dist(temp.path());
+        assert_eq!(read_version(temp.path()).unwrap(), "v1.2.3");
+    }
+
+    #[test]
+    fn missing_version_file_is_an_error_not_a_default() {
+        let temp = tempfile::tempdir().unwrap();
+        write(&temp.path().join("index.html"), "<html>app</html>");
+        assert!(read_version(temp.path()).is_err());
+    }
+
+    #[test]
+    fn zip_excludes_old_ui_and_keeps_bundle_at_root() {
+        let temp = tempfile::tempdir().unwrap();
+        dist(temp.path());
+
+        let mut buffer = Cursor::new(Vec::new());
+        zip_dist(temp.path(), &mut buffer).unwrap();
+
+        let mut archive = zip::ZipArchive::new(buffer).unwrap();
+        let names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect();
+
+        // index.html at the zip root is what fetch-frontend.js and our own unpack
+        // both check for.
+        assert!(names.contains(&"index.html".to_string()));
+        assert!(names.contains(&"assets/app-abc123.js".to_string()));
+        assert!(names.contains(&VERSION_FILE.to_string()));
+        // The old UI ships with the installer and is the escape hatch — never synced.
+        assert!(
+            !names.iter().any(|n| n.starts_with("old-ui")),
+            "old-ui was included: {names:?}"
+        );
+    }
+
+    #[test]
+    fn zip_of_unchanged_dist_is_reproducible() {
+        let temp = tempfile::tempdir().unwrap();
+        dist(temp.path());
+
+        let mut first = Cursor::new(Vec::new());
+        let hash_a = zip_dist(temp.path(), &mut first).unwrap();
+        let mut second = Cursor::new(Vec::new());
+        let hash_b = zip_dist(temp.path(), &mut second).unwrap();
+
+        // Same input, same hash — so republishing the same dist can be detected
+        // rather than producing a second bundle that differs only by file order.
+        assert_eq!(hash_a, hash_b);
+        assert_eq!(first.into_inner(), second.into_inner());
+    }
+
+    #[test]
+    fn hash_changes_when_a_file_changes() {
+        let temp = tempfile::tempdir().unwrap();
+        dist(temp.path());
+        let mut buffer = Cursor::new(Vec::new());
+        let before = zip_dist(temp.path(), &mut buffer).unwrap();
+
+        write(&temp.path().join("assets/app-abc123.js"), "console.log(2)");
+        let mut buffer = Cursor::new(Vec::new());
+        let after = zip_dist(temp.path(), &mut buffer).unwrap();
+
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn refuses_a_directory_that_is_not_a_dist() {
+        let temp = tempfile::tempdir().unwrap();
+        write(&temp.path().join("readme.md"), "not a dist");
+        let mut buffer = Cursor::new(Vec::new());
+        assert!(zip_dist(temp.path(), &mut buffer).is_err());
+    }
+
+    #[test]
+    fn round_trips_version_through_a_zip() {
+        let temp = tempfile::tempdir().unwrap();
+        dist(temp.path());
+
+        // Zip to a path outside the dist, then read the version back out of the
+        // archive — the manual-upload path only ever has the zip.
+        let out = tempfile::tempdir().unwrap();
+        let zip_path = out.path().join("bundle.zip");
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&zip_path)
+            .unwrap();
+        let hash = zip_dist(temp.path(), file).unwrap();
+
+        assert_eq!(read_version_from_zip(&zip_path).unwrap(), "v1.2.3");
+        // The hash zip_dist reports is the hash of the bytes actually on disk.
+        assert_eq!(sha256_of_file(&zip_path).unwrap(), hash);
+    }
+
+    #[test]
+    fn rejects_a_zip_without_a_bundle_at_its_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let zip_path = temp.path().join("not-a-bundle.zip");
+
+        let file = std::fs::File::create(&zip_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default();
+        zip.start_file("some/nested/index.html", options).unwrap();
+        zip.write_all(b"<html></html>").unwrap();
+        zip.finish().unwrap();
+
+        // index.html must be at the zip root — an uploaded zip with the bundle nested
+        // one level down would unpack to a directory the server can't serve.
+        assert!(read_version_from_zip(&zip_path).is_err());
+    }
+}

--- a/server/service/src/frontend_bundle/mod.rs
+++ b/server/service/src/frontend_bundle/mod.rs
@@ -1,0 +1,589 @@
+//! Publishing front-end bundles from the central server.
+//!
+//! A bundle is distributed in two halves: a small `frontend_bundle` record that rides
+//! normal sync (version, compatibility, sha256, active flag), and the dist zip itself,
+//! which rides file sync as a `sync_file_reference` owned by that record. Publishing
+//! writes both. See `decisions/2026-08-03_frontend_sync_transport.md`.
+//!
+//! Two ways in, mirroring how reports work:
+//!
+//! - [`publish_from_frontend_dir`] — the normal path. Central publishes the dist it is
+//!   already serving, so upgrading central is what releases a new front end to the
+//!   fleet. Runs at startup and is idempotent.
+//! - [`install_uploaded_bundle`] — an admin uploads a dist zip. The hotfix path.
+
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use repository::{
+    migrations::Version,
+    sync_file_reference_row::{
+        SyncFileDirection, SyncFileReferenceRow, SyncFileReferenceRowRepository, SyncFileStatus,
+    },
+    FrontendBundleRow, FrontendBundleRowRepository, RepositoryError, StorageConnection,
+};
+use thiserror::Error;
+use util::uuid::uuid;
+
+use crate::{
+    service_provider::ServiceContext,
+    settings::Settings,
+    static_files::{StaticFileCategory, StaticFileService},
+    usize_to_i32, UploadedFile, UploadedFileConversionError,
+};
+
+pub mod dist;
+
+pub use dist::sha256_of_file;
+
+/// `sync_file_reference.table_name` for a bundle's zip. The owning record's id is the
+/// `record_id`, which is also how the bytes are laid out on disk.
+pub const FRONTEND_BUNDLE_TABLE: &str = "frontend_bundle";
+
+/// The name the zip is stored under. Only cosmetic — the file is addressed by id.
+const BUNDLE_FILE_NAME: &str = "frontend-dist.zip";
+
+#[derive(Error, Debug)]
+pub enum PublishBundleError {
+    #[error("Front-end directory not found: {0}")]
+    FrontendDirNotFound(String),
+    #[error("Could not read the front-end dist")]
+    InvalidDist(#[source] anyhow::Error),
+    #[error("Could not store the bundle")]
+    FileError(#[source] anyhow::Error),
+    #[error("Database error")]
+    DatabaseError(#[from] RepositoryError),
+    #[error(transparent)]
+    UploadedFileError(#[from] UploadedFileConversionError),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum PublishOutcome {
+    /// A new bundle record (and its file) was written.
+    Published(FrontendBundleRow),
+    /// This version is already published — nothing to do. Central re-checks on every
+    /// startup, so this is the normal case.
+    AlreadyPublished(FrontendBundleRow),
+}
+
+impl PublishOutcome {
+    pub fn row(&self) -> &FrontendBundleRow {
+        match self {
+            PublishOutcome::Published(row) | PublishOutcome::AlreadyPublished(row) => row,
+        }
+    }
+}
+
+/// Publish the dist in `settings.server.frontend_dir` — the bundle central is itself
+/// serving, put there by packaging from the verified pin.
+///
+/// Idempotent, and cheap when there is nothing to do: the version is read from
+/// `VERSION.txt` and checked against the existing records *before* the directory is
+/// zipped, so a restart with an unchanged front end does no work.
+pub fn publish_from_frontend_dir(
+    ctx: &ServiceContext,
+    settings: &Settings,
+) -> Result<PublishOutcome, PublishBundleError> {
+    let dist_dir = PathBuf::from(&settings.server.frontend_dir);
+    if !dist_dir.is_dir() {
+        return Err(PublishBundleError::FrontendDirNotFound(
+            settings.server.frontend_dir.clone(),
+        ));
+    }
+
+    let version = dist::read_version(&dist_dir).map_err(PublishBundleError::InvalidDist)?;
+
+    // Check before zipping — this is the path that runs on every central startup.
+    if let Some(existing) = existing_for_version(&ctx.connection, &version)? {
+        return Ok(PublishOutcome::AlreadyPublished(existing));
+    }
+
+    let bundle_id = uuid();
+    let (file_path, static_file_id) = reserve_bundle_file(settings, &bundle_id)?;
+
+    // Read-write: zip_dist hashes the finished archive by reading it back.
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&file_path)
+        .map_err(|e| PublishBundleError::FileError(e.into()))?;
+    let sha256 = match dist::zip_dist(&dist_dir, file) {
+        Ok(sha256) => sha256,
+        Err(error) => {
+            // Don't leave a half-written zip behind for the next startup to find.
+            let _ = std::fs::remove_file(&file_path);
+            return Err(PublishBundleError::InvalidDist(error));
+        }
+    };
+
+    insert_bundle(
+        ctx,
+        NewBundle {
+            bundle_id,
+            static_file_id,
+            version,
+            server_version: Version::from_package_json().to_string(),
+            sha256,
+            description: Some(format!(
+                "Published from {} on startup",
+                settings.server.frontend_dir
+            )),
+            file_path,
+        },
+    )
+}
+
+/// Publish a dist zip uploaded through `POST /upload`.
+///
+/// `server_version` is supplied by the caller: an uploaded zip says nothing about which
+/// server it was built for, and getting it wrong means offering sites a bundle they
+/// cannot run. Defaults to this server's version, which is right when an admin is
+/// uploading a build for the server in front of them.
+pub fn install_uploaded_bundle(
+    ctx: &ServiceContext,
+    settings: &Settings,
+    uploaded_file: UploadedFile,
+    server_version: Option<String>,
+) -> Result<PublishOutcome, PublishBundleError> {
+    let uploaded = uploaded_file.as_static_file(settings)?;
+    let uploaded_path = PathBuf::from(&uploaded.path);
+
+    let version =
+        dist::read_version_from_zip(&uploaded_path).map_err(PublishBundleError::InvalidDist)?;
+
+    if let Some(existing) = existing_for_version(&ctx.connection, &version)? {
+        return Ok(PublishOutcome::AlreadyPublished(existing));
+    }
+
+    let sha256 = dist::sha256_of_file(&uploaded_path).map_err(PublishBundleError::FileError)?;
+
+    let bundle_id = uuid();
+    let (file_path, static_file_id) = reserve_bundle_file(settings, &bundle_id)?;
+    // Copy rather than move: the uploaded file lives in the temporary category, which
+    // is swept on a timer, and we want the bundle's bytes owned by the sync-file
+    // category from here on.
+    std::fs::copy(&uploaded_path, &file_path)
+        .map_err(|e| PublishBundleError::FileError(e.into()))?;
+
+    insert_bundle(
+        ctx,
+        NewBundle {
+            bundle_id,
+            static_file_id,
+            version,
+            server_version: server_version
+                .unwrap_or_else(|| Version::from_package_json().to_string()),
+            sha256,
+            description: Some("Uploaded".to_string()),
+            file_path,
+        },
+    )
+}
+
+/// Activate or withdraw a bundle. Withdrawing is how a broken bundle is taken out of
+/// circulation: the flag syncs, and sites fall back to the next qualifying bundle or to
+/// the installer-shipped baseline.
+pub fn set_active(
+    ctx: &ServiceContext,
+    id: &str,
+    is_active: bool,
+) -> Result<FrontendBundleRow, PublishBundleError> {
+    let repo = FrontendBundleRowRepository::new(&ctx.connection);
+    let Some(row) = repo.find_one_by_id(id)? else {
+        return Err(RepositoryError::NotFound.into());
+    };
+
+    let updated = FrontendBundleRow { is_active, ..row };
+    repo.upsert_one(&updated)?;
+    Ok(updated)
+}
+
+pub fn all_bundles(ctx: &ServiceContext) -> Result<Vec<FrontendBundleRow>, RepositoryError> {
+    FrontendBundleRowRepository::new(&ctx.connection).all()
+}
+
+fn existing_for_version(
+    connection: &StorageConnection,
+    version: &str,
+) -> Result<Option<FrontendBundleRow>, RepositoryError> {
+    FrontendBundleRowRepository::new(connection).find_one_by_version(version)
+}
+
+/// Reserve the on-disk path for a bundle's zip under the sync-file category, so the
+/// file-sync download endpoints can find it by id later.
+fn reserve_bundle_file(
+    settings: &Settings,
+    bundle_id: &str,
+) -> Result<(PathBuf, String), PublishBundleError> {
+    let file_service =
+        StaticFileService::new(&settings.server.base_dir).map_err(PublishBundleError::FileError)?;
+
+    let static_file = file_service
+        .reserve_file(
+            BUNDLE_FILE_NAME,
+            &StaticFileCategory::SyncFile(FRONTEND_BUNDLE_TABLE.to_string(), bundle_id.to_string()),
+            None,
+        )
+        .map_err(PublishBundleError::FileError)?;
+
+    Ok((PathBuf::from(&static_file.path), static_file.id))
+}
+
+struct NewBundle {
+    bundle_id: String,
+    static_file_id: String,
+    version: String,
+    server_version: String,
+    sha256: String,
+    description: Option<String>,
+    file_path: PathBuf,
+}
+
+/// Write the bundle record and its file reference in one transaction, so a site never
+/// sees a bundle record whose file reference is missing.
+fn insert_bundle(
+    ctx: &ServiceContext,
+    new_bundle: NewBundle,
+) -> Result<PublishOutcome, PublishBundleError> {
+    let NewBundle {
+        bundle_id,
+        static_file_id,
+        version,
+        server_version,
+        sha256,
+        description,
+        file_path,
+    } = new_bundle;
+
+    let total_bytes = usize_to_i32(file_size(&file_path)?);
+    let created_datetime = Utc::now().naive_utc();
+
+    let row = FrontendBundleRow {
+        id: bundle_id.clone(),
+        version,
+        server_version,
+        sha256,
+        is_active: true,
+        description,
+        created_datetime,
+    };
+
+    let row = ctx
+        .connection
+        .transaction_sync(|connection| {
+            FrontendBundleRowRepository::new(connection).upsert_one(&row)?;
+
+            // The bytes are already here — central *is* where files come from. Anything
+            // other than Done would put this row in find_all_to_upload, and central
+            // would spend forever trying to upload the file to itself.
+            SyncFileReferenceRowRepository::new(connection).upsert_one(&SyncFileReferenceRow {
+                id: static_file_id,
+                table_name: FRONTEND_BUNDLE_TABLE.to_string(),
+                record_id: bundle_id,
+                file_name: BUNDLE_FILE_NAME.to_string(),
+                mime_type: Some("application/zip".to_string()),
+                total_bytes,
+                uploaded_bytes: total_bytes,
+                status: SyncFileStatus::Done,
+                direction: SyncFileDirection::Upload,
+                created_datetime,
+                ..Default::default()
+            })?;
+
+            Ok(row) as Result<FrontendBundleRow, RepositoryError>
+        })
+        .map_err(|error: repository::TransactionError<RepositoryError>| error.to_inner_error())?;
+
+    log::info!(
+        "Published front-end bundle {} (for server {}, {} bytes)",
+        row.version,
+        row.server_version,
+        total_bytes
+    );
+
+    Ok(PublishOutcome::Published(row))
+}
+
+fn file_size(path: &Path) -> Result<usize, PublishBundleError> {
+    let metadata = std::fs::metadata(path).map_err(|e| PublishBundleError::FileError(e.into()))?;
+    Ok(metadata.len() as usize)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test_helpers::{setup_all_and_service_provider, ServiceTestContext};
+    use repository::mock::MockDataInserts;
+
+    fn write(path: &Path, contents: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn write_dist(dir: &Path, version: &str) {
+        write(&dir.join("index.html"), "<html>app</html>");
+        write(&dir.join("assets/app-abc.js"), "console.log(1)");
+        write(
+            &dir.join(dist::VERSION_FILE),
+            &format!("version: {version}\npackage: 0.0.1\ncommit: abc\n"),
+        );
+        write(&dir.join("old-ui/index.html"), "<html>old</html>");
+    }
+
+    /// Point settings at temp dirs for both the dist and the static file store.
+    fn settings_for(context: &ServiceTestContext, dist: &Path, base: &Path) -> Settings {
+        let mut settings = context.settings.clone();
+        settings.server.frontend_dir = dist.to_string_lossy().to_string();
+        settings.server.base_dir = base.to_string_lossy().to_string();
+        settings
+    }
+
+    #[actix_rt::test]
+    async fn publish_writes_record_and_file_reference() {
+        let context = setup_all_and_service_provider(
+            "publish_writes_record_and_file_reference",
+            MockDataInserts::none(),
+        )
+        .await;
+        let ctx = &context.service_context;
+
+        let dist_dir = tempfile::tempdir().unwrap();
+        let base_dir = tempfile::tempdir().unwrap();
+        write_dist(dist_dir.path(), "v1.2.3");
+        let settings = settings_for(&context, dist_dir.path(), base_dir.path());
+
+        let outcome = publish_from_frontend_dir(&ctx, &settings).unwrap();
+        let row = match &outcome {
+            PublishOutcome::Published(row) => row.clone(),
+            other => panic!("expected Published, got {other:?}"),
+        };
+
+        assert_eq!(row.version, "v1.2.3");
+        assert!(row.is_active);
+        assert_eq!(row.sha256.len(), 64);
+        // server_version is stamped from central's own app version: central packaging
+        // pinned this dist for this release, so it is true by construction.
+        assert_eq!(row.server_version, Version::from_package_json().to_string());
+
+        // The owning file reference exists, and its bytes are on disk.
+        let file_refs = SyncFileReferenceRowRepository::new(&ctx.connection)
+            .find_all_by_record_id(&row.id)
+            .unwrap();
+        assert_eq!(file_refs.len(), 1);
+        let file_ref = &file_refs[0];
+        assert_eq!(file_ref.table_name, FRONTEND_BUNDLE_TABLE);
+        assert!(file_ref.total_bytes > 0);
+        // Done, not New: central is the source of file bytes, so this row must never
+        // be picked up by find_all_to_upload.
+        assert_eq!(file_ref.status, SyncFileStatus::Done);
+
+        let stored = StaticFileService::new(&settings.server.base_dir)
+            .unwrap()
+            .find_file(
+                &file_ref.id,
+                StaticFileCategory::SyncFile(FRONTEND_BUNDLE_TABLE.to_string(), row.id.clone()),
+            )
+            .unwrap()
+            .expect("bundle zip should be on disk");
+        assert_eq!(
+            dist::sha256_of_file(Path::new(&stored.path)).unwrap(),
+            row.sha256
+        );
+    }
+
+    #[actix_rt::test]
+    async fn publish_is_idempotent_for_the_same_version() {
+        let context = setup_all_and_service_provider(
+            "publish_is_idempotent_for_the_same_version",
+            MockDataInserts::none(),
+        )
+        .await;
+        let ctx = &context.service_context;
+
+        let dist_dir = tempfile::tempdir().unwrap();
+        let base_dir = tempfile::tempdir().unwrap();
+        write_dist(dist_dir.path(), "v1.2.3");
+        let settings = settings_for(&context, dist_dir.path(), base_dir.path());
+
+        let first = publish_from_frontend_dir(&ctx, &settings).unwrap();
+        let second = publish_from_frontend_dir(&ctx, &settings).unwrap();
+
+        assert!(matches!(first, PublishOutcome::Published(_)));
+        // Every central startup calls this; the second time must be a no-op, not a
+        // second bundle for the same version.
+        assert!(matches!(second, PublishOutcome::AlreadyPublished(_)));
+        assert_eq!(first.row().id, second.row().id);
+        assert_eq!(all_bundles(&ctx).unwrap().len(), 1);
+    }
+
+    #[actix_rt::test]
+    async fn publish_adds_a_second_bundle_for_a_new_version() {
+        let context = setup_all_and_service_provider(
+            "publish_adds_a_second_bundle_for_a_new_version",
+            MockDataInserts::none(),
+        )
+        .await;
+        let ctx = &context.service_context;
+
+        let dist_dir = tempfile::tempdir().unwrap();
+        let base_dir = tempfile::tempdir().unwrap();
+        write_dist(dist_dir.path(), "v1.2.3");
+        let settings = settings_for(&context, dist_dir.path(), base_dir.path());
+        publish_from_frontend_dir(&ctx, &settings).unwrap();
+
+        // Central upgraded: a newer dist is now in frontend_dir.
+        write_dist(dist_dir.path(), "v1.3.0");
+        let outcome = publish_from_frontend_dir(&ctx, &settings).unwrap();
+        assert!(matches!(outcome, PublishOutcome::Published(_)));
+
+        let mut versions: Vec<String> = all_bundles(&ctx)
+            .unwrap()
+            .into_iter()
+            .map(|b| b.version)
+            .collect();
+        versions.sort();
+        // Both are kept — a site running the older one keeps working until it takes
+        // the newer, and previous versions must stay available.
+        assert_eq!(versions, vec!["v1.2.3", "v1.3.0"]);
+    }
+
+    #[actix_rt::test]
+    async fn publish_fails_loudly_on_a_missing_or_invalid_dist() {
+        let context = setup_all_and_service_provider(
+            "publish_fails_loudly_on_a_missing_or_invalid_dist",
+            MockDataInserts::none(),
+        )
+        .await;
+        let ctx = &context.service_context;
+        let base_dir = tempfile::tempdir().unwrap();
+
+        // No such directory.
+        let settings = settings_for(&context, Path::new("/no/such/dist"), base_dir.path());
+        assert!(matches!(
+            publish_from_frontend_dir(&ctx, &settings),
+            Err(PublishBundleError::FrontendDirNotFound(_))
+        ));
+
+        // A directory with no VERSION.txt: we cannot order it against other bundles,
+        // so publishing must fail rather than invent a version.
+        let dist_dir = tempfile::tempdir().unwrap();
+        write(&dist_dir.path().join("index.html"), "<html>app</html>");
+        let settings = settings_for(&context, dist_dir.path(), base_dir.path());
+        assert!(matches!(
+            publish_from_frontend_dir(&ctx, &settings),
+            Err(PublishBundleError::InvalidDist(_))
+        ));
+
+        assert_eq!(all_bundles(&ctx).unwrap().len(), 0);
+    }
+
+    #[actix_rt::test]
+    async fn install_uploaded_bundle_publishes_from_a_zip() {
+        let context = setup_all_and_service_provider(
+            "install_uploaded_bundle_publishes_from_a_zip",
+            MockDataInserts::none(),
+        )
+        .await;
+        let ctx = &context.service_context;
+
+        let base_dir = tempfile::tempdir().unwrap();
+        let settings = settings_for(&context, Path::new("/no/such/dist"), base_dir.path());
+
+        // Stage a dist zip where POST /upload would have left it: the temporary
+        // static-file category, addressed by id.
+        let source = tempfile::tempdir().unwrap();
+        write_dist(source.path(), "v2.0.0");
+        let file_service = StaticFileService::new(&settings.server.base_dir).unwrap();
+        let reserved = file_service
+            .reserve_file("frontend-dist.zip", &StaticFileCategory::Temporary, None)
+            .unwrap();
+        let handle = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&reserved.path)
+            .unwrap();
+        let uploaded_sha = dist::zip_dist(source.path(), handle).unwrap();
+
+        let outcome = install_uploaded_bundle(
+            ctx,
+            &settings,
+            UploadedFile {
+                file_id: reserved.id.clone(),
+            },
+            Some("3.1.0".to_string()),
+        )
+        .unwrap();
+
+        let row = match &outcome {
+            PublishOutcome::Published(row) => row.clone(),
+            other => panic!("expected Published, got {other:?}"),
+        };
+        assert_eq!(row.version, "v2.0.0");
+        // The version read out of the zip, and the caller-supplied server version —
+        // an uploaded zip says nothing about which server it was built for.
+        assert_eq!(row.server_version, "3.1.0");
+        assert_eq!(row.sha256, uploaded_sha);
+
+        // The bytes were copied into the sync-file category, not left in the
+        // temporary one (which is swept on a timer).
+        let file_refs = SyncFileReferenceRowRepository::new(&ctx.connection)
+            .find_all_by_record_id(&row.id)
+            .unwrap();
+        assert_eq!(file_refs.len(), 1);
+        let stored = file_service
+            .find_file(
+                &file_refs[0].id,
+                StaticFileCategory::SyncFile(FRONTEND_BUNDLE_TABLE.to_string(), row.id.clone()),
+            )
+            .unwrap()
+            .expect("uploaded bundle should be in the sync-file category");
+        assert_eq!(
+            dist::sha256_of_file(Path::new(&stored.path)).unwrap(),
+            uploaded_sha
+        );
+
+        // Re-uploading the same version is a no-op rather than a duplicate.
+        let again = install_uploaded_bundle(
+            ctx,
+            &settings,
+            UploadedFile {
+                file_id: reserved.id,
+            },
+            None,
+        )
+        .unwrap();
+        assert!(matches!(again, PublishOutcome::AlreadyPublished(_)));
+        assert_eq!(all_bundles(ctx).unwrap().len(), 1);
+    }
+
+    #[actix_rt::test]
+    async fn set_active_toggles_withdrawal() {
+        let context = setup_all_and_service_provider(
+            "set_active_toggles_withdrawal",
+            MockDataInserts::none(),
+        )
+        .await;
+        let ctx = &context.service_context;
+
+        let dist_dir = tempfile::tempdir().unwrap();
+        let base_dir = tempfile::tempdir().unwrap();
+        write_dist(dist_dir.path(), "v1.2.3");
+        let settings = settings_for(&context, dist_dir.path(), base_dir.path());
+        let row = publish_from_frontend_dir(&ctx, &settings)
+            .unwrap()
+            .row()
+            .clone();
+
+        let withdrawn = set_active(&ctx, &row.id, false).unwrap();
+        assert!(!withdrawn.is_active);
+
+        let reactivated = set_active(&ctx, &row.id, true).unwrap();
+        assert!(reactivated.is_active);
+
+        assert!(set_active(&ctx, "does-not-exist", false).is_err());
+    }
+}

--- a/server/service/src/lib.rs
+++ b/server/service/src/lib.rs
@@ -67,6 +67,7 @@ pub mod name;
 pub mod name_property;
 pub mod number;
 pub mod permission;
+pub mod frontend_bundle;
 pub mod plugin;
 pub mod plugin_data;
 pub mod preference;


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Part of #12622 — getting bundles into central, so sync has something to distribute.

**Central publishes the dist it is already serving.** On startup it reads the version from `frontend_dir/VERSION.txt`, and if no `frontend_bundle` row has that version it zips the directory (excluding `old-ui/`), hashes it, stores the zip in the sync-file category, and writes the record plus its `sync_file_reference` in one transaction. So upgrading central is what releases a new front end to the fleet — **no packaging or CI change**, and it works identically on every platform.

The version check happens *before* the zip, so the common case (restart, front end unchanged) does no work.

`server_version` is stamped from central's own app version: packaging pinned that dist for this release, so it's true by construction and needs nothing from the front-end repo.

Also here: the manual-upload path (an admin uploads a dist zip, as plugins are installed today), withdrawal via `is_active`, a `frontendBundles` query and two central mutations.

## 💌 Any notes for the reviewer?

**Third in a 5-PR stack; targets `12622-fe-sync-table`.**

Judgement calls worth a look:

- **The `sync_file_reference` is written with `status: Done`.** Anything else puts it in `find_all_to_upload` and central spends forever trying to upload the file to itself. This is the sharpest edge in the PR.
- **The zip is reproducible** — files are collected sorted, so the same dist zips to identical bytes and the same sha256. That's what makes "already published?" answerable and stops a restart producing a second bundle differing only by file order. There's a test.
- **`zip_dist` hashes by reading the finished archive back**, so it needs a read-write handle rather than `File::create`. Zip seeks backwards to write its central directory, so hashing during the write wouldn't describe the final bytes.
- **Auth reuses `Resource::ConfigurePlugin`** (→ `ServerAdmin`) rather than adding a resource: installing a bundle and installing a plugin are the same trust level, since both ship code that executes in users' browsers. Push back if you'd rather have a distinct resource.
- **`frontendBundles` is on `GeneralQueries`, not central-only** — an admin on a remote wants to see which bundles reached that site and which is active. The publish/withdraw mutations are central-only.
- **Startup publishing is non-fatal**: a server that can't publish a bundle should still start and serve its own.
- No admin UI yet, by agreement — the normal path is bundled-with-central, so the manual path is a hotfix tool and a UI can follow once we know the shape.

`find_all_by_record_id` on `sync_file_reference` is added here and used again in the download PR.

# 🧪 Tested

- `cargo nextest run -p service frontend_bundle` — 14 passed: record + file reference written (asserting `status: Done` and that the zip on disk hashes to the record's `sha256`); publish is idempotent and does **not** re-zip; a new version adds a second bundle and keeps the first; missing/invalid dist fails loudly rather than inventing a version; upload path publishes from a zip and is idempotent; `set_active` toggles.
- Zip helpers tested separately (no DB): `old-ui` excluded, bundle at zip root, reproducible hash, hash changes when a file changes, non-dist directory refused, version round-trips through a zip, nested-bundle zip rejected.
- `cargo nextest run -p service sync` (256), `-p repository` full (249), `-p graphql` (3, incl. the permissions resource mapping).
- `cargo build` and `cargo build --features postgres`.

# 📃 Documentation

- [x] **Part of an epic** — documentation will be completed for the feature as a whole