### PR TITLE
Show which front end a plugin bundle is for

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -1683,6 +1683,7 @@
   "label.rnr-stock-out-duration": "Stock out duration",
   "label.rows-per-page": "Rows per page:",
   "label.rtmd": "mSupply",
+  "label.runtime": "Runtime",
   "label.save-log": "Save log to file",
   "label.save-table-config-as-global-default": "Save table changes as global default",
   "label.schedule": "Schedule",

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -4810,6 +4810,15 @@ export enum InstalledPluginKindType {
 export type InstalledPluginNode = {
   __typename: 'InstalledPluginNode';
   code: Scalars['String']['output'];
+  /**
+   * Which front end a frontend bundle is for (`react`, `solid`, ...). Null
+   * on backend plugins, which have no host.
+   *
+   * One plugin ships a bundle per front end and the two can share a code and
+   * a version, so without this the list shows one line twice and there is
+   * nothing to tell an admin which of the pair they are about to uninstall.
+   */
+  hostRuntime?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
   kind: InstalledPluginKindType;
   types: Array<Scalars['String']['output']>;

--- a/client/packages/system/src/Manage/Plugins/ListView/ListView.tsx
+++ b/client/packages/system/src/Manage/Plugins/ListView/ListView.tsx
@@ -85,6 +85,16 @@ export const PluginsList = () => {
             : t('label.frontend'),
         enableSorting: true,
       },
+      // A plugin ships one bundle per front end, and the two can share a code
+      // and a version — so without the runtime this list shows one row twice,
+      // and the delete button acts on a row id it never displays.
+      {
+        id: 'hostRuntime',
+        header: t('label.runtime'),
+        // Blank for backend plugins, which have no host.
+        accessorFn: row => row.hostRuntime ?? '',
+        enableSorting: true,
+      },
       {
         id: 'types',
         header: t('label.types'),

--- a/client/packages/system/src/Manage/Plugins/api/operations.generated.ts
+++ b/client/packages/system/src/Manage/Plugins/api/operations.generated.ts
@@ -10,6 +10,7 @@ export type InstalledPluginNodeFragment = {
   version: string;
   kind: Types.InstalledPluginKindType;
   types: Array<string>;
+  hostRuntime?: string | null;
 };
 
 export type InstalledPluginsQueryVariables = Types.Exact<{
@@ -32,6 +33,7 @@ export type InstalledPluginsQuery = {
           version: string;
           kind: Types.InstalledPluginKindType;
           types: Array<string>;
+          hostRuntime?: string | null;
         }>;
       };
     };
@@ -119,6 +121,7 @@ export const InstalledPluginNodeFragmentDoc = gql`
     version
     kind
     types
+    hostRuntime
   }
 `;
 export const InstalledPluginsDocument = gql`

--- a/client/packages/system/src/Manage/Plugins/api/operations.graphql
+++ b/client/packages/system/src/Manage/Plugins/api/operations.graphql
@@ -1,3 +1,7 @@
+# hostRuntime is null for backend plugins, which have no host. It is selected
+# because one plugin ships a bundle per front end and the two can share a code
+# and a version — without it the list shows one row twice, and delete acts on an
+# id it never displays.
 fragment InstalledPluginNode on InstalledPluginNode {
   __typename
   id
@@ -5,6 +9,7 @@ fragment InstalledPluginNode on InstalledPluginNode {
   version
   kind
   types
+  hostRuntime
 }
 
 query installedPlugins {

--- a/server/graphql/plugin/src/queries/installed_plugins.rs
+++ b/server/graphql/plugin/src/queries/installed_plugins.rs
@@ -16,6 +16,13 @@ pub struct InstalledPluginNode {
     pub version: String,
     pub kind: InstalledPluginKindType,
     pub types: Vec<String>,
+    /// Which front end a frontend bundle is for (`react`, `solid`, ...). Null
+    /// on backend plugins, which have no host.
+    ///
+    /// One plugin ships a bundle per front end and the two can share a code and
+    /// a version, so without this the list shows one line twice and there is
+    /// nothing to tell an admin which of the pair they are about to uninstall.
+    pub host_runtime: Option<String>,
 }
 
 #[derive(Enum, Copy, Clone, PartialEq, Eq)]
@@ -35,6 +42,7 @@ impl InstalledPluginNode {
                 InstalledPluginKind::Frontend => InstalledPluginKindType::Frontend,
             },
             types: plugin.types,
+            host_runtime: plugin.host_runtime,
         }
     }
 }

--- a/server/service/src/plugin/mod.rs
+++ b/server/service/src/plugin/mod.rs
@@ -156,6 +156,14 @@ pub struct InstalledPlugin {
     pub version: String,
     pub kind: InstalledPluginKind,
     pub types: Vec<String>,
+    /// Which front end this bundle is for — `None` for backend plugins, which
+    /// have no host.
+    ///
+    /// Present so the two rows that are now normal — one code, one version, a
+    /// React bundle and a SolidJS one — are distinguishable to whoever is
+    /// deciding which to uninstall. Without it the list shows one line twice,
+    /// and delete is a guess against an id it does not display.
+    pub host_runtime: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -256,6 +264,7 @@ pub trait PluginServiceTrait: Sync + Send {
                 types: row.types.0.iter().filter_map(|t| {
                     serde_json::to_value(t).ok().and_then(|v| v.as_str().map(ToString::to_string))
                 }).collect(),
+                host_runtime: None,
             });
         }
 
@@ -267,6 +276,7 @@ pub trait PluginServiceTrait: Sync + Send {
                 version: row.version,
                 kind: InstalledPluginKind::Frontend,
                 types: row.types.0,
+                host_runtime: Some(row.host_runtime.0),
             });
         }
 
@@ -549,6 +559,7 @@ mod test {
             code: "my_frontend_plugin".to_string(),
             version: "2.0.0".to_string(),
             types: FrontendPluginTypes(vec!["report".to_string(), "dashboard".to_string()]),
+            host_runtime: HostRuntime("solid".to_string()),
             ..Default::default()
         };
         FrontendPluginRowRepository::new(&connection)
@@ -575,6 +586,9 @@ mod test {
             backend.types,
             vec!["average_monthly_consumption", "get_consumption"]
         );
+        // A backend plugin has no host, and says so rather than borrowing the
+        // frontend default.
+        assert_eq!(backend.host_runtime, None);
 
         let frontend = &plugins[1];
         assert_eq!(frontend.id, "frontend-1");
@@ -582,6 +596,42 @@ mod test {
         assert_eq!(frontend.version, "2.0.0");
         assert_eq!(frontend.kind, InstalledPluginKind::Frontend);
         assert_eq!(frontend.types, vec!["report", "dashboard"]);
+        assert_eq!(frontend.host_runtime.as_deref(), Some("solid"));
+    }
+
+    /// The listing exists to be acted on — its rows are what an admin picks
+    /// from when uninstalling. Two bundles of one plugin can share a code AND a
+    /// version, so the host fields are the only thing that tells the pair
+    /// apart.
+    #[actix_rt::test]
+    async fn installed_plugins_distinguishes_bundles_of_one_code() {
+        let ServiceTestContext {
+            service_provider,
+            service_context,
+            connection,
+            ..
+        } = setup_all_with_data_and_service_provider(
+            "installed_plugins_distinguishes_bundles_of_one_code",
+            MockDataInserts::none(),
+            MockData::default(),
+        )
+        .await;
+
+        let repo = FrontendPluginRowRepository::new(&connection);
+        repo.upsert_one(civ_bundle("react", "3.0.0", "react"))
+            .unwrap();
+        repo.upsert_one(civ_bundle("solid", "3.0.0", "solid"))
+            .unwrap();
+
+        let mut plugins = service_provider
+            .plugin_service
+            .installed_plugins(&service_context)
+            .unwrap();
+        plugins.sort_by(|a, b| a.id.cmp(&b.id));
+
+        // Same code, same version — every other listed field is identical.
+        let runtimes: Vec<Option<&str>> = plugins.iter().map(|p| p.host_runtime.as_deref()).collect();
+        assert_eq!(runtimes, vec![Some("react"), Some("solid")]);
     }
 
     #[actix_rt::test]


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Follow-up to #12639, and **based on it** — merge that first.

That PR makes it normal for one plugin to have **two installed rows**: a React bundle for the old UI and a SolidJS one for the new front end, which can share a code *and* a version. The plugins list was never built for that. It renders code, version, kind and types ([`ListView.tsx`](client/packages/system/src/Manage/Plugins/ListView/ListView.tsx)) — all four identical across the pair — so two bundles of `civ_plugins` 3.0.0 appear as one row printed twice. The delete button then acts on a row id the table does not display, which makes "remove the React one" a coin flip that can take out a front end.

So `InstalledPlugin` carries `host_runtime`, `InstalledPluginNode` exposes it, and the list gains a **Runtime** column. It is `Option`/nullable and null for backend plugins, which have no host — rather than defaulting to `react`, which would be a description of a row that does not have one.

## 💌 Any notes for the reviewer?

- **The runtime is the only field added.** An earlier revision also carried `plugin_api_version`; #12639 has since dropped that column entirely — plugin compatibility rides on the server's major/minor, and the runtime is the part that does not collapse into a version.
- **`schema.ts` is hand-edited to the one type this PR changes**, for the same reason as #12639: `yarn gql-codegen` regenerates it wholesale and drags in unrelated server-side drift, two fields of which break `yarn build` on develop today (`PricingNode.totalVolume`, `SyncErrorVariantV7.SYNC_FILE_NOT_FOUND`). The generated `operations.generated.ts` is the real codegen output, untouched by hand.
- No new server behaviour — `installed_plugins` already read both rows; it just was not passing the runtime on.

# 🧪 Tested

- `installed_plugins_distinguishes_bundles_of_one_code` installs a React and a SolidJS `civ_plugins` **at the same version**, so every other listed field is identical, and asserts the pair is distinguishable in the result.
- `installed_plugins` extended: the frontend row now declares `solid` (proving the value is carried rather than defaulted), and the backend row asserts it is `None`.
- `cargo nextest run -p service plugin` 16/16 · `cargo build -p graphql_plugin` clean · `yarn build` (old UI, webpack) compiles clean.

# 📃 Documentation

- [x] **Part of an epic** — documentation will be completed for the feature as a whole (#12523 dual-frontend serving, #12622 front-end sync)
