### PR TITLE
Clear the remembered old-UI choice on "try new UI"

### DIFF
--- a/client/packages/host/src/components/Login/Login.tsx
+++ b/client/packages/host/src/components/Login/Login.tsx
@@ -27,6 +27,24 @@ import { useHost } from '../../api';
 // statically reducible, so it would ship the link in every build.
 declare const PUBLIC_PATH: string;
 
+// A device that followed the new frontend's own "switch to old UI" link
+// remembers that choice (open-msupply-frontend#1075) and bounces itself back
+// here on every later cold load/logout. Clicking this link back to '/' must
+// clear that choice, or the new frontend's login page redirects straight back
+// to this one. Deliberately a raw, un-prefixed localStorage key rather than
+// going through `LocalStorage` (which namespaces under '@openmsupply-client'
+// and JSON-encodes) — this key is a cross-app contract with a different
+// codebase, not this app's own preference store, so it stays outside both
+// apps' internal serialisation formats. Keep this key name in sync with
+// `oms-preferred-frontend` in that repo's src/preferredFrontend.ts.
+const clearPreferredFrontend = () => {
+  try {
+    localStorage.setItem('oms-preferred-frontend', 'new');
+  } catch {
+    // storage unavailable (private mode) — the link still navigates
+  }
+};
+
 export const Login = ({ fullSize = true }: { fullSize?: boolean }) => {
   const t = useTranslation();
   const { setPageTitle } = useHostContext();
@@ -233,6 +251,7 @@ export const Login = ({ fullSize = true }: { fullSize?: boolean }) => {
             variant="body2"
             color="secondary"
             data-testid="try-new-ui-link"
+            onClick={clearPreferredFrontend}
           >
             {t('login.try-new-ui')}
           </MuiLink>


### PR DESCRIPTION
## 👩🏻‍💻 What does this PR do?

The new (SolidJS) frontend just added a sticky old-UI/new-UI choice ([open-msupply-frontend#1075](https://github.com/msupply-foundation/open-msupply-frontend/issues/1075) / [open-msupply-frontend#1086](https://github.com/msupply-foundation/open-msupply-frontend/pull/1086)): once a device follows its login page's "Switch to old UI" link, that new frontend remembers the choice in a `localStorage` key and bounces itself straight to `/old-ui/` on every later cold load, logout, or session expiry — instead of showing its own login page again.

This client's own "try new UI" link (`Login.tsx`, only rendered in the dual-frontend `PUBLIC_PATH=/old-ui/` build) is the only way back, and it currently writes nothing. Without this change, clicking it breaks: it navigates to `/`, the new frontend's login gate sees the old-UI choice is still set, and immediately redirects straight back here — a permanent loop, with the button no longer doing anything.

This PR makes that link write `oms-preferred-frontend = "new"` into the same shared key before navigating, so the round trip actually completes.

## 💌 Any notes for the reviewer?

- The key is intentionally a **raw, un-prefixed `localStorage.setItem` call**, not routed through this app's own `LocalStorage` wrapper (which namespaces under `@openmsupply-client/...` and JSON-encodes). It's a cross-app contract with a different codebase, not this app's own preference store, so it deliberately stays outside both apps' internal serialisation formats — see the comment above `clearPreferredFrontend` in `Login.tsx`.
- No behaviour changes for anyone on a default (non-dual-frontend) build — the link and its handler are only reachable when `PUBLIC_PATH !== '/'`, same as today.
- Separately, this PR does **not** touch [open-msupply-frontend#1072](https://github.com/msupply-foundation/open-msupply-frontend/issues/1072) ("old UI logs out into new UI's login") — that already looks fixed by the basename-aware `useLogout`/`RequireAuthentication` navigation already on `develop`, worth a re-check/close on its own rather than folded into this change.

## 🧪 Tested

- `tsc --noEmit` on the `host` package is clean (one pre-existing, unrelated `@types/electron` error in a different file).
- `eslint --no-ignore` on the changed file is clean.
- Not manually click-tested end-to-end against a real dual-frontend deploy this session (needs the `/old-ui/` build + the companion new-frontend PR running together) — worth a manual pass once both PRs are ready to merge.

## 📃 Documentation

- [x] **No documentation required** — no user-facing change on its own (a default build never renders this link); the user-facing behaviour is documented against the paired open-msupply-frontend PR.
