### PR TITLE
#12579 Backfill changelog rows for pre-v2.7 form schemas

### DIFF
--- a/server/repository/src/migrations/v3_00_00/mod.rs
+++ b/server/repository/src/migrations/v3_00_00/mod.rs
@@ -32,6 +32,7 @@ mod create_site_table;
 mod migrate_user_permission_to_deterministic_id;
 mod partition_changelog_by_cursor;
 mod populate_changelog_with_rows_for_sync_v7_tables;
+mod populate_missing_changelog_for_form_schema;
 mod populate_routed_changelog_for_sync_v7_tables;
 mod populate_sync_version;
 mod rebuild_sync_buffer;
@@ -99,6 +100,7 @@ impl Migration for V3_00_00 {
             Box::new(add_site_sync_metadata::Migrate),
             Box::new(add_sync_batch_size_key_value_store::Migrate),
             Box::new(add_frontend_plugin_host_runtime::Migrate),
+            Box::new(populate_missing_changelog_for_form_schema::Migrate),
         ]
     }
 }

--- a/server/repository/src/migrations/v3_00_00/populate_missing_changelog_for_form_schema.rs
+++ b/server/repository/src/migrations/v3_00_00/populate_missing_changelog_for_form_schema.rs
@@ -1,0 +1,158 @@
+use crate::migrations::*;
+
+pub(crate) struct Migrate;
+
+impl MigrationFragment for Migrate {
+    fn identifier(&self) -> &'static str {
+        "populate_missing_changelog_for_form_schema"
+    }
+
+    fn migrate(&self, connection: &StorageConnection) -> anyhow::Result<()> {
+        // form_schema predates changelog support for it (added in v2_06_00), so schemas
+        // integrated before then and not edited since have no changelog row. Under v5/v6 they
+        // still reached remotes via the remote's own pull from legacy central; v7 only pulls
+        // from OMS central via the changelog, so those schemas are never distributed and
+        // patient documents referencing them fail to integrate.
+        //
+        // Not added to populate_changelog_with_rows_for_sync_v7_tables because that fragment
+        // has already run in the field; this one is guarded by NOT EXISTS so it is safe to
+        // run on a database that already has changelog rows for form_schema (there's no unique
+        // key on (table_name, record_id) to drive ON CONFLICT).
+        //
+        // source_site_id mirrors the other v7 backfills: the central server's site_id from
+        // key_value_store, falling back to 0 (OMS-Central convention) when the key isn't set.
+        // These rows are legacy-sourced, so stamping them with the central site id also keeps
+        // them from being pushed back out by the edited-on-this-site push filters.
+        sql!(
+            connection,
+            r#"
+            INSERT INTO changelog (table_name, record_id, row_action, source_site_id)
+            SELECT 'form_schema', t.id, 'UPSERT',
+                COALESCE(
+                    (SELECT value_int FROM key_value_store WHERE id = 'SETTINGS_SYNC_CENTRAL_SERVER_SITE_ID'),
+                    0
+                )
+            FROM form_schema t
+            WHERE NOT EXISTS (
+                SELECT 1 FROM changelog c
+                WHERE c.table_name = 'form_schema' AND c.record_id = t.id
+            );
+            "#
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        migrations::{v2_18_00::V2_18_00, v3_00_00::V3_00_00, *},
+        test_db::*,
+    };
+    use diesel::{connection::SimpleConnection, prelude::*, RunQueryDsl};
+
+    // Minimal changelog columns needed for verification.
+    // The test runs the full v3_00_00 sequence, which includes the
+    // partition_changelog_by_cursor rename, so the helper sees `patient_link_id`.
+    table! {
+        changelog (cursor) {
+            cursor -> BigInt,
+            table_name -> Text,
+            record_id -> Text,
+            row_action -> Text,
+            store_id -> Nullable<Text>,
+            source_site_id -> Nullable<Integer>,
+            transfer_store_id -> Nullable<Text>,
+            patient_link_id -> Nullable<Text>,
+        }
+    }
+
+    #[actix_rt::test]
+    async fn test_populate_missing_changelog_for_form_schema() {
+        let previous_version = V2_18_00.version();
+        let version = V3_00_00.version();
+
+        let SetupResult { connection, .. } = setup_test(SetupOption {
+            db_name: "migration_populate_missing_changelog_for_form_schema",
+            version: Some(previous_version.clone()),
+            ..Default::default()
+        })
+        .await;
+
+        // Two schemas of the shape a pre-v2.7 database holds: rows with no changelog entry.
+        connection
+            .lock()
+            .connection()
+            .batch_execute(
+                r#"
+                INSERT INTO form_schema (id, type, json_schema, ui_schema) VALUES
+                    ('schema1', 'Patient', '{}', '{}'),
+                    ('schema2', 'ProgramEnrolment', '{}', '{}');
+                INSERT INTO key_value_store (id, value_int) VALUES
+                    ('SETTINGS_SYNC_CENTRAL_SERVER_SITE_ID', 42);
+                "#,
+            )
+            .unwrap();
+
+        migrate(
+            &connection,
+            Some(version.clone()),
+            MigrationConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(get_database_version(&connection), version);
+
+        let count_for = |record_id: &str| -> i64 {
+            changelog::table
+                .filter(changelog::table_name.eq("form_schema"))
+                .filter(changelog::record_id.eq(record_id))
+                .count()
+                .get_result::<i64>(connection.lock().connection())
+                .unwrap()
+        };
+
+        assert_eq!(count_for("schema1"), 1);
+        assert_eq!(count_for("schema2"), 1);
+
+        // Verify the backfilled row's shape: row_action='UPSERT', source_site_id from the
+        // seeded central site id (42), and the routing columns NULL (a keyless central row).
+        let row = changelog::table
+            .filter(changelog::table_name.eq("form_schema"))
+            .filter(changelog::record_id.eq("schema1"))
+            .select((
+                changelog::row_action,
+                changelog::store_id,
+                changelog::source_site_id,
+                changelog::transfer_store_id,
+                changelog::patient_link_id,
+            ))
+            .first::<(
+                String,
+                Option<String>,
+                Option<i32>,
+                Option<String>,
+                Option<String>,
+            )>(connection.lock().connection())
+            .unwrap();
+        assert_eq!(
+            row,
+            ("UPSERT".to_string(), None, Some(42), None, None),
+            "expected ('UPSERT', NULL, Some(42), NULL, NULL) for form_schema/schema1"
+        );
+
+        // Re-running must not duplicate: schemas that already have a changelog row are skipped.
+        super::Migrate.migrate(&connection).unwrap();
+
+        assert_eq!(
+            count_for("schema1"),
+            1,
+            "schema with an existing changelog row should not get a second one"
+        );
+        assert_eq!(
+            count_for("schema2"),
+            1,
+            "schema with an existing changelog row should not get a second one"
+        );
+    }
+}


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12579

Fetching a patient from central failed because the remote site was missing the `form_schema` rows that the patient's documents reference.

On sync v7, `form_schema` reaches a remote only via a changelog row on OMS central. Changelog writing for `form_schema` was only added in `v2_06_00` (`c765ed9f72`, Feb 2025), and the v7 backfill migration `populate_changelog_with_rows_for_sync_v7_tables` doesn't include `form_schema`. So schemas integrated on central before ~v2.7 and not edited since have no changelog row, are never distributed, and are missing on every remote site. Verified on the server from the issue: the schema row exists on central with zero changelog rows for it, and the remote has no patient schemas at all.

It only surfaced now because v7 removed the direct legacy → remote route for central data. In 2.21.x every site, including remotes, ran a PULL CENTRAL step against legacy mSupply over v5, so `form_schema` could arrive via `FormSchemaTranslation` with the OMS-central changelog never involved. `SynchroniserV7` only talks to OMS central, so legacy-sourced central data now has to come through the changelog — and for pre-~v2.7 rows there was nothing to come through.

This adds one `v3_00_00` migration fragment, `populate_missing_changelog_for_form_schema`, which inserts a keyless `UPSERT` changelog row for every `form_schema` that doesn't have one. Remotes then pull the schemas on their next sync cycle.

## 💌 Any notes for the reviewer?

**Why a new fragment rather than adding `form_schema` to the existing `TABLES` list.** v3.00.00-RC is already deployed, so `populate_changelog_with_rows_for_sync_v7_tables` has already run in the field — extending its list wouldn't re-run, and changing its `identifier()` to force a re-run would duplicate all 38 tables' rows (it has no `NOT EXISTS` guard). The new fragment is guarded by `NOT EXISTS`, mirroring `populate_routed_changelog_for_sync_v7_tables`, so it's safe on databases that already have changelog rows for `form_schema` and safe to re-run.

**Why only `form_schema` and not the other central tables missing from that list.** Every other `Distribution::Central` table is already covered, for one of two reasons: it was created at v2.0 or later with changelog writing in its row repository from the first migration (`asset_*`, `vaccine_course*`, `demographic`, `property`, `name_property`, `item_variant`, `bundled_item`, `packaging_variant`, `campaign`, `report` — recreated in `v2_06_00/reinitialise_reports.rs` — `help_document`, plugins, `insurance_provider`, `custom_field_scope`), or it predates v2.0 and was covered by the old DB changelog triggers removed in `v2_00_00/remove_changelog_triggers.rs` (`name`, `barcode`, `clinician`, `currency`, `document`, …). `form_schema` is the one table that falls between the two: it's in `base_migrations/sqlite_earliest.sql` from the programs era, it appears nowhere in the trigger set dropped by `v2_00_00/remove_changelog_triggers.rs` so it was never trigger-covered, and it only got changelog writing in `v2_06_00/add_form_schema_sync.rs`.

**Deliberately out of scope, happy to split out if you disagree:**

- **No `seed_sync_request_for_table` call.** The backfilled rows get fresh (high) cursors, so already-synced v7 remotes pull them on the next cycle. `seed_sync_request_user_tables` exists for the routed backfill, which mutates existing rows in place and leaves their cursors behind the remote's position.
- **No site-type gating**, matching the existing backfill which runs everywhere. On a remote the rows are inert: both push filters (`all_data_edited_on_site`, `all_data_edited_on_multi_device_site`) require `source_site_id == own site id`, and these rows carry the central site id.
- **No repair of documents already holding a null `form_schema_id`** (nulled by the v5/v6 `fk_check` in `sync/translations/document.rs`). It's read in exactly one place — schema validation in `document_service.rs` — and every writer supplies `form_schema_id` from the document registry on the next edit, so it self-heals.
- **No hardening of the v7 patient-lookup path.** A missing FK parent still aborts the whole fetch in one transaction, and the v7 path passes `form_schema_id` through verbatim rather than nulling it like the v5/v6 translator does. That's arguably the right call for a patient fetch (a half-integrated patient is worse), and the error does surface to the user, as the issue screenshot shows.

**Performance.** Not expected to need large-dataset testing. The work is bounded by the `form_schema` row count (tens), and the `NOT EXISTS` probe filters on `table_name = 'form_schema'`, which `index_changelog_table_name` supports — the fragment is registered after `create_changelog_indexes`, so that index exists by the time it runs. Lock footprint on Postgres is identical to the two existing changelog backfills (each fragment gets its own transaction and touches the same partitioned table), so it doesn't add exposure to the `max_locks_per_transaction` problem from #11826. For comparison, the migrations that did need care here — `add_invoice_custom_fields`, `add_legacy_goods_received_link_fields` — were joining against `sync_buffer`'s millions of rows and had to create and drop temporary indexes.

# 🧪 Tested

- Added `test_populate_missing_changelog_for_form_schema`, following the pattern in `populate_changelog_with_rows_for_sync_v7_tables`: seeds two `form_schema` rows at `V2_18_00`, migrates to 3.00.0, asserts each gets exactly one changelog row with the expected keyless central shape (`row_action = 'UPSERT'`, `source_site_id` from `SETTINGS_SYNC_CENTRAL_SERVER_SITE_ID`, `store_id` / `transfer_store_id` / `patient_link_id` all NULL), then re-runs the fragment and asserts no duplicates.
- `cargo nextest run -p repository migrations::v3_00_00` — all 11 tests pass on SQLite. Postgres not run locally (no local instance); the SQL is a single portable `INSERT … SELECT … WHERE NOT EXISTS` with no `UPDATE … FROM` and no casts, so relying on CI for that leg.

Still to do on affected dataset (can tag and install on server using this version if wanted):

- On the affected central: confirm `SELECT count(*) FROM changelog WHERE table_name = 'form_schema'` is 0 before, equals the `form_schema` row count after, and doesn't grow on a second start-up.
- Sync the affected remote, confirm the patient schemas land in its `form_schema` table, then re-run the failing fetch for Daniel Mathers (CAM0006) / Nick Bjorn (1212) and confirm the patient and their documents integrate.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:

---
Reopened against `develop` as a new PR; original #12587 was closed against `v3.0.0-RC` and gh doesn't support reopening a closed PR onto a different base.
