### PR TITLE
Update data for requisition e2e

### DIFF
--- a/server/data/e2e/export.json
+++ b/server/data/e2e/export.json
@@ -46899,7 +46899,7 @@
     "universal_code": null,
     "vaccine_doses": 3,
     "ven_category": "NotAssigned",
-    "volume_per_pack": 0.0
+    "volume_per_pack": 2.0
    },
    "sync_version": "V7",
    "app_version": null,
@@ -80308,7 +80308,7 @@
    "action": "Upsert",
    "data": {
     "edit_prescribed_quantity_on_prescription": false,
-    "extra_fields_in_requisition": false,
+    "extra_fields_in_requisition": true,
     "id": "e2e_feature_store",
     "issue_in_foreign_currency": true,
     "keep_requisition_lines_with_zero_requested_quantity_on_finalised": true,
@@ -83854,32 +83854,6 @@
    "app_version": null,
    "source_site_id": 6,
    "store_id": null,
-   "transfer_store_id": null,
-   "patient_id": null,
-   "reference_id": null,
-   "is_integrated": false
-  },
-  {
-   "cursor": 2358,
-   "record_id": "e2e_nsj_gry_feat",
-   "received_datetime": "2026-07-09T00:00:00",
-   "integration_started_datetime": null,
-   "integration_datetime": null,
-   "integration_error": null,
-   "integration_result": null,
-   "table_name": "name_store_join",
-   "action": "Upsert",
-   "data": {
-    "id": "e2e_nsj_gry_feat",
-    "name_id": "e2e_feature_store_name",
-    "name_is_customer": true,
-    "name_is_supplier": true,
-    "store_id": "80004C94067A4CE5A34FC343EB1B4306"
-   },
-   "sync_version": "V7",
-   "app_version": null,
-   "source_site_id": 6,
-   "store_id": "80004C94067A4CE5A34FC343EB1B4306",
    "transfer_store_id": null,
    "patient_id": null,
    "reference_id": null,


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #
Updates data for requisition e2e. Pair with https://github.com/msupply-foundation/open-msupply-frontend/pull/1121 for updated tests

## 💌 Any notes for the reviewer?

<!-- 
Do you have any specific questions for the reviewer?
Is there a high risk/complicated change they should focus on?
Any general areas of the codebase touched? any side effects caused?
Anything half cooked but going to be finished off in a different PR? 
-->

# 🧪 Tested

<!-- What did you do to verify this works? Include any automated tests you added/updated and the manual steps you ran. -->

- _(e.g.)_ Added unit tests covering the issued-quantity calculation in the requisition service
- _(e.g.)_ Set up a Central Sync server with 1 Legacy Desktop remote site and 1 OMS remote site running this PR (sample datafile: _google drive link_)
- _(e.g.)_ Opened a requisition, added some lines, and made a couple of invoices supplying some of those lines
- _(e.g.)_ Confirmed the "Issued" column showed the sum of the amounts already issued in invoices for the requisition

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [ ] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
