### PR TITLE
Stop the /login <-> /initialise redirect loop on uninitialised sites

### DIFF
--- a/client/packages/common/src/authentication/hooks/useLogout.ts
+++ b/client/packages/common/src/authentication/hooks/useLogout.ts
@@ -12,7 +12,8 @@ import { clearAuthState } from '../AuthContext';
  *      Errors are swallowed (already-expired session / network problem shouldn't block local
  *      cleanup; the goal is "ensure no live session").
  *   2. Clears the locally cached auth state and any auth-error indicator.
- *   3. Navigates to /login.
+ *   3. Navigates to /login — unless the app was redirected elsewhere while step 1 was in
+ *      flight (see below).
  */
 export const useLogout = () => {
   const api = useAuthApi();
@@ -20,9 +21,19 @@ export const useLogout = () => {
   const [, , removeAuthError] = useLocalStorage('/error/auth');
 
   return useCallback(async () => {
+    const pathBeforeLogout = window.location.pathname;
+
     await api.get.logout();
     clearAuthState();
     removeAuthError();
+
+    // A redirect during the await means some other guard has already decided where the user
+    // belongs, so navigating to /login here would fight it. That fight was a real loop: the
+    // login route redirected to /initialise on an uninitialised server, this navigate pulled
+    // it straight back, and the two ping-ponged forever. If the new location does turn out to
+    // need auth, its own guard will route to /login anyway.
+    if (window.location.pathname !== pathBeforeLogout) return;
+
     navigate(RouteBuilder.create(AppRoute.Login).build());
   }, [api, navigate, removeAuthError]);
 };

--- a/client/packages/host/src/Host.tsx
+++ b/client/packages/host/src/Host.tsx
@@ -20,6 +20,7 @@ import {
   AuthError,
   createBrowserRouter,
   createRoutesFromElements,
+  Navigate,
   RouterProvider,
   initialiseI18n,
   KBarProvider,
@@ -75,6 +76,34 @@ const PreInit: React.FC<React.PropsWithChildren> = ({ children }) => {
   clearAuthState();
 
   return null;
+};
+
+/**
+ * Guards the /login route while the server is still uninitialised.
+ *
+ * Until initialisation completes the server only serves the reduced
+ * `InitialisationQueries` schema — there is no `me` field and no `UserStoreNode` type — so
+ * Login's mount-time `logout()` fails schema validation and arms the ServerError alert.
+ *
+ * Redirecting *before* Login can mount matters as much as the redirect itself. Letting it
+ * mount and bounce itself away via useLoginForm raced `useLogout`'s post-await navigate back
+ * to /login, and the two redirects chased each other indefinitely. Each lap remounted the
+ * Initialise form, whose username field re-fired its `autoFocus`, so the Android soft keyboard
+ * flapped open/closed several times a second on the initialisation screen.
+ */
+const RequireInitialised: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const { data } = useInitialisationStatus();
+
+  // Status unknown — render nothing rather than guessing; a wrong guess either flashes the
+  // login form or bounces a legitimate login attempt.
+  if (!data) return null;
+
+  if (data.status !== InitialisationStatusType.Initialised)
+    return <Navigate to={`/${AppRoute.Initialise}`} replace />;
+
+  return children;
 };
 
 /**
@@ -144,7 +173,11 @@ const router = createBrowserRouter(
                 />
                 <Route
                   path={RouteBuilder.create(AppRoute.Login).build()}
-                  element={<Login />}
+                  element={
+                    <RequireInitialised>
+                      <Login />
+                    </RequireInitialised>
+                  }
                 />
                 <Route
                   path={RouteBuilder.create(AppRoute.Discovery).build()}

--- a/client/packages/host/src/components/Login/hooks.ts
+++ b/client/packages/host/src/components/Login/hooks.ts
@@ -99,8 +99,10 @@ export const useLoginForm = (
   useEffect(() => {
     if (!initStatus) return;
 
+    // `replace` so the uninitialised login page never becomes a back-button target — pushing
+    // let a redirect loop bury the real history under thousands of entries.
     if (initStatus.status != InitialisationStatusType.Initialised)
-      navigate(`/${AppRoute.Initialise}`);
+      navigate(`/${AppRoute.Initialise}`, { replace: true });
   }, [initStatus]);
 
   return {


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes an infinite `/login` ↔ `/initialise` redirect loop that fires on any **uninitialised** site. On Android it made the soft keyboard flap open and closed several times a second on the initialisation screen, leaving the form unusable.

**Root cause.** Three long-standing pieces became a cycle when the auth refactor (#12421, commit `214891d859` "Wire real server logout") landed:

1. `Login` calls `logout()` on mount (added Feb 2026, harmless at the time — the old `useAuthContext().logout()` was synchronous and **never navigated**).
2. `useLogout` now `await`s an HTTP round trip and *then* navigates to `/login`.
3. `useLoginForm` redirects to `/initialise` whenever the site isn't initialised.

So: Login mounts → fires `logout()` → the initialisation guard redirects to `/initialise` while that request is still in flight → `logout()` resolves and navigates straight back to `/login` → Login mounts again. Forever.

On Android it's deterministic rather than racy, because the native layer boots the WebView directly to `/login` (`setServerMode` passes `path: 'login'` while unauthenticated). Each lap remounted the Initialise form, and the username field's `autoFocus` re-fired on every mount — which is what drove the keyboard.

**The changes:**

| File | Change |
|---|---|
| `client/packages/host/src/Host.tsx` | New `RequireInitialised` guard on the `/login` route. `Login` can no longer mount before the site is initialised. |
| `client/packages/common/src/authentication/hooks/useLogout.ts` | Skip the `navigate('/login')` if the location changed while the logout request was in flight. |
| `client/packages/host/src/components/Login/hooks.ts` | Login → initialise redirect now uses `replace`. |

The guard is the actual fix; the other two are hardening. Guarding the route is also just correct on its own — there is nothing to log into on an uninitialised site, and the server only serves the reduced `InitialisationQueries` schema at that point, so Login's `me` query fails schema validation (`Unknown type "UserStoreNode"`) and arms the ServerError alert.

## 💌 Any notes for the reviewer?

- **`useLogout` behaviour change worth a look.** It now returns early without navigating if the path changed during the await. The intent is "another guard already decided where the user belongs, don't fight it". The edge case: if a user clicks sign-out and something else navigates concurrently, they'd stay put while logged out — self-healing, since the next query 401s and routes them to login. I think this is right, but it's the one judgement call here.
- **`RequireInitialised` renders `null` while the status query is in flight.** It shares the `['initialisationStatus']` query key with the existing `PreInit`, so it's normally already cached and there's no flash — but on a slow first load the login screen could blank briefly before appearing. Matches the existing `PreInit` convention of returning `null` rather than guessing.
- Deliberately **not** changing the `autoFocus` on the Initialise username field. It's correct behaviour; it was only pathological because of the remount loop.
- Unrelated to the file-sync work on `12232-file-sync-init-poll` — branched off `develop` so it can merge independently.

# 🧪 Tested

Debugged and verified live on a Galaxy Tab A8 (SM-X200, Android 14) against an uninitialised site, over ADB + Chrome DevTools Protocol attached to the WebView.

- Confirmed the mechanism on the running app before fixing: captured async stack traces for both `history.pushState` legs, verified the username `<input>` DOM node was genuinely being *replaced* (not just re-rendered), and confirmed the server serves only `InitialisationQueries` (`{ me { … } }` → `Unknown field "me" on type "InitialisationQueries"`).
- Built the frontend, staged it with `npx cap copy`, assembled `assembleArm64Debug`, installed on the tablet, and measured an 8-second cold boot before and after:

  | Signal | Before | After |
  |---|---|---|
  | Keyboard show/hide events | ~70 | **0** |
  | IME `showSoftInput`/`hideSoftInput` | ~78 | **0** |
  | Route navigations (per 6s) | 78 | **0** |
  | `autoFocus` refires / remounts (per 6s) | 78 | **0** |
  | `Unknown type "UserStoreNode"` errors | 34 | **0** |
  | Capacitor console lines | 888 | 57 |

- Confirmed via CDP after the fix: app settles on `/initialise`, `0` navigations and `0` focus calls over 8s, and the input DOM node is stable across the window.
- Visually confirmed the initialisation form renders correctly and the keyboard behaves normally.
- `yarn compile-full` passes for all three changed files. (Two pre-existing `tsc` errors remain in unrelated test files — `common/src/hooks/useFormErrors/ErrorDisplay.test.tsx` and `invoices/src/Prescriptions/DetailView/hooks/utils.test.tsx` — untouched by this PR.)

Not yet exercised: the logged-in sign-out path on an initialised site, since the test tablet is uninitialised. Worth a quick manual check by the reviewer given the `useLogout` change.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
