### PR TITLE
Reword sync token error: re-init → re-initialisation

### DIFF
--- a/server/repository/src/syncv7/sync_record.rs
+++ b/server/repository/src/syncv7/sync_record.rs
@@ -28,7 +28,7 @@ diesel_json_type! {
         Authentication,
         #[error("Invalid site name or password")]
         InvalidSiteNameOrPassword,
-        #[error("Site already has a token allocated; admin must clear it before re-init")]
+        #[error("Site already has a token allocated; admin must clear it before re-initialisation")]
         TokenAlreadyAllocated,
         #[error("Token not found")]
         TokenNotFound,


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Corrects the wording of the v7 sync `TokenAlreadyAllocated` authentication error so it reads "…admin must clear it before re-initialisation" instead of the abbreviated "re-init".

## 💌 Any notes for the reviewer?

Cosmetic, single-string wording change in `server/repository/src/syncv7/sync_record.rs`. No behavioural change — the error variant and the conditions that trigger it are untouched.

# 🧪 Tested

- No functional change; the edit is a single error-string literal.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
