### PR TITLE
Frontend sync: fixes from testing and review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ server/target-postgres/
 
 # Playwright MCP scratch logs / page dumps
 .playwright-mcp/
+server/central_app_data/

--- a/docs/content/docs/sync/sync_styles/_index.md
+++ b/docs/content/docs/sync/sync_styles/_index.md
@@ -79,7 +79,6 @@ The split between `Remote` and `RemoteOwned` is about write authority, not routi
 | **OMS-native** | Lives on the v6 transport. |
 | **both** | Tagged for both v5 and v6 (only `Name`). |
 | **v7-only** | Tagged for neither v5 nor v6 — the table has no legacy counterpart, so it only ever travels on v7. |
-| (no v7 tag) | v7 covers every table that has any sync style. |
 
 Filters that ask for "v6 only" pull just the OMS-native tables. Filters that ask for "v5 only" pull just the legacy-only tables. Filters that pass no transport flag (used by v7) pull every table that has any sync style.
 

--- a/server/repository/src/db_diesel/frontend_bundle_row.rs
+++ b/server/repository/src/db_diesel/frontend_bundle_row.rs
@@ -257,6 +257,45 @@ mod test {
         assert_eq!(repo.find_one_by_id(&row.id), Ok(None));
     }
 
+    /// A version identifies at most one bundle. Publishing keys its "already published?"
+    /// guard on this, and a bundle unpacks to a directory named after its version, so two
+    /// rows sharing one would make the guard ambiguous and collide on disk.
+    #[actix_rt::test]
+    async fn frontend_bundle_version_is_unique() {
+        let (_, connection, _, _) =
+            setup_all("frontend_bundle_version_is_unique", MockDataInserts::none()).await;
+        let repo = FrontendBundleRowRepository::new(&connection);
+
+        let first = test_row();
+        repo.upsert_one(&first).unwrap();
+
+        // A different bundle claiming the same version is refused by the database, not
+        // merely avoided by the call sites that happen to check first.
+        let duplicate = FrontendBundleRow {
+            id: uuid(),
+            ..first.clone()
+        };
+        assert!(
+            repo.upsert_one(&duplicate).is_err(),
+            "a second bundle with version {} should not be insertable",
+            first.version
+        );
+
+        // Re-upserting the *same* bundle is still fine — that is the idempotent path
+        // publishing and sync integration both rely on.
+        repo.upsert_one(&first).unwrap();
+
+        // And the version is reusable once the original is gone.
+        repo.delete(&first.id).unwrap();
+        repo.upsert_one(&duplicate).unwrap();
+        assert_eq!(
+            repo.find_one_by_version(&first.version)
+                .unwrap()
+                .map(|b| b.id),
+            Some(duplicate.id)
+        );
+    }
+
     #[actix_rt::test]
     async fn frontend_bundle_writes_changelog_on_upsert_and_delete() {
         let (_, connection, _, _) = setup_all(

--- a/server/repository/src/db_diesel/sync_file_reference_row.rs
+++ b/server/repository/src/db_diesel/sync_file_reference_row.rs
@@ -261,23 +261,37 @@ impl<'a> SyncFileReferenceRowRepository<'a> {
     /// Files this site has asked to hold and does not have yet — the background download
     /// queue drained by the file sync driver.
     ///
-    /// Mirrors [`Self::find_all_to_upload`], with one extra condition: a request datetime
-    /// must be set. Without it this would return every reference on the site, since
-    /// references broadcast everywhere and default to `Download`. `InProgress` is
-    /// included so a download interrupted by a restart is resumed rather than stranded.
-    pub fn find_all_to_download(&self) -> Result<Vec<SyncFileReferenceRow>, RepositoryError> {
+    /// Filtered entirely on **local** columns, which is the important difference from
+    /// [`Self::find_all_to_upload`]. `status` deliberately plays no part: it is the
+    /// *origin's* upload state, and it crosses sync. A file published by central arrives
+    /// here already `Done` (central holds the bytes — it must say so, or it would try to
+    /// upload the file to itself), which says nothing about whether *this* site has them.
+    /// Filtering on it would leave the queue permanently empty.
+    ///
+    /// So:
+    /// - `download_requested_datetime` — this site decided it wants the file. Without it
+    ///   this would return every reference on the site, since references broadcast
+    ///   everywhere and default to `Download`.
+    /// - `downloaded_bytes < total_bytes` — we don't have all of it yet. Set to
+    ///   `total_bytes` on success, so a completed file leaves the queue, and to the
+    ///   partial offset on failure, so a resumable download stays in it. Implies
+    ///   `total_bytes > 0`: a reference with no declared size is not background-
+    ///   downloadable (the on-demand path still serves it).
+    /// - `retry_at` — local backoff. Null for a file never attempted.
+    /// - `retries < max_retries` — give up eventually. Also local: the caller owns the cap,
+    ///   since it owns the retry schedule. Without this the queue would spin forever on a
+    ///   file that can never arrive.
+    pub fn find_all_to_download(
+        &self,
+        max_retries: i32,
+    ) -> Result<Vec<SyncFileReferenceRow>, RepositoryError> {
         let result = sync_file_reference
             .filter(deleted_datetime.is_null())
             .filter(direction.eq(SyncFileDirection::Download))
             .filter(download_requested_datetime.is_not_null())
-            .filter(
-                status
-                    .eq(SyncFileStatus::New)
-                    .or(status.eq(SyncFileStatus::InProgress))
-                    .or(status
-                        .eq(SyncFileStatus::Error)
-                        .and(retry_at.lt(diesel::dsl::now))),
-            )
+            .filter(downloaded_bytes.lt(total_bytes))
+            .filter(retry_at.is_null().or(retry_at.lt(diesel::dsl::now)))
+            .filter(retries.lt(max_retries))
             .order_by(created_datetime.asc())
             .load(self.connection.lock().connection())?;
         Ok(result)
@@ -378,9 +392,12 @@ mod test {
         }
     }
 
+    /// Matches the service layer's MAX_UPLOAD_ATTEMPTS closely enough for these tests.
+    const MAX_RETRIES: i32 = 168;
+
     fn queued_ids(connection: &StorageConnection) -> Vec<String> {
         SyncFileReferenceRowRepository::new(connection)
-            .find_all_to_download()
+            .find_all_to_download(MAX_RETRIES)
             .unwrap()
             .into_iter()
             .map(|r| r.id)
@@ -446,10 +463,15 @@ mod test {
         assert_eq!(first, second);
     }
 
+    /// Queueing is decided by local state only, and specifically **not** by `status`.
+    ///
+    /// This is the bug this test exists to pin: `status` is the origin's upload state and
+    /// it crosses sync, so a file central published arrives here already `Done`. Filtering
+    /// on it left the queue permanently empty and no remote ever downloaded a bundle.
     #[actix_rt::test]
-    async fn download_queue_respects_status_and_retry_schedule() {
+    async fn download_queue_ignores_the_synced_status() {
         let (_, connection, _, _) = setup_all(
-            "download_queue_respects_status_and_retry_schedule",
+            "download_queue_ignores_the_synced_status",
             MockDataInserts::none(),
         )
         .await;
@@ -460,52 +482,84 @@ mod test {
         repo.request_download(&row.id).unwrap();
         let requested = repo.find_one_by_id(&row.id).unwrap().unwrap();
 
-        // Done: nothing more to fetch.
+        // Whatever the origin says about its own upload, we still need the bytes.
+        for synced_status in [
+            SyncFileStatus::New,
+            SyncFileStatus::InProgress,
+            SyncFileStatus::Done,
+            SyncFileStatus::Error,
+        ] {
+            repo.upsert_without_changelog(&SyncFileReferenceRow {
+                status: synced_status.clone(),
+                ..requested.clone()
+            })
+            .unwrap();
+            assert_eq!(
+                queued_ids(&connection),
+                vec![row.id.clone()],
+                "status {:?} must not affect queueing",
+                synced_status
+            );
+        }
+    }
+
+    #[actix_rt::test]
+    async fn download_queue_tracks_local_completion_and_backoff() {
+        let (_, connection, _, _) = setup_all(
+            "download_queue_tracks_local_completion_and_backoff",
+            MockDataInserts::none(),
+        )
+        .await;
+        let repo = SyncFileReferenceRowRepository::new(&connection);
+
+        let row = reference(SyncFileDirection::Download);
+        repo.upsert_one(&row).unwrap();
+        repo.request_download(&row.id).unwrap();
+        let requested = repo.find_one_by_id(&row.id).unwrap().unwrap();
+        assert_eq!(queued_ids(&connection), vec![row.id.clone()]);
+
+        // Fully downloaded: leaves the queue.
         repo.upsert_without_changelog(&SyncFileReferenceRow {
-            status: SyncFileStatus::Done,
+            downloaded_bytes: requested.total_bytes,
             ..requested.clone()
         })
         .unwrap();
         assert!(queued_ids(&connection).is_empty());
 
-        // InProgress: included, so a download interrupted by a restart is resumed
-        // rather than stranded.
+        // Partially downloaded: stays queued, so the transfer resumes.
         repo.upsert_without_changelog(&SyncFileReferenceRow {
-            status: SyncFileStatus::InProgress,
+            downloaded_bytes: requested.total_bytes / 2,
             ..requested.clone()
         })
         .unwrap();
         assert_eq!(queued_ids(&connection), vec![row.id.clone()]);
 
-        // Error with a future retry_at: waiting out its backoff.
+        // Backoff not yet elapsed.
         repo.upsert_without_changelog(&SyncFileReferenceRow {
-            status: SyncFileStatus::Error,
             retry_at: Some(chrono::Utc::now().naive_utc() + chrono::Duration::hours(1)),
             ..requested.clone()
         })
         .unwrap();
         assert!(queued_ids(&connection).is_empty());
 
-        // Error with retry_at in the past: due for another attempt.
+        // Backoff elapsed: due for another attempt.
         repo.upsert_without_changelog(&SyncFileReferenceRow {
-            status: SyncFileStatus::Error,
             retry_at: Some(chrono::Utc::now().naive_utc() - chrono::Duration::minutes(1)),
             ..requested.clone()
         })
         .unwrap();
         assert_eq!(queued_ids(&connection), vec![row.id.clone()]);
 
-        // PermanentFailure: given up on, never retried.
+        // Out of attempts: given up on, so the queue doesn't spin on it forever.
         repo.upsert_without_changelog(&SyncFileReferenceRow {
-            status: SyncFileStatus::PermanentFailure,
+            retries: MAX_RETRIES,
             ..requested.clone()
         })
         .unwrap();
         assert!(queued_ids(&connection).is_empty());
 
-        // Soft-deleted rows drop out regardless of status.
+        // Soft-deleted drops out.
         repo.upsert_without_changelog(&SyncFileReferenceRow {
-            status: SyncFileStatus::New,
             deleted_datetime: Some(chrono::Utc::now().naive_utc()),
             ..requested
         })
@@ -544,5 +598,35 @@ mod test {
         // And the direction stays local too, so a bundle we asked for keeps being a
         // download rather than flipping to an upload.
         assert_eq!(merged.direction, SyncFileDirection::Download);
+    }
+
+    /// What a remote actually receives: central publishes the bundle's file reference with
+    /// status Done (it must, or central tries to upload the file to itself), and `status`
+    /// crosses the v7 wire. So the remote's copy is Done before it has any bytes.
+    #[actix_rt::test]
+    async fn a_reference_that_arrived_as_done_is_still_downloadable() {
+        let (_, connection, _, _) = setup_all(
+            "a_reference_that_arrived_as_done_is_still_downloadable",
+            MockDataInserts::none(),
+        )
+        .await;
+        let repo = SyncFileReferenceRowRepository::new(&connection);
+
+        // Exactly the row shape a remote ends up with after pulling central's reference:
+        // synced status Done + total_bytes, no local bytes yet.
+        let row = SyncFileReferenceRow {
+            status: SyncFileStatus::Done,
+            downloaded_bytes: 0,
+            total_bytes: 1024,
+            ..reference(SyncFileDirection::Download)
+        };
+        repo.upsert_one(&row).unwrap();
+        repo.request_download(&row.id).unwrap();
+
+        assert_eq!(
+            queued_ids(&connection),
+            vec![row.id.clone()],
+            "a requested bundle whose bytes are not here yet must be queued"
+        );
     }
 }

--- a/server/repository/src/migrations/v3_00_00/add_frontend_bundle_version_unique.rs
+++ b/server/repository/src/migrations/v3_00_00/add_frontend_bundle_version_unique.rs
@@ -1,0 +1,39 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "add_frontend_bundle_version_unique"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // Three things already assume a version identifies at most one bundle, and until
+        // now nothing enforced it:
+        //
+        // - publishing treats "a row with this version exists" as "already published", so
+        //   a duplicate would make that guard ambiguous;
+        // - `find_one_by_version` has no ORDER BY, so with duplicates it returns an
+        //   arbitrary row;
+        // - a bundle unpacks to a directory named after its version, so two bundles
+        //   sharing one would collide on disk.
+        //
+        // Central prevents duplicates today (both publish paths check first, and bundles
+        // are central-authored), so this is not fixing a live bug — it turns an assumption
+        // three call sites happen to respect into one the database guarantees. If a
+        // duplicate ever does arrive over sync, integration fails loudly for that one
+        // record rather than silently producing two bundles claiming the same version.
+        //
+        // Added as its own fragment rather than folded into `add_frontend_bundle_table`:
+        // that fragment has already run on development databases, so editing it would
+        // leave them without the constraint and enforce it only on fresh installs.
+        sql!(
+            connection,
+            r#"
+            CREATE UNIQUE INDEX index_frontend_bundle_version ON frontend_bundle (version);
+            "#
+        )?;
+
+        Ok(())
+    }
+}

--- a/server/repository/src/migrations/v3_00_00/mod.rs
+++ b/server/repository/src/migrations/v3_00_00/mod.rs
@@ -42,6 +42,7 @@ mod reintegrate_items_for_custom_field_options;
 mod reintegrate_label_prefs_for_custom_field_names;
 mod reintegrate_transaction_categories_for_custom_field_options;
 mod remove_add_central_patient_visibility_processor_cursor;
+mod seed_frontend_bundle_processor_cursor;
 mod seed_sync_request_user_tables;
 mod update_changelog_for_sync_v7;
 
@@ -104,6 +105,10 @@ impl Migration for V3_00_00 {
             Box::new(add_sync_file_download_request::Migrate),
             // Must follow add_frontend_bundle_table.
             Box::new(add_frontend_bundle_version_unique::Migrate),
+            // Must follow add_sync_file_download_request, and be a fragment of its own:
+            // Postgres won't let a transaction use an enum value that same transaction
+            // added, and that fragment is what adds FRONTEND_BUNDLE_PROCESSOR_CURSOR.
+            Box::new(seed_frontend_bundle_processor_cursor::Migrate),
         ]
     }
 }

--- a/server/repository/src/migrations/v3_00_00/mod.rs
+++ b/server/repository/src/migrations/v3_00_00/mod.rs
@@ -4,6 +4,7 @@ use crate::StorageConnection;
 mod add_changelog_dedup_cursor_key_type;
 mod add_custom_field_sort_order;
 mod add_frontend_bundle_table;
+mod add_frontend_bundle_version_unique;
 mod add_invoice_custom_fields;
 mod add_is_standalone_central_pg_enum;
 mod add_item_custom_fields;
@@ -101,6 +102,8 @@ impl Migration for V3_00_00 {
             Box::new(add_sync_batch_size_key_value_store::Migrate),
             Box::new(add_frontend_bundle_table::Migrate),
             Box::new(add_sync_file_download_request::Migrate),
+            // Must follow add_frontend_bundle_table.
+            Box::new(add_frontend_bundle_version_unique::Migrate),
         ]
     }
 }

--- a/server/repository/src/migrations/v3_00_00/seed_frontend_bundle_processor_cursor.rs
+++ b/server/repository/src/migrations/v3_00_00/seed_frontend_bundle_processor_cursor.rs
@@ -15,13 +15,17 @@ impl MigrationFragment for Migrate {
         // history on first start to reach the only rows it can act on, which are all in the
         // future. Seed it so it starts where the work actually is.
         //
-        // Earliest frontend_bundle row minus one if any exist (so that row is still seen —
-        // the processor's filter is `cursor > stored`), otherwise the current end of the
-        // changelog. The first branch cannot fire on a normal upgrade: the table is created
-        // by `add_frontend_bundle_table` in this same batch, and the changelog-populating
-        // fragments ran before it, so there are no frontend_bundle rows yet. It is here so
-        // the seed stays correct if that ever stops being true, rather than silently
-        // skipping bundles.
+        // Seeding to the current end of the changelog skips no bundle, because at this point
+        // no bundle can have a changelog row yet: `frontend_bundle` is created by
+        // `add_frontend_bundle_table` in this same batch, after the fragments that populate
+        // the changelog for v7 tables.
+        //
+        // A site part-way through an upgrade may well be *holding* a frontend_bundle record —
+        // sync could have put one in its sync buffer before the restart — but a buffered
+        // record is not an integrated one. Integration runs after migrations, and it is
+        // integration that writes the changelog row, which therefore lands beyond this seed
+        // and is picked up normally. The buffer is why "seed to the end" is safe rather than
+        // merely convenient.
         //
         // Kept apart from `add_sync_file_download_request`, which adds the
         // FRONTEND_BUNDLE_PROCESSOR_CURSOR value to the `key_type` enum, because Postgres
@@ -33,10 +37,7 @@ impl MigrationFragment for Migrate {
             INSERT INTO key_value_store (id, value_int)
             SELECT
                 'FRONTEND_BUNDLE_PROCESSOR_CURSOR',
-                COALESCE(
-                    (SELECT MIN(cursor) - 1 FROM changelog WHERE table_name = 'frontend_bundle'),
-                    (SELECT COALESCE(MAX(cursor), 0) FROM changelog)
-                )
+                COALESCE((SELECT MAX(cursor) FROM changelog), 0)
             WHERE NOT EXISTS (
                 SELECT 1 FROM key_value_store WHERE id = 'FRONTEND_BUNDLE_PROCESSOR_CURSOR'
             );

--- a/server/repository/src/migrations/v3_00_00/seed_frontend_bundle_processor_cursor.rs
+++ b/server/repository/src/migrations/v3_00_00/seed_frontend_bundle_processor_cursor.rs
@@ -1,0 +1,119 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "seed_frontend_bundle_processor_cursor"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // A processor with no stored cursor starts at 0 and walks the changelog from the
+        // beginning. The frontend_bundle processor listens on `frontend_bundle` AND
+        // `sync_file_reference`, and an established site can hold a very large number of
+        // the latter — so an unseeded cursor means chewing through the site's entire file
+        // history on first start to reach the only rows it can act on, which are all in the
+        // future. Seed it so it starts where the work actually is.
+        //
+        // Earliest frontend_bundle row minus one if any exist (so that row is still seen —
+        // the processor's filter is `cursor > stored`), otherwise the current end of the
+        // changelog. The first branch cannot fire on a normal upgrade: the table is created
+        // by `add_frontend_bundle_table` in this same batch, and the changelog-populating
+        // fragments ran before it, so there are no frontend_bundle rows yet. It is here so
+        // the seed stays correct if that ever stops being true, rather than silently
+        // skipping bundles.
+        //
+        // Kept apart from `add_sync_file_download_request`, which adds the
+        // FRONTEND_BUNDLE_PROCESSOR_CURSOR value to the `key_type` enum, because Postgres
+        // refuses to *use* a new enum value in the transaction that added it — and each
+        // migration fragment runs in its own transaction.
+        sql!(
+            connection,
+            r#"
+            INSERT INTO key_value_store (id, value_int)
+            SELECT
+                'FRONTEND_BUNDLE_PROCESSOR_CURSOR',
+                COALESCE(
+                    (SELECT MIN(cursor) - 1 FROM changelog WHERE table_name = 'frontend_bundle'),
+                    (SELECT COALESCE(MAX(cursor), 0) FROM changelog)
+                )
+            WHERE NOT EXISTS (
+                SELECT 1 FROM key_value_store WHERE id = 'FRONTEND_BUNDLE_PROCESSOR_CURSOR'
+            );
+            "#
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        migrations::{v2_18_00::V2_18_00, v3_00_00::V3_00_00, *},
+        test_db::*,
+    };
+    use diesel::{sql_types::BigInt, QueryableByName, RunQueryDsl};
+
+    #[derive(QueryableByName)]
+    struct BigintValue {
+        #[diesel(sql_type = BigInt)]
+        value: i64,
+    }
+
+    fn scalar(connection: &StorageConnection, query: &str) -> i64 {
+        diesel::sql_query(query)
+            .get_result::<BigintValue>(connection.lock().connection())
+            .unwrap()
+            .value
+    }
+
+    /// An established site upgrading must not leave the frontend_bundle processor at 0:
+    /// it listens on `sync_file_reference` as well as `frontend_bundle`, so it would walk
+    /// the site's entire file history on first start to reach rows that are all still in
+    /// the future.
+    #[actix_rt::test]
+    async fn seeds_cursor_to_the_end_of_the_changelog() {
+        let SetupResult { connection, .. } = setup_test(SetupOption {
+            db_name: "migration_seed_frontend_bundle_processor_cursor",
+            version: Some(V2_18_00.version()),
+            ..Default::default()
+        })
+        .await;
+
+        // Pre-existing history, of the kind this processor would otherwise chew through.
+        // record_ids reference nothing, so later v3 fragments skip these rows.
+        diesel::sql_query(
+            "INSERT INTO changelog (table_name, record_id, row_action) VALUES
+                ('sync_file_reference', 'file_a', 'UPSERT'),
+                ('sync_file_reference', 'file_b', 'UPSERT'),
+                ('sync_file_reference', 'file_c', 'UPSERT')",
+        )
+        .execute(connection.lock().connection())
+        .unwrap();
+
+        migrate(
+            &connection,
+            Some(V3_00_00.version()),
+            MigrationConfig::default(),
+        )
+        .unwrap();
+
+        let max_cursor = scalar(
+            &connection,
+            "SELECT CAST(COALESCE(MAX(cursor), 0) AS BIGINT) AS value FROM changelog",
+        );
+        // Guards against the assertion below passing vacuously on an empty changelog.
+        assert!(max_cursor > 0, "expected changelog history to exist");
+
+        let seeded = scalar(
+            &connection,
+            "SELECT CAST(value_int AS BIGINT) AS value FROM key_value_store \
+             WHERE id = 'FRONTEND_BUNDLE_PROCESSOR_CURSOR'",
+        );
+        assert_eq!(
+            seeded, max_cursor,
+            "processor should start at the end of the changelog, not walk it from 0"
+        );
+    }
+}

--- a/server/server/src/serve_frontend.rs
+++ b/server/server/src/serve_frontend.rs
@@ -10,6 +10,10 @@ use service::{frontend_bundle::ActiveFrontendBundle, settings::Settings};
 use std::path::{Path, PathBuf};
 
 const INDEX: &str = "index.html";
+/// Version marker inside every front-end dist, served at `/VERSION.txt` so a deployed
+/// version stays inspectable — and so a running client can tell when the served bundle has
+/// been swapped underneath it (front-end sync, #12622).
+const VERSION_FILE: &str = "VERSION.txt";
 const CACHE_MAX_AGE: u32 = 365 * 60 * 60 * 24; // 1 year
 
 /// Read a frontend asset, preferring a synced bundle over the packaged baseline.
@@ -79,12 +83,18 @@ fn old_ui_frontend_root(settings: &Settings) -> Option<PathBuf> {
     frontend_root(settings)?.join("old-ui").canonicalize().ok()
 }
 
-/// Cache-control for a frontend asset by path. The index and translation files
-/// can change so we don't want to cache them; everything else is static and
-/// cached for a year. (config.js technically shouldn't change either but if it
-/// did we'd want to pick it up immediately, hence no-cache on index.)
+/// Cache-control for a frontend asset by path. The index, the version marker and the
+/// translation files can change so we don't want to cache them; everything else is static
+/// and cached for a year. (config.js technically shouldn't change either but if it did we'd
+/// want to pick it up immediately, hence no-cache on index.)
+///
+/// `VERSION.txt` is the one clients poll to notice the served bundle has been swapped, and
+/// it is *the same URL* across bundles — unlike the content-hashed assets, there is no new
+/// URL to force a refetch. Cached for a year it would answer with the version that was live
+/// when the client first asked, defeating both the polling and the "deployed versions stay
+/// inspectable" intent it was published for.
 fn cache_control_for(path: &str) -> header::CacheControl {
-    if path == INDEX {
+    if path == INDEX || path == VERSION_FILE {
         header::CacheControl(vec![header::CacheDirective::NoCache])
     } else if path.starts_with("locales/") {
         // Translation json files: cached in local storage in the frontend and
@@ -356,6 +366,56 @@ mod test {
             body
         );
         assert!(!body.contains("NEW index"));
+    }
+
+    /// The version marker must not be cached. It is the one URL a client polls to notice
+    /// the served bundle has been swapped, and unlike the content-hashed assets it keeps
+    /// the same URL across bundles — so there is no new URL to force a refetch. A long
+    /// cache would pin a client to whatever version was live when it first asked.
+    #[actix_web::test]
+    async fn version_file_is_not_cached() {
+        let dir = TempDir::new().unwrap();
+        write_dist(dir.path(), "NEW");
+        fs::write(dir.path().join("VERSION.txt"), "version: v1.2.3\n").unwrap();
+
+        let settings = settings_with(dir.path());
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(settings))
+                .app_data(Data::new(ActiveFrontendBundle::new()))
+                .configure(config_serve_frontend),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get().uri("/VERSION.txt").to_request(),
+        )
+        .await;
+        let cache = resp
+            .headers()
+            .get("cache-control")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(cache.contains("no-cache"), "got {}", cache);
+        assert!(body_string(resp).await.contains("v1.2.3"));
+
+        // Content-hashed assets keep their long cache — a new bundle gives them new URLs.
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get().uri("/assets/x.js").to_request(),
+        )
+        .await;
+        let cache = resp
+            .headers()
+            .get("cache-control")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(cache.contains("max-age=31536000"), "got {}", cache);
     }
 
     #[actix_web::test]

--- a/server/service/src/frontend_bundle/active.rs
+++ b/server/service/src/frontend_bundle/active.rs
@@ -271,7 +271,7 @@ pub fn prune_unpacked(base_dir: &str, keep_first: Option<&str>, known: &[Fronten
         known
             .iter()
             .find(|b| dir_name_for(&b.version).ok().as_deref() == Some(name.as_str()))
-            .map(|b| repository::migrations::Version::from_str(&b.version))
+            .map(|b| super::parse_version(&b.version))
     };
     present.sort_by(|a, b| rank(b).cmp(&rank(a)));
 

--- a/server/service/src/frontend_bundle/active.rs
+++ b/server/service/src/frontend_bundle/active.rs
@@ -404,7 +404,10 @@ mod test {
 
         std::fs::write(dir.join("index.html"), "<html></html>").unwrap();
         // Canonical, so serving's path-traversal check compares like with like.
-        assert_eq!(unpacked_root(&base, "v1.0.0"), Some(dir.canonicalize().unwrap()));
+        assert_eq!(
+            unpacked_root(&base, "v1.0.0"),
+            Some(dir.canonicalize().unwrap())
+        );
     }
 
     fn row(version: &str) -> FrontendBundleRow {

--- a/server/service/src/frontend_bundle/mod.rs
+++ b/server/service/src/frontend_bundle/mod.rs
@@ -232,21 +232,31 @@ pub(crate) fn parse_version(raw: &str) -> Version {
 /// There is no upper bound, matching `is_compatible_by_major_and_minor` everywhere else: a
 /// server 4.0 release is expected to ship a 4.0-compatible front end, so the newest
 /// compatible bundle is the right one. `is_active` is the manual override when it isn't.
-pub fn best_usable_bundle(
+pub fn usable_bundles(
     connection: &StorageConnection,
-) -> Result<Option<FrontendBundleRow>, RepositoryError> {
+) -> Result<Vec<FrontendBundleRow>, RepositoryError> {
     let app_version = Version::from_package_json();
 
-    let best = FrontendBundleRowRepository::new(connection)
+    let mut bundles: Vec<FrontendBundleRow> = FrontendBundleRowRepository::new(connection)
         .all()?
         .into_iter()
         .filter(|bundle| bundle.is_active)
         .filter(|bundle| {
             parse_version(&bundle.server_version).is_compatible_by_major_and_minor(&app_version)
         })
-        .max_by(|a, b| parse_version(&a.version).cmp(&parse_version(&b.version)));
+        .collect();
 
-    Ok(best)
+    // Newest first.
+    bundles.sort_by(|a, b| parse_version(&b.version).cmp(&parse_version(&a.version)));
+    Ok(bundles)
+}
+
+/// The newest bundle this site could run — the one worth downloading. Serving picks from
+/// [`usable_bundles`] instead, because the newest is not necessarily *here* yet.
+pub fn best_usable_bundle(
+    connection: &StorageConnection,
+) -> Result<Option<FrontendBundleRow>, RepositoryError> {
+    Ok(usable_bundles(connection)?.into_iter().next())
 }
 
 /// Outcome of asking for a bundle's bytes.
@@ -304,9 +314,12 @@ pub(crate) fn request_bundle_download(
 /// bytes are downloaded and verified, serve it; otherwise serve the installer-shipped
 /// baseline in `frontend_dir`.
 ///
-/// A bundle that is the best candidate but not yet usable does **not** fall back to an
-/// older synced bundle: the older one keeps serving until the new one is genuinely ready,
-/// which is what makes activation a swap rather than a gap.
+/// "Downloaded and verified" is part of the filter, not an afterthought: the newest
+/// *candidate* is not necessarily the newest one that is actually here. A bundle still in
+/// flight — or one that can never arrive, because its bytes were withdrawn or fail their
+/// checksum — must not mask an older bundle that is unpacked and ready, or the site sits on
+/// the packaged baseline while a good bundle goes unused. The newest candidate is still
+/// requested for download on every pass, so the site catches up as soon as it can.
 pub fn reconcile_active_bundle(
     ctx: &ServiceContext,
     settings: &Settings,
@@ -315,8 +328,9 @@ pub fn reconcile_active_bundle(
     let base_dir = &settings.server.base_dir;
     let all = FrontendBundleRowRepository::new(&ctx.connection).all()?;
     let previous = active.get();
+    let candidates = usable_bundles(&ctx.connection)?;
 
-    let Some(best) = best_usable_bundle(&ctx.connection)? else {
+    let Some(best) = candidates.first() else {
         // Nothing usable — serve the baseline. This is also the withdrawal path: central
         // clears is_active and the site drops back.
         if previous.is_some() {
@@ -327,59 +341,88 @@ pub fn reconcile_active_bundle(
         return Ok(None);
     };
 
-    // Already unpacked (e.g. from a previous run) — nothing to do but point at it.
-    let root = match active::unpacked_root(base_dir, &best.version) {
-        Some(root) => root,
-        None => {
-            // Not unpacked, so we need its bytes. Make sure they're queued — this is the
-            // guarantee, not the changelog processor: a trigger fires once and can fire
-            // before the file reference has arrived, whereas this runs at startup and
-            // after every download pass until the bundle is actually here.
-            match request_bundle_download(ctx, &best) {
-                Ok(DownloadRequest::Queued) | Ok(DownloadRequest::AuthoredHere) => {}
-                Ok(DownloadRequest::NoFileReference) => log::debug!(
-                    "Front-end bundle {} has no file reference yet",
-                    best.version
-                ),
-                Err(error) => log::error!(
-                    "Could not queue front-end bundle {} for download: {}",
-                    best.version,
-                    format_error(&error)
-                ),
-            }
+    // Always chase the newest candidate, whether or not it is the one we can serve today.
+    // This is the guarantee that the bytes get requested, not the changelog processor: a
+    // trigger fires once and can fire before the file reference has arrived, whereas this
+    // runs at startup and after every download pass until the bundle is actually here.
+    match request_bundle_download(ctx, best) {
+        Ok(DownloadRequest::Queued) | Ok(DownloadRequest::AuthoredHere) => {}
+        Ok(DownloadRequest::NoFileReference) => {
+            log::debug!(
+                "Front-end bundle {} has no file reference yet",
+                best.version
+            )
+        }
+        Err(error) => log::error!(
+            "Could not queue front-end bundle {} for download: {}",
+            best.version,
+            format_error(&error)
+        ),
+    }
 
-            let file_service = match StaticFileService::new(base_dir) {
-                Ok(service) => service,
-                Err(error) => {
-                    log::error!("Cannot access static files: {:#}", error);
-                    return Ok(previous);
-                }
-            };
-
-            match active::verify_and_unpack(&ctx.connection, &file_service, base_dir, &best) {
-                Ok(root) => root,
-                Err(active::ActivateBundleError::NotDownloaded { version }) => {
-                    // Expected: the record arrived before its bytes. The download queue
-                    // is working on it and this runs again when it lands.
-                    log::debug!("Front-end bundle {version} is not downloaded yet");
-                    return Ok(previous);
-                }
-                Err(error) => {
-                    // A checksum failure or a bad archive. Keep serving whatever we were
-                    // serving; a broken candidate must not take the UI down.
-                    log::error!(
-                        "Could not activate front-end bundle {}: {}",
-                        best.version,
-                        format_error(&error)
-                    );
-                    return Ok(previous);
-                }
-            }
+    let file_service = match StaticFileService::new(base_dir) {
+        Ok(service) => service,
+        Err(error) => {
+            log::error!("Cannot access static files: {:#}", error);
+            return Ok(previous);
         }
     };
 
+    // Serve the newest candidate that is actually *here*, which is not always the newest
+    // candidate. A bundle whose bytes have not arrived — or cannot, because its file was
+    // withdrawn or fails its checksum — must not mask an older one that is downloaded,
+    // verified and ready: doing so strands the site on the packaged baseline while a
+    // perfectly good bundle sits unpacked on disk.
+    let mut serving = None;
+    for candidate in &candidates {
+        if let Some(root) = active::unpacked_root(base_dir, &candidate.version) {
+            serving = Some((candidate, root));
+            break;
+        }
+
+        match active::verify_and_unpack(&ctx.connection, &file_service, base_dir, candidate) {
+            Ok(root) => {
+                serving = Some((candidate, root));
+                break;
+            }
+            Err(active::ActivateBundleError::NotDownloaded { version }) => {
+                // Expected while the bytes are in flight; try the next-newest.
+                log::debug!("Front-end bundle {version} is not downloaded yet");
+            }
+            Err(error) => {
+                // A checksum failure or a bad archive. Skip it — a broken candidate must
+                // not take the UI down, nor block a good older one.
+                log::error!(
+                    "Could not activate front-end bundle {}: {}",
+                    candidate.version,
+                    format_error(&error)
+                );
+            }
+        }
+    }
+
+    let Some((best_available, root)) = serving else {
+        if previous.is_some() {
+            log::info!(
+                "No front-end bundle is ready yet; serving the packaged baseline while {} downloads",
+                best.version
+            );
+        }
+        active.set(None);
+        active::prune_unpacked(base_dir, None, &all);
+        return Ok(None);
+    };
+
+    if best_available.version != best.version {
+        log::info!(
+            "Serving front-end bundle {} while the newer {} is still being fetched",
+            best_available.version,
+            best.version
+        );
+    }
+
     let bundle = ActiveBundle {
-        version: best.version.clone(),
+        version: best_available.version.clone(),
         root,
     };
 
@@ -387,7 +430,7 @@ pub fn reconcile_active_bundle(
         log::info!(
             "Serving front-end bundle {} (built for server {})",
             bundle.version,
-            best.server_version
+            best_available.server_version
         );
     }
     active.set(Some(bundle.clone()));
@@ -1176,6 +1219,72 @@ mod test {
         assert!(file_repo.find_all_by_record_id(&bundle.id).unwrap()[0]
             .download_requested_datetime
             .is_none());
+    }
+
+    /// Reproduces what real two-server testing hit: a remote had v0.0.232 downloaded and
+    /// unpacked, but served the packaged baseline instead, because a newer v1.0.0 record
+    /// existed whose bytes it did not have. The unavailable newest must not mask a ready
+    /// older one.
+    #[actix_rt::test]
+    async fn an_unavailable_newer_bundle_does_not_mask_a_ready_older_one() {
+        let context = setup_all_and_service_provider(
+            "an_unavailable_newer_bundle_does_not_mask_a_ready_older_one",
+            MockDataInserts::none(),
+        )
+        .await;
+        let ctx = &context.service_context;
+
+        let dist_dir = tempfile::tempdir().unwrap();
+        let base_dir = tempfile::tempdir().unwrap();
+        write_dist(dist_dir.path(), "v0.0.232");
+        let settings = settings_for(&context, dist_dir.path(), base_dir.path());
+        let active = ActiveFrontendBundle::new();
+
+        // A bundle that is here: published locally, so its bytes are on disk.
+        publish_from_frontend_dir(ctx, &settings).unwrap();
+        assert_eq!(
+            reconcile_active_bundle(ctx, &settings, &active)
+                .unwrap()
+                .map(|b| b.version),
+            Some("v0.0.232".to_string())
+        );
+
+        // A newer record arrives with no bytes — the state a remote is in between the
+        // record syncing and the download completing (or forever, if it never can).
+        FrontendBundleRowRepository::new(&ctx.connection)
+            .upsert_one(&bundle_row(
+                "v1.0.0",
+                &Version::from_package_json().to_string(),
+                true,
+            ))
+            .unwrap();
+        assert_eq!(
+            best_usable_bundle(&ctx.connection)
+                .unwrap()
+                .map(|b| b.version),
+            Some("v1.0.0".to_string()),
+            "v1.0.0 is the newest candidate"
+        );
+
+        // ...but v0.0.232 keeps serving, rather than dropping to the baseline.
+        assert_eq!(
+            reconcile_active_bundle(ctx, &settings, &active)
+                .unwrap()
+                .map(|b| b.version),
+            Some("v0.0.232".to_string()),
+            "a ready bundle must keep serving while a newer one is unavailable"
+        );
+
+        // And from cold — no cached previous value to fall back on, which is the case
+        // that actually stranded the remote on its baseline.
+        let cold = ActiveFrontendBundle::new();
+        assert_eq!(
+            reconcile_active_bundle(ctx, &settings, &cold)
+                .unwrap()
+                .map(|b| b.version),
+            Some("v0.0.232".to_string()),
+            "a restart must still find the ready bundle"
+        );
     }
 
     #[actix_rt::test]

--- a/server/service/src/frontend_bundle/mod.rs
+++ b/server/service/src/frontend_bundle/mod.rs
@@ -249,18 +249,28 @@ pub fn best_usable_bundle(
     Ok(best)
 }
 
+/// Outcome of asking for a bundle's bytes.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum DownloadRequest {
+    /// Queued for the file sync driver to fetch.
+    Queued,
+    /// This site produced the bytes, so there is nothing to fetch. Central publishing its
+    /// own bundle lands here.
+    AuthoredHere,
+    /// The bundle record arrived ahead of its file reference — they are separate changelog
+    /// rows and can land in different pull batches. Not an error; the next reconcile asks
+    /// again.
+    NoFileReference,
+}
+
 /// Mark a bundle's bytes as wanted, putting them in the background download queue.
 ///
 /// Idempotent, so it is safe for both callers (the changelog processor, for promptness, and
 /// [`reconcile_active_bundle`], as the guarantee) to call it repeatedly.
-///
-/// `false` means the bundle's file reference hasn't arrived yet — the record and the
-/// reference are separate changelog rows and can land in different pull batches. Not an
-/// error: the next reconcile requests it.
 pub(crate) fn request_bundle_download(
     ctx: &ServiceContext,
     bundle: &FrontendBundleRow,
-) -> Result<bool, RepositoryError> {
+) -> Result<DownloadRequest, RepositoryError> {
     let file_repo = SyncFileReferenceRowRepository::new(&ctx.connection);
 
     let Some(reference) = file_repo
@@ -268,11 +278,20 @@ pub(crate) fn request_bundle_download(
         .into_iter()
         .find(|r| r.table_name == FRONTEND_BUNDLE_TABLE)
     else {
-        return Ok(false);
+        return Ok(DownloadRequest::NoFileReference);
     };
 
+    // Central publishes with direction Upload, meaning "these bytes originate here". The
+    // download queue filters on direction, so a marker set here could never be acted on —
+    // but it would still be written, and both callers would announce a download that is
+    // never going to happen. Central logging "Requested download of bundle X" for a bundle
+    // it just published itself is confusing enough to be worth this guard.
+    if reference.direction == SyncFileDirection::Upload {
+        return Ok(DownloadRequest::AuthoredHere);
+    }
+
     file_repo.request_download(&reference.id)?;
-    Ok(true)
+    Ok(DownloadRequest::Queued)
 }
 
 /// Decide which bundle this server should be serving and make it so.
@@ -317,8 +336,8 @@ pub fn reconcile_active_bundle(
             // before the file reference has arrived, whereas this runs at startup and
             // after every download pass until the bundle is actually here.
             match request_bundle_download(ctx, &best) {
-                Ok(true) => {}
-                Ok(false) => log::debug!(
+                Ok(DownloadRequest::Queued) | Ok(DownloadRequest::AuthoredHere) => {}
+                Ok(DownloadRequest::NoFileReference) => log::debug!(
                     "Front-end bundle {} has no file reference yet",
                     best.version
                 ),
@@ -1083,7 +1102,10 @@ mod test {
         FrontendBundleRowRepository::new(&ctx.connection)
             .upsert_one(&bundle)
             .unwrap();
-        assert!(!request_bundle_download(ctx, &bundle).unwrap());
+        assert_eq!(
+            request_bundle_download(ctx, &bundle).unwrap(),
+            DownloadRequest::NoFileReference
+        );
 
         // The reference arrives later, with no further bundle-record change behind it.
         let file_repo = SyncFileReferenceRowRepository::new(&ctx.connection);
@@ -1119,6 +1141,41 @@ mod test {
             vec![reference.id],
             "reconcile must queue the bundle the processor could not"
         );
+    }
+
+    /// Central publishes its own bundle, so it holds the bytes already. Asking to download
+    /// them would stamp a marker the queue can never act on (it filters on direction) and
+    /// make central log a download it is never going to perform.
+    #[actix_rt::test]
+    async fn a_bundle_published_here_is_not_queued_for_download() {
+        let context = setup_all_and_service_provider(
+            "a_bundle_published_here_is_not_queued_for_download",
+            MockDataInserts::none(),
+        )
+        .await;
+        let ctx = &context.service_context;
+
+        let dist_dir = tempfile::tempdir().unwrap();
+        let base_dir = tempfile::tempdir().unwrap();
+        write_dist(dist_dir.path(), "v1.0.0");
+        let settings = settings_for(&context, dist_dir.path(), base_dir.path());
+
+        let bundle = publish_from_frontend_dir(ctx, &settings)
+            .unwrap()
+            .row()
+            .clone();
+
+        assert_eq!(
+            request_bundle_download(ctx, &bundle).unwrap(),
+            DownloadRequest::AuthoredHere
+        );
+
+        // Nothing queued, and no marker left behind on central's own reference.
+        let file_repo = SyncFileReferenceRowRepository::new(&ctx.connection);
+        assert!(file_repo.find_all_to_download(100).unwrap().is_empty());
+        assert!(file_repo.find_all_by_record_id(&bundle.id).unwrap()[0]
+            .download_requested_datetime
+            .is_none());
     }
 
     #[actix_rt::test]

--- a/server/service/src/frontend_bundle/mod.rs
+++ b/server/service/src/frontend_bundle/mod.rs
@@ -25,8 +25,6 @@ use repository::{
 use thiserror::Error;
 use util::{format_error, uuid::uuid};
 
-use crate::processors::frontend_bundle::best_usable_bundle;
-
 use crate::{
     service_provider::ServiceContext,
     settings::Settings,
@@ -204,6 +202,60 @@ pub fn set_active(
     Ok(updated)
 }
 
+/// The bundle this site should be running: of those that are active and compatible with
+/// this server, the highest version.
+///
+/// The same rule reports and plugins use — filter by compatibility, then take the newest —
+/// but compared against `server_version`, not `version`. The front end has its own version
+/// line, so its own version says nothing about which server it needs; `server_version` is
+/// the value on the server's line.
+///
+/// There is no upper bound, matching `is_compatible_by_major_and_minor` everywhere else: a
+/// server 4.0 release is expected to ship a 4.0-compatible front end, so the newest
+/// compatible bundle is the right one. `is_active` is the manual override when it isn't.
+pub fn best_usable_bundle(
+    connection: &StorageConnection,
+) -> Result<Option<FrontendBundleRow>, RepositoryError> {
+    let app_version = Version::from_package_json();
+
+    let best = FrontendBundleRowRepository::new(connection)
+        .all()?
+        .into_iter()
+        .filter(|bundle| bundle.is_active)
+        .filter(|bundle| {
+            Version::from_str(&bundle.server_version).is_compatible_by_major_and_minor(&app_version)
+        })
+        .max_by(|a, b| Version::from_str(&a.version).cmp(&Version::from_str(&b.version)));
+
+    Ok(best)
+}
+
+/// Mark a bundle's bytes as wanted, putting them in the background download queue.
+///
+/// Idempotent, so it is safe for both callers (the changelog processor, for promptness, and
+/// [`reconcile_active_bundle`], as the guarantee) to call it repeatedly.
+///
+/// `false` means the bundle's file reference hasn't arrived yet — the record and the
+/// reference are separate changelog rows and can land in different pull batches. Not an
+/// error: the next reconcile requests it.
+pub(crate) fn request_bundle_download(
+    ctx: &ServiceContext,
+    bundle: &FrontendBundleRow,
+) -> Result<bool, RepositoryError> {
+    let file_repo = SyncFileReferenceRowRepository::new(&ctx.connection);
+
+    let Some(reference) = file_repo
+        .find_all_by_record_id(&bundle.id)?
+        .into_iter()
+        .find(|r| r.table_name == FRONTEND_BUNDLE_TABLE)
+    else {
+        return Ok(false);
+    };
+
+    file_repo.request_download(&reference.id)?;
+    Ok(true)
+}
+
 /// Decide which bundle this server should be serving and make it so.
 ///
 /// Run at startup and after a bundle download completes. Idempotent, and safe to call
@@ -241,6 +293,23 @@ pub fn reconcile_active_bundle(
     let root = match active::unpacked_root(base_dir, &best.version) {
         Some(root) => root,
         None => {
+            // Not unpacked, so we need its bytes. Make sure they're queued — this is the
+            // guarantee, not the changelog processor: a trigger fires once and can fire
+            // before the file reference has arrived, whereas this runs at startup and
+            // after every download pass until the bundle is actually here.
+            match request_bundle_download(ctx, &best) {
+                Ok(true) => {}
+                Ok(false) => log::debug!(
+                    "Front-end bundle {} has no file reference yet",
+                    best.version
+                ),
+                Err(error) => log::error!(
+                    "Could not queue front-end bundle {} for download: {}",
+                    best.version,
+                    format_error(&error)
+                ),
+            }
+
             let file_service = match StaticFileService::new(base_dir) {
                 Ok(service) => service,
                 Err(error) => {
@@ -803,6 +872,159 @@ mod test {
             )
             .unwrap()
             .is_none());
+    }
+
+    fn bundle_row(version: &str, server_version: &str, is_active: bool) -> FrontendBundleRow {
+        FrontendBundleRow {
+            id: uuid(),
+            version: version.to_string(),
+            server_version: server_version.to_string(),
+            sha256: "hash".to_string(),
+            is_active,
+            description: None,
+            created_datetime: chrono::NaiveDate::from_ymd_opt(2026, 8, 5)
+                .unwrap()
+                .and_hms_opt(9, 0, 0)
+                .unwrap(),
+        }
+    }
+
+    #[actix_rt::test]
+    async fn picks_the_newest_active_compatible_bundle() {
+        let context = setup_all_and_service_provider(
+            "picks_the_newest_active_compatible_bundle",
+            MockDataInserts::none(),
+        )
+        .await;
+        let connection = &context.service_context.connection;
+        let repo = FrontendBundleRowRepository::new(connection);
+
+        let app_version = Version::from_package_json();
+        let this_server = app_version.to_string();
+        let future_server = format!("{}.0.0", app_version.major + 1);
+
+        assert_eq!(best_usable_bundle(connection).unwrap(), None);
+
+        // Ordering is on the front end's own version line, not the server's.
+        let older = bundle_row("1.2.0", &this_server, true);
+        let newer = bundle_row("1.10.0", &this_server, true);
+        repo.upsert_one(&older).unwrap();
+        repo.upsert_one(&newer).unwrap();
+        // 1.10.0 > 1.2.0 — string ordering would get this wrong, version ordering doesn't.
+        assert_eq!(
+            best_usable_bundle(connection).unwrap().map(|b| b.version),
+            Some("1.10.0".to_string())
+        );
+
+        // A bundle built for a newer server is not usable here, however new it is.
+        repo.upsert_one(&bundle_row("2.0.0", &future_server, true))
+            .unwrap();
+        assert_eq!(
+            best_usable_bundle(connection).unwrap().map(|b| b.version),
+            Some("1.10.0".to_string())
+        );
+
+        // Withdrawing the best one falls back to the next, rather than to nothing.
+        repo.upsert_one(&FrontendBundleRow {
+            is_active: false,
+            ..newer
+        })
+        .unwrap();
+        assert_eq!(
+            best_usable_bundle(connection).unwrap().map(|b| b.version),
+            Some("1.2.0".to_string())
+        );
+
+        // Withdrawing them all leaves nothing — the caller then serves the baseline.
+        repo.upsert_one(&FrontendBundleRow {
+            is_active: false,
+            ..older
+        })
+        .unwrap();
+        assert_eq!(best_usable_bundle(connection).unwrap(), None);
+    }
+
+    #[actix_rt::test]
+    async fn older_server_version_stays_usable() {
+        let context = setup_all_and_service_provider(
+            "older_server_version_stays_usable",
+            MockDataInserts::none(),
+        )
+        .await;
+        let connection = &context.service_context.connection;
+
+        // "Compatible forever" downwards: a bundle built for an older server keeps
+        // working, on the basis that a newer bundle is how an incompatibility gets fixed.
+        // Without this, upgrading the server would strand the site with no usable bundle
+        // until central published a new one.
+        FrontendBundleRowRepository::new(connection)
+            .upsert_one(&bundle_row("1.0.0", "1.0.0", true))
+            .unwrap();
+        assert_eq!(
+            best_usable_bundle(connection).unwrap().map(|b| b.version),
+            Some("1.0.0".to_string())
+        );
+    }
+
+    /// The bug this exists to pin: the changelog processor fires once, and can fire before
+    /// the bundle's file reference has arrived (they are separate changelog rows and can
+    /// land in different pull batches). Nothing would re-trigger it, so the download has to
+    /// be requested by reconcile too, or the bundle is never fetched at all.
+    #[actix_rt::test]
+    async fn reconcile_requests_the_download_when_the_processor_could_not() {
+        let context = setup_all_and_service_provider(
+            "reconcile_requests_the_download_when_the_processor_could_not",
+            MockDataInserts::none(),
+        )
+        .await;
+        let ctx = &context.service_context;
+
+        let base_dir = tempfile::tempdir().unwrap();
+        let settings = settings_for(&context, Path::new("/no/such/dist"), base_dir.path());
+        let active = ActiveFrontendBundle::new();
+
+        // A bundle record with no file reference yet — exactly what the processor sees when
+        // the reference is in the next batch.
+        let bundle = bundle_row("1.0.0", &Version::from_package_json().to_string(), true);
+        FrontendBundleRowRepository::new(&ctx.connection)
+            .upsert_one(&bundle)
+            .unwrap();
+        assert!(!request_bundle_download(ctx, &bundle).unwrap());
+
+        // The reference arrives later, with no further bundle-record change behind it.
+        let file_repo = SyncFileReferenceRowRepository::new(&ctx.connection);
+        let reference = SyncFileReferenceRow {
+            id: uuid(),
+            table_name: FRONTEND_BUNDLE_TABLE.to_string(),
+            record_id: bundle.id.clone(),
+            file_name: BUNDLE_FILE_NAME.to_string(),
+            total_bytes: 2048,
+            status: SyncFileStatus::Done,
+            direction: SyncFileDirection::Download,
+            created_datetime: chrono::Utc::now().naive_utc(),
+            ..Default::default()
+        };
+        file_repo.upsert_one(&reference).unwrap();
+
+        // Nothing has queued it: the processor already ran and advanced its cursor.
+        assert!(file_repo.find_all_to_download(100).unwrap().is_empty());
+
+        // Reconcile is the backstop. It can't activate (no bytes on disk) so it leaves
+        // serving alone, but it must queue the download.
+        assert_eq!(
+            reconcile_active_bundle(ctx, &settings, &active).unwrap(),
+            None
+        );
+        assert_eq!(
+            file_repo
+                .find_all_to_download(100)
+                .unwrap()
+                .into_iter()
+                .map(|r| r.id)
+                .collect::<Vec<_>>(),
+            vec![reference.id],
+            "reconcile must queue the bundle the processor could not"
+        );
     }
 
     #[actix_rt::test]

--- a/server/service/src/frontend_bundle/mod.rs
+++ b/server/service/src/frontend_bundle/mod.rs
@@ -202,6 +202,25 @@ pub fn set_active(
     Ok(updated)
 }
 
+/// Parse a version string that may carry the front end's `v` tag prefix.
+///
+/// The front-end repo releases tags like `v0.0.231`, and that string is what lands in
+/// `frontend_bundle.version`. `Version::from_str` splits on `.` and parses each part as a
+/// number, so a leading `v` makes the **major** component fail to parse and silently
+/// become 0 (`unwrap_or(0)`). Every v-prefixed version would then compare as major 0,
+/// which breaks ordering across major versions: `v1.0.0` parses as `0.0.0` and would rank
+/// *below* `v0.0.231`'s `0.0.231`, so the front end's move to 1.0.0 would look like a
+/// downgrade and no site would advance to it.
+///
+/// Stripping the prefix at the point of comparison keeps the stored string faithful to the
+/// real release tag, rather than normalising it on the way in and having the record
+/// disagree with the tag, `VERSION.txt` and the unpack directory. It also leaves shared
+/// `Version::from_str` alone — migrations, reports and plugins are all unprefixed, and
+/// that parser is load-bearing for migration ordering.
+pub(crate) fn parse_version(raw: &str) -> Version {
+    Version::from_str(raw.strip_prefix(['v', 'V']).unwrap_or(raw))
+}
+
 /// The bundle this site should be running: of those that are active and compatible with
 /// this server, the highest version.
 ///
@@ -223,9 +242,9 @@ pub fn best_usable_bundle(
         .into_iter()
         .filter(|bundle| bundle.is_active)
         .filter(|bundle| {
-            Version::from_str(&bundle.server_version).is_compatible_by_major_and_minor(&app_version)
+            parse_version(&bundle.server_version).is_compatible_by_major_and_minor(&app_version)
         })
-        .max_by(|a, b| Version::from_str(&a.version).cmp(&Version::from_str(&b.version)));
+        .max_by(|a, b| parse_version(&a.version).cmp(&parse_version(&b.version)));
 
     Ok(best)
 }
@@ -887,6 +906,81 @@ mod test {
                 .and_hms_opt(9, 0, 0)
                 .unwrap(),
         }
+    }
+
+    #[test]
+    fn parse_version_tolerates_the_front_end_tag_prefix() {
+        // The front-end repo releases `v`-prefixed tags, and that string is what lands in
+        // frontend_bundle.version. Version::from_str parses each dot-separated part as a
+        // number and falls back to 0 on failure, so a leading `v` silently zeroes the
+        // *major* component.
+        assert_eq!(parse_version("v1.2.3"), Version::from_str("1.2.3"));
+        assert_eq!(parse_version("V1.2.3"), Version::from_str("1.2.3"));
+        assert_eq!(parse_version("1.2.3"), Version::from_str("1.2.3"));
+
+        // The case that matters, and the one that is imminent: the front end moving from
+        // the 0.0.x line to 1.0.0. Parsed naively, `v1.0.0` becomes 0.0.0 and ranks below
+        // `v0.0.231`'s 0.0.231 — the new release would look like a downgrade and no site
+        // would take it.
+        assert!(
+            parse_version("v1.0.0") > parse_version("v0.0.231"),
+            "the move to 1.0.0 must not read as a downgrade"
+        );
+        assert!(parse_version("v2.0.0") > parse_version("v1.10.0"));
+    }
+
+    /// Ordering must hold across a major-version boundary with the real tag format.
+    #[actix_rt::test]
+    async fn selection_orders_v_prefixed_versions_correctly() {
+        let context = setup_all_and_service_provider(
+            "selection_orders_v_prefixed_versions_correctly",
+            MockDataInserts::none(),
+        )
+        .await;
+        let connection = &context.service_context.connection;
+        let repo = FrontendBundleRowRepository::new(connection);
+        let this_server = Version::from_package_json().to_string();
+
+        // Exactly the shape of a real pin: the 0.0.x line, then the move to 1.0.0.
+        repo.upsert_one(&bundle_row("v0.0.231", &this_server, true))
+            .unwrap();
+        repo.upsert_one(&bundle_row("v1.0.0", &this_server, true))
+            .unwrap();
+
+        assert_eq!(
+            best_usable_bundle(connection).unwrap().map(|b| b.version),
+            Some("v1.0.0".to_string())
+        );
+    }
+
+    /// A `v`-prefixed server_version (possible via manual upload, where an admin types it)
+    /// must not zero its major component and silently pass or fail the compatibility check
+    /// for the wrong reason.
+    #[actix_rt::test]
+    async fn compatibility_tolerates_a_v_prefixed_server_version() {
+        let context = setup_all_and_service_provider(
+            "compatibility_tolerates_a_v_prefixed_server_version",
+            MockDataInserts::none(),
+        )
+        .await;
+        let connection = &context.service_context.connection;
+        let repo = FrontendBundleRowRepository::new(connection);
+
+        let app_version = Version::from_package_json();
+        let future_server = format!("v{}.0.0", app_version.major + 1);
+
+        // Built for a newer server, written with the prefix: still must be rejected.
+        repo.upsert_one(&bundle_row("v9.0.0", &future_server, true))
+            .unwrap();
+        assert_eq!(best_usable_bundle(connection).unwrap(), None);
+
+        // Built for this server, with the prefix: accepted.
+        repo.upsert_one(&bundle_row("v1.0.0", &format!("v{}", app_version), true))
+            .unwrap();
+        assert_eq!(
+            best_usable_bundle(connection).unwrap().map(|b| b.version),
+            Some("v1.0.0".to_string())
+        );
     }
 
     #[actix_rt::test]

--- a/server/service/src/processors/frontend_bundle/frontend_bundle.rs
+++ b/server/service/src/processors/frontend_bundle/frontend_bundle.rs
@@ -3,7 +3,7 @@ use repository::{ChangelogRow, ChangelogTableName, KeyType};
 
 use crate::{
     cursor_controller::CursorType,
-    frontend_bundle::{best_usable_bundle, request_bundle_download},
+    frontend_bundle::{best_usable_bundle, request_bundle_download, DownloadRequest},
     processors::general_processor::{Processor, ProcessorError},
     service_provider::{ServiceContext, ServiceProvider},
 };
@@ -49,19 +49,21 @@ impl Processor for RequestFrontendBundleDownload {
             return Ok(Some("No usable bundle for this server version".to_string()));
         };
 
-        let requested = request_bundle_download(ctx, &best)?;
-
-        Ok(Some(if requested {
-            format!(
+        Ok(Some(match request_bundle_download(ctx, &best)? {
+            DownloadRequest::Queued => format!(
                 "Requested download of bundle {} (for server {})",
                 best.version, best.server_version
-            )
-        } else {
-            // Not a failure: reconcile will pick it up once the reference lands.
-            format!(
+            ),
+            // Central, reacting to a bundle it published itself.
+            DownloadRequest::AuthoredHere => format!(
+                "Bundle {} was published here; no download needed",
+                best.version
+            ),
+            // Not a failure: reconcile asks again once the reference lands.
+            DownloadRequest::NoFileReference => format!(
                 "Bundle {} has no file reference yet; reconcile will request it",
                 best.version
-            )
+            ),
         }))
     }
 

--- a/server/service/src/processors/frontend_bundle/frontend_bundle.rs
+++ b/server/service/src/processors/frontend_bundle/frontend_bundle.rs
@@ -1,33 +1,28 @@
 use async_trait::async_trait;
-use repository::{
-    migrations::Version, sync_file_reference_row::SyncFileReferenceRowRepository, ChangelogRow,
-    ChangelogTableName, FrontendBundleRow, FrontendBundleRowRepository, KeyType, RepositoryError,
-    StorageConnection,
-};
+use repository::{ChangelogRow, ChangelogTableName, KeyType};
 
 use crate::{
     cursor_controller::CursorType,
-    frontend_bundle::FRONTEND_BUNDLE_TABLE,
+    frontend_bundle::{best_usable_bundle, request_bundle_download},
     processors::general_processor::{Processor, ProcessorError},
     service_provider::{ServiceContext, ServiceProvider},
 };
 
 const DESCRIPTION: &str = "Request download of the newest usable front-end bundle";
 
-/// Decides which front-end bundle this site should be holding, and queues its bytes for
-/// background download.
+/// Queues the newest usable front-end bundle's bytes for background download as soon as a
+/// bundle record changes.
 ///
-/// This is the "only download what's relevant" half of front-end sync. Bundle records
-/// broadcast to every site, so every site learns about every bundle — but a site should
-/// only spend bandwidth on one it could actually run. Because the compatibility
-/// information rides the *record*, that decision is made here, locally, before any bytes
-/// move. Central does not (and with the changelog's store/patient-keyed routing, cannot)
-/// target a bundle at particular sites.
+/// This is a **promptness** trigger, not the mechanism. The same request is made by
+/// [`crate::frontend_bundle::reconcile_active_bundle`], which runs at startup and after
+/// every download pass, and that is what actually guarantees it happens.
 ///
-/// Deliberately just marks intent: the file sync driver moves the bytes, and
-/// activation happens once they arrive. Keeping "what is worth having" separate from
-/// "move it" is what would let reports or plugins queue their own payloads later without
-/// touching the transport.
+/// The distinction matters: a changelog trigger fires once. A bundle record and its file
+/// reference are separate changelog rows, and although central writes them in one
+/// transaction they can land in different pull batches. If the reference arrives in the
+/// later batch, this processor has already run and advanced its cursor, and no further
+/// bundle-record change will ever arrive to react to — so on its own it would leave the
+/// bundle permanently un-downloaded. Reconcile is the backstop that closes that.
 pub(crate) struct RequestFrontendBundleDownload;
 
 #[async_trait]
@@ -54,28 +49,20 @@ impl Processor for RequestFrontendBundleDownload {
             return Ok(Some("No usable bundle for this server version".to_string()));
         };
 
-        let file_repo = SyncFileReferenceRowRepository::new(&ctx.connection);
-        let references = file_repo.find_all_by_record_id(&best.id)?;
+        let requested = request_bundle_download(ctx, &best)?;
 
-        let Some(reference) = references
-            .iter()
-            .find(|r| r.table_name == FRONTEND_BUNDLE_TABLE)
-        else {
-            // The record arrived ahead of its file reference. Both are written in one
-            // transaction on central, but they are separate changelog rows and can land
-            // in separate sync batches. The next batch re-triggers this processor.
-            return Ok(Some(format!(
-                "Bundle {} has no file reference yet",
+        Ok(Some(if requested {
+            format!(
+                "Requested download of bundle {} (for server {})",
+                best.version, best.server_version
+            )
+        } else {
+            // Not a failure: reconcile will pick it up once the reference lands.
+            format!(
+                "Bundle {} has no file reference yet; reconcile will request it",
                 best.version
-            )));
-        };
-
-        file_repo.request_download(&reference.id)?;
-
-        Ok(Some(format!(
-            "Requested download of bundle {} (for server {})",
-            best.version, best.server_version
-        )))
+            )
+        }))
     }
 
     fn change_log_table_names(&self) -> Vec<ChangelogTableName> {
@@ -84,130 +71,5 @@ impl Processor for RequestFrontendBundleDownload {
 
     fn cursor_type(&self) -> CursorType {
         CursorType::Standard(KeyType::FrontendBundleProcessorCursor)
-    }
-}
-
-/// The bundle this site should be running: of those that are active and compatible with
-/// this server, the highest version.
-///
-/// The same rule reports and plugins use — filter by compatibility, then take the newest
-/// — but compared against `server_version`, not `version`. The front end has its own
-/// version line, so its own version says nothing about which server it needs;
-/// `server_version` is the value on the server's line.
-///
-/// There is no upper bound, matching `is_compatible_by_major_and_minor` everywhere else:
-/// a server 4.0 release is expected to ship a 4.0-compatible front end, so the newest
-/// compatible bundle is the right one. `is_active` is the manual override when it isn't.
-pub(crate) fn best_usable_bundle(
-    connection: &StorageConnection,
-) -> Result<Option<FrontendBundleRow>, RepositoryError> {
-    let app_version = Version::from_package_json();
-
-    let best = FrontendBundleRowRepository::new(connection)
-        .all()?
-        .into_iter()
-        .filter(|bundle| bundle.is_active)
-        .filter(|bundle| {
-            Version::from_str(&bundle.server_version).is_compatible_by_major_and_minor(&app_version)
-        })
-        .max_by(|a, b| Version::from_str(&a.version).cmp(&Version::from_str(&b.version)));
-
-    Ok(best)
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use chrono::NaiveDate;
-    use repository::{
-        mock::MockDataInserts, test_db::setup_all, FrontendBundleRow, FrontendBundleRowRepository,
-    };
-    use util::uuid::uuid;
-
-    fn bundle(version: &str, server_version: &str, is_active: bool) -> FrontendBundleRow {
-        FrontendBundleRow {
-            id: uuid(),
-            version: version.to_string(),
-            server_version: server_version.to_string(),
-            sha256: "hash".to_string(),
-            is_active,
-            description: None,
-            created_datetime: NaiveDate::from_ymd_opt(2026, 8, 4)
-                .unwrap()
-                .and_hms_opt(9, 0, 0)
-                .unwrap(),
-        }
-    }
-
-    #[actix_rt::test]
-    async fn picks_the_newest_active_compatible_bundle() {
-        let (_, connection, _, _) = setup_all(
-            "picks_the_newest_active_compatible_bundle",
-            MockDataInserts::none(),
-        )
-        .await;
-        let repo = FrontendBundleRowRepository::new(&connection);
-
-        let app_version = Version::from_package_json();
-        let this_server = app_version.to_string();
-        let future_server = format!("{}.0.0", app_version.major + 1);
-
-        assert_eq!(best_usable_bundle(&connection).unwrap(), None);
-
-        // Ordering is on the front end's own version line, not the server's.
-        let older = bundle("1.2.0", &this_server, true);
-        let newer = bundle("1.10.0", &this_server, true);
-        repo.upsert_one(&older).unwrap();
-        repo.upsert_one(&newer).unwrap();
-        // 1.10.0 > 1.2.0 — string ordering would get this wrong, version ordering
-        // doesn't.
-        assert_eq!(
-            best_usable_bundle(&connection).unwrap().map(|b| b.version),
-            Some("1.10.0".to_string())
-        );
-
-        // A bundle built for a newer server is not usable here, however new it is.
-        repo.upsert_one(&bundle("2.0.0", &future_server, true))
-            .unwrap();
-        assert_eq!(
-            best_usable_bundle(&connection).unwrap().map(|b| b.version),
-            Some("1.10.0".to_string())
-        );
-
-        // Withdrawing the best one falls back to the next, rather than to nothing.
-        repo.upsert_one(&FrontendBundleRow {
-            is_active: false,
-            ..newer.clone()
-        })
-        .unwrap();
-        assert_eq!(
-            best_usable_bundle(&connection).unwrap().map(|b| b.version),
-            Some("1.2.0".to_string())
-        );
-
-        // Withdrawing them all leaves nothing — the caller then serves the baseline.
-        repo.upsert_one(&FrontendBundleRow {
-            is_active: false,
-            ..older
-        })
-        .unwrap();
-        assert_eq!(best_usable_bundle(&connection).unwrap(), None);
-    }
-
-    #[actix_rt::test]
-    async fn older_server_version_stays_usable() {
-        let (_, connection, _, _) =
-            setup_all("older_server_version_stays_usable", MockDataInserts::none()).await;
-        let repo = FrontendBundleRowRepository::new(&connection);
-
-        // "Compatible forever" downwards: a bundle built for an older server keeps
-        // working, on the basis that a newer bundle is how an incompatibility gets
-        // fixed. Without this, upgrading the server would strand the site with no
-        // usable bundle at all until central published a new one.
-        repo.upsert_one(&bundle("1.0.0", "1.0.0", true)).unwrap();
-        assert_eq!(
-            best_usable_bundle(&connection).unwrap().map(|b| b.version),
-            Some("1.0.0".to_string())
-        );
     }
 }

--- a/server/service/src/processors/frontend_bundle/mod.rs
+++ b/server/service/src/processors/frontend_bundle/mod.rs
@@ -1,3 +1,3 @@
 mod frontend_bundle;
 
-pub(crate) use frontend_bundle::{best_usable_bundle, RequestFrontendBundleDownload};
+pub(crate) use frontend_bundle::RequestFrontendBundleDownload;

--- a/server/service/src/sync/file_sync_driver.rs
+++ b/server/service/src/sync/file_sync_driver.rs
@@ -19,8 +19,8 @@ use tokio::{
 };
 use util::format_error;
 
-const FILE_SYNC_TRANSFER_DELAY: Duration = Duration::from_millis(100); // This just gives time for a PAUSE message to be received between transferring files
-const FILE_SYNC_NO_FILES_DELAY: Duration = Duration::from_millis(10000); // If there's nothing to transfer or there was an error, wait a longer before checking again
+const FILE_SYNC_BETWEEN_FILES_DELAY: Duration = Duration::from_millis(100); // This just gives time for a PAUSE message to be received between uploading or downloading files
+const FILE_SYNC_NO_FILES_DELAY: Duration = Duration::from_millis(10000); // If there's nothing to upload or download, or there was an error, wait a longer before checking again
 
 pub enum FileSyncMessage {
     Start, // Start sync (could be manual trigger, or automatic on server startup)
@@ -112,12 +112,12 @@ impl FileSyncDriver {
                     // unobserved for up to FILE_SYNC_NO_FILES_DELAY. The match against Ok ignores
                     // sender-dropped errors (which only happen during shutdown).
                     Ok(()) = self.pause_rx.changed() => {},
-                    // OR wait between transferring files
+                    // OR wait between uploading/downloading files
                     _ = async {
                         if files_to_upload == 0 && files_to_download == 0 {
                             tokio::time::sleep(FILE_SYNC_NO_FILES_DELAY).await;
                         } else {
-                            tokio::time::sleep(FILE_SYNC_TRANSFER_DELAY).await;
+                            tokio::time::sleep(FILE_SYNC_BETWEEN_FILES_DELAY).await;
                         }
                     } => {},
                     else => break,
@@ -135,8 +135,9 @@ impl FileSyncDriver {
             // across the await point and the whole `run` future becomes !Send.
             let paused = *self.pause_rx.borrow();
 
-            // If not stopped or paused and we have a central server URL to transfer with
-            // (file bytes only ever transfer remote ↔ central, never on central itself)
+            // If not stopped or paused and we have a central server URL to upload to and
+            // download from (file bytes only ever move remote ↔ central, never on central
+            // itself)
             if !stopped && !paused {
                 if let Some(url) = file_sync_central_url(&service_provider) {
                     files_to_upload = self

--- a/server/service/src/sync/file_synchroniser.rs
+++ b/server/service/src/sync/file_synchroniser.rs
@@ -163,7 +163,7 @@ impl FileSynchroniser {
         let ctx = self.service_provider.basic_context()?;
         let sync_file_repo = SyncFileReferenceRowRepository::new(&ctx.connection);
 
-        let queued = sync_file_repo.find_all_to_download()?;
+        let queued = sync_file_repo.find_all_to_download(MAX_UPLOAD_ATTEMPTS)?;
         let Some(sync_file_reference) = queued.first() else {
             return Ok(0);
         };
@@ -190,9 +190,21 @@ impl FileSynchroniser {
                 .find_one_by_id(&sync_file_reference.id)?
                 .unwrap_or_else(|| sync_file_reference.clone());
 
-            let update = if current.retries >= MAX_UPLOAD_ATTEMPTS {
+            // Bytes already on disk are kept, so record how far we got — the next attempt
+            // resumes from there, and the queue uses this to tell "incomplete" from "done".
+            let downloaded = self
+                .static_file_service
+                .partial_download_offset(sync_file_reference) as i32;
+            let retries_after = current.retries + 1;
+
+            // Mark the give-up *on* the attempt that exhausts the budget, not after it:
+            // `find_all_to_download` stops returning the row once retries reaches the cap,
+            // so a later pass would never run to record it and the row would just go quiet.
+            let update = if retries_after >= MAX_UPLOAD_ATTEMPTS {
                 SyncFileReferenceRow {
                     status: SyncFileStatus::PermanentFailure,
+                    retries: retries_after,
+                    downloaded_bytes: downloaded,
                     ..current
                 }
             } else {
@@ -203,14 +215,9 @@ impl FileSynchroniser {
                     ));
                 SyncFileReferenceRow {
                     status: SyncFileStatus::Error,
-                    retries: current.retries + 1,
+                    retries: retries_after,
                     retry_at: Some(retry_at),
-                    // Bytes already on disk are kept, so record how far we got — the
-                    // next attempt resumes from there.
-                    downloaded_bytes: self
-                        .static_file_service
-                        .partial_download_offset(sync_file_reference)
-                        as i32,
+                    downloaded_bytes: downloaded,
                     ..current
                 }
             };

--- a/server/service/src/sync/file_synchroniser.rs
+++ b/server/service/src/sync/file_synchroniser.rs
@@ -33,6 +33,12 @@ use super::{
 };
 
 pub static MAX_UPLOAD_ATTEMPTS: i32 = 7 * 24; // 7 days * 24 hours Retry sending for up to for 1 week before giving up
+// Downloads carry their own budget rather than borrowing the upload one. The two are not the
+// same kind of failure: a failing upload is this site's own data not reaching central, which
+// is worth a long retry; a failing download is something this site merely asked for, and
+// central may legitimately no longer have it. Same value for now — the point is that tuning
+// one can no longer silently retune the other.
+pub static MAX_DOWNLOAD_ATTEMPTS: i32 = 7 * 24;
 pub static RETRY_DELAY_MINUTES: i64 = 15; // Doubles each retry until MAX_RETRY_DELAY_MINUTES
 pub static MAX_RETRY_DELAY_MINUTES: i64 = 60; // 1 hour
 
@@ -163,7 +169,7 @@ impl FileSynchroniser {
         let ctx = self.service_provider.basic_context()?;
         let sync_file_repo = SyncFileReferenceRowRepository::new(&ctx.connection);
 
-        let queued = sync_file_repo.find_all_to_download(MAX_UPLOAD_ATTEMPTS)?;
+        let queued = sync_file_repo.find_all_to_download(MAX_DOWNLOAD_ATTEMPTS)?;
         let Some(sync_file_reference) = queued.first() else {
             return Ok(0);
         };
@@ -200,7 +206,7 @@ impl FileSynchroniser {
             // Mark the give-up *on* the attempt that exhausts the budget, not after it:
             // `find_all_to_download` stops returning the row once retries reaches the cap,
             // so a later pass would never run to record it and the row would just go quiet.
-            let update = if retries_after >= MAX_UPLOAD_ATTEMPTS {
+            let update = if retries_after >= MAX_DOWNLOAD_ATTEMPTS {
                 SyncFileReferenceRow {
                     status: SyncFileStatus::PermanentFailure,
                     retries: retries_after,

--- a/server/spec/sync/frontend-sync.md
+++ b/server/spec/sync/frontend-sync.md
@@ -187,9 +187,25 @@ Deliberately out of scope, each worth its own issue:
 
 ## Open questions
 
+- **A JSON manifest in the dist, rather than `VERSION.txt`** — the preferred direction, to settle
+  before more metadata accretes. Today the server reads the bundle's version by hand-parsing the
+  `version:` line out of `VERSION.txt`, which the front-end release workflow writes (and which is
+  also served at `/VERSION.txt`, where the login footer reads it). That is fine for one field and
+  poor for several, and several are coming: the plugin-API version pair the server-side plugin gate
+  needs (below), a compatibility claim the bundle makes about the server rather than one central
+  stamps on its behalf, and eventually whatever a bundle would have to declare for per-site
+  targeting. A JSON manifest is typed, nests, extends without inventing parsing rules, and matches
+  the pin file (`frontend-version.json`) which is already JSON.
+
+  Two constraints on the change: it needs the front-end repo to emit the manifest, and
+  `VERSION.txt` has an existing consumer (the login/init footer), so a manifest either supplements
+  it or that consumer moves at the same time.
 - Does the server-side plugin gate need the dist to declare its `plugin_api_version` /
-  `plugin_api_min_supported` (in `VERSION.txt` or a manifest)? Until it does, only the existing
-  client-side gate is live.
+  `plugin_api_min_supported`? Until it does, only the existing client-side gate is live. Best
+  carried by the manifest above rather than by adding lines to `VERSION.txt`.
 - Packaging currently discards the dist zip after unpacking (`build/fetch-frontend.js`). Central
-  needs the zip to publish it — retain it during packaging, or reconstruct it?
-- How many previous versions to retain, and what triggers the cleanup?
+  needs the zip to publish it — retain it during packaging, or reconstruct it? (Currently central
+  re-zips its own `frontend_dir`, so this is only a question if we want the published sha256 to
+  match the front-end release's own sidecar.)
+- How many previous versions to retain, and what triggers the cleanup? (Currently two, pruned on
+  activation.)


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Part of #12622. Seven fixes to the frontend-sync stack, found after #12630 was written — **five of them by actually running two servers**, which is the point worth taking from this PR: none would have been caught by the 1173 tests that were green when the feature was declared done.

With these, frontend sync is **verified end to end**: central published `v0.0.247`, a remote site downloaded, verified, unpacked and served it in place of its packaged `v0.0.231` baseline.

| # | Fix | Found by |
|---|---|---|
| 1 | **Download queue never returned anything.** `find_all_to_download` filtered on `status`, copied from the upload filter — but for a download `status` is the *origin's* upload state, and it crosses sync. Central must publish as `Done`, so a remote's copy was `Done` before it had a single byte, and `Done` was excluded. Empty queue, forever, silently. Now filtered entirely on local columns. | setting up testing |
| 2 | **Download request lost on a batch split.** Only a changelog processor requested the download, and a changelog trigger fires once. The bundle record and its file reference are separate rows and can land in different pull batches; if the reference arrived second, nothing re-triggered. `reconcile_active_bundle` now requests it too, and runs at startup and after every download pass. | self-review |
| 3 | **No uniqueness on `version`.** Three things assumed one bundle per version (the "already published?" guard, `find_one_by_version`'s missing `ORDER BY`, and the version-named unpack directory). Now a unique index. | self-review |
| 4 | **`v` tag prefix zeroed the major version.** FE releases are `v0.0.247`; `Version::from_str` parses each dot-separated part as a number and falls back to 0, so `v1.0.0` became `0.0.0` and ranked *below* `v0.0.231`. The imminent move to 1.0.0 would have read as a downgrade. | fetching a real dist |
| 5 | **Central announced downloading its own bytes.** Harmless in effect, but "Requested download of bundle X" is the line you grep to check the remote leg, so central emitting it made the signal useless. | reported from central's logs |
| 6 | **An unavailable newer bundle masked a ready older one.** A remote had `v0.0.232` downloaded and unpacked but served the packaged baseline, because a newer record existed whose bytes it did not have. reconcile took the single highest candidate and gave up. The spec already said "…and whose bytes are downloaded, verified and unpacked"; the implementation had diverged, and its doc comment asserted the opposite. | two-server testing |
| 7 | **`VERSION.txt` cached for a year.** It keeps the *same URL* across bundles — unlike the content-hashed assets there is no new URL to force a refetch — so a long cache pins a client to whatever version was live when it first asked. Defeats "deployed versions stay inspectable", and blocks the reload prompt ([open-msupply-frontend#925](https://github.com/msupply-foundation/open-msupply-frontend/issues/925)). | scoping the FE prompt |

## 💌 Any notes for the reviewer?

`develop` was merged up through the whole stack, so each PR's diff is scoped to its own commits again — this one is the 11 frontend-sync files below. Verified after the merge: 1187 tests pass, both SQLite and Postgres builds are clean, and the Postgres migration guard still passes.

Two judgement calls worth challenging:

- **`status` plays no part in download queueing at all.** The alternative reading is that `status == Done` is a useful *availability* gate (don't fetch bytes the origin hasn't uploaded — you'd 404). I dropped it because the local error path writes `status` too, so requiring `Done` would exclude a row the moment its first attempt failed; the 404 case is already covered by backoff.
- **Fix 2 addresses the class, not the instance.** Twice now a bug here has been a silent no-op from assuming event-triggered work is sufficient. Anything that must "eventually happen" now hangs off `reconcile`, with the processor only providing promptness.

Also worth noting fix 6 changes a documented behaviour: a candidate that fails its checksum is now *skipped* rather than freezing activation, so one bad bundle can't strand a site.

# 🧪 Tested

- **End to end on two servers** (git worktrees, separate `base_dir` each): central publishes on startup → record syncs → processor queues → background download → checksum verify → unpack → serve. Confirmed the remote served `v0.0.247` rather than its `v0.0.231` baseline, and that a real ~1 MB transfer works, not just the 4 KB placeholder.
- Every fix has a regression test built from the state that produced it — notably `download_queue_ignores_the_synced_status` (the exact row a remote ends up with) and `an_unavailable_newer_bundle_does_not_mask_a_ready_older_one` (v0.0.232 ready, v1.0.0 recorded but absent, asserted warm *and* from cold).
- Reverting the `v`-prefix helper fails 12 tests, so that one is pinned rather than asserted.
- `cargo nextest run -p repository -p service -p server` — **1183 passed**.
- `cargo nextest run -p repository --features postgres --test-threads 1 migration_3_00_00 integration_order` — 8 passed.
- `cargo build` and `cargo build --features postgres`.

# 📃 Documentation

- [x] **Part of an epic** — documentation will be completed for the feature as a whole
