### PR TITLE
#12232 Start file sync after a fresh v5/v6 initialisation

### DIFF
--- a/server/service/src/sync/file_sync_driver.rs
+++ b/server/service/src/sync/file_sync_driver.rs
@@ -15,12 +15,32 @@ use tokio::{
         mpsc::{self, Receiver, Sender},
         watch,
     },
-    time::Duration,
+    time::{timeout, Duration},
 };
 use util::format_error;
 
 const FILE_SYNC_UPLOAD_DELAY: Duration = Duration::from_millis(100); // This just gives time for a PAUSE message to be received between uploading files
 const FILE_SYNC_NO_FILES_DELAY: Duration = Duration::from_millis(10000); // If there's nothing to upload or there was an error, wait a longer before checking again
+
+/// How long to wait before re-checking initialisation state while still uninitialised.
+///
+/// Unlike the initialised branch, this one has no waker for "initialisation just
+/// finished": the only production `Start` sender is the one-shot
+/// `SiteIsInitialisedCallback` in server/src/lib.rs. Contrast `SynchroniserDriver`, which
+/// *can* safely block on its trigger, because its own trigger is what causes
+/// initialisation — this driver has no such intrinsic waker, so it has to poll.
+///
+/// Kept coarse deliberately: each poll takes a pooled connection and runs the
+/// `get_initialisation_status` queries, and the pre-initialisation window is the DB-hottest
+/// phase of a site's life (initial integration). Latency after initialisation doesn't
+/// matter — nothing is uploadable before initialisation, and steady state already idles for
+/// FILE_SYNC_NO_FILES_DELAY. Once initialised the `IS_INITIALISED` latch means no queries
+/// at all.
+#[cfg(not(test))]
+const FILE_SYNC_NOT_INITIALISED_DELAY: Duration = Duration::from_secs(5);
+/// Tests flip initialisation state by hand and assert on the next poll.
+#[cfg(test)]
+const FILE_SYNC_NOT_INITIALISED_DELAY: Duration = Duration::from_millis(50);
 
 pub enum FileSyncMessage {
     Start, // Start sync (could be manual trigger, or automatic on server startup)
@@ -80,7 +100,8 @@ impl FileSyncDriver {
     /// Operations:
     /// * loop
     ///    * If initialised await for  trigger OR interval sec timeout
-    ///    * If not initialised await only for start trigger
+    ///    * If not initialised await for start trigger OR re-check initialisation after
+    ///      FILE_SYNC_NOT_INITIALISED_DELAY
     ///    * do sync if any of the above were triggered
     pub async fn run(mut self, service_provider: Arc<ServiceProvider>) {
         let mut stopped = false;
@@ -119,10 +140,38 @@ impl FileSyncDriver {
                     else => break,
                 };
             } else {
-                // If not initialised, only wait for start trigger
-                if let Some(FileSyncMessage::Start) = self.receiver.recv().await {
-                    log::info!("Starting file sync");
-                    stopped = false;
+                // If not initialised, wait for a lifecycle event OR re-check periodically.
+                //
+                // Polling rather than blocking, because `Start` is effectively a one-shot in
+                // production (SiteIsInitialisedCallback consumes itself after a single
+                // message, and FileSyncTrigger::stop is never called) and on the v5/v6
+                // initialisation path it is delivered *before* SyncLogger::done writes
+                // finished_datetime — i.e. while is_initialised() is still false. Blocking
+                // on recv() here therefore spent the only wake-up this driver would ever
+                // get and parked it until the next server restart, so no file ever uploaded
+                // from a freshly initialised remote (issue #12232).
+                //
+                // recv() is cancel safe, so the timeout can't drop a message.
+                match timeout(FILE_SYNC_NOT_INITIALISED_DELAY, self.receiver.recv()).await {
+                    Ok(Some(FileSyncMessage::Start)) => {
+                        log::info!("Starting file sync");
+                        stopped = false;
+                    }
+                    Ok(Some(FileSyncMessage::Stop)) => {
+                        log::info!("Stopping file sync");
+                        stopped = true;
+                    }
+                    // All senders dropped, which only happens on shutdown. Break rather than
+                    // loop: recv() on a closed channel returns immediately, so continuing
+                    // would spin. Matches SynchroniserDriver::run, and the resulting
+                    // `unreachable!("File sync unexpectedly stopped")` in server/src/lib.rs
+                    // is the intended loud failure rather than an oversight.
+                    Ok(None) => break,
+                    // Timed out: re-check initialisation at the top of the loop. `continue`
+                    // rather than falling through, so "no file sync before initialisation"
+                    // stays a hard gate — below this branch the only remaining guard is
+                    // `paused`, and get_sync_settings expects settings to exist.
+                    Err(_elapsed) => continue,
                 }
             }
 
@@ -264,10 +313,20 @@ pub fn file_sync_central_url(service_provider: &ServiceProvider) -> Option<Strin
 
 #[cfg(test)]
 mod tests {
-    use repository::{mock::MockDataInserts, test_db::setup_all};
+    use repository::{
+        mock::MockDataInserts, test_db::setup_all, SyncFileDirection, SyncFileReferenceRow,
+        SyncFileReferenceRowRepository, SyncFileStatus, SyncLogV5V6Row, SyncLogV5V6RowRepository,
+    };
+    use std::time::Instant;
 
     use super::*;
-    use crate::sync::{test_util_set_central_server_url, test_util_set_is_central_server};
+    use crate::{
+        sync::{
+            test_util_set_central_server_url, test_util_set_is_central_server,
+            test_util_set_is_initialised,
+        },
+        test_helpers::{setup_all_and_service_provider, ServiceTestContext},
+    };
 
     #[actix_rt::test]
     async fn file_sync_central_url_dispatches_on_sync_version() {
@@ -311,5 +370,124 @@ mod tests {
         // The central server itself never has an upstream to transfer file bytes with
         test_util_set_is_central_server(true);
         assert_eq!(file_sync_central_url(&service_provider), None);
+    }
+
+    /// Regression test for issue #12232 — support upload files never sync from a remote site
+    /// after a fresh initialisation.
+    ///
+    /// `Start` is effectively a one-shot in production, and on the v5/v6 initialisation path
+    /// `run_post_sync_triggers` used to fire it from inside `sync_inner`, before
+    /// `SyncLogger::done` writes finished_datetime. The driver therefore consumed `Start`
+    /// while `is_initialised()` was still false, and then parked on an unbounded
+    /// `recv().await` forever.
+    ///
+    /// This reproduces that exact ordering: deliver `Start` while uninitialised, then
+    /// initialise the site behind the driver's back with no further `Start`. A driver that
+    /// only ever wakes on `Start` can never notice.
+    #[actix_rt::test]
+    async fn file_sync_driver_recovers_when_start_arrives_before_initialisation() {
+        const FILE_ID: &str = "issue_12232_file";
+
+        let ServiceTestContext {
+            service_provider,
+            service_context,
+            settings,
+            connection,
+            ..
+        } = setup_all_and_service_provider(
+            "file_sync_driver_start_before_initialised",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        // Pin the process globals the driver reads, so this test doesn't inherit whatever
+        // another test in this binary left behind (nextest gives each test its own process,
+        // plain `cargo test` does not).
+        test_util_set_is_initialised(false);
+        // V5/V6 remote — the driver resolves the upload URL from CentralServerConfig. The URL
+        // is never dialled: the seeded row has no bytes on disk, so FileSynchroniser::sync
+        // fails at find_file before any HTTP happens.
+        SyncVersion::set(&connection, SyncVersion::V5V6).unwrap();
+        test_util_set_central_server_url("http://central-oms.invalid:2000".to_string());
+
+        // Sync settings must exist before the site can look initialised:
+        // get_initialisation_status unwraps them, and the driver's get_sync_settings expects
+        // them.
+        service_provider
+            .settings
+            .update_sync_settings(
+                &service_context,
+                &SyncSettings {
+                    url: "http://legacy.invalid:8080".to_string(),
+                    username: "site".to_string(),
+                    password_sha256: "abc".to_string(),
+                    interval_seconds: 300,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        // A file waiting to be uploaded. The driver reaching FileSynchroniser::sync is
+        // observable as New -> InProgress: that status is written before the bytes are looked
+        // for on disk, and nothing else writes it. We're asserting the driver woke up, not
+        // that an upload succeeded, so no HTTP mock is needed.
+        let file_repo = SyncFileReferenceRowRepository::new(&connection);
+        file_repo
+            .upsert_without_changelog(&SyncFileReferenceRow {
+                id: FILE_ID.to_string(),
+                table_name: "invoice".to_string(),
+                record_id: "issue_12232_record".to_string(),
+                file_name: "test.txt".to_string(),
+                total_bytes: 4,
+                direction: SyncFileDirection::Upload,
+                status: SyncFileStatus::New,
+                ..Default::default()
+            })
+            .unwrap();
+        let status = || file_repo.find_one_by_id(FILE_ID).unwrap().unwrap().status;
+
+        let (trigger, driver) = FileSyncDriver::init(&settings);
+        let driver_task = tokio::spawn(driver.run(service_provider.clone()));
+
+        // The buggy ordering: `Start` lands while the site still looks uninitialised, so it is
+        // consumed for nothing.
+        trigger.start();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            status(),
+            SyncFileStatus::New,
+            "driver must not touch pending uploads before initialisation"
+        );
+
+        // Initialise the site behind the driver's back — this is what SyncLogger::done does at
+        // the end of a v5/v6 sync — then unpause, as SynchroniserDriver::sync does when its
+        // cycle finishes. Note there is no second `Start`: the one-shot is spent.
+        SyncLogV5V6RowRepository::new(&connection)
+            .upsert_one(&SyncLogV5V6Row {
+                id: "issue_12232_sync_log".to_string(),
+                started_datetime: chrono::Utc::now().naive_utc(),
+                finished_datetime: Some(chrono::Utc::now().naive_utc()),
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(service_provider
+            .sync_status_service
+            .is_initialised(&service_context)
+            .unwrap());
+        trigger.unpause();
+
+        // Poll rather than sleeping a fixed amount, so the assertion isn't coupled to
+        // FILE_SYNC_NOT_INITIALISED_DELAY.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while status() == SyncFileStatus::New {
+            assert!(
+                Instant::now() < deadline,
+                "FileSyncDriver never picked up the pending upload after initialisation — \
+                 it is parked on the not-initialised recv().await (issue #12232)"
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        driver_task.abort();
     }
 }

--- a/server/service/src/sync/mod.rs
+++ b/server/service/src/sync/mod.rs
@@ -212,3 +212,12 @@ pub fn test_util_set_is_central_server(is_central: bool) {
 pub fn test_util_set_central_server_url(url: String) {
     *CENTRAL_SERVER_CONFIG.write().unwrap() = CentralServerConfig::CentralServerUrl(url);
 }
+
+// TEST ONLY — reset the cached initialisation latch. `is_initialised` only ever caches
+// `true`, so a test that needs to observe the not-yet-initialised path has to clear it.
+// nextest (used in CI) gives every test its own process, so this only guards against
+// another test in the same process latching first — it is not protection against
+// concurrent mutation.
+pub fn test_util_set_is_initialised(is_initialised: bool) {
+    *IS_INITIALISED.write().unwrap() = is_initialised;
+}

--- a/server/service/src/sync/synchroniser.rs
+++ b/server/service/src/sync/synchroniser.rs
@@ -322,8 +322,6 @@ impl SynchroniserV5V6 {
             }
         }
 
-        run_post_sync_triggers(ctx, &self.service_provider, is_initialised);
-
         // After a successful v5+v6 sync on a remote, ask the legacy server
         // for the v7 URL. On success, persist KV + carry cursors over and
         // kick off a v7 get_token in the background. On failure, surface the
@@ -331,6 +329,19 @@ impl SynchroniserV5V6 {
         if !CentralServerConfig::is_central_server() {
             self.try_upgrade_to_v7(ctx).await?;
         }
+
+        // Deliberately *after* try_upgrade_to_v7, and as late in the cycle as possible. On
+        // first initialisation this fires site_is_initialised_trigger, whose consumers (the
+        // graphql schema swap and FileSyncTrigger::start — see server/src/lib.rs) read the
+        // initialisation state that SyncLogger::done writes once we return. Firing before the
+        // v7 upgrade handed them a site that still looked uninitialised across a whole HTTP
+        // round trip — which parked the FileSyncDriver forever (issue #12232) — and, if the
+        // upgrade failed, spent the one-shot callback on a sync that never completed. Nothing
+        // between here and SyncLogger::done awaits, so `done` is guaranteed to land first.
+        // FileSyncDriver no longer relies on that (see FILE_SYNC_NOT_INITIALISED_DELAY), but
+        // the trigger's other consumers do. V7 orders these the same way, see
+        // sync_v7::sync::sync_inner.
+        run_post_sync_triggers(ctx, &self.service_provider, is_initialised);
 
         ctx.processors_trigger
             .trigger_processor(ProcessorType::SupportUploadFiles);

--- a/server/service/src/sync/test/integration/driver_harness.rs
+++ b/server/service/src/sync/test/integration/driver_harness.rs
@@ -42,16 +42,15 @@ impl RemoteDrivers {
         let (file_sync_trigger, file_sync_driver) = FileSyncDriver::init(settings);
         let (sync_trigger, sync_driver) = SynchroniserDriver::init(file_sync_trigger.clone());
 
-        // Start lifecycle event — without it the FileSyncDriver sits on the
-        // `recv().await` branch in its "not initialised" arm. `is_initialised`
-        // returns true after the caller's `synchroniser.sync(None)` populated
-        // settings, so the driver will reach the main `select!` once Start is
-        // received.
+        // Start lifecycle event, so the driver reaches its main `select!` on the first
+        // iteration rather than after a FILE_SYNC_NOT_INITIALISED_DELAY poll. Callers
+        // have already run `synchroniser.sync()`, so `is_initialised` returns true —
+        // this is only about not paying the poll delay in a timing-sensitive test.
         file_sync_trigger.start();
 
         let file_sync_task = tokio::spawn(file_sync_driver.run(provider.clone()));
         // force_run=false: don't kick a sync at spawn time. The test calls
-        // `sync_trigger.trigger(None)` itself when it wants pause/unpause to
+        // `sync_trigger.trigger()` itself when it wants pause/unpause to
         // fire — keeps timing assertions deterministic.
         let sync_task = tokio::spawn(sync_driver.run(provider, false));
 

--- a/server/service/src/sync/test/integration/file_sync_pause.rs
+++ b/server/service/src/sync/test/integration/file_sync_pause.rs
@@ -13,7 +13,7 @@
 //!    regressions where the pause-default-true initial state leaves the driver
 //!    silently dormant.
 //! 2. `pause_mid_upload_via_real_sync` — once the driver is mid-upload, the test
-//!    fires `sync_trigger.trigger(None)`. `SynchroniserDriver::sync()` pauses
+//!    fires `sync_trigger.trigger()`. `SynchroniserDriver::sync()` pauses
 //!    file sync, runs a V5 cycle, unpauses. The upload chunk loop observes the
 //!    pause at the next ACK, the file synchroniser persists the chunk-aligned
 //!    offset on disk, the driver re-enters via the watch's `changed()` arm after
@@ -161,7 +161,7 @@ mod tests {
             config: _,
             synchroniser,
         } = create_site("file_sync_baseline_driver", vec![]).await;
-        synchroniser.sync(None).await.unwrap();
+        synchroniser.sync().await.unwrap();
 
         let upstream = central_upstream_addr();
         let proxy =
@@ -204,7 +204,7 @@ mod tests {
             config: _,
             synchroniser,
         } = create_site("file_sync_pause_mid_driver", vec![]).await;
-        synchroniser.sync(None).await.unwrap();
+        synchroniser.sync().await.unwrap();
 
         let upstream = central_upstream_addr();
         let proxy =
@@ -232,13 +232,13 @@ mod tests {
 
         // Now fire a real sync. SynchroniserDriver::sync() will:
         //   1. file_sync_trigger.pause()
-        //   2. Synchroniser::sync(None) against the mock — near-instant
+        //   2. Synchroniser::sync() against the mock — near-instant
         //   3. file_sync_trigger.unpause()
         // The upload's chunk loop returns `Paused` between chunks, the file
         // synchroniser persists `uploaded_bytes = bytes_uploaded` without a
         // status change (so it stays re-pickup-able), and the FileSyncDriver
         // re-enters via the watch arm and continues.
-        drivers.sync_trigger.trigger(None);
+        drivers.sync_trigger.trigger();
 
         let trace = UploadTrace::record(
             &context.connection,
@@ -291,9 +291,9 @@ mod tests {
             config: _,
             synchroniser,
         } = create_site("file_sync_unpause_latency_driver", vec![]).await;
-        // Required so `is_initialised` returns true and the driver enters its
-        // full `select!` rather than only awaiting Start.
-        synchroniser.sync(None).await.unwrap();
+        // Required so `is_initialised` returns true and the driver enters its full
+        // `select!` immediately, rather than polling the not-initialised branch.
+        synchroniser.sync().await.unwrap();
 
         // File-sync-only variant: we don't want a background SynchroniserDriver
         // firing pause/unpause cycles during the measurement.
@@ -370,7 +370,7 @@ mod tests {
             config: _,
             synchroniser,
         } = create_site("file_sync_bad_internet", vec![]).await;
-        synchroniser.sync(None).await.unwrap();
+        synchroniser.sync().await.unwrap();
 
         let upstream = central_upstream_addr();
         let proxy =
@@ -397,7 +397,7 @@ mod tests {
         let sync_trigger = drivers.sync_trigger.clone();
         let churn = tokio::spawn(async move {
             for _ in 0..30 {
-                sync_trigger.trigger(None);
+                sync_trigger.trigger();
                 tokio::time::sleep(Duration::from_millis(750)).await;
             }
         });

--- a/server/service/src/sync/test/integration/mod.rs
+++ b/server/service/src/sync/test/integration/mod.rs
@@ -1,13 +1,9 @@
 mod bandwidth_harness;
 mod central;
 mod central_server_configurations;
-// TODO: re-enable once file-sync pause-during-sync is re-wired for v7. The v7 merge
-// decoupled FileSyncDriver from the SynchroniserDriver, so these modules no longer
-// compile (sync()/trigger()/init() lost their pause args). See server/server/src/lib.rs
-// (FileSyncDriver::init is commented out there).
-// mod driver_harness;
+mod driver_harness;
 mod errors;
-// mod file_sync_pause;
+mod file_sync_pause;
 mod omsupply_central;
 mod remote;
 mod site_info;


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12232

`FileSyncDriver` could park permanently on a freshly initialised site, so support uploads (and internal order attachments) stayed at `status = NEW` and central reported "File not found" until the server was restarted.

The issue's diagnosis was right about the mechanism but the gap it described has moved. #12564 restored the file sync wiring and added `file_sync_trigger.start()` to `SiteIsInitialisedCallback`, which fixed the v7 path. What's left is an **ordering** problem on the v5/v6 path:

1. `run_post_sync_triggers` fires `site_is_initialised_trigger` from inside `sync_inner`.
2. `sync_inner` then does `try_upgrade_to_v7(ctx).await?` — an HTTP round trip to the legacy server.
3. Only after `sync_inner` returns does `Synchroniser::sync` call `logger.done()`, and *that* is what makes `is_initialised()` return true.
4. Meanwhile the spawned callback sends `Start`. The driver wakes, loops, re-checks `is_initialised()` → still false → parks on `recv().await` again. The one-shot `Start` is spent and `on_trigger` has already consumed itself, so nothing can ever wake it.

This is **deterministic, not a race**: `server/src/main.rs` uses `#[actix_web::main]` (current-thread runtime), so the spawned callback is guaranteed to be scheduled while `try_upgrade_to_v7` is suspended. The driver always loses.

### Changes

- **`file_sync_driver.rs`** — the not-initialised branch now wraps `recv()` in a `timeout` and re-checks initialisation on each pass, so no single missed signal can park the driver. `SynchroniserDriver` can safely block on its trigger because its own trigger is what *causes* initialisation; this driver has no such intrinsic waker. Also handles `Stop` (previously swallowed by the `if let Some(Start)` pattern) and `break`s on channel close instead of hot-spinning. 5s in prod, 50ms under `cfg(test)`.
- **`synchroniser.rs`** — moved `run_post_sync_triggers` below `try_upgrade_to_v7`, so the trigger's other consumers (the GraphQL schema swap) also see a correctly-initialised site.
- **`sync/mod.rs`** — added `test_util_set_is_initialised`, matching the existing `test_util_set_*` helpers.
- **Re-enabled the file-sync pause integration tests** (4 tests) that were disabled behind a stale TODO.

## 💌 Any notes for the reviewer?

**The affected population is narrower than the issue title suggests.** `populate_sync_version.rs` stamps `V5_V6` only when `SETTINGS_SYNC_URL` already exists at migration time, so a genuinely fresh install gets `V7` and takes the correctly-ordered v7 path (`sync_v7/sync.rs` calls `logger.finish()` *before* `run_post_sync_triggers`). The reachable shape is a site with sync settings configured whose initial sync never completed, then upgraded/restarted — e.g. a 2.x site whose first sync errored or was interrupted, upgraded into 3.x.

**So I can't prove this closes the reporter's exact repro.** The issue thread says "it was fixed by simply restarting the app" and never records the site's sync version. If they were on a fresh V7 install, #12564 already fixed their case and this fixes the adjacent v5/v6 path. Either way the parked-driver failure mode is real and reachable; I'd rather flag the uncertainty than claim more than I verified.

**The `synchroniser.rs` move is scope beyond the issue, and fixes a second bug.** `try_upgrade_to_v7` explicitly anticipates a 503 `stores_not_migrated` while a fleet is mid-migration. Today the trigger has already fired by then, so on that failure GraphQL flips to `Operational` while `sync_status` still says `Initialising`, *and* the one-shot callback is spent on a sync that never completed — every later `trigger()` just logs "Problem triggering site is initialised". Happy to split this out if you'd prefer the PR stay minimal. Note it also removes an existing inconsistency: `ProcessorType::SupportUploadFiles` already sat below `try_upgrade_to_v7`.

**On the stale TODO.** It claimed `FileSyncDriver::init` was commented out in `lib.rs` and that both modules couldn't compile. Three of its four claims were false — `init` is live, `SynchroniserDriver` still calls pause/unpause, and `driver_harness` compiled fine. Only `file_sync_pause` was stale, needing 6 one-token edits where #11595 dropped the args from `sync()`/`trigger()`. I also refreshed comments in those modules that described the old parking behaviour, so they don't become the next stale TODO.

**Deliberately not done**, both worth follow-up issues:
- Splitting `run_post_sync_triggers` into processor vs. initialisation triggers past `logger.done()`/`logger.finish()` on both transports. Correct by construction, but it changes processor-on-sync-failure semantics.
- Making `SiteIsInitialisedCallback::on_trigger` re-armable (`while recv().await.is_some()`). A one-shot that can be spent by a sync that later fails is the structural cause of the burnt-callback bug above.

**Poll interval choice.** 5s, kept coarse on purpose: each poll takes a pooled connection and runs the `get_initialisation_status` queries, `is_initialised` `.unwrap()`s `basic_context()` on the main loop, and the pre-initialisation window is the DB-hottest phase of a site's life. Latency here buys nothing — nothing is uploadable before initialisation, and steady state already idles for 10s. Once initialised the `IS_INITIALISED` latch means zero further queries.

# 🧪 Tested

- Added `file_sync_driver_recovers_when_start_arrives_before_initialisation`, which reproduces the exact ordering: deliver `Start` while uninitialised, then initialise the site behind the driver's back with **no second `Start`**. Asserts `New → InProgress` on a seeded upload row — no HTTP mock needed, since `FileSynchroniser::sync` writes that status before looking for bytes on disk, and line 175 is its only writer.
- **Confirmed the test guards the bug**: temporarily restoring the blocking `recv()` makes it fail with `FileSyncDriver never picked up the pending upload after initialisation`. It passes with the fix in ~50ms of the unpause.
- `cargo nextest run -p service --features sqlite` — 864/864 pass.
- `cargo check -p service --features "sqlite integration_test" --all-targets` — the 4 re-enabled tests compile, 0 errors, no new warnings.
- Clippy: 0 warnings in any changed region. **Note** `cargo clippy --workspace --all-targets -- -D warnings` does *not* pass on this branch, but only because of two pre-existing lints in the untouched `util` crate (`util/src/error.rs:34` empty line after doc comment, `util/src/file.rs:53` missing `truncate`). Unrelated to this PR — flagging so it isn't mistaken for a regression.

**Not verified — worth a reviewer's attention:**
- The 4 re-enabled integration tests are **compile-verified only**. They need postgres + toxiproxy + a real OMS central, so whether they still pass against a live v7 central is unproven.
- No manual multi-site run. The end-to-end check would be: a `V5_V6`-stamped remote with sync settings written but no completed sync → start server → run initial sync → request a support upload → confirm the `sync_file_reference` row leaves `NEW` and the file lands on central *without* a restart, with "Starting file sync" followed by "Found N files to upload" in the log.

# 📃 Documentation

- [x] **No documentation required** — restores intended behaviour (files sync from a remote) rather than changing it; nothing new for a user to learn.
