### PR TITLE
Report a cell's effective indicator value type over GraphQL

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -3651,6 +3651,13 @@ export type IndicatorColumnNode = {
   isActive: Scalars['Boolean']['output'];
   name: Scalars['String']['output'];
   value?: Maybe<IndicatorValueNode>;
+  /**
+   * The cell's effective type — this column's configured type, falling back
+   * to its line's where the column declares none (`var` in mSupply). This is
+   * the type an edit is validated against, so it is the one to render an
+   * input from. Null where neither declares a type: an edit is then not
+   * type-checked at all.
+   */
   valueType?: Maybe<IndicatorValueTypeNode>;
 };
 
@@ -3679,6 +3686,11 @@ export type IndicatorLineRowNode = {
   isActive: Scalars['Boolean']['output'];
   lineNumber: Scalars['Int']['output'];
   name: Scalars['String']['output'];
+  /**
+   * The line's own configured type, null where it declares none (`var` in
+   * mSupply). A CELL's type is its column's `valueType`, which already
+   * resolves the fallback to this one.
+   */
   valueType?: Maybe<IndicatorValueTypeNode>;
 };
 

--- a/client/packages/requisitions/src/RequestRequisition/ListView/CreateRequisitionModal.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/ListView/CreateRequisitionModal.tsx
@@ -43,7 +43,6 @@ export const CreateRequisitionModal = ({
     isOpen,
     onClose,
     disableBackdrop: false,
-    testId: 'create-internal-order-modal',
   });
   const noSuppliers = programSettings?.every(
     setting => setting.suppliers.length === 0
@@ -78,6 +77,7 @@ export const CreateRequisitionModal = ({
 
   return (
     <Modal
+      testId="create-internal-order-modal"
       height={700}
       width={700}
       slideAnimation={false}

--- a/server/graphql/types/src/types/program/program_indicator.rs
+++ b/server/graphql/types/src/types/program/program_indicator.rs
@@ -190,8 +190,6 @@ impl IndicatorLineRowNode {
     /// The line's own configured type, null where it declares none (`var` in
     /// mSupply). A CELL's type is its column's `valueType`, which already
     /// resolves the fallback to this one.
-    // Reported as configured: `unwrap_or_default()` here answered Number for a
-    // `var` line, which no caller could tell from a line genuinely typed Number.
     pub async fn value_type(&self) -> Option<IndicatorValueTypeNode> {
         self.line
             .value_type
@@ -209,10 +207,6 @@ impl IndicatorColumnNode {
         IndicatorColumnNode { column, line }
     }
 
-    // Answering the column's RAW type here (`unwrap_or_default()`, i.e. Number)
-    // made a `var` column on a text line indistinguishable from a genuinely
-    // numeric one, so clients gave it a numeric input for a cell
-    // `update_indicator_value` accepts text into.
     fn effective_value_type(&self) -> Option<IndicatorValueTypeNode> {
         indicator_value_type(&self.line, &self.column)
             .clone()

--- a/server/graphql/types/src/types/program/program_indicator.rs
+++ b/server/graphql/types/src/types/program/program_indicator.rs
@@ -13,7 +13,10 @@ use repository::{
     EqualFilter, IndicatorColumnRow, IndicatorLineRow, IndicatorValueRow, ProgramIndicatorFilter,
     ProgramIndicatorSort, ProgramIndicatorSortField,
 };
-use service::requisition::program_indicator::query::{IndicatorLine, ProgramIndicator};
+use service::requisition::{
+    common::indicator_value_type,
+    program_indicator::query::{IndicatorLine, ProgramIndicator},
+};
 
 use super::{
     program_node::ProgramNode, requisition_indicator_info::CustomerIndicatorInformationNode,
@@ -152,7 +155,7 @@ impl IndicatorLineNode {
             .columns
             .clone()
             .into_iter()
-            .map(|column| IndicatorColumnNode::from_domain(column, self.line.line.id.clone()))
+            .map(|column| IndicatorColumnNode::from_domain(column, self.line.line.clone()))
             .collect()
     }
 }
@@ -184,10 +187,16 @@ impl IndicatorLineRowNode {
         self.line.line_number
     }
 
+    /// The line's own configured type, null where it declares none (`var` in
+    /// mSupply). A CELL's type is its column's `valueType`, which already
+    /// resolves the fallback to this one.
+    // Reported as configured: `unwrap_or_default()` here answered Number for a
+    // `var` line, which no caller could tell from a line genuinely typed Number.
     pub async fn value_type(&self) -> Option<IndicatorValueTypeNode> {
-        Some(IndicatorValueTypeNode::from(
-            self.line.value_type.clone().unwrap_or_default(),
-        ))
+        self.line
+            .value_type
+            .clone()
+            .map(IndicatorValueTypeNode::from)
     }
 
     pub async fn is_active(&self) -> bool {
@@ -196,14 +205,26 @@ impl IndicatorLineRowNode {
 }
 
 impl IndicatorColumnNode {
-    pub fn from_domain(column: IndicatorColumnRow, line_id: String) -> IndicatorColumnNode {
-        IndicatorColumnNode { column, line_id }
+    pub fn from_domain(column: IndicatorColumnRow, line: IndicatorLineRow) -> IndicatorColumnNode {
+        IndicatorColumnNode { column, line }
+    }
+
+    // Answering the column's RAW type here (`unwrap_or_default()`, i.e. Number)
+    // made a `var` column on a text line indistinguishable from a genuinely
+    // numeric one, so clients gave it a numeric input for a cell
+    // `update_indicator_value` accepts text into.
+    fn effective_value_type(&self) -> Option<IndicatorValueTypeNode> {
+        indicator_value_type(&self.line, &self.column)
+            .clone()
+            .map(IndicatorValueTypeNode::from)
     }
 }
 
 pub struct IndicatorColumnNode {
     pub column: IndicatorColumnRow,
-    pub line_id: String,
+    /// The column's own line — its id addresses the stored value, and its
+    /// configured type is the fallback behind `value_type` below.
+    pub line: IndicatorLineRow,
 }
 
 #[Object]
@@ -216,10 +237,13 @@ impl IndicatorColumnNode {
         &self.column.id
     }
 
+    /// The cell's effective type — this column's configured type, falling back
+    /// to its line's where the column declares none (`var` in mSupply). This is
+    /// the type an edit is validated against, so it is the one to render an
+    /// input from. Null where neither declares a type: an edit is then not
+    /// type-checked at all.
     pub async fn value_type(&self) -> Option<IndicatorValueTypeNode> {
-        Some(IndicatorValueTypeNode::from(
-            self.column.value_type.clone().unwrap_or_default(),
-        ))
+        self.effective_value_type()
     }
 
     pub async fn column_number(&self) -> i32 {
@@ -236,7 +260,7 @@ impl IndicatorColumnNode {
         let loader = ctx.get_loader::<DataLoader<IndicatorValueLoader>>();
         let result = loader
             .load_one(IndicatorValueLoaderInput::new(
-                &self.line_id,
+                &self.line.id,
                 &self.column.id,
                 &period_id,
                 &store_id,
@@ -282,5 +306,66 @@ impl IndicatorValueNode {
 impl IndicatorValueNode {
     pub fn from_domain(value: IndicatorValueRow) -> IndicatorValueNode {
         IndicatorValueNode { value }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use repository::IndicatorValueType;
+
+    fn line(value_type: Option<IndicatorValueType>) -> IndicatorLineRow {
+        IndicatorLineRow {
+            id: "line".to_string(),
+            value_type,
+            ..Default::default()
+        }
+    }
+
+    fn column(value_type: Option<IndicatorValueType>) -> IndicatorColumnRow {
+        IndicatorColumnRow {
+            id: "column".to_string(),
+            value_type,
+            ..Default::default()
+        }
+    }
+
+    // What the `valueType` field answers (the resolver delegates to it).
+    fn value_type_of(
+        column_type: Option<IndicatorValueType>,
+        line_type: Option<IndicatorValueType>,
+    ) -> Option<IndicatorValueTypeNode> {
+        IndicatorColumnNode::from_domain(column(column_type), line(line_type))
+            .effective_value_type()
+    }
+
+    /// The cell's effective type is reported, not the column's raw one: a `var`
+    /// column takes its line's type (what an edit is validated against), and
+    /// only a cell typed nowhere answers null.
+    #[test]
+    fn column_value_type_falls_back_to_its_line() {
+        use IndicatorValueType::{Number, String as Text};
+
+        // The column's own type wins wherever it has one.
+        assert_eq!(
+            value_type_of(Some(Number), Some(Text)),
+            Some(IndicatorValueTypeNode::Number)
+        );
+        assert_eq!(
+            value_type_of(Some(Text), Some(Number)),
+            Some(IndicatorValueTypeNode::String)
+        );
+        // A `var` column takes the line's — the case that used to report the
+        // enum default (Number) and earn a numeric input on a text line.
+        assert_eq!(
+            value_type_of(None, Some(Text)),
+            Some(IndicatorValueTypeNode::String)
+        );
+        assert_eq!(
+            value_type_of(None, Some(Number)),
+            Some(IndicatorValueTypeNode::Number)
+        );
+        // Typed nowhere: null, and the update validates nothing either.
+        assert_eq!(value_type_of(None, None), None);
     }
 }

--- a/server/service/src/requisition/common.rs
+++ b/server/service/src/requisition/common.rs
@@ -236,7 +236,11 @@ pub(crate) fn related_indicator_schema(
     })
 }
 
-pub(crate) fn indicator_value_type<'a>(
+/// A cell's effective value type: the column's configured type, falling back to
+/// the line's when the column declares none (`var` in mSupply). This is what an
+/// edit is validated against, and what `IndicatorColumnNode.value_type` reports,
+/// so the input a client renders matches what the update will accept.
+pub fn indicator_value_type<'a>(
     line: &'a IndicatorLineRow,
     column: &'a IndicatorColumnRow,
 ) -> &'a Option<IndicatorValueType> {


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

`IndicatorColumnNode.valueType` reported the column's **raw** type, defaulting to `Number` where the column declared none (`var`, in mSupply terms). But an edit is validated against the cell's **effective** type — the column's, falling back to its line's — which `update_indicator_value` gets from the shared `indicator_value_type` helper.

So a `var` column on a text line advertised `Number`, and [IndicatorLineEdit.tsx:90](client/packages/requisitions/src/common/IndicatorEdit/IndicatorLineEdit.tsx#L90) picks its input straight off that field: the user got a numeric input (coercing to `0`) for a cell the server would have accepted text into.

`IndicatorColumnNode` now carries its line rather than just the line id, and resolves `valueType` through that same helper (`pub` now, was `pub(crate)`). `IndicatorLineRowNode.valueType` likewise stops defaulting to `Number`. Both fields were already nullable, so no TS type changes and no client change is needed — the frontend was just being told the wrong thing.

The regenerated `schema.ts` is committed separately. Its only diff is the two new field descriptions: the doc comments on the resolvers become GraphQL descriptions, which is worth keeping — the column/line fallback isn't something a consumer can infer from the field's type.

## 💌 Any notes for the reviewer?

`null` now has a meaning — "typed nowhere", where neither column nor line declares a type. Such a cell isn't type-checked by the update either, and the frontend's `!== Number` branch already renders text for it, so the behaviour is right. Flagging in case you know another consumer.

I left `default_indicator_value` (just below the helper) alone — it uses a subtly different rule, and whether that's intended or the same bug again felt like a separate question.

# 🧪 Tested

- Added a unit test covering the resolution table: column type wins where present, a `var` column inherits its line's type, a cell typed nowhere reports null
- `cargo nextest run -p graphql_types column_value_type` passes; `cargo check --workspace --all-targets` clean
- Three `graphql_types` tests fail on my machine for unrelated pre-existing reasons (mock insert hits `table requisition has no column named destination_customer_link_id`)
- `yarn generate` in `./client` run to completion; re-running it now leaves the tree clean, which is what the drift check asserts

Manual check, with an indicator-configured datafile: configure a text-typed indicator line with a column declaring no type, open a program requisition's indicator editor — the column should now render a text input that saves, where before it rendered a numeric one and coerced to `0`.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:

