### PR TITLE
12674 Atomic deletes for campaigns and close backend gap with new frontend

### DIFF
--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -1226,11 +1226,16 @@ export type CampaignFilterInput = {
 export type CampaignMutations = {
   __typename: 'CampaignMutations';
   deleteCampaign: DeleteCampaignResponse;
+  deleteCampaigns: DeleteCampaignsResponse;
   upsertCampaign: UpsertCampaignResponse;
 };
 
 export type CampaignMutationsDeleteCampaignArgs = {
   input: DeleteCampaignInput;
+};
+
+export type CampaignMutationsDeleteCampaignsArgs = {
+  ids: Array<Scalars['String']['input']>;
 };
 
 export type CampaignMutationsUpsertCampaignArgs = {
@@ -2181,6 +2186,13 @@ export type DeleteCampaignSuccess = {
   __typename: 'DeleteCampaignSuccess';
   id: Scalars['String']['output'];
 };
+
+export type DeleteCampaignsNode = {
+  __typename: 'DeleteCampaignsNode';
+  ids: Array<Scalars['String']['output']>;
+};
+
+export type DeleteCampaignsResponse = DeleteCampaignsNode;
 
 export type DeleteCustomerReturnError = {
   __typename: 'DeleteCustomerReturnError';

--- a/server/graphql/general/src/campaign/mod.rs
+++ b/server/graphql/general/src/campaign/mod.rs
@@ -44,4 +44,12 @@ impl CampaignMutations {
     ) -> Result<DeleteCampaignResponse> {
         delete_campaign(ctx, input)
     }
+
+    async fn delete_campaigns(
+        &self,
+        ctx: &Context<'_>,
+        ids: Vec<String>,
+    ) -> Result<DeleteCampaignsResponse> {
+        delete_campaigns(ctx, ids)
+    }
 }

--- a/server/graphql/general/src/campaign/mutations/delete.rs
+++ b/server/graphql/general/src/campaign/mutations/delete.rs
@@ -37,6 +37,16 @@ pub enum DeleteCampaignResponse {
     Response(DeleteCampaignSuccess),
 }
 
+#[derive(SimpleObject)]
+pub struct DeleteCampaignsNode {
+    pub ids: Vec<String>,
+}
+
+#[derive(Union)]
+pub enum DeleteCampaignsResponse {
+    Response(DeleteCampaignsNode),
+}
+
 pub fn delete_campaign(
     ctx: &Context<'_>,
     input: DeleteCampaignInput,
@@ -58,6 +68,42 @@ pub fn delete_campaign(
         .delete_campaign(&service_context, DeleteCampaign { id: input.id });
 
     map_response(result)
+}
+
+pub fn delete_campaigns(ctx: &Context<'_>, ids: Vec<String>) -> Result<DeleteCampaignsResponse> {
+    validate_auth(
+        ctx,
+        &ResourceAccessRequest {
+            resource: Resource::MutateCampaigns,
+            store_id: None,
+            require_central_standalone: false,
+        },
+    )?;
+
+    let service_provider = ctx.service_provider();
+    let service_context = service_provider.basic_context()?;
+
+    match service_provider
+        .campaign_service
+        .delete_campaigns(&service_context, ids)
+    {
+        Ok(ids) => Ok(DeleteCampaignsResponse::Response(DeleteCampaignsNode {
+            ids,
+        })),
+        Err(error) => Err(map_bulk_error(error)),
+    }
+}
+
+fn map_bulk_error(error: ServiceError) -> async_graphql::Error {
+    use StandardGraphqlError::*;
+    let formatted_error = format!("{error:#?}");
+
+    let graphql_error = match error {
+        ServiceError::CampaignDoesNotExist => BadUserInput(formatted_error),
+        ServiceError::DatabaseError(_) => InternalError(formatted_error),
+    };
+
+    graphql_error.extend()
 }
 
 fn map_response(result: Result<String, ServiceError>) -> Result<DeleteCampaignResponse> {

--- a/server/service/src/campaign/delete.rs
+++ b/server/service/src/campaign/delete.rs
@@ -1,4 +1,6 @@
-use repository::{campaign::campaign_row::CampaignRowRepository, RepositoryError};
+use repository::{
+    campaign::campaign_row::CampaignRowRepository, RepositoryError, StorageConnection,
+};
 
 use crate::service_provider::ServiceContext;
 
@@ -21,22 +23,98 @@ pub fn delete_campaign(
 ) -> Result<String, DeleteCampaignError> {
     let campaign_id = ctx
         .connection
-        .transaction_sync(|connection| {
-            let campaign_exists = check_campaign_exists(connection, &input.id)?;
-            if !campaign_exists {
-                return Err(DeleteCampaignError::CampaignDoesNotExist);
-            }
-
-            CampaignRowRepository::new(connection).mark_deleted(&input.id)?;
-            Ok(input.id.clone())
-        })
+        .transaction_sync(|connection| delete_one(connection, &input.id))
         .map_err(|error| error.to_inner_error())?;
 
     Ok(campaign_id)
 }
 
+pub fn delete_campaigns(
+    ctx: &ServiceContext,
+    ids: Vec<String>,
+) -> Result<Vec<String>, DeleteCampaignError> {
+    let campaign_ids = ctx
+        .connection
+        .transaction_sync(|connection| {
+            ids.iter()
+                .map(|id| delete_one(connection, id))
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .map_err(|error| error.to_inner_error())?;
+
+    Ok(campaign_ids)
+}
+
+fn delete_one(connection: &StorageConnection, id: &str) -> Result<String, DeleteCampaignError> {
+    let campaign_exists = check_campaign_exists(connection, id)?;
+    if !campaign_exists {
+        return Err(DeleteCampaignError::CampaignDoesNotExist);
+    }
+
+    CampaignRowRepository::new(connection).mark_deleted(id)?;
+    Ok(id.to_string())
+}
+
 impl From<RepositoryError> for DeleteCampaignError {
     fn from(error: RepositoryError) -> Self {
         DeleteCampaignError::DatabaseError(error)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use repository::{mock::MockDataInserts, test_db::setup_all};
+
+    use crate::campaign::{check_campaign_exists, UpsertCampaign};
+    use crate::service_provider::ServiceProvider;
+
+    use super::*;
+
+    #[actix_rt::test]
+    async fn delete_campaigns_is_atomic() {
+        let (_, _, connection_manager, _) =
+            setup_all("delete_campaigns_is_atomic", MockDataInserts::none()).await;
+        let service_provider = ServiceProvider::new(connection_manager);
+        let ctx = service_provider.basic_context().unwrap();
+        let service = &service_provider.campaign_service;
+
+        for id in ["campaign_a", "campaign_b"] {
+            service
+                .upsert_campaign(
+                    &ctx,
+                    UpsertCampaign {
+                        id: id.to_string(),
+                        name: id.to_string(),
+                        start_date: None,
+                        end_date: None,
+                    },
+                )
+                .unwrap();
+        }
+
+        // A selection containing an unknown id deletes nothing at all.
+        let result =
+            service.delete_campaigns(&ctx, vec!["campaign_a".to_string(), "missing".to_string()]);
+        assert_eq!(result, Err(DeleteCampaignError::CampaignDoesNotExist));
+        assert!(check_campaign_exists(&ctx.connection, "campaign_a").unwrap());
+        assert!(check_campaign_exists(&ctx.connection, "campaign_b").unwrap());
+
+        // A selection of known ids deletes in full, reporting every id back.
+        let deleted = service
+            .delete_campaigns(
+                &ctx,
+                vec!["campaign_a".to_string(), "campaign_b".to_string()],
+            )
+            .unwrap();
+        assert_eq!(
+            deleted,
+            vec!["campaign_a".to_string(), "campaign_b".to_string()]
+        );
+        assert!(!check_campaign_exists(&ctx.connection, "campaign_a").unwrap());
+        assert!(!check_campaign_exists(&ctx.connection, "campaign_b").unwrap());
+
+        // Already deleted is the same rejection as never existed.
+        let result = service.delete_campaigns(&ctx, vec!["campaign_a".to_string()]);
+        assert_eq!(result, Err(DeleteCampaignError::CampaignDoesNotExist));
     }
 }

--- a/server/service/src/campaign/mod.rs
+++ b/server/service/src/campaign/mod.rs
@@ -4,7 +4,7 @@ mod upsert;
 mod validate;
 
 use crate::{service_provider::ServiceContext, ListError, ListResult};
-pub use delete::{delete_campaign, DeleteCampaign, DeleteCampaignError};
+pub use delete::{delete_campaign, delete_campaigns, DeleteCampaign, DeleteCampaignError};
 pub use query::get_campaigns;
 use repository::{
     campaign::campaign::{Campaign, CampaignFilter, CampaignSort},
@@ -38,6 +38,14 @@ pub trait CampaignServiceTrait: Send + Sync {
         input: DeleteCampaign,
     ) -> Result<String, DeleteCampaignError> {
         delete_campaign(ctx, input)
+    }
+
+    fn delete_campaigns(
+        &self,
+        ctx: &ServiceContext,
+        ids: Vec<String>,
+    ) -> Result<Vec<String>, DeleteCampaignError> {
+        delete_campaigns(ctx, ids)
     }
 }
 


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12674
Atomically delete campaigns so that it's all or nothing fail; aligns with how we do deletes for the rest of the app

## 💌 Any notes for the reviewer?
Should we be checking if the campaign exists on an item and not delete it? Or since it's soft-deleted it doesn't matter? 
Frontend-rewrite PR: https://github.com/msupply-foundation/open-msupply-frontend/pull/939

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- Run tests

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [ ] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
