### PR TITLE
Add local-dev scripts for both frontends (fetch-frontend, build:old-ui)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,8 @@
     "android:build:server": "yarn build && yarn workspace @openmsupply-client/android build:server",
     "android:run": "npx cap run android",
     "build": "yarn workspace @openmsupply-client/host build",
+    "//build:old-ui": "Builds this client as the legacy UI and puts it where a locally-run server serves it (/old-ui/). PUBLIC_PATH must be set at build time — it fixes the asset URLs and the router base, so a bundle built for / cannot be relocated by copying. Mirrors what packaging does (build/mac/build.sh, dockerise.yaml, build-windows-installers.yaml, android:build:release), which each copy to their own destination.",
+    "build:old-ui": "PUBLIC_PATH=/old-ui/ yarn build && mkdir -p ../server/frontend && rm -rf ../server/frontend/old-ui && cp -R packages/host/dist ../server/frontend/old-ui",
     "build-stats": "yarn workspace @openmsupply-client/host build-stats",
     "build-storybook": "storybook build",
     "compile-full": "yarn workspaces foreach -A --parallel --exclude open-msupply --exclude openmsupply-client --exclude @openmsupply-client/android --exclude standard_reports --exclude standard_forms run tsc",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "start": "cd ./server && cargo run & cd ./client && yarn start-local",
     "build": "cd ./client && yarn build && cd ../server && cargo build --release",
     "test": "cd ./server && ulimit -n 1000 && cargo test && cd ../client && yarn test",
+    "//fetch-frontend": "Fetches the pinned open-msupply-frontend dist (frontend-version.json) into server/frontend, where a server run from server/ serves it at /. Defaults to the public B2 mirror so no GitHub token is needed — the FE repo is private, and the pin's sha256 is enforced either way. Override FRONTEND_DIST_BASE_URL, or FRONTEND_DIST_URL for a local zip.",
+    "fetch-frontend": "FRONTEND_DIST_BASE_URL=${FRONTEND_DIST_BASE_URL:-https://f002.backblazeb2.com/file/msupply-releases} node build/fetch-frontend.js server/frontend",
     "dockerise": "bash docker/dockerise.sh",
     "plugin": "node scripts/plugin-management/plugin.js",
     "load-test": "cd scripts/load-testing && mkdir -p output && k6 run main.js"

--- a/server/README.md
+++ b/server/README.md
@@ -17,7 +17,14 @@ the `old-ui` subdirectory of `frontend_dir`, when present — by convention, not
 configuration, so every deployment gets the same URL. When the subdirectory
 doesn't exist nothing is mounted at `/old-ui/` and root serving is unaffected.
 The old UI must be built with its `publicPath`/router base set to `/old-ui/`
-(see the client's `PUBLIC_PATH` build variable).
+(see the client's `PUBLIC_PATH` build variable) — it fixes the asset URLs and the
+router base at build time, so a bundle built for `/` cannot be relocated by
+copying it.
+
+For local development, `yarn build:old-ui` in `client/` does that build and puts
+the result in `server/frontend/old-ui`, where a server run from `server/` serves
+it. Packaging does the same two steps itself, since each pipeline copies to its
+own destination.
 
 ### Pinned frontend dist (new FE at `/`)
 

--- a/server/README.md
+++ b/server/README.md
@@ -26,6 +26,21 @@ the result in `server/frontend/old-ui`, where a server run from `server/` serves
 it. Packaging does the same two steps itself, since each pipeline copies to its
 own destination.
 
+### Getting both UIs in place locally
+
+From the repo root:
+
+```sh
+yarn fetch-frontend          # new FE (the pin) -> server/frontend
+cd client && yarn build:old-ui   # old UI -> server/frontend/old-ui
+```
+
+`fetch-frontend` defaults to the public B2 mirror, so it needs no GitHub token
+even though the FE repo is private; the pin's `sha256` is enforced either way.
+Note it **replaces** `server/frontend` wholesale, and that directory is
+gitignored — so it is shared across every branch in your checkout, not per
+branch.
+
 ### Pinned frontend dist (new FE at `/`)
 
 The new frontend lives in a separate repo,


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Two convenience scripts for getting the front ends in place on a local checkout. Since the new FE moved to its own repo, doing that by hand means reverse-engineering the packaging pipelines.

```sh
yarn fetch-frontend                # new FE (the pin) -> server/frontend
cd client && yarn build:old-ui     # old UI          -> server/frontend/old-ui
```

**`fetch-frontend`** (root `package.json`) unpacks the pinned dist from `frontend-version.json`. It defaults to the public B2 mirror, so it works with **no credentials** — otherwise you have to discover that the FE repo is private, that the default GitHub source therefore needs a token, and that a public mirror exists. The pin's `sha256` is enforced either way, so the mirror costs nothing in integrity. `FRONTEND_DIST_BASE_URL` is respected if already set, and `FRONTEND_DIST_URL` still wins for a local zip.

**`build:old-ui`** (`client/package.json`) builds this client as the legacy UI and copies it to `server/frontend/old-ui`. Four packaging pipelines each hand-roll these same two steps ([build/mac/build.sh](build/mac/build.sh), [dockerise.yaml](.github/workflows/dockerise.yaml), [build-windows-installers.yaml](.github/workflows/build-windows-installers.yaml), `android:build:release`).

[server/README.md](server/README.md) now shows both together, and states the non-obvious bits: `PUBLIC_PATH` must be set at **build** time (it fixes asset URLs *and* the router base, so a bundle built for `/` cannot be relocated by copying), the fetch **replaces** `server/frontend` wholesale, and that directory is gitignored — so it is shared across every branch in a checkout, not per branch. That last one is a genuine trap: a stale `server/frontend` makes *every* branch look like it has the wrong UI.

## 💌 Any notes for the reviewer?

Three deliberate non-changes:

- **Packaging still hand-rolls its own copy.** Each pipeline copies to a different destination (`$DESTINATION/frontend/old-ui`, the Android staging dir, …), so they can't share `build:old-ui`'s hardcoded target. Deduplicating properly means parameterising the destination — a bigger change than the problem justifies.
- **`yarn build` stays root-relative.** Tempting to default it to `/old-ui/` now that this client is only ever the legacy UI in deployments, but three things legitimately serve it at `/`: the webpack dev server (`yarn start`), the debug-build fallback in [serve_frontend.rs](server/server/src/serve_frontend.rs) that serves `client/packages/host/dist` at root when `frontend_dir` is absent, and `android:build:debug` / `android:build:server`. If we flip it, those should move together as one deliberate change.
- **`fetch-frontend` lives in the root `package.json`**, not the client's — it fetches into `server/frontend` via `build/fetch-frontend.js`, so it has nothing to do with the client workspace.

`build:old-ui` matches the existing `android:build:release` in using an inline env var and POSIX `cp`/`rm`, so it inherits the same "won't run in Windows `cmd`" limitation. Flagged rather than silently introduced — happy to add `cross-env` and a Node copy if we care about Windows dev shells.

# 🧪 Tested

- **`fetch-frontend`: verified against the real mirror.** Fetched `v0.0.247`, checksum OK, unpacked (292 files, 4.4 MB — and confirmed the release zip does *not* include the `showcase/` track). Run against a scratch directory rather than `server/frontend`, so as not to disturb a working tree mid-test.
- **`build:old-ui`: partially verified.** Ran the copy half from `client/` against an existing dist to confirm the relative paths resolve, then removed the result — that dist was built for `/`, so leaving it at `/old-ui/` would 404 its own assets and mislead. The `PUBLIC_PATH=/old-ui/ yarn build` half is unverified beyond being identical to what `android:build:release` and the mac build already run.
- Both `package.json` files still parse.

# 📃 Documentation

- [x] **Developer docs needed** (`docs: internal`) — done in this PR: `server/README.md` documents both scripts, why `PUBLIC_PATH` is build-time, and the gitignored-and-shared `server/frontend` trap.