### PR TITLE
Correct the add-a-table guides: no ALTER TYPE changelog_table_name

### DIFF
--- a/.claude/skills/add-synced-table/SKILL.md
+++ b/.claude/skills/add-synced-table/SKILL.md
@@ -28,7 +28,7 @@ Scenario B is a superset of A (same repository layer + V7 bits) plus the legacy 
 
 Each guide has a TL;DR checklist table at the top, then a step-per-section walkthrough with the exact file paths and code. The layers, in order:
 
-1. **Repository + migration** — `CREATE TABLE` (incl. the Postgres `ALTER TYPE changelog_table_name ADD VALUE`), the `*_row.rs` row struct + repository + `Upsert`/`Delete` impls, `db_diesel/mod.rs` wiring.
+1. **Repository + migration** — `CREATE TABLE`, the `*_row.rs` row struct + repository + `Upsert`/`Delete` impls, `db_diesel/mod.rs` wiring. Note: **no** `ALTER TYPE changelog_table_name ADD VALUE` — v3 made `changelog.table_name` plain TEXT and dropped that type, so the old call now fails on Postgres. Other PG enums (e.g. `key_type`, for a processor cursor) still need registering.
 2. **Changelog** — add the `ChangelogTableName` variant, the `generate_changelog` impl (store-scoped `RowOrId` vs central id-string flavour), the `sync_style.rs` classification (`authoring` / `distribution` / `transport: V5|V6|V5_V6`), and the `Row` enum + `fetch_rows_for_table` arm in `batch_query.rs` (the V7 **push** path).
 3. **Legacy v5/v6 translation** *(scenario B only)* — a `SyncTranslation` in `service/src/sync/translations/`, registered in `all_translators()`, with a test-data fixture. Note: `table_name()` must match central exactly; `pull_dependencies()` references the dependency translation's own `table_name()` (e.g. `vec![StoreTranslation.table_name()]`), not a string literal.
 4. **V7 sync** — `INTEGRATION_ORDER` (FK order), `serde.rs` `serialize`/`deserialize` arms, and the `translate_delete` arm (if the table supports hard deletes).

--- a/docs/content/docs/sync/adding-a-table/v5-v6-and-v7/_index.md
+++ b/docs/content/docs/sync/adding-a-table/v5-v6-and-v7/_index.md
@@ -49,7 +49,7 @@ Repo layer (same as the V7-only guide — see it for full code):
 
 | # | File | What you add |
 |---|------|--------------|
-| R1 | `repository/src/migrations/v3_00_00/add_widget_table.rs` *(new)* + `mod.rs` | `CREATE TABLE`; PG `ALTER TYPE` |
+| R1 | `repository/src/migrations/v3_00_00/add_widget_table.rs` *(new)* + `mod.rs` | `CREATE TABLE` (no changelog enum change — v3 made `changelog.table_name` TEXT) |
 | R2 | `repository/src/db_diesel/widget_row.rs` *(new)* + `mod.rs` wiring | row + repository + `Upsert`/`Delete` |
 | R3 | `changelog/changelog.rs` | `Widget` in `ChangelogTableName` |
 | R4 | `changelog/generate_changelog.rs` | `impl WidgetRow { generate_changelog }` |
@@ -404,7 +404,8 @@ cd server
 cargo nextest run test_widget_translation   # the legacy translation test
 cargo nextest run integration_order          # V7 FK order / completeness
 cargo nextest run sync                        # broader legacy sync suite
-cargo build --features postgres               # missing ALTER TYPE / enum arms
+cargo build --features postgres               # missing enum arms
+cargo nextest run --features postgres migration_3_00_00   # migrations actually run on PG
 ```
 
 ## Common mistakes (in addition to the V7 guide's list)

--- a/docs/content/docs/sync/adding-a-table/v7-sync/_index.md
+++ b/docs/content/docs/sync/adding-a-table/v7-sync/_index.md
@@ -42,7 +42,7 @@ add an arm to.
 
 | # | File | What you add |
 |---|------|--------------|
-| 1 | `repository/src/migrations/v3_00_00/add_widget_table.rs` *(new)* | `CREATE TABLE widget`; PG: `ALTER TYPE changelog_table_name ADD VALUE 'widget'` |
+| 1 | `repository/src/migrations/v3_00_00/add_widget_table.rs` *(new)* | `CREATE TABLE widget` (no changelog enum change needed — see step 1) |
 | 2 | `repository/src/migrations/v3_00_00/mod.rs` | register the migration fragment |
 | 3 | `repository/src/db_diesel/widget_row.rs` *(new)* | `table!`, `WidgetRow`, `WidgetRowRepository`, `Upsert`/`Delete` impls |
 | 4 | `repository/src/db_diesel/mod.rs` | `pub mod widget_row;` + `pub use widget_row::*;` |
@@ -95,16 +95,6 @@ impl MigrationFragment for Migrate {
             "#
         )?;
 
-        // Postgres stores changelog_table_name as an ENUM, so the new value
-        // must be registered before any changelog row can reference it.
-        // SQLite stores it as TEXT, so this is Postgres-only.
-        if cfg!(feature = "postgres") {
-            sql!(
-                connection,
-                r#"ALTER TYPE changelog_table_name ADD VALUE IF NOT EXISTS 'widget';"#
-            )?;
-        }
-
         Ok(())
     }
 }
@@ -115,9 +105,16 @@ Notes:
 - `{DATETIME}`, `{DOUBLE}`, etc. are placeholders the `sql!` macro substitutes per backend
   (`TIMESTAMP`/`DATETIME`, `DOUBLE PRECISION`/`REAL`). Use them so the SQL runs on both
   Postgres and SQLite.
-- The `ALTER TYPE ... ADD VALUE` is **required** for any table that writes to the changelog
-  (i.e. anything that syncs). Forgetting it passes SQLite tests but breaks on Postgres at
-  runtime.
+- **No changelog enum change is needed.** `changelog.table_name` used to be a Postgres
+  `changelog_table_name` enum, so a new table had to register its value with
+  `ALTER TYPE … ADD VALUE`. As of `v3_00_00` that column is plain TEXT on both backends and
+  the type is dropped (by the `alter_changelog_table_for_sync_v7` fragment), so an
+  `ALTER TYPE` on it now **fails** on Postgres with `type "changelog_table_name" does not
+  exist`. Migrations before v3 still contain the old call; don't copy it.
+- Other Postgres enums are still enums — notably `key_type`. If your table needs a
+  processor cursor, that value *does* need registering:
+  `ALTER TYPE key_type ADD VALUE IF NOT EXISTS 'MY_PROCESSOR_CURSOR';` (guarded by
+  `cfg!(feature = "postgres")`). See `add_changelog_dedup_cursor_key_type` for the shape.
 - Triggers are **not** used for the changelog any more (they were removed in `v2_02_00`).
   Changelog rows are written programmatically by the repository (Step 3).
 
@@ -622,7 +619,8 @@ Key points:
 cd server
 cargo nextest run integration_order        # FK order / completeness guard
 cargo nextest run sync_v7                   # V7 sync tests
-cargo build --features postgres             # catches the missing ALTER TYPE / enum arms
+cargo build --features postgres             # catches missing enum arms
+cargo nextest run --features postgres migration_3_00_00   # migrations actually run on PG
 ```
 
 The compiler is your friend here: a missing `Row` / `serialize` / `deserialize` /
@@ -631,8 +629,10 @@ the rest. If those four pass, the table is fully wired for V7.
 
 ## Common mistakes
 
-- **Forgetting the Postgres `ALTER TYPE changelog_table_name ADD VALUE`** — green on SQLite,
-  runtime failure on Postgres.
+- **Copying the old `ALTER TYPE changelog_table_name ADD VALUE` from a pre-v3 migration** —
+  green on SQLite, and the Postgres *build* is fine too; it fails when migrations actually
+  run, because v3 dropped that type. Caught by `cargo nextest run --features postgres
+  migration_3_00_00`, which is why that test is in the verify list.
 - **Wrong `sync_style` transport/distribution** — the table compiles and "syncs" but rows go
   to the wrong sites (or nowhere). Copy from the closest existing table.
 - **Placing the table wrong in `INTEGRATION_ORDER`** — caught by the test, but only against


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes a stale instruction in both add-a-table guides and the `add-synced-table` skill.

They tell you to register a new table in the Postgres `changelog_table_name` enum:

```rust
sql!(connection, r#"ALTER TYPE changelog_table_name ADD VALUE 'widget';"#)?;
```

That was right before v3. `alter_changelog_table_for_sync_v7` now **drops** that type and makes
`changelog.table_name` plain TEXT, so a migration written from the guide fails on Postgres with
`type "changelog_table_name" does not exist`.

- `docs/.../adding-a-table/v7-sync/_index.md` — the `ALTER TYPE` removed from the migration
  example, the checklist row, and the common-mistakes list
- `docs/.../adding-a-table/v5-v6-and-v7/_index.md` — same, plus the verification command
- `.claude/skills/add-synced-table/SKILL.md` — layer 1 of the walkthrough

The note is explicit that this applies *only* to the changelog enum — other PG enums still need
registering, e.g. a `key_type` value for a processor cursor.

## 💌 Any notes for the reviewer?

Split out of #12629 on review feedback: it's a documentation correction with no bearing on the
front-end-sync feature, so it shouldn't need that stack's review to land.

Worth knowing how this was found — the guide's advice is silently wrong in a way local checks
don't surface. `cargo build --features postgres` passes (it's a runtime SQL string), and the
whole SQLite suite passes (SQLite stores the column as TEXT). Only `migration_3_00_00` under
Postgres actually executes the statement. Following the guide produced exactly this failure in
CI on #12627. The verification sections now name that test rather than leaving `cargo build
--features postgres` to imply coverage it doesn't give.

# 🧪 Tested

- Documentation only — no code changes, nothing to run.
- The correctness of the claim is demonstrated by #12627: with the `ALTER TYPE` present,
  `Test Database Migration (Postgres)` fails with `type "changelog_table_name" does not exist`;
  with it removed, that job passes.

# 📃 Documentation

- [x] **Developer docs needed** (`docs: internal`) — this PR *is* the developer-docs change: it
  corrects the two add-a-table guides under `./docs` and the matching skill.