### PR TITLE
#1074 Fix easter egg iframe path in dual front-end old UI

### DIFF
--- a/client/packages/host/src/components/EasterEggModal/EasterEggModal.tsx
+++ b/client/packages/host/src/components/EasterEggModal/EasterEggModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BasicModal, DialogButton } from '@common/components';
 import { Box } from '@openmsupply-client/common';
+import { Environment } from '@openmsupply-client/config';
 
 interface ConfirmationModalProps {
   open: boolean;
@@ -26,7 +27,10 @@ export const EasterEggModal = ({
         sx={{ backgroundColor: '#f7f7f7' }}
       >
         <iframe
-          src="/game/index.html"
+          // Served alongside the frontend bundle, so it needs the build-time
+          // base path (Environment.PUBLIC_PATH, '/old-ui/' for the dual-FE build)
+          // to resolve when the old UI is served from a sub-path.
+          src={`${Environment.PUBLIC_PATH}game/index.html`}
           style={{
             width: 600,
             height: 250,


### PR DESCRIPTION
Fixes msupply-foundation/open-msupply-frontend#1074

The easter egg iframe used the absolute path `/game/index.html`, which 404s when this build is served as the "old UI" under `/old-ui/` in the dual-frontend setup. Prefixed it with `Environment.PUBLIC_PATH`, same as other same-origin asset paths (locales, error fallback link).

## 💌 Any notes for the reviewer?

Small, isolated one-line fix in `EasterEggModal.tsx`.

# 🧪 Tested

- `tsc --noEmit` passes.
- Confirmed the game assets are always copied to the webpack output root, so `PUBLIC_PATH + game/index.html` resolves correctly in both single- and dual-frontend builds.

# 📃 Documentation

- [x] **No documentation required** — bug fix, no behaviour change from pre-regression state.
