### PR TITLE
#1088 Read session cookie from every Cookie header field

### DIFF
--- a/server/graphql/core/src/lib.rs
+++ b/server/graphql/core/src/lib.rs
@@ -125,11 +125,19 @@ pub fn auth_data_from_request(http_req: &HttpRequest, cookie_suffix: &str) -> Re
 
 fn session_cookie_value(http_req: &HttpRequest, cookie_suffix: &str) -> Option<String> {
     let cookie_name = format!("session_{cookie_suffix}");
-    let header = http_req.headers().get(COOKIE)?.to_str().ok()?;
-    // RFC 6265: a Cookie header is a `; `-separated list of name=value pairs.
-    header
-        .split("; ")
-        .filter_map(|raw_cookie| Cookie::parse(raw_cookie).ok())
+    // RFC 6265: a Cookie header is a `; `-separated list of name=value pairs — but a request
+    // may carry *several* Cookie header fields: HTTP/2+ clients split ("crumble") the cookie
+    // list into one field per cookie for better compression (RFC 9113 §8.2.3), ordered
+    // oldest-created first, so the freshly issued session cookie tends to arrive last. Scan
+    // every field (skipping any individually malformed cookie) rather than only the first,
+    // otherwise any stale cookie on the origin hides the session cookie (issue
+    // msupply-foundation/open-msupply-frontend#1088).
+    http_req
+        .headers()
+        .get_all(COOKIE)
+        .filter_map(|header_value| header_value.to_str().ok())
+        .flat_map(|header| header.split(';'))
+        .filter_map(|raw_cookie| Cookie::parse(raw_cookie.trim()).ok())
         .find(|cookie| cookie.name() == cookie_name)
         .map(|cookie| cookie.value().to_owned())
 }
@@ -151,4 +159,55 @@ macro_rules! map_filter {
             is_null: None,
         }
     }};
+}
+
+#[cfg(test)]
+mod session_cookie_tests {
+    use super::*;
+    use actix_web::test::TestRequest;
+
+    #[test]
+    fn finds_session_cookie_in_single_combined_header() {
+        // HTTP/1.1 style: one Cookie header with a `; `-separated list.
+        let req = TestRequest::default()
+            .insert_header((COOKIE, "refresh_token=stale; session_8000=the-token"))
+            .to_http_request();
+        assert_eq!(
+            session_cookie_value(&req, "8000"),
+            Some("the-token".to_string())
+        );
+    }
+
+    #[test]
+    fn finds_session_cookie_split_across_multiple_headers() {
+        // HTTP/2 style: the client "crumbles" the cookie list into one header field per
+        // cookie, oldest first — the fresh session cookie arrives last (issue
+        // msupply-foundation/open-msupply-frontend#1088).
+        let req = TestRequest::default()
+            .append_header((COOKIE, "auth=legacy-json-blob"))
+            .append_header((COOKIE, "refresh_token=stale"))
+            .append_header((COOKIE, "session_8000=the-token"))
+            .to_http_request();
+        assert_eq!(
+            session_cookie_value(&req, "8000"),
+            Some("the-token".to_string())
+        );
+    }
+
+    #[test]
+    fn missing_session_cookie_returns_none() {
+        let req = TestRequest::default()
+            .append_header((COOKIE, "refresh_token=stale"))
+            .to_http_request();
+        assert_eq!(session_cookie_value(&req, "8000"), None);
+    }
+
+    #[test]
+    fn wrong_suffix_is_not_matched() {
+        // Two instances on one domain must not read each other's sessions.
+        let req = TestRequest::default()
+            .append_header((COOKIE, "session_8000=the-token"))
+            .to_http_request();
+        assert_eq!(session_cookie_value(&req, "8002"), None);
+    }
 }

--- a/server/server/src/support/mod.rs
+++ b/server/server/src/support/mod.rs
@@ -40,16 +40,18 @@ fn validate_request(
     // the session token from the HttpOnly cookie. There's no longer a separate refresh token —
     // the session cookie IS the auth token, and `validate_auth` slides its expiry as a side
     // effect of validation.
+    // HTTP/2+ clients split the cookie list into one Cookie header field per cookie
+    // (RFC 9113 §8.2.3), so scan every field — not just the first — the same way as the
+    // GraphQL pipeline's `session_cookie_value`.
     let cookie_name = format!("session_{}", auth_data.cookie_suffix);
-    let session_token = request.headers().get(COOKIE).and_then(|header_value| {
-        header_value.to_str().ok().and_then(|header| {
-            header
-                .split("; ")
-                .filter_map(|raw_cookie| Cookie::parse(raw_cookie).ok())
-                .find(|cookie| cookie.name() == cookie_name)
-                .map(|cookie| cookie.value().to_owned())
-        })
-    });
+    let session_token = request
+        .headers()
+        .get_all(COOKIE)
+        .filter_map(|header_value| header_value.to_str().ok())
+        .flat_map(|header| header.split(';'))
+        .filter_map(|raw_cookie| Cookie::parse(raw_cookie.trim()).ok())
+        .find(|cookie| cookie.name() == cookie_name)
+        .map(|cookie| cookie.value().to_owned());
 
     if session_token.is_none() {
         return Err(AuthError::Denied(AuthDeniedKind::NotAuthenticated(


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes msupply-foundation/open-msupply-frontend#1088

After upgrading v3.0 → v3.1, login failed on both frontends with "Unable to connect to server … Unauthenticated", while a fresh initialise worked fine.

Root cause: HTTP/2 clients split ("crumble") the cookie list into **one `cookie` header field per cookie** (RFC 9113 §8.2.3), ordered oldest-created first — verified empirically against Chrome with a raw-header-logging h2 server. The session cookie extractor (`session_cookie_value` in `graphql_core`, plus a copy in the support endpoint) only parsed the **first** Cookie header field. An upgraded device still has v3.0's `auth` (~3.3KB client-side JSON) and `refresh_token` cookies in the WebView jar; both are older than the freshly issued `session_{port}` cookie, so the session cookie arrives in a later header field and was never seen. Login itself succeeds (needs no cookie), then the immediate `me` query fails with `Unauthenticated("Missing auth token")` — exactly the error in the issue screenshot.

The fix scans every `Cookie` header field (`headers().get_all(COOKIE)`), splits each on `;`, and skips individually malformed cookies.

## 💌 Any notes for the reviewer?

- Why nobody saw this in dev/e2e: cookie crumbling only happens on HTTP/2, which browsers only use over TLS. Dev servers run plain HTTP → HTTP/1.1 → one combined `Cookie: a=1; b=2` header, which parsed fine. Android always runs self-signed TLS → h2. Same reason a desktop-Chrome repro over http didn't show the split.
- Why fresh initialise worked: an empty cookie jar means the session cookie is the only (first) field.
- The failure window is bounded — v3.0's leftover cookies expire after 1–2h — so in the field this would have looked intermittent, biting anyone upgrading shortly after last using v3.0.
- Two copies of the parsing existed: `server/graphql/core/src/lib.rs` (GraphQL + WS pipeline) and `server/server/src/support/mod.rs` (support/download endpoint). Both fixed identically. The REST-side `validate_cookie_auth` already used actix's multi-header-aware `request.cookie()` and is untouched.
- Linked issue lives in the open-msupply-frontend repo (it affects both frontends, but the bug is in this server).
- Targeting `v3.01.00-RC` since this blocks the RC upgrade path; develop picks it up via the regular RC → develop merges.

# 🧪 Tested

- Added unit tests for `session_cookie_value`: combined single header (HTTP/1.1 style), cookie list split across three header fields with the session cookie last (the upgrade scenario), missing session cookie, and wrong port suffix (`session_8000` vs suffix `8002`). All pass under `cargo nextest run -p graphql_core`.
- Reproduced the bug against a live server before the fix: `POST /graphql me` with a valid session sent as one combined Cookie header succeeds; the identical request with the cookies sent as **separate** Cookie header fields returns `Unauthenticated("Missing auth token")`.
- Confirmed the wire behaviour that triggers it: Chrome over h2 to a local TLS test server sends five separate `cookie` header fields for five stored cookies, newest (the session cookie) last.
- `cargo check -p server` clean.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
