### PR TITLE
Frontend sync: activate and serve synced front-end bundles

### DIFF
--- a/server/server/src/lib.rs
+++ b/server/server/src/lib.rs
@@ -4,17 +4,10 @@
 extern crate machine_uid;
 
 use crate::{
-    central::config_central,
-    certs::Certificates,
-    cold_chain::config_cold_chain,
-    cors::cors_policy,
-    custom_translations::config_custom_translations,
-    middleware::central_server_only,
-    print::config_print,
-    serve_frontend::config_serve_frontend,
-    static_files::config_static_files,
-    support::config_support,
-    upload_fridge_tag::config_upload_fridge_tag,
+    central::config_central, certs::Certificates, cold_chain::config_cold_chain, cors::cors_policy,
+    custom_translations::config_custom_translations, middleware::central_server_only,
+    print::config_print, serve_frontend::config_serve_frontend, static_files::config_static_files,
+    support::config_support, upload_fridge_tag::config_upload_fridge_tag,
 };
 
 use self::middleware::{compress as compress_middleware, logger as logger_middleware};
@@ -46,11 +39,11 @@ use service::{
     plugin::validation::ValidatedPluginBucket,
     processors::Processors,
     service_provider::ServiceProvider,
+    session_store::SessionStore,
     settings::{is_develop, ServerSettings, Settings},
     standalone_central::InitialiseAsCentralServerInput,
     standard_reports::StandardReports,
     subscription::{SubscriptionTrigger, SubscriptionWorker},
-    session_store::SessionStore,
     sync::{
         file_sync_driver::FileSyncDriver,
         sync_status::status::InitialisationStatus,
@@ -172,7 +165,9 @@ pub async fn start_server(
         .map(|s| s.relax_hardware_id_token_checks)
         .unwrap_or(false);
     if relax_hardware_id_token_checks {
-        log::warn!("relax_hardware_id_token_checks is set — v7 hardware-id/token guards are RELAXED");
+        log::warn!(
+            "relax_hardware_id_token_checks is set — v7 hardware-id/token guards are RELAXED"
+        );
     }
     let service_provider = Data::new(ServiceProvider::new_with_triggers(
         connection_manager.clone(),
@@ -239,6 +234,9 @@ pub async fn start_server(
 
     let validated_plugins = ValidatedPluginBucket::new(&settings.server.base_dir).unwrap();
     let validated_plugins = Data::new(Mutex::new(validated_plugins));
+    // Same handle the activation path writes to, so a swap is visible to serving
+    // immediately without a restart.
+    let active_frontend_bundle = Data::new(service_provider.active_frontend_bundle.clone());
 
     let (subscription_task_handle, subscription_broadcast) =
         subscription_worker.spawn(service_provider.clone().into_inner());
@@ -337,6 +335,7 @@ pub async fn start_server(
             .app_data(closure_service_provider.clone())
             .app_data(auth.clone())
             .app_data(validated_plugins.clone())
+            .app_data(active_frontend_bundle.clone())
             .app_data(get_default_directory(&closure_settings))
             .configure(attach_graphql_schema(closure_schema.clone()))
             .configure(config_static_files)
@@ -461,6 +460,22 @@ pub async fn start_server(
         }
     }
 
+    // Point serving at the best bundle already on disk (every site, central included —
+    // central serves the UI too). Anything downloaded while the server was down is
+    // verified and unpacked here, so a restart is enough to pick it up.
+    match frontend_bundle::reconcile_active_bundle(
+        &service_context,
+        &settings,
+        &service_provider.active_frontend_bundle,
+    ) {
+        Ok(None) => info!("Serving the packaged front-end (no synced bundle active)"),
+        Ok(Some(bundle)) => info!("Serving synced front-end bundle {}", bundle.version),
+        Err(e) => log::error!(
+            "Could not resolve the active front-end bundle: {}",
+            format_error(&e)
+        ),
+    }
+
     // Log the server starting message with the startup timestamp
     let status_log = StatusLog(&connection);
     status_log.no_console_with_timestamp(&server_start_message, server_start_timestamp);
@@ -487,10 +502,7 @@ pub async fn start_server(
     // CHECK SYNC STATUS
     info!("Checking sync status..");
     // A flags-only `sync:` block (no credentials) counts as "no sync settings" here.
-    let yaml_sync_settings = settings
-        .sync
-        .clone()
-        .filter(|s| s.has_core_sync_settings());
+    let yaml_sync_settings = settings.sync.clone().filter(|s| s.has_core_sync_settings());
     let database_sync_settings = service_provider
         .settings
         .sync_settings(&service_context)

--- a/server/server/src/serve_frontend.rs
+++ b/server/server/src/serve_frontend.rs
@@ -6,20 +6,37 @@ use actix_web::{
     HttpRequest, HttpResponse, Responder,
 };
 use mime_guess::{from_path, mime};
-use service::settings::Settings;
+use service::{frontend_bundle::ActiveFrontendBundle, settings::Settings};
 use std::path::{Path, PathBuf};
 
 const INDEX: &str = "index.html";
 const CACHE_MAX_AGE: u32 = 365 * 60 * 60 * 24; // 1 year
 
-/// Read a frontend asset from `server.frontend_dir`. The bundle is shipped
-/// alongside the server by packaging (or copied there by the Android app
-/// shell), so it can be swapped without rebuilding the server.
-fn get_asset(settings: &Settings, path: &str) -> Option<Vec<u8>> {
+/// Read a frontend asset, preferring a synced bundle over the packaged baseline.
+///
+/// The active bundle (if any) is the newest one this server can run whose bytes have
+/// arrived and verified — see `frontend_bundle::reconcile_active_bundle`. When there
+/// isn't one we serve `server.frontend_dir`, the bundle packaging shipped alongside the
+/// server (or that the Android app shell copied in).
+///
+/// Falling through to the baseline per *asset* rather than per *request* matters during a
+/// swap: a tab that loaded the previous bundle may still ask for one of its
+/// content-hashed assets, and the previous bundle's directory is retained precisely so
+/// that keeps working.
+fn get_asset(settings: &Settings, active: &ActiveFrontendBundle, path: &str) -> Option<Vec<u8>> {
+    if let Some(bundle) = active.get() {
+        if let Some(content) = read_asset(&bundle.root, path) {
+            return Some(content);
+        }
+    }
     read_asset(&frontend_root(settings)?, path)
 }
 
 /// Read an asset from the old UI bundle (served under `/old-ui/`).
+///
+/// Always from `frontend_dir`, never from a synced bundle: the old UI is built from this
+/// repo and ships with the installer, and `/old-ui/` is the escape hatch when the synced
+/// front end is broken. A synced bundle must not be able to affect it.
 fn get_old_ui_asset(settings: &Settings, path: &str) -> Option<Vec<u8>> {
     read_asset(&old_ui_frontend_root(settings)?, path)
 }
@@ -89,8 +106,8 @@ fn asset_response(path: &str, content: Vec<u8>) -> HttpResponse {
         .body(content)
 }
 
-fn serve_frontend(settings: &Settings, path: &str) -> HttpResponse {
-    match get_asset(settings, path) {
+fn serve_frontend(settings: &Settings, active: &ActiveFrontendBundle, path: &str) -> HttpResponse {
+    match get_asset(settings, active, path) {
         Some(content) => asset_response(path, content),
         None => HttpResponse::NotFound().body("file not found"),
     }
@@ -105,15 +122,19 @@ fn serve_old_ui_frontend(settings: &Settings, path: &str) -> HttpResponse {
 
 // Match file paths (ending  ($) with dot (\.) and at least one character (.+) )
 #[get(r#"/{filename:.*\..+$}"#)]
-async fn file(req: HttpRequest, settings: Data<Settings>) -> impl Responder {
+async fn file(
+    req: HttpRequest,
+    settings: Data<Settings>,
+    active: Data<ActiveFrontendBundle>,
+) -> impl Responder {
     let filename: String = req.match_info().query("filename").parse().unwrap();
-    serve_frontend(&settings, &filename)
+    serve_frontend(&settings, &active, &filename)
 }
 
 // Match all paths
 #[get("/{_:.*}")]
-async fn index(settings: Data<Settings>) -> impl Responder {
-    let result = serve_frontend(&settings, INDEX);
+async fn index(settings: Data<Settings>, active: Data<ActiveFrontendBundle>) -> impl Responder {
+    let result = serve_frontend(&settings, &active, INDEX);
 
     // If index not found the frontend bundle is missing from frontend_dir
     if result.status() == StatusCode::NOT_FOUND {
@@ -178,7 +199,11 @@ mod test {
     /// Build a `Settings` whose frontend dirs point at temp dirs. Each dir gets
     /// an `index.html` with distinguishable content and a nested `assets/x.js`.
     fn write_dist(dir: &Path, marker: &str) {
-        fs::write(dir.join("index.html"), format!("<html>{marker} index</html>")).unwrap();
+        fs::write(
+            dir.join("index.html"),
+            format!("<html>{marker} index</html>"),
+        )
+        .unwrap();
         fs::create_dir_all(dir.join("assets")).unwrap();
         fs::write(dir.join("assets/x.js"), format!("// {marker} js")).unwrap();
     }
@@ -203,6 +228,15 @@ mod test {
         settings
     }
 
+    /// Point the shared handle at an unpacked bundle, as activation does — including
+    /// canonicalising the root, which activation also does (see `unpacked_root`).
+    fn activate(active: &ActiveFrontendBundle, version: &str, root: &Path) {
+        active.set_for_test(service::frontend_bundle::ActiveBundle {
+            version: version.to_string(),
+            root: root.canonicalize().unwrap(),
+        });
+    }
+
     async fn body_string(resp: actix_web::dev::ServiceResponse) -> String {
         let bytes = test::read_body(resp).await;
         String::from_utf8(bytes.to_vec()).unwrap()
@@ -222,6 +256,7 @@ mod test {
         let app = test::init_service(
             App::new()
                 .app_data(Data::new(settings))
+                .app_data(Data::new(ActiveFrontendBundle::new()))
                 .configure(config_serve_frontend),
         )
         .await;
@@ -252,7 +287,9 @@ mod test {
         // /old-ui SPA route -> old index
         let resp = test::call_service(
             &app,
-            test::TestRequest::get().uri("/old-ui/some/route").to_request(),
+            test::TestRequest::get()
+                .uri("/old-ui/some/route")
+                .to_request(),
         )
         .await;
         assert!(body_string(resp).await.contains("OLD index"));
@@ -260,7 +297,9 @@ mod test {
         // /old-ui asset -> old js with long cache header
         let resp = test::call_service(
             &app,
-            test::TestRequest::get().uri("/old-ui/assets/x.js").to_request(),
+            test::TestRequest::get()
+                .uri("/old-ui/assets/x.js")
+                .to_request(),
         )
         .await;
         let cache = resp
@@ -291,6 +330,7 @@ mod test {
         let app = test::init_service(
             App::new()
                 .app_data(Data::new(settings))
+                .app_data(Data::new(ActiveFrontendBundle::new()))
                 .configure(config_serve_frontend),
         )
         .await;
@@ -303,12 +343,18 @@ mod test {
         // /old-ui/anything is graceful (plain-text hint, not a swallow of the new app)
         let resp = test::call_service(
             &app,
-            test::TestRequest::get().uri("/old-ui/anything").to_request(),
+            test::TestRequest::get()
+                .uri("/old-ui/anything")
+                .to_request(),
         )
         .await;
         assert!(resp.status().is_success());
         let body = body_string(resp).await;
-        assert!(body.contains("Cannot find index.html in old UI"), "got {}", body);
+        assert!(
+            body.contains("Cannot find index.html in old UI"),
+            "got {}",
+            body
+        );
         assert!(!body.contains("NEW index"));
     }
 
@@ -320,6 +366,7 @@ mod test {
         let app = test::init_service(
             App::new()
                 .app_data(Data::new(settings))
+                .app_data(Data::new(ActiveFrontendBundle::new()))
                 .configure(config_serve_frontend),
         )
         .await;
@@ -333,5 +380,99 @@ mod test {
             .unwrap()
             .to_string();
         assert!(cache.contains("no-cache"), "got {}", cache);
+    }
+
+    /// An active synced bundle is served in preference to the packaged baseline, while
+    /// `/old-ui/` stays on the baseline — it is the escape hatch and must not be
+    /// affected by anything that arrived over sync.
+    #[actix_web::test]
+    async fn active_bundle_is_preferred_and_old_ui_is_not() {
+        let baseline_dir = TempDir::new().unwrap();
+        write_dist(baseline_dir.path(), "BASELINE");
+        let old_dir = baseline_dir.path().join("old-ui");
+        fs::create_dir_all(&old_dir).unwrap();
+        write_dist(&old_dir, "OLD");
+
+        // A synced bundle, unpacked where activation puts it (outside frontend_dir).
+        let bundle_dir = TempDir::new().unwrap();
+        write_dist(bundle_dir.path(), "SYNCED");
+
+        let settings = settings_with(baseline_dir.path());
+        let active = ActiveFrontendBundle::new();
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(settings))
+                .app_data(Data::new(active.clone()))
+                .configure(config_serve_frontend),
+        )
+        .await;
+
+        // With no active bundle, the baseline serves.
+        let resp = test::call_service(&app, test::TestRequest::get().uri("/").to_request()).await;
+        assert!(body_string(resp).await.contains("BASELINE index"));
+
+        activate(&active, "1.0.0", bundle_dir.path());
+
+        // Root and assets now come from the synced bundle.
+        let resp = test::call_service(&app, test::TestRequest::get().uri("/").to_request()).await;
+        assert!(body_string(resp).await.contains("SYNCED index"));
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get().uri("/assets/x.js").to_request(),
+        )
+        .await;
+        assert!(body_string(resp).await.contains("SYNCED js"));
+
+        // The old UI is untouched by the swap.
+        let resp =
+            test::call_service(&app, test::TestRequest::get().uri("/old-ui/").to_request()).await;
+        assert!(body_string(resp).await.contains("OLD index"));
+    }
+
+    /// A tab that loaded the previous bundle may ask for an asset the new one does not
+    /// have. Falling back per asset (rather than per request) is what keeps it working.
+    #[actix_web::test]
+    async fn assets_missing_from_the_bundle_fall_back_to_the_baseline() {
+        let baseline_dir = TempDir::new().unwrap();
+        write_dist(baseline_dir.path(), "BASELINE");
+        fs::write(
+            baseline_dir.path().join("assets/only-baseline.js"),
+            "// legacy",
+        )
+        .unwrap();
+
+        let bundle_dir = TempDir::new().unwrap();
+        write_dist(bundle_dir.path(), "SYNCED");
+
+        let settings = settings_with(baseline_dir.path());
+        let active = ActiveFrontendBundle::new();
+        activate(&active, "1.0.0", bundle_dir.path());
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(settings))
+                .app_data(Data::new(active))
+                .configure(config_serve_frontend),
+        )
+        .await;
+
+        // Present in the bundle: bundle wins.
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get().uri("/assets/x.js").to_request(),
+        )
+        .await;
+        assert!(body_string(resp).await.contains("SYNCED js"));
+
+        // Absent from the bundle: the baseline still answers rather than 404ing.
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/assets/only-baseline.js")
+                .to_request(),
+        )
+        .await;
+        assert!(resp.status().is_success());
+        assert!(body_string(resp).await.contains("legacy"));
     }
 }

--- a/server/service/src/frontend_bundle/active.rs
+++ b/server/service/src/frontend_bundle/active.rs
@@ -1,0 +1,509 @@
+//! Turning a downloaded bundle into the front end the server actually serves.
+//!
+//! Three steps, kept separate because they fail differently: verify the bytes against
+//! the sha256 the record carries, unpack them somewhere safe, and point serving at the
+//! result. See `server/spec/sync/frontend-sync.md` § Selection and serving.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use repository::{
+    sync_file_reference_row::{SyncFileReferenceRowRepository, SyncFileStatus},
+    FrontendBundleRow, RepositoryError, StorageConnection,
+};
+use thiserror::Error;
+
+use crate::static_files::{StaticFileCategory, StaticFileService};
+
+use super::{dist, FRONTEND_BUNDLE_TABLE};
+
+/// Where unpacked bundles live, relative to `base_dir`.
+///
+/// Deliberately **not** inside `frontend_dir`: on Android the app shell deletes and
+/// re-copies `<filesDir>/frontend` from the APK whenever the app version changes, so a
+/// synced bundle stored there would be destroyed by every upgrade. `frontend_dir` stays
+/// the installer-shipped baseline and the fallback.
+const BUNDLES_DIR: &str = "frontend_bundles";
+
+/// How many unpacked bundles to keep. The active one plus one more: a browser tab that
+/// loaded the previous bundle holds `immutable, max-age=1y` content-hashed asset URLs,
+/// and those files must still exist for it to keep working until the user reloads.
+const RETAINED_BUNDLES: usize = 2;
+
+/// The bundle currently being served, if any.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ActiveBundle {
+    pub version: String,
+    /// Directory to serve assets from — the unpacked bundle's root.
+    pub root: PathBuf,
+}
+
+/// Shared handle to the active bundle, read on every asset request.
+///
+/// Lives on `ServiceProvider` and is cloned into the HTTP app data, so serving resolves
+/// its root from memory and never touches the database or its connection pool.
+#[derive(Clone, Default)]
+pub struct ActiveFrontendBundle(Arc<RwLock<Option<ActiveBundle>>>);
+
+impl ActiveFrontendBundle {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get(&self) -> Option<ActiveBundle> {
+        self.0.read().ok().and_then(|guard| guard.clone())
+    }
+
+    /// Only `reconcile_active_bundle` should call this — activation has to run the
+    /// selection rule, not just set a pointer.
+    pub(super) fn set(&self, bundle: Option<ActiveBundle>) {
+        if let Ok(mut guard) = self.0.write() {
+            *guard = bundle;
+        }
+    }
+
+    /// Set the active bundle directly, for tests in crates that only need to exercise
+    /// *serving* (the server crate's `serve_frontend`) without running a real activation.
+    pub fn set_for_test(&self, bundle: ActiveBundle) {
+        self.set(Some(bundle));
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ActivateBundleError {
+    #[error("Database error")]
+    DatabaseError(#[from] RepositoryError),
+    #[error("Bundle {0} has no file reference")]
+    NoFileReference(String),
+    #[error("Bundle {version} bytes are not downloaded yet")]
+    NotDownloaded { version: String },
+    #[error("Bundle {version} failed its checksum (expected {expected}, got {actual})")]
+    ChecksumMismatch {
+        version: String,
+        expected: String,
+        actual: String,
+    },
+    #[error("Bundle version {0} is not usable as a directory name")]
+    UnsafeVersion(String),
+    #[error("Could not unpack the bundle")]
+    UnpackError(#[source] anyhow::Error),
+}
+
+pub fn bundles_dir(base_dir: &str) -> PathBuf {
+    PathBuf::from(base_dir).join(BUNDLES_DIR)
+}
+
+/// Directory name for a bundle. The version is used rather than the id so an
+/// administrator poking around on disk can see what is there.
+///
+/// Versions come from `VERSION.txt` inside a bundle, i.e. ultimately from outside this
+/// process, so anything that isn't plainly safe as a single path component is rejected
+/// rather than sanitised — quietly rewriting it could collapse two versions onto one
+/// directory. Real versions (`v1.2.3`) pass.
+fn dir_name_for(version: &str) -> Result<String, ActivateBundleError> {
+    let safe = !version.is_empty()
+        && version.len() <= 64
+        && version
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+        // `.` and `..` are path components, not names.
+        && version.chars().any(|c| c != '.');
+
+    if safe {
+        Ok(version.to_string())
+    } else {
+        Err(ActivateBundleError::UnsafeVersion(version.to_string()))
+    }
+}
+
+/// Is this bundle already unpacked and servable?
+///
+/// The path is canonicalised, because serving resolves each asset path and checks it is
+/// still inside the root — a root containing a symlink (a symlinked data directory, or
+/// `/tmp` on macOS) would fail that check for every asset and serve nothing.
+pub fn unpacked_root(base_dir: &str, version: &str) -> Option<PathBuf> {
+    let dir = bundles_dir(base_dir).join(dir_name_for(version).ok()?);
+    if !dir.join("index.html").is_file() {
+        return None;
+    }
+    dir.canonicalize().ok()
+}
+
+/// Verify a downloaded bundle's bytes and unpack them, returning the servable root.
+///
+/// Stage-then-swap, the same shape as `fetch-frontend.js` and the Android app shell's
+/// asset copy: an interrupted unpack can never leave a half-populated directory being
+/// served. A checksum failure also discards the partial download, because a resumed
+/// download of corrupt bytes would fail forever.
+pub fn verify_and_unpack(
+    connection: &StorageConnection,
+    static_file_service: &StaticFileService,
+    base_dir: &str,
+    bundle: &FrontendBundleRow,
+) -> Result<PathBuf, ActivateBundleError> {
+    let references =
+        SyncFileReferenceRowRepository::new(connection).find_all_by_record_id(&bundle.id)?;
+    let reference = references
+        .into_iter()
+        .find(|r| r.table_name == FRONTEND_BUNDLE_TABLE)
+        .ok_or_else(|| ActivateBundleError::NoFileReference(bundle.id.clone()))?;
+
+    if reference.status != SyncFileStatus::Done {
+        return Err(ActivateBundleError::NotDownloaded {
+            version: bundle.version.clone(),
+        });
+    }
+
+    let category =
+        StaticFileCategory::SyncFile(FRONTEND_BUNDLE_TABLE.to_string(), bundle.id.clone());
+    let file = static_file_service
+        .find_file(&reference.id, category)
+        .map_err(ActivateBundleError::UnpackError)?
+        .ok_or_else(|| ActivateBundleError::NotDownloaded {
+            version: bundle.version.clone(),
+        })?;
+
+    let zip_path = PathBuf::from(&file.path);
+    let actual = dist::sha256_of_file(&zip_path).map_err(ActivateBundleError::UnpackError)?;
+    if actual != bundle.sha256 {
+        // The bytes we hold are not the bytes central published. Throw away both the
+        // assembled file and any partial, so the next attempt starts clean.
+        let _ = std::fs::remove_file(&zip_path);
+        static_file_service.discard_partial_download(&reference);
+        return Err(ActivateBundleError::ChecksumMismatch {
+            version: bundle.version.clone(),
+            expected: bundle.sha256.clone(),
+            actual,
+        });
+    }
+
+    let target = bundles_dir(base_dir).join(dir_name_for(&bundle.version)?);
+    let staging = target.with_extension("tmp");
+
+    let unpack = || -> anyhow::Result<()> {
+        let _ = std::fs::remove_dir_all(&staging);
+        std::fs::create_dir_all(&staging)?;
+        unzip_into(&zip_path, &staging)?;
+
+        if !staging.join("index.html").is_file() {
+            return Err(anyhow::anyhow!("unpacked bundle has no index.html at root"));
+        }
+
+        let _ = std::fs::remove_dir_all(&target);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::rename(&staging, &target)?;
+        Ok(())
+    };
+
+    if let Err(error) = unpack() {
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(ActivateBundleError::UnpackError(error));
+    }
+
+    log::info!(
+        "Unpacked front-end bundle {} to {:?}",
+        bundle.version,
+        target
+    );
+    // Canonical, for the same reason as `unpacked_root`.
+    Ok(target.canonicalize().unwrap_or(target))
+}
+
+/// Extract a zip into `target`, refusing entries that would escape it.
+///
+/// `enclosed_name` is the zip crate's guard against zip-slip (`../` traversal, absolute
+/// paths, Windows drive prefixes). A bundle arrives over authenticated sync, but it is
+/// still archive data from off-box and gets unpacked with server privileges.
+fn unzip_into(zip_path: &Path, target: &Path) -> anyhow::Result<()> {
+    let file = std::fs::File::open(zip_path)?;
+    let mut archive = zip::ZipArchive::new(file)?;
+
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index)?;
+        let Some(relative) = entry.enclosed_name() else {
+            return Err(anyhow::anyhow!(
+                "zip entry '{}' would escape the target directory",
+                entry.name()
+            ));
+        };
+        let out_path = target.join(relative);
+
+        if entry.is_dir() {
+            std::fs::create_dir_all(&out_path)?;
+            continue;
+        }
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let mut buffer = Vec::with_capacity(entry.size() as usize);
+        entry.read_to_end(&mut buffer)?;
+        std::fs::write(&out_path, buffer)?;
+    }
+
+    Ok(())
+}
+
+/// Delete unpacked bundles we no longer need, keeping [`RETAINED_BUNDLES`].
+///
+/// `keep_first` is the active bundle's directory name; the rest are ranked by the version
+/// ordering of `known` (newest first), so what survives is stable across restarts rather
+/// than depending on what happened to be active last time.
+pub fn prune_unpacked(base_dir: &str, keep_first: Option<&str>, known: &[FrontendBundleRow]) {
+    let dir = bundles_dir(base_dir);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return;
+    };
+
+    let mut present: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        // Leave staging directories to their own cleanup.
+        .filter(|name| !name.ends_with(".tmp"))
+        .collect();
+
+    // Newest first, by version order rather than name order ("1.10.0" > "1.2.0").
+    let rank = |name: &String| {
+        known
+            .iter()
+            .find(|b| dir_name_for(&b.version).ok().as_deref() == Some(name.as_str()))
+            .map(|b| repository::migrations::Version::from_str(&b.version))
+    };
+    present.sort_by(|a, b| rank(b).cmp(&rank(a)));
+
+    let mut keep: Vec<String> = Vec::new();
+    if let Some(first) = keep_first {
+        if present.iter().any(|n| n == first) {
+            keep.push(first.to_string());
+        }
+    }
+    for name in &present {
+        if keep.len() >= RETAINED_BUNDLES {
+            break;
+        }
+        if !keep.contains(name) {
+            keep.push(name.clone());
+        }
+    }
+
+    for name in present {
+        if keep.contains(&name) {
+            continue;
+        }
+        let path = dir.join(&name);
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => log::info!("Removed superseded front-end bundle {:?}", path),
+            Err(error) => log::warn!("Could not remove {:?}: {}", path, error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::io::Write;
+
+    fn write_zip(path: &Path, entries: &[(&str, &str)]) -> String {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)
+            .unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default();
+        for (name, contents) in entries {
+            zip.start_file(*name, options).unwrap();
+            zip.write_all(contents.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+        dist::sha256_of_file(path).unwrap()
+    }
+
+    #[test]
+    fn unzip_rejects_entries_that_escape_the_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let zip_path = temp.path().join("evil.zip");
+        write_zip(&zip_path, &[("../escaped.txt", "pwned")]);
+
+        let target = temp.path().join("unpacked");
+        std::fs::create_dir_all(&target).unwrap();
+
+        // A bundle arrives over authenticated sync, but it is still archive data from
+        // off-box unpacked with server privileges — zip-slip must be refused.
+        assert!(unzip_into(&zip_path, &target).is_err());
+        assert!(!temp.path().join("escaped.txt").exists());
+    }
+
+    #[test]
+    fn unzip_writes_nested_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let zip_path = temp.path().join("bundle.zip");
+        write_zip(
+            &zip_path,
+            &[
+                ("index.html", "<html>app</html>"),
+                ("assets/app-abc.js", "console.log(1)"),
+                ("VERSION.txt", "version: v1.0.0\n"),
+            ],
+        );
+
+        let target = temp.path().join("unpacked");
+        unzip_into(&zip_path, &target).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target.join("index.html")).unwrap(),
+            "<html>app</html>"
+        );
+        assert_eq!(
+            std::fs::read_to_string(target.join("assets/app-abc.js")).unwrap(),
+            "console.log(1)"
+        );
+    }
+
+    #[test]
+    fn version_must_be_safe_as_a_directory_name() {
+        // Real versions.
+        assert_eq!(dir_name_for("v1.2.3").unwrap(), "v1.2.3");
+        assert_eq!(dir_name_for("1.2.3-rc1").unwrap(), "1.2.3-rc1");
+
+        // A version comes from VERSION.txt inside a bundle, i.e. from outside this
+        // process. Anything that isn't plainly a safe single path component is rejected
+        // rather than sanitised.
+        for bad in [
+            "../etc",
+            "a/b",
+            "a\\b",
+            "..",
+            ".",
+            "",
+            "with space",
+            "semi;colon",
+        ] {
+            assert!(dir_name_for(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn unpacked_root_requires_an_index_html() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().to_string_lossy().to_string();
+
+        assert_eq!(unpacked_root(&base, "v1.0.0"), None);
+
+        // A directory alone isn't enough — a half-populated one must not be served.
+        let dir = bundles_dir(&base).join("v1.0.0");
+        std::fs::create_dir_all(&dir).unwrap();
+        assert_eq!(unpacked_root(&base, "v1.0.0"), None);
+
+        std::fs::write(dir.join("index.html"), "<html></html>").unwrap();
+        // Canonical, so serving's path-traversal check compares like with like.
+        assert_eq!(unpacked_root(&base, "v1.0.0"), Some(dir.canonicalize().unwrap()));
+    }
+
+    fn row(version: &str) -> FrontendBundleRow {
+        FrontendBundleRow {
+            id: version.to_string(),
+            version: version.to_string(),
+            server_version: "3.0.0".to_string(),
+            sha256: "hash".to_string(),
+            is_active: true,
+            description: None,
+            created_datetime: chrono::NaiveDate::from_ymd_opt(2026, 8, 4)
+                .unwrap()
+                .and_hms_opt(9, 0, 0)
+                .unwrap(),
+        }
+    }
+
+    fn unpack_fake(base: &str, version: &str) {
+        let dir = bundles_dir(base).join(version);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("index.html"), version).unwrap();
+    }
+
+    fn dirs_present(base: &str) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(bundles_dir(base))
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .map(|e| e.file_name().to_string_lossy().into_owned())
+                    .collect()
+            })
+            .unwrap_or_default();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn prune_keeps_the_active_bundle_and_one_more() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().to_string_lossy().to_string();
+
+        for version in ["1.0.0", "1.2.0", "1.10.0"] {
+            unpack_fake(&base, version);
+        }
+        let known = vec![row("1.0.0"), row("1.2.0"), row("1.10.0")];
+
+        prune_unpacked(&base, Some("1.10.0"), &known);
+
+        // Active plus the next newest survive; a tab still holding 1.2.0's hashed asset
+        // URLs keeps working until it reloads. Ranking is by version order, so 1.10.0
+        // beats 1.2.0 (string order would get this backwards).
+        assert_eq!(dirs_present(&base), vec!["1.10.0", "1.2.0"]);
+    }
+
+    #[test]
+    fn prune_leaves_staging_directories_alone() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().to_string_lossy().to_string();
+
+        unpack_fake(&base, "1.0.0");
+        std::fs::create_dir_all(bundles_dir(&base).join("1.1.0.tmp")).unwrap();
+
+        prune_unpacked(&base, Some("1.0.0"), &[row("1.0.0")]);
+
+        // An in-flight unpack is not ours to delete; verify_and_unpack owns its staging
+        // directory and clears it itself.
+        assert_eq!(dirs_present(&base), vec!["1.0.0", "1.1.0.tmp"]);
+    }
+
+    /// A directory whose bundle record is gone (deleted on central) ranks *below* every
+    /// known bundle, so it loses the retained slot to a real one — but it is not deleted
+    /// just for having no record. Retention protects open tabs, and a tab that loaded that
+    /// bundle still needs its content-hashed assets regardless of what central has since
+    /// deleted.
+    #[test]
+    fn prune_ranks_unknown_directories_last() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().to_string_lossy().to_string();
+
+        unpack_fake(&base, "1.0.0");
+        unpack_fake(&base, "0.9.0-deleted");
+        unpack_fake(&base, "1.1.0");
+
+        // Two known bundles fill both slots; the recordless one is reclaimed.
+        prune_unpacked(&base, Some("1.1.0"), &[row("1.0.0"), row("1.1.0")]);
+        assert_eq!(dirs_present(&base), vec!["1.0.0", "1.1.0"]);
+    }
+
+    #[test]
+    fn prune_keeps_a_recordless_directory_when_a_slot_is_free() {
+        let temp = tempfile::tempdir().unwrap();
+        let base = temp.path().to_string_lossy().to_string();
+
+        unpack_fake(&base, "1.0.0");
+        unpack_fake(&base, "0.9.0-deleted");
+
+        // Only one known bundle, so the spare slot keeps the previous directory around
+        // for tabs that are still on it.
+        prune_unpacked(&base, Some("1.0.0"), &[row("1.0.0")]);
+        assert_eq!(dirs_present(&base), vec!["0.9.0-deleted", "1.0.0"]);
+    }
+}

--- a/server/service/src/frontend_bundle/mod.rs
+++ b/server/service/src/frontend_bundle/mod.rs
@@ -23,7 +23,9 @@ use repository::{
     FrontendBundleRow, FrontendBundleRowRepository, RepositoryError, StorageConnection,
 };
 use thiserror::Error;
-use util::uuid::uuid;
+use util::{format_error, uuid::uuid};
+
+use crate::processors::frontend_bundle::best_usable_bundle;
 
 use crate::{
     service_provider::ServiceContext,
@@ -32,8 +34,10 @@ use crate::{
     usize_to_i32, UploadedFile, UploadedFileConversionError,
 };
 
+pub mod active;
 pub mod dist;
 
+pub use active::{ActiveBundle, ActiveFrontendBundle};
 pub use dist::sha256_of_file;
 
 /// `sync_file_reference.table_name` for a bundle's zip. The owning record's id is the
@@ -198,6 +202,98 @@ pub fn set_active(
     let updated = FrontendBundleRow { is_active, ..row };
     repo.upsert_one(&updated)?;
     Ok(updated)
+}
+
+/// Decide which bundle this server should be serving and make it so.
+///
+/// Run at startup and after a bundle download completes. Idempotent, and safe to call
+/// when there is nothing to do — which is the common case.
+///
+/// The rule (spec § Selection and serving): of the bundles that are active and whose
+/// `server_version` is compatible with this server, take the highest `version`; if its
+/// bytes are downloaded and verified, serve it; otherwise serve the installer-shipped
+/// baseline in `frontend_dir`.
+///
+/// A bundle that is the best candidate but not yet usable does **not** fall back to an
+/// older synced bundle: the older one keeps serving until the new one is genuinely ready,
+/// which is what makes activation a swap rather than a gap.
+pub fn reconcile_active_bundle(
+    ctx: &ServiceContext,
+    settings: &Settings,
+    active: &ActiveFrontendBundle,
+) -> Result<Option<ActiveBundle>, RepositoryError> {
+    let base_dir = &settings.server.base_dir;
+    let all = FrontendBundleRowRepository::new(&ctx.connection).all()?;
+    let previous = active.get();
+
+    let Some(best) = best_usable_bundle(&ctx.connection)? else {
+        // Nothing usable — serve the baseline. This is also the withdrawal path: central
+        // clears is_active and the site drops back.
+        if previous.is_some() {
+            log::info!("No usable front-end bundle; serving the packaged baseline");
+        }
+        active.set(None);
+        active::prune_unpacked(base_dir, None, &all);
+        return Ok(None);
+    };
+
+    // Already unpacked (e.g. from a previous run) — nothing to do but point at it.
+    let root = match active::unpacked_root(base_dir, &best.version) {
+        Some(root) => root,
+        None => {
+            let file_service = match StaticFileService::new(base_dir) {
+                Ok(service) => service,
+                Err(error) => {
+                    log::error!("Cannot access static files: {:#}", error);
+                    return Ok(previous);
+                }
+            };
+
+            match active::verify_and_unpack(&ctx.connection, &file_service, base_dir, &best) {
+                Ok(root) => root,
+                Err(active::ActivateBundleError::NotDownloaded { version }) => {
+                    // Expected: the record arrived before its bytes. The download queue
+                    // is working on it and this runs again when it lands.
+                    log::debug!("Front-end bundle {version} is not downloaded yet");
+                    return Ok(previous);
+                }
+                Err(error) => {
+                    // A checksum failure or a bad archive. Keep serving whatever we were
+                    // serving; a broken candidate must not take the UI down.
+                    log::error!(
+                        "Could not activate front-end bundle {}: {}",
+                        best.version,
+                        format_error(&error)
+                    );
+                    return Ok(previous);
+                }
+            }
+        }
+    };
+
+    let bundle = ActiveBundle {
+        version: best.version.clone(),
+        root,
+    };
+
+    if previous.as_ref() != Some(&bundle) {
+        log::info!(
+            "Serving front-end bundle {} (built for server {})",
+            bundle.version,
+            best.server_version
+        );
+    }
+    active.set(Some(bundle.clone()));
+
+    // Prune after activating, so the directory we just started serving is never a
+    // candidate for removal.
+    active::prune_unpacked(
+        base_dir,
+        bundle.root.file_name().and_then(|n| n.to_str()),
+        &all,
+    );
+
+    Ok(Some(bundle))
 }
 
 pub fn all_bundles(ctx: &ServiceContext) -> Result<Vec<FrontendBundleRow>, RepositoryError> {
@@ -558,6 +654,155 @@ mod test {
         .unwrap();
         assert!(matches!(again, PublishOutcome::AlreadyPublished(_)));
         assert_eq!(all_bundles(ctx).unwrap().len(), 1);
+    }
+
+    /// Publish → download → activate, then withdraw, in one pass.
+    ///
+    /// Publishing on central already leaves the zip on disk with a Done file reference,
+    /// which is exactly the state a remote is in once its background download finishes —
+    /// so this exercises the remote's activation path without a second server.
+    #[actix_rt::test]
+    async fn reconcile_activates_then_falls_back_on_withdrawal() {
+        let context = setup_all_and_service_provider(
+            "reconcile_activates_then_falls_back_on_withdrawal",
+            MockDataInserts::none(),
+        )
+        .await;
+        let ctx = &context.service_context;
+
+        let dist_dir = tempfile::tempdir().unwrap();
+        let base_dir = tempfile::tempdir().unwrap();
+        write_dist(dist_dir.path(), "v1.0.0");
+        let settings = settings_for(&context, dist_dir.path(), base_dir.path());
+        let active = ActiveFrontendBundle::new();
+
+        // Nothing published: serve the packaged baseline.
+        assert_eq!(
+            reconcile_active_bundle(ctx, &settings, &active).unwrap(),
+            None
+        );
+        assert_eq!(active.get(), None);
+
+        let first = publish_from_frontend_dir(ctx, &settings)
+            .unwrap()
+            .row()
+            .clone();
+
+        let activated = reconcile_active_bundle(ctx, &settings, &active)
+            .unwrap()
+            .expect("bundle should activate");
+        assert_eq!(activated.version, "v1.0.0");
+        assert_eq!(active.get(), Some(activated.clone()));
+        // Unpacked somewhere the Android app shell will not wipe on upgrade — under
+        // base_dir, never inside frontend_dir. Compared canonically, since the activated
+        // root is canonicalised (temp dirs sit behind a symlink on macOS).
+        assert!(activated
+            .root
+            .starts_with(base_dir.path().canonicalize().unwrap()));
+        assert!(!activated
+            .root
+            .starts_with(dist_dir.path().canonicalize().unwrap()));
+        assert_eq!(
+            std::fs::read_to_string(activated.root.join("index.html")).unwrap(),
+            "<html>app</html>"
+        );
+        // The old UI is never part of a bundle — it ships with the installer and is the
+        // escape hatch.
+        assert!(!activated.root.join("old-ui").exists());
+
+        // Idempotent: running again changes nothing.
+        assert_eq!(
+            reconcile_active_bundle(ctx, &settings, &active).unwrap(),
+            Some(activated.clone())
+        );
+
+        // A newer bundle wins once published.
+        write_dist(dist_dir.path(), "v1.1.0");
+        publish_from_frontend_dir(ctx, &settings).unwrap();
+        let newer = reconcile_active_bundle(ctx, &settings, &active)
+            .unwrap()
+            .unwrap();
+        assert_eq!(newer.version, "v1.1.0");
+        // The previous bundle's files survive the swap, so a tab still holding its
+        // content-hashed asset URLs keeps working until it reloads.
+        assert!(activated.root.join("index.html").is_file());
+
+        // Withdrawing the newest falls back to the older synced bundle, not the baseline.
+        set_active(ctx, &newer_id(ctx, "v1.1.0"), false).unwrap();
+        let fallen_back = reconcile_active_bundle(ctx, &settings, &active)
+            .unwrap()
+            .unwrap();
+        assert_eq!(fallen_back.version, "v1.0.0");
+
+        // Withdrawing them all falls back to the baseline.
+        set_active(ctx, &first.id, false).unwrap();
+        assert_eq!(
+            reconcile_active_bundle(ctx, &settings, &active).unwrap(),
+            None
+        );
+        assert_eq!(active.get(), None);
+    }
+
+    fn newer_id(ctx: &ServiceContext, version: &str) -> String {
+        all_bundles(ctx)
+            .unwrap()
+            .into_iter()
+            .find(|b| b.version == version)
+            .unwrap()
+            .id
+    }
+
+    /// Bytes that do not match the record's sha256 must never be served, and must not
+    /// wedge the site on a doomed retry loop.
+    #[actix_rt::test]
+    async fn reconcile_refuses_a_bundle_that_fails_its_checksum() {
+        let context = setup_all_and_service_provider(
+            "reconcile_refuses_a_bundle_that_fails_its_checksum",
+            MockDataInserts::none(),
+        )
+        .await;
+        let ctx = &context.service_context;
+
+        let dist_dir = tempfile::tempdir().unwrap();
+        let base_dir = tempfile::tempdir().unwrap();
+        write_dist(dist_dir.path(), "v1.0.0");
+        let settings = settings_for(&context, dist_dir.path(), base_dir.path());
+        let active = ActiveFrontendBundle::new();
+
+        let row = publish_from_frontend_dir(ctx, &settings)
+            .unwrap()
+            .row()
+            .clone();
+
+        // Corrupt the record's expectation, standing in for corrupt bytes on the wire.
+        FrontendBundleRowRepository::new(&ctx.connection)
+            .upsert_one(&FrontendBundleRow {
+                sha256: "0".repeat(64),
+                ..row.clone()
+            })
+            .unwrap();
+
+        // Serves the baseline rather than unverified bytes.
+        assert_eq!(
+            reconcile_active_bundle(ctx, &settings, &active).unwrap(),
+            None
+        );
+        assert_eq!(active.get(), None);
+        assert!(active::unpacked_root(&settings.server.base_dir, &row.version).is_none());
+
+        // The bad zip is discarded, so the download queue fetches it again rather than
+        // re-verifying the same corrupt file forever.
+        let references = SyncFileReferenceRowRepository::new(&ctx.connection)
+            .find_all_by_record_id(&row.id)
+            .unwrap();
+        let file_service = StaticFileService::new(&settings.server.base_dir).unwrap();
+        assert!(file_service
+            .find_file(
+                &references[0].id,
+                StaticFileCategory::SyncFile(FRONTEND_BUNDLE_TABLE.to_string(), row.id.clone())
+            )
+            .unwrap()
+            .is_none());
     }
 
     #[actix_rt::test]

--- a/server/service/src/processors/frontend_bundle/mod.rs
+++ b/server/service/src/processors/frontend_bundle/mod.rs
@@ -1,3 +1,3 @@
 mod frontend_bundle;
 
-pub(crate) use frontend_bundle::RequestFrontendBundleDownload;
+pub(crate) use frontend_bundle::{best_usable_bundle, RequestFrontendBundleDownload};

--- a/server/service/src/processors/mod.rs
+++ b/server/service/src/processors/mod.rs
@@ -21,7 +21,7 @@ use general_processor::{process_records, ProcessorError};
 mod assign_prescription_number;
 mod assign_requisition_number;
 mod contact_form;
-mod frontend_bundle;
+pub(crate) mod frontend_bundle;
 mod general_processor;
 mod load_plugin;
 mod merge_sync_message;

--- a/server/service/src/service_provider.rs
+++ b/server/service/src/service_provider.rs
@@ -10,6 +10,7 @@ use crate::{
     contact::{ContactService, ContactServiceTrait},
     contact_form::{ContactFormService, ContactFormServiceTrait},
     currency::{CurrencyService, CurrencyServiceTrait},
+    custom_field::{CustomFieldService, CustomFieldServiceTrait},
     dashboard::{
         invoice_count::{InvoiceCountService, InvoiceCountServiceTrait},
         item_count::{ItemCountServiceTrait, ItemServiceCount},
@@ -24,6 +25,7 @@ use crate::{
         form_schema_service::{FormSchemaService, FormSchemaServiceTrait},
     },
     email::{EmailService, EmailServiceTrait},
+    frontend_bundle::ActiveFrontendBundle,
     help_document::{HelpDocumentService, HelpDocumentServiceTrait},
     insurance::{InsuranceService, InsuranceServiceTrait},
     insurance_provider::{InsuranceProviderService, InsuranceProviderServiceTrait},
@@ -44,7 +46,6 @@ use crate::{
     pricing::{PricingService, PricingServiceTrait},
     printer::{PrinterService, PrinterServiceTrait},
     processors::ProcessorsTrigger,
-    custom_field::{CustomFieldService, CustomFieldServiceTrait},
     program::ProgramServiceTrait,
     programs::{
         contact_trace::{ContactTraceService, ContactTraceServiceTrait},
@@ -71,8 +72,8 @@ use crate::{
     site::{SiteService, SiteServiceTrait},
     standalone_central::{StandaloneCentralService, StandaloneCentralServiceTrait},
     standard_reports::StandardReports,
-    stock_relocation::{StockRelocationService, StockRelocationServiceTrait},
     stock_line::{StockLineService, StockLineServiceTrait},
+    stock_relocation::{StockRelocationService, StockRelocationServiceTrait},
     stocktake::{StocktakeService, StocktakeServiceTrait},
     stocktake_line::{StocktakeLineService, StocktakeLineServiceTrait},
     store::{get_store, get_stores},
@@ -198,6 +199,10 @@ pub struct ServiceProvider {
     pub contact_form_service: Box<dyn ContactFormServiceTrait>,
     // Cache
     pub(crate) frontend_plugins_cache: FrontendPluginCache,
+    /// The synced front-end bundle currently being served, if any. Read on every
+    /// asset request (cloned into the HTTP app data), so it is held here rather than
+    /// on `ServiceContext` — resolving it must never need a database connection.
+    pub active_frontend_bundle: ActiveFrontendBundle,
     // Preferences
     pub preference_service: Box<dyn PreferenceServiceTrait>,
     // VVM
@@ -345,6 +350,7 @@ impl ServiceProvider {
             insurance_provider_service: Box::new(InsuranceProviderService {}),
             printer_service: Box::new(PrinterService {}),
             frontend_plugins_cache: FrontendPluginCache::new(),
+            active_frontend_bundle: ActiveFrontendBundle::new(),
             preference_service: Box::new(PreferenceService {}),
             vvm_service: Box::new(VVMService {}),
             campaign_service: Box::new(CampaignService),

--- a/server/service/src/sync/file_sync_driver.rs
+++ b/server/service/src/sync/file_sync_driver.rs
@@ -30,6 +30,8 @@ pub enum FileSyncMessage {
 pub struct FileSyncDriver {
     receiver: Receiver<FileSyncMessage>,
     static_file_service: Arc<StaticFileService>,
+    /// Needed to verify and unpack a downloaded front-end bundle once its bytes land.
+    settings: Settings,
     /// Pause is a *state* (currently paused or not), not an event — `FileSyncTrigger::pause` /
     /// `unpause` write to this watch synchronously so the transition takes effect immediately
     /// even while the driver is mid-file. The chunk loop in `SyncApiV6::upload_file` reads the
@@ -68,6 +70,7 @@ impl FileSyncDriver {
             FileSyncDriver {
                 receiver,
                 static_file_service,
+                settings: settings.clone(),
                 pause_rx,
             },
         )
@@ -152,6 +155,32 @@ impl FileSyncDriver {
         }
     }
 
+    /// Verify and unpack a newly downloaded front-end bundle, and point serving at it.
+    ///
+    /// Deliberately best-effort: a bundle that can't be activated (bad checksum, bad
+    /// archive) must not stop file sync or take down the UI — the previous bundle, or the
+    /// packaged baseline, keeps serving and the failure is logged.
+    fn reconcile_frontend_bundle(&self, service_provider: &Arc<ServiceProvider>) {
+        let ctx = match service_provider.basic_context() {
+            Ok(ctx) => ctx,
+            Err(error) => {
+                log::error!("Cannot open a context to activate a bundle: {error:#?}");
+                return;
+            }
+        };
+
+        if let Err(error) = crate::frontend_bundle::reconcile_active_bundle(
+            &ctx,
+            &self.settings,
+            &service_provider.active_frontend_bundle,
+        ) {
+            log::error!(
+                "Could not resolve the active front-end bundle: {}",
+                format_error(&error)
+            );
+        }
+    }
+
     /// Drain one file from the background download queue. Returns how many remain
     /// queued, which the loop above uses to choose its next delay.
     pub async fn download(
@@ -162,7 +191,7 @@ impl FileSyncDriver {
         let synchroniser = FileSynchroniser::new(
             sync_v6_url,
             get_sync_settings(&service_provider),
-            service_provider,
+            service_provider.clone(),
             self.static_file_service.clone(),
         );
 
@@ -179,6 +208,12 @@ impl FileSyncDriver {
                 if remaining > 0 {
                     log::info!("{remaining} files still queued for download");
                 }
+
+                // A download may have completed a front-end bundle. Reconciling is cheap
+                // and idempotent when it hasn't, and this is the only moment the bytes
+                // can newly be available without a restart.
+                self.reconcile_frontend_bundle(&service_provider);
+
                 remaining
             }
             Err(error) => {


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12622 — the last piece. The parts existed (a record, bytes arriving in the background) but nothing turned them into the front end the server actually serves.

**Activation** verifies the downloaded zip against the `sha256` the record carries, then unpacks stage-then-swap into `<base_dir>/frontend_bundles/` — **never** into `frontend_dir`, because on Android the app shell deletes and re-copies `<filesDir>/frontend` from the APK on every app-version change, so a bundle stored there would be destroyed by each upgrade. `frontend_dir` stays the installer-shipped baseline and the fallback.

**`reconcile_active_bundle`** runs the selection rule from the spec — of the active, `server_version`-compatible bundles take the highest `version`; serve it if its bytes verify, else the baseline — at startup and after each download. Idempotent, and it never leaves the UI worse than it found it: a candidate that fails its checksum or its unpack logs and leaves the previous bundle (or baseline) serving. A failed checksum also discards the bytes, so the queue refetches rather than re-verifying the same corrupt file forever.

**Serving** reads the active bundle from an `Arc<RwLock<..>>` on `ServiceProvider`, cloned into the HTTP app data.

## 💌 Any notes for the reviewer?

**Last in a 5-PR stack; targets `12622-fe-sync-download`.** After this merges the feature is live end-to-end.

- **The cache is on `ServiceProvider`, not `ServiceContext`** — deliberately. Resolving an asset root must not take a database connection per request, and `ServiceContext` is constructed per request with a fresh connection.
- **Fallback is per *asset*, not per request.** A tab still on the previous bundle may ask for one of its content-hashed assets; that's also why retention keeps the previous unpacked bundle instead of deleting it on swap (`RETAINED_BUNDLES = 2`).
- **`/old-ui/` is always served from `frontend_dir`** and can never be affected by a synced bundle — it's the escape hatch when the synced front end is broken.
- **A real bug this surfaced:** `read_asset` canonicalises the asset path and checks it's still inside the root, so an un-canonicalised bundle root fails for *every* asset — silently serving nothing. That would bite any symlinked data directory (and `/tmp` on macOS). Roots are canonicalised when stored.
- **Unpacking refuses zip-slip entries**, and a bundle version that isn't plainly safe as a single path component is rejected rather than sanitised (quietly rewriting it could collapse two versions onto one directory). A bundle arrives over authenticated sync, but it's still archive data from off-box unpacked with server privileges.
- **One test expectation I inverted on purpose.** I'd assumed a directory whose bundle record was deleted should be reclaimed immediately; the test failed and the code was right. Retention protects open tabs, which still need those assets regardless of what central deleted. Unknown directories now rank *below* known bundles for the retained slot but aren't deleted merely for lacking a record.
- **Still to come (not in this stack):** proactive "new version available" notification and user-triggered reload are front-end work in the FE repo. The server side of it is that `/VERSION.txt` already reflects the served bundle. Note `staleBundle.ts` will usually *not* fire for us, since retaining the previous bundle means its chunks don't 404.

# 🧪 Tested

- `cargo nextest run -p service frontend_bundle` — 31 passed, including the full cycle: nothing published → baseline; publish → activates, unpacked under `base_dir` and not in `frontend_dir`, no `old-ui` in the bundle; idempotent re-run; newer bundle wins and the previous bundle's files survive the swap; withdrawing the newest falls back to the older *synced* bundle; withdrawing all falls back to the baseline. Plus: a bundle failing its checksum serves the baseline, doesn't unpack, and has its bytes discarded so the queue refetches.
- Activation unit tests: zip-slip refused; nested entries written; unsafe versions rejected (`../etc`, `a/b`, `..`, `""`, spaces …); `unpacked_root` requires an `index.html` so a half-populated directory is never served; pruning keeps active + one more (ranked by *version* order, so `1.10.0` beats `1.2.0`), leaves `.tmp` staging alone, and ranks recordless directories last.
- `cargo nextest run -p server serve_frontend` — 5 passed: active bundle preferred over baseline while `/old-ui/` stays on the baseline; an asset missing from the bundle falls back rather than 404ing.
- `cargo nextest run -p repository -p service -p server` — **1173 passed**. `-p graphql` — 3 passed.
- `cargo nextest run -p repository --features postgres --test-threads 1 migration_3_00_00 integration_order` — 8 passed.
- `cargo build` and `cargo build --features postgres`.
- Manual end-to-end testing to follow (central publishes on startup → remote syncs → downloads → activates; `GET /VERSION.txt` on the remote reports the live bundle; `setFrontendBundleActive(id, false)` on central makes it fall back).

# 📃 Documentation

- [x] **Part of an epic** — documentation will be completed for the feature as a whole