### PR TITLE
Fix concurrent stocktake finalisation race Fixes #12640

### DIFF
--- a/server/repository/src/db_diesel/stocktake_row.rs
+++ b/server/repository/src/db_diesel/stocktake_row.rs
@@ -114,6 +114,38 @@ impl<'a> StocktakeRowRepository<'a> {
         result.map_err(RepositoryError::from)
     }
 
+    /// Like `find_one_by_id`, but takes a row-level lock (`SELECT ... FOR UPDATE`) on the
+    /// stocktake row for the duration of the current transaction.
+    ///
+    /// This is used to serialise concurrent stocktake finalisations: two transactions both
+    /// reading `status = New` and both finalising would otherwise be accepted under Postgres'
+    /// default READ COMMITTED isolation. With the lock, the second transaction blocks until the
+    /// first commits, then re-reads the (now finalised) row and is rejected.
+    // feature postgres
+    #[cfg(feature = "postgres")]
+    pub fn find_one_by_id_for_update(
+        &self,
+        id: &str,
+    ) -> Result<Option<StocktakeRow>, RepositoryError> {
+        let result = stocktake::table
+            .filter(stocktake::id.eq(id))
+            .for_update()
+            .first(self.connection.lock().connection())
+            .optional();
+        result.map_err(RepositoryError::from)
+    }
+
+    // feature sqlite
+    // SQLite allows only a single write transaction at a time (transactions are opened with
+    // `BEGIN IMMEDIATE`), so writers are already serialised and no row-level lock is needed.
+    #[cfg(not(feature = "postgres"))]
+    pub fn find_one_by_id_for_update(
+        &self,
+        id: &str,
+    ) -> Result<Option<StocktakeRow>, RepositoryError> {
+        self.find_one_by_id(id)
+    }
+
     pub fn find_many_by_id(&self, ids: &[String]) -> Result<Vec<StocktakeRow>, RepositoryError> {
         let result = stocktake::table
             .filter(stocktake::id.eq_any(ids))

--- a/server/service/src/stocktake/update/mod.rs
+++ b/server/service/src/stocktake/update/mod.rs
@@ -932,4 +932,124 @@ mod test {
             Some(mock_immunisation_program_a().id)
         );
     }
+
+    /// Regression test for the concurrent-finalisation race: two users in the same store
+    /// finalising the same stocktake at the same time must result in exactly one success and one
+    /// `CannotEditFinalised` error, with the inventory adjustment applied only once.
+    ///
+    /// Postgres-only: under Postgres' default READ COMMITTED isolation both transactions could
+    /// otherwise read `status = New` and both commit. SQLite serialises writers via
+    /// `BEGIN IMMEDIATE`, so the interleaving can't occur there and the test wouldn't exercise the
+    /// race.
+    #[cfg(feature = "postgres")]
+    #[actix_rt::test]
+    async fn finalise_stocktake_concurrent_only_one_succeeds() {
+        use std::sync::{Arc, Barrier};
+
+        let stock_line = StockLineRow {
+            id: "stock_line_concurrent_finalise".to_string(),
+            item_id: mock_item_a().id,
+            store_id: mock_store_a().id,
+            pack_size: 1.0,
+            available_number_of_packs: 5.0,
+            total_number_of_packs: 5.0,
+            ..Default::default()
+        };
+
+        let stocktake = StocktakeRow {
+            id: "stocktake_concurrent_finalise".to_string(),
+            store_id: mock_store_a().id,
+            stocktake_number: 200,
+            created_datetime: NaiveDate::from_ymd_opt(2024, 1, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+            status: StocktakeStatus::New,
+            ..Default::default()
+        };
+
+        // Counted (10) > snapshot (5) => inventory addition, bringing the stock line to 10 packs.
+        let stocktake_line = StocktakeLineRow {
+            id: "stocktake_line_concurrent_finalise".to_string(),
+            stocktake_id: stocktake.id.clone(),
+            stock_line_id: Some(stock_line.id.clone()),
+            item_id: mock_item_a().id,
+            snapshot_number_of_packs: 5.0,
+            counted_number_of_packs: Some(10.0),
+            ..Default::default()
+        };
+
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "finalise_stocktake_concurrent_only_one_succeeds",
+            MockDataInserts::all(),
+            MockData {
+                stock_lines: vec![stock_line.clone()],
+                stocktakes: vec![stocktake.clone()],
+                stocktake_lines: vec![stocktake_line],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = Arc::new(ServiceProvider::new(connection_manager));
+        let barrier = Arc::new(Barrier::new(2));
+
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let service_provider = service_provider.clone();
+                let barrier = barrier.clone();
+                let stocktake_id = stocktake.id.clone();
+                std::thread::spawn(move || {
+                    // Each thread gets its own DB connection (and therefore its own transaction).
+                    let context = service_provider
+                        .context(mock_store_a().id, "".to_string())
+                        .unwrap();
+                    // Release both threads as close together as possible to exercise the race.
+                    barrier.wait();
+                    service_provider.stocktake_service.update_stocktake(
+                        &context,
+                        UpdateStocktake {
+                            id: stocktake_id,
+                            status: Some(UpdateStocktakeStatus::Finalised),
+                            ..Default::default()
+                        },
+                    )
+                })
+            })
+            .collect();
+
+        let results: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect();
+
+        let successes = results.iter().filter(|result| result.is_ok()).count();
+        let already_finalised_errors = results
+            .iter()
+            .filter(|result| matches!(result, Err(UpdateStocktakeError::CannotEditFinalised)))
+            .count();
+
+        assert_eq!(
+            successes, 1,
+            "exactly one concurrent finalisation should succeed, got: {results:?}"
+        );
+        assert_eq!(
+            already_finalised_errors, 1,
+            "the losing finalisation should be rejected as already finalised, got: {results:?}"
+        );
+
+        // Stocktake finalised exactly once.
+        let finalised = StocktakeRepository::new(&connection)
+            .find_one_by_id(&stocktake.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(finalised.status, StocktakeStatus::Finalised);
+
+        // Inventory adjustment applied exactly once: 5 -> 10 packs (not 15).
+        let adjusted_stock_line = StockLineRowRepository::new(&connection)
+            .find_one_by_id(&stock_line.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(adjusted_stock_line.total_number_of_packs, 10.0);
+    }
 }

--- a/server/service/src/stocktake/update/validate.rs
+++ b/server/service/src/stocktake/update/validate.rs
@@ -4,7 +4,7 @@ use repository::{
 };
 
 use crate::{
-    stocktake::{check_stocktake_exist, check_stocktake_not_finalised},
+    stocktake::{check_stocktake_exist_for_update, check_stocktake_not_finalised},
     validate::check_store_id_matches,
 };
 
@@ -15,7 +15,11 @@ pub fn validate(
     store_id: &str,
     input: &UpdateStocktake,
 ) -> Result<(StocktakeRow, Vec<StocktakeLine>, bool), UpdateStocktakeError> {
-    let existing = match check_stocktake_exist(connection, &input.id)? {
+    // Take a row-level lock on the stocktake (as the first operation in the transaction) so that
+    // two users finalising the same stocktake concurrently are serialised: the second transaction
+    // blocks here until the first commits, then re-reads the now-finalised status below and is
+    // rejected with CannotEditFinalised, having performed no writes.
+    let existing = match check_stocktake_exist_for_update(connection, &input.id)? {
         Some(existing) => existing,
         None => return Err(UpdateStocktakeError::StocktakeDoesNotExist),
     };

--- a/server/service/src/stocktake/validate.rs
+++ b/server/service/src/stocktake/validate.rs
@@ -9,6 +9,16 @@ pub fn check_stocktake_exist(
     StocktakeRowRepository::new(connection).find_one_by_id(id)
 }
 
+/// Like `check_stocktake_exist`, but takes a row-level lock on the stocktake row so that
+/// concurrent transactions editing/finalising the same stocktake are serialised. Must be called
+/// inside a transaction (see `find_one_by_id_for_update`).
+pub fn check_stocktake_exist_for_update(
+    connection: &StorageConnection,
+    id: &str,
+) -> Result<Option<StocktakeRow>, RepositoryError> {
+    StocktakeRowRepository::new(connection).find_one_by_id_for_update(id)
+}
+
 pub fn check_stocktake_not_finalised(status: &StocktakeStatus) -> bool {
     *status != StocktakeStatus::Finalised
 }


### PR DESCRIPTION
Two users finalising the same stocktake at the same time both succeeded, double-applying the inventory adjustment. Under Postgres' default READ COMMITTED isolation, each transaction read status=New in its own snapshot (the read took no lock) and both committed.

Take a row-level lock (SELECT ... FOR UPDATE) on the stocktake row as the first operation in update_stocktake's transaction. The second transaction now blocks until the first commits, then re-reads the finalised status and is rejected with CannotEditFinalised, performing no writes. The lock is cfg-gated: it is a no-op on SQLite, which already serialises writers via BEGIN IMMEDIATE.

Adds a Postgres-gated regression test asserting exactly one of two concurrent finalisations succeeds and the inventory adjustment is applied once.


Claude-Session: https://claude.ai/code/session_01XhG48LfVQiKiUE7PGhLNrj

# 👩🏻‍💻 What does this PR do?

Fixes #12640

<!-- Explain the changes you made and why. If UI changes include screenshots or even videos -->

## 💌 Any notes for the reviewer?
Claude, untested, but code reviewed by Craig (pretty useless, but understood), and Brian (useful)

# 🧪 Tested

read the code, including Diesel & PG docs ;-) 
https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-ROWS

# 📃 Documentation
- [X] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)

