### PR TITLE
Trigger central's own sync when a site is waiting on its v7 upgrade

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2673,6 +2673,7 @@
   "messages.vaccination-saved-and-stock-recorded": "Vaccination saved and stock transaction recorded 🥳",
   "messages.vaccination-was-given": "Vaccination was given on {{date}}.",
   "messages.vaccine-course-saved": "Vaccine course updated",
+  "messages.waiting-for-central-server": "Waiting for the central server to prepare this site…",
   "messages.yes": "Yes",
   "messages.zero-line-quantities_few": "The quantity of {{count}} lines has been set to 0",
   "messages.zero-line-quantities_many": "The quantity of {{count}} lines has been set to 0",

--- a/client/packages/host/src/components/Initialise/Initialise.tsx
+++ b/client/packages/host/src/components/Initialise/Initialise.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
+  Alert,
   Tab,
   TabList,
   useTranslation,
@@ -185,6 +186,7 @@ const RemoteForm: React.FC<RemoteFormProps> = ({
     setBatchSize,
     siteCredentialsError: error,
     syncStatus,
+    waitingForCentral,
   } = formState;
 
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -276,6 +278,11 @@ const RemoteForm: React.FC<RemoteFormProps> = ({
               </Box>
             </Collapse>
           </Box>
+          {waitingForCentral && (
+            <Alert severity="info">
+              {t('messages.waiting-for-central-server')}
+            </Alert>
+          )}
           {error && <BoxedErrorWithDetails {...error} />}
           <Box display="flex" justifyContent="flex-end">
             <LoadingButton

--- a/client/packages/host/src/components/Initialise/Initialise.tsx
+++ b/client/packages/host/src/components/Initialise/Initialise.tsx
@@ -48,7 +48,8 @@ export const Initialise = () => {
   const isAndroid = EnvUtils.platform === Platform.Android;
   // Only offer the standalone-central setup in dev (`yarn start`), not in
   // production builds.
-  const showCentralTab = !isAndroid && isCentralServer && !EnvUtils.isProduction();
+  const showCentralTab =
+    !isAndroid && isCentralServer && !EnvUtils.isProduction();
   const isInputDisabled = formState.isInitialising || formState.isLoading;
   const isExtraSmallScreen = useIsExtraSmallScreen();
   const nativeClient = useNativeClient();
@@ -105,7 +106,11 @@ export const Initialise = () => {
             justifyContent: 'center',
           })}
         >
-          <Stack spacing={isExtraSmallScreen ? 2 : 3} width="100%" maxWidth={360}>
+          <Stack
+            spacing={isExtraSmallScreen ? 2 : 3}
+            width="100%"
+            maxWidth={360}
+          >
             <Stack direction="row" sx={{ justifyContent: 'center' }}>
               <LoginIcon small />
             </Stack>
@@ -276,7 +281,11 @@ const RemoteForm: React.FC<RemoteFormProps> = ({
               </Box>
             </Collapse>
           </Box>
-          {error && <BoxedErrorWithDetails {...error} />}
+          {/* Full width of the form Stack — the container bounding the inputs
+              and the Initialise button — rather than the component's fixed
+              300px default, which neither matches the inputs nor the panel
+              (open-msupply-frontend#504). */}
+          {error && <BoxedErrorWithDetails {...error} width="100%" />}
           <Box display="flex" justifyContent="flex-end">
             <LoadingButton
               isLoading={isLoading}

--- a/client/packages/host/src/components/Initialise/Initialise.tsx
+++ b/client/packages/host/src/components/Initialise/Initialise.tsx
@@ -281,11 +281,7 @@ const RemoteForm: React.FC<RemoteFormProps> = ({
               </Box>
             </Collapse>
           </Box>
-          {/* Full width of the form Stack — the container bounding the inputs
-              and the Initialise button — rather than the component's fixed
-              300px default, which neither matches the inputs nor the panel
-              (open-msupply-frontend#504). */}
-          {error && <BoxedErrorWithDetails {...error} width="100%" />}
+          {error && <BoxedErrorWithDetails {...error} />}
           <Box display="flex" justifyContent="flex-end">
             <LoadingButton
               isLoading={isLoading}

--- a/client/packages/host/src/components/Initialise/Initialise.tsx
+++ b/client/packages/host/src/components/Initialise/Initialise.tsx
@@ -48,8 +48,7 @@ export const Initialise = () => {
   const isAndroid = EnvUtils.platform === Platform.Android;
   // Only offer the standalone-central setup in dev (`yarn start`), not in
   // production builds.
-  const showCentralTab =
-    !isAndroid && isCentralServer && !EnvUtils.isProduction();
+  const showCentralTab = !isAndroid && isCentralServer && !EnvUtils.isProduction();
   const isInputDisabled = formState.isInitialising || formState.isLoading;
   const isExtraSmallScreen = useIsExtraSmallScreen();
   const nativeClient = useNativeClient();
@@ -106,11 +105,7 @@ export const Initialise = () => {
             justifyContent: 'center',
           })}
         >
-          <Stack
-            spacing={isExtraSmallScreen ? 2 : 3}
-            width="100%"
-            maxWidth={360}
-          >
+          <Stack spacing={isExtraSmallScreen ? 2 : 3} width="100%" maxWidth={360}>
             <Stack direction="row" sx={{ justifyContent: 'center' }}>
               <LoginIcon small />
             </Stack>

--- a/client/packages/host/src/components/Initialise/hooks.ts
+++ b/client/packages/host/src/components/Initialise/hooks.ts
@@ -7,11 +7,20 @@ import {
   InitialisationStatusType,
   useInitialisationStatus,
   useNativeClient,
+  SyncErrorVariantV7,
 } from '@openmsupply-client/common';
 import { useSync, mapSyncError } from '@openmsupply-client/system';
 
 const STATUS_POLLING_INTERVAL = 500;
 const DEFAULT_SYNC_INTERVAL_IN_SECONDS = 300;
+// A fresh site can land on WaitingForCentralV7Upgrade: the central server has
+// asked the legacy central to move this site onto the current sync protocol and
+// is waiting for its own sync to deliver the result. The server now triggers
+// that sync immediately (open-msupply#12650), so a short poll of quiet retries
+// turns a scary red error + manual retry into a few seconds' wait — matching
+// the new frontend (open-msupply-frontend#972).
+const CENTRAL_WAIT_RETRY_INTERVAL_MS = 5000;
+const CENTRAL_WAIT_RETRY_ATTEMPTS = 12;
 
 interface InitialiseForm {
   // Error on validation of sync credentials, there is another error for sync progress
@@ -40,6 +49,10 @@ interface InitialiseForm {
   // Used to enable polling of syncStatus and initialisationStatus
   // false by default and toggled to STATUS_POLLING_INTERVAL when isInitialising
   refetchInterval: number | false;
+  // true while quietly retrying because the central server has not yet prepared
+  // this site (WaitingForCentralV7Upgrade); shows a friendly notice in place of
+  // the red error, no user action needed.
+  waitingForCentral: boolean;
 }
 
 const useInitialiseFormState = () => {
@@ -52,6 +65,7 @@ const useInitialiseFormState = () => {
     url: 'https://',
     batchSize: null,
     refetchInterval: false,
+    waitingForCentral: false,
   });
 
   return {
@@ -66,6 +80,8 @@ const useInitialiseFormState = () => {
     setUrl: (url: string) => set(state => ({ ...state, url })),
     setBatchSize: (batchSize: number | null) =>
       set(state => ({ ...state, batchSize })),
+    setWaitingForCentral: (waitingForCentral: boolean) =>
+      set(state => ({ ...state, waitingForCentral })),
     // When sync is already ongoing either after initialise button is pressed
     // or when initialisation page is loaded while sync is ongoing
     // inputs should be disabled and polling for syncStatus should start
@@ -95,6 +111,7 @@ export const useInitialiseForm = () => {
     setUrl,
     setUsername,
     setBatchSize,
+    setWaitingForCentral,
   } = state;
   const t = useTranslation();
   const { mutateAsync: initialise } = useSync.sync.initialise();
@@ -110,34 +127,63 @@ export const useInitialiseForm = () => {
 
   const onInitialise = async () => {
     setSiteCredentialsError(null);
+    setWaitingForCentral(false);
     setIsLoading(true);
-    try {
-      const response = await initialise({
-        intervalSeconds: DEFAULT_SYNC_INTERVAL_IN_SECONDS,
-        password,
-        url,
-        username,
-        batchSize: batchSize ?? undefined,
-      });
-      // Map structured error
+
+    // Snapshot once: the fields are locked for the whole loop, and
+    // setIsInitialising() would blank the password before a later retry.
+    const settings = {
+      intervalSeconds: DEFAULT_SYNC_INTERVAL_IN_SECONDS,
+      password,
+      url,
+      username,
+      batchSize: batchSize ?? undefined,
+    };
+
+    for (let attempt = 0; ; attempt++) {
+      let response: Awaited<ReturnType<typeof initialise>>;
+      try {
+        response = await initialise(settings);
+      } catch (e) {
+        // Set standard error
+        setWaitingForCentral(false);
+        setSiteCredentialsError({
+          error: t('error.unable-to-initialise'),
+          details: (e as Error)?.message || '',
+        });
+        return setIsLoading(false);
+      }
+
+      // The one transient variant: hold the form locked, show the waiting
+      // notice, and try again after the interval until the budget is spent.
+      const isWaitingForCentral =
+        response.__typename === 'SyncErrorV7Node' &&
+        response.variantV7 === SyncErrorVariantV7.WaitingForCentralV7Upgrade;
+      if (isWaitingForCentral && attempt < CENTRAL_WAIT_RETRY_ATTEMPTS) {
+        setWaitingForCentral(true);
+        await new Promise(resolve =>
+          setTimeout(resolve, CENTRAL_WAIT_RETRY_INTERVAL_MS)
+        );
+        continue;
+      }
+
+      // Any other structured error (or the wait budget exhausted) is real —
+      // map it and unlock the form.
       if (
         response.__typename === 'SyncErrorNode' ||
         response.__typename === 'SyncErrorV7Node'
       ) {
+        setWaitingForCentral(false);
         setSiteCredentialsError(
           mapSyncError(t, response, 'error.unable-to-initialise')
         );
         return setIsLoading(false);
       }
-    } catch (e) {
-      // Set standard error
-      setSiteCredentialsError({
-        error: t('error.unable-to-initialise'),
-        details: (e as Error)?.message || '',
-      });
-      return setIsLoading(false);
+
+      break; // SyncSettingsNode — initialisation accepted
     }
 
+    setWaitingForCentral(false);
     setIsInitialising(true);
   };
 

--- a/docs/content/docs/sync/transition/_index.md
+++ b/docs/content/docs/sync/transition/_index.md
@@ -79,6 +79,8 @@ This is the implemented flow. A ROMS that has been upgraded to a V7-capable vers
 
 **Re-initialising a V7 site.** When a site that was previously on V5/V6 re-initialises against COMS, COMS itself checks with COGS whether the site is marked V7; if it isn't, COMS moves it back to V5/V6 so the two stay consistent.
 
+**Initialising a site COMS doesn't yet show as V7** (e.g. a site freshly created in legacy mSupply). Authentication (`get_token`) gates on the site being V7 on COMS. When it isn't, COMS asks COGS to transition it (the same `v7_url_and_upgrade` request as step 4); on success it answers `WaitingForCentralV7Upgrade` **and triggers its own sync with COGS**, so the flipped `site` row typically arrives and integrates within seconds. The initialising remote retries and gets through on the next attempt — without the trigger it would wait out COMS's whole sync interval ([open-msupply-frontend#504](https://github.com/msupply-foundation/open-msupply-frontend/issues/504)).
+
 **Hardware id.** During the transition the hardware id sometimes has to be reset on OG — but only once, before the V7 transition (for example when the site was previously running a legacy app such as legacy mSupply mobile). After transition, V7 site authentication is handled by COMS.
 
 ![migration_to_v7](./images/migrating_to_v7.drawio.svg)

--- a/server/service/src/sync/synchroniser_driver.rs
+++ b/server/service/src/sync/synchroniser_driver.rs
@@ -123,6 +123,14 @@ impl SyncTrigger {
             sender: mpsc::channel(1).0,
         }
     }
+
+    /// A trigger whose receiver the test holds, so it can assert whether a
+    /// code path fired a sync (e.g. `ensure_site_is_v7`'s central kick).
+    #[cfg(test)]
+    pub(crate) fn new_test() -> (SyncTrigger, mpsc::Receiver<()>) {
+        let (sender, receiver) = mpsc::channel(1);
+        (SyncTrigger { sender }, receiver)
+    }
 }
 
 fn get_sync_settings(service_provider: &ServiceProvider) -> SyncSettings {

--- a/server/service/src/sync_v7/sync_on_central/mod.rs
+++ b/server/service/src/sync_v7/sync_on_central/mod.rs
@@ -165,7 +165,8 @@ pub async fn get_token(
 ///   until every store's data has been moved to COMS — that error is propagated
 ///   unchanged so ROMS retries. On success the legacy server has flipped to v7,
 ///   but COMS must wait for that to arrive via sync, so we return
-///   `WaitingForCentralV7Upgrade` rather than upgrading locally.
+///   `WaitingForCentralV7Upgrade` rather than upgrading locally — after
+///   triggering COMS's own sync, so the wait is seconds, not a sync interval.
 ///
 /// Acquires a connection per DB touch rather than holding one across the legacy
 /// server roundtrip, so a pool slot isn't tied up during the network call.
@@ -202,6 +203,15 @@ async fn ensure_site_is_v7(
     // don't let ROMS initialise before this site's data is fully integrated on
     // COMS. ROMS retries; the early return above succeeds once the v7 `site` row
     // has synced + integrated.
+    //
+    // That arrival only happens on a COMS sync cycle, so kick one off now rather
+    // than leaving ROMS to wait out COMS's sync interval
+    // (open-msupply-frontend#504 — ROMS retries for ~a minute before showing the
+    // error). The trigger's single-slot channel coalesces: concurrent get_token
+    // calls while a sync is already queued are no-ops, and deliberately NOT
+    // triggering on the `stores_not_migrated` path above — that needs stores
+    // moved to COMS by an operator, which no sync cycle can do.
+    service_provider.sync_trigger.trigger();
     Err(SyncError::WaitingForCentralV7Upgrade)
 }
 
@@ -656,7 +666,7 @@ fn set_site_lock(site_id: i32, error: Option<SiteLockError>) {
 mod tests {
     use super::*;
     use crate::{
-        sync::test_util_set_is_central_server,
+        sync::{synchroniser_driver::SyncTrigger, test_util_set_is_central_server},
         test_helpers::{setup_all_and_service_provider, ServiceTestContext},
     };
     use httpmock::MockServer;
@@ -1027,7 +1037,7 @@ mod tests {
 
         let ServiceTestContext {
             connection,
-            service_provider,
+            connection_manager,
             ..
         } = setup_all_and_service_provider(
             "ensure_site_is_v7_waits_for_central",
@@ -1035,6 +1045,11 @@ mod tests {
         )
         .await;
         test_util_set_is_central_server(true);
+
+        // A service provider whose sync trigger the test can observe.
+        let (sync_trigger, mut sync_receiver) = SyncTrigger::new_test();
+        let mut service_provider = ServiceProvider::new(connection_manager);
+        service_provider.sync_trigger = sync_trigger;
 
         let site = non_v7_site(&connection, &mock_server.base_url());
 
@@ -1044,6 +1059,10 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, SyncError::WaitingForCentralV7Upgrade));
+
+        // ...and it must have kicked off its own sync to fetch that row, so the
+        // wait is seconds rather than a sync interval (open-msupply-frontend#504).
+        assert!(sync_receiver.try_recv().is_ok());
 
         // The local site row must be untouched (still V5_V6).
         let stored = SiteRowRepository::new(&connection)
@@ -1066,7 +1085,7 @@ mod tests {
 
         let ServiceTestContext {
             connection,
-            service_provider,
+            connection_manager,
             ..
         } = setup_all_and_service_provider(
             "ensure_site_is_v7_stores_not_migrated",
@@ -1074,6 +1093,10 @@ mod tests {
         )
         .await;
         test_util_set_is_central_server(true);
+
+        let (sync_trigger, mut sync_receiver) = SyncTrigger::new_test();
+        let mut service_provider = ServiceProvider::new(connection_manager);
+        service_provider.sync_trigger = sync_trigger;
 
         let site = non_v7_site(&connection, &mock_server.base_url());
 
@@ -1083,6 +1106,10 @@ mod tests {
             .await
             .unwrap_err();
         assert!(!matches!(err, SyncError::WaitingForCentralV7Upgrade));
+
+        // No sync is kicked off for this path: syncing cannot move stores to
+        // COMS — that is an operator task on the legacy server.
+        assert!(sync_receiver.try_recv().is_err());
 
         // The local site row must remain V5_V6.
         let stored = SiteRowRepository::new(&connection)


### PR DESCRIPTION
Fixes both halves of a fresh remote's initialisation opening on a scary red error (msupply-foundation/open-msupply-frontend#504); pairs with the new frontend's fix in msupply-foundation/open-msupply-frontend#972.

## Server: trigger central's own sync

`ensure_site_is_v7` returns `WaitingForCentralV7Upgrade` after COGS accepts the upgrade, but the flipped `site` row only arrives on COMS's next sync cycle — so an initialising remote sat on the error until the interval elapsed. This calls `service_provider.sync_trigger.trigger()` at that moment: the single-slot channel coalesces concurrent `get_token` calls, and the `stores_not_migrated` path deliberately does **not** trigger (that needs an operator moving stores, not a sync). With the frontends' ~1-minute retry window, the wait becomes seconds.

- `SyncTrigger::new_test()` (`#[cfg(test)]`) so the two existing `ensure_site_is_v7` tests now assert the trigger fired on the waiting path and not on `stores_not_migrated` — 3/3 green under `cargo nextest`.
- Transition doc: new paragraph documenting the fresh-site `get_token` gate + the immediate central sync.

## Legacy client: wait it out instead of erroring

The trigger above is only half the fix — the legacy UI still met `WaitingForCentralV7Upgrade` with the red error box and a manual **Retry**, so the operator saw a failure at the exact moment the server had just started resolving it. `Initialise`'s `onInitialise` now recognises that one transient variant and, instead of surfacing it, holds the form locked, shows a quiet "waiting for the central server…" notice, and silently retries the initialise mutation (12 × 5 s). Any other structured error — or the retry budget running out — surfaces exactly as before. This mirrors the new frontend (msupply-foundation/open-msupply-frontend#972).

- `Initialise/hooks.ts`: the retry loop + a `waitingForCentral` flag; the `try` wraps only the network call, so classifying the returned `SyncError*` union stays outside the catch.
- `Initialise.tsx`: an `<Alert severity="info">` notice in place of the red box while waiting.
- `en/common.json`: `messages.waiting-for-central-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
