### PR TITLE
#12679 Global logo preference as fallback for store logos

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -3128,8 +3128,8 @@
   "warning.manual-store-requisition": "Entering a requisition for this store may result in duplicates if the store also submits an internal order.",
   "warning.nothing-to-supply": "Nothing left to supply!",
   "warning.requested-exceeds-suggested": "Your requested quantity is higher than the suggested",
-  "preference.globalLogo": "Global logo (used on printed documents when a store has no logo)",
+  "preference.globalLogo": "Global logo",
   "label.edit-image": "Edit image",
-  "messages.no-image-uploaded": "No image uploaded",
+  "messages.none-uploaded": "None uploaded",
   "messages.image-upload-helper": "PNG, JPEG, GIF or SVG, up to {{maxSize}}"
 }

--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -3127,5 +3127,9 @@
   "warning.insufficient-recent-stocktake-items": "You have not completed stocktake(s) containing at least {{ minItems }} items within the last {{maxAge}} days. Your stock levels may not be accurate. Are you sure that you want to continue?",
   "warning.manual-store-requisition": "Entering a requisition for this store may result in duplicates if the store also submits an internal order.",
   "warning.nothing-to-supply": "Nothing left to supply!",
-  "warning.requested-exceeds-suggested": "Your requested quantity is higher than the suggested"
+  "warning.requested-exceeds-suggested": "Your requested quantity is higher than the suggested",
+  "preference.globalLogo": "Global logo (used on printed documents when a store has no logo)",
+  "label.edit-image": "Edit image",
+  "messages.no-image-uploaded": "No image uploaded",
+  "messages.image-upload-helper": "PNG, JPEG, GIF or SVG, up to {{maxSize}}"
 }

--- a/client/packages/common/src/types/schema.ts
+++ b/client/packages/common/src/types/schema.ts
@@ -7711,6 +7711,7 @@ export enum PreferenceKey {
   ExternalInboundShipmentLinesMustBeAuthorised = 'externalInboundShipmentLinesMustBeAuthorised',
   FirstThresholdForExpiringItems = 'firstThresholdForExpiringItems',
   GenderOptions = 'genderOptions',
+  GlobalLogo = 'globalLogo',
   GlobalTableConfigs = 'globalTableConfigs',
   InboundShipmentAutoVerify = 'inboundShipmentAutoVerify',
   InvoiceStatusOptions = 'invoiceStatusOptions',
@@ -7761,6 +7762,7 @@ export enum PreferenceValueNodeType {
   CustomTranslations = 'CUSTOM_TRANSLATIONS',
   CustomTranslationsV2 = 'CUSTOM_TRANSLATIONS_V2',
   Float = 'FLOAT',
+  Image = 'IMAGE',
   Integer = 'INTEGER',
   MultiChoice = 'MULTI_CHOICE',
   String = 'STRING',
@@ -7786,6 +7788,11 @@ export type PreferencesNode = {
   externalInboundShipmentLinesMustBeAuthorised: Scalars['Boolean']['output'];
   firstThresholdForExpiringItems: Scalars['Int']['output'];
   genderOptions: Array<GenderTypeNode>;
+  /**
+   * Base64 data-URL logo used as fallback when a store has no logo.
+   * Large - don't add to eagerly-fetched preference queries.
+   */
+  globalLogo: Scalars['String']['output'];
   globalTableConfigs: Scalars['JSON']['output'];
   inboundShipmentAutoVerify: Scalars['Boolean']['output'];
   invoiceStatusOptions: Array<InvoiceNodeStatus>;
@@ -10774,7 +10781,8 @@ export type StoreNode = {
   /** Whether the store has been disabled, either by a user or as a result of a store merge. */
   isDisabled: Scalars['Boolean']['output'];
   /**
-   * Returns the associated store logo.
+   * Returns the associated store logo, falling back to the global logo
+   * preference when the store has none.
    * The logo is returned as a data URL schema, e.g. "data:image/png;base64,..."
    * Lazy-loaded — the logo is not pulled with the default store row.
    */
@@ -12696,6 +12704,7 @@ export type UpsertPreferencesInput = {
   >;
   firstThresholdForExpiringItems?: InputMaybe<Array<IntegerStorePrefInput>>;
   genderOptions?: InputMaybe<Array<GenderTypeNode>>;
+  globalLogo?: InputMaybe<Scalars['String']['input']>;
   globalTableConfigs?: InputMaybe<Scalars['JSON']['input']>;
   inboundShipmentAutoVerify?: InputMaybe<Array<BoolStorePrefInput>>;
   invoiceStatusOptions?: InputMaybe<Array<InvoiceStatusOptionsInput>>;

--- a/client/packages/system/src/Manage/Preferences/Components/EditImagePreference.test.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/EditImagePreference.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TestingProvider } from '@openmsupply-client/common';
+import { EditImagePreference, MAX_FILE_BYTES } from './EditImagePreference';
+
+const mockError = jest.fn(() => jest.fn());
+const mockSuccess = jest.fn(() => jest.fn());
+jest.mock('@common/hooks', () => ({
+  ...jest.requireActual('@common/hooks'),
+  useNotification: () => ({
+    error: mockError,
+    success: mockSuccess,
+  }),
+}));
+jest.mock('@common/intl', () => ({
+  ...jest.requireActual('@common/intl'),
+  useTranslation: () => (key: string) => key,
+}));
+
+const PNG_DATA_URL = 'data:image/png;base64,iVBORw0KGgo=';
+
+const uploadFile = (file: File) => {
+  const input = document.querySelector(
+    'input[type="file"]'
+  ) as HTMLInputElement;
+  fireEvent.change(input, { target: { files: [file] } });
+};
+
+describe('EditImagePreference', () => {
+  const mockUpdate = jest.fn(async (_: string) => true);
+
+  beforeEach(() => {
+    mockError.mockClear();
+    mockSuccess.mockClear();
+    mockUpdate.mockClear();
+  });
+
+  const renderComponent = (value = '') =>
+    render(
+      <TestingProvider>
+        <EditImagePreference
+          value={value}
+          update={mockUpdate}
+          disabled={false}
+        />
+      </TestingProvider>
+    );
+
+  it('saves an uploaded image only on save, as a data URL', async () => {
+    renderComponent();
+    fireEvent.click(screen.getByText('button.edit'));
+
+    uploadFile(new File(['fake png'], 'logo.png', { type: 'image/png' }));
+
+    // Preview appears once the file is read; nothing is saved yet
+    await waitFor(() =>
+      expect(
+        document.querySelector('img[src^="data:image/png;base64,"]')
+      ).toBeInTheDocument()
+    );
+    expect(mockUpdate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('button.save'));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.stringMatching(/^data:image\/png;base64,/)
+    );
+    expect(mockError).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported file type', async () => {
+    renderComponent();
+    fireEvent.click(screen.getByText('button.edit'));
+
+    uploadFile(new File(['<html/>'], 'page.html', { type: 'text/html' }));
+
+    await waitFor(() =>
+      expect(mockError).toHaveBeenCalledWith('error.file-type-not-supported')
+    );
+    fireEvent.click(screen.getByText('button.save'));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    // Nothing was accepted, so save persists the unchanged (empty) value
+    expect(mockUpdate).toHaveBeenCalledWith('');
+  });
+
+  it('rejects an oversized file', async () => {
+    renderComponent();
+    fireEvent.click(screen.getByText('button.edit'));
+
+    const oversized = new File(
+      [new Uint8Array(MAX_FILE_BYTES + 1)],
+      'big.png',
+      { type: 'image/png' }
+    );
+    uploadFile(oversized);
+
+    await waitFor(() =>
+      expect(mockError).toHaveBeenCalledWith('error.file-exceeds-size-limit')
+    );
+    expect(
+      document.querySelector('img[src^="data:image/png;base64,"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('clears the image via remove + save', async () => {
+    renderComponent(PNG_DATA_URL);
+    fireEvent.click(screen.getByText('button.edit'));
+
+    fireEvent.click(screen.getByText('label.remove'));
+    fireEvent.click(screen.getByText('button.save'));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith(''));
+  });
+});

--- a/client/packages/system/src/Manage/Preferences/Components/EditImagePreference.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/EditImagePreference.tsx
@@ -1,0 +1,214 @@
+import React, { useState } from 'react';
+import {
+  Accept,
+  ButtonWithIcon,
+  DialogButton,
+  FileRejection,
+  LoadingButton,
+  UploadFile,
+} from '@common/components';
+import { Box, Typography } from '@openmsupply-client/common';
+import { DeleteIcon, EditIcon, SaveIcon } from '@common/icons';
+import { useTranslation } from '@common/intl';
+import { useDialog, useNotification, useToggle } from '@common/hooks';
+
+/// Max length of the stored data-URL string. Must match
+/// MAX_GLOBAL_LOGO_DATA_URL_LENGTH in the server's global_logo.rs.
+export const MAX_DATA_URL_LENGTH = 250 * 1024;
+
+/// Raw file cap, allowing for base64's 4/3 inflation plus the data-URL prefix.
+export const MAX_FILE_BYTES = Math.floor((MAX_DATA_URL_LENGTH * 3) / 4) - 64;
+
+export const IMAGE_ACCEPT: Accept = {
+  'image/png': ['.png'],
+  'image/jpeg': ['.jpg', '.jpeg'],
+  'image/gif': ['.gif'],
+  'image/svg+xml': ['.svg'],
+};
+
+const MAX_SIZE_LABEL = `${Math.floor(MAX_FILE_BYTES / 1024)}KB`;
+
+const ALLOWED_MIME_TYPES = new Set(Object.keys(IMAGE_ACCEPT));
+
+// The stored data URL's prefix comes from the file's MIME type, which some
+// platforms don't report - fall back to mapping the extension so the prefix
+// always matches the server's whitelist.
+const mimeForFile = ({ name, type }: Pick<File, 'name' | 'type'>) => {
+  if (ALLOWED_MIME_TYPES.has(type)) return type;
+  return Object.entries(IMAGE_ACCEPT).find(([, extensions]) =>
+    extensions.some(extension => name.toLowerCase().endsWith(extension))
+  )?.[0];
+};
+
+interface EditImagePreferenceProps {
+  /** Current image as a base64 data URL; '' when not set */
+  value: string;
+  update: (value: string) => Promise<boolean>;
+  disabled: boolean;
+}
+
+export const EditImagePreference = ({
+  value,
+  update,
+  disabled,
+}: EditImagePreferenceProps) => {
+  const t = useTranslation();
+  const isOpen = useToggle();
+
+  return (
+    <Box display="flex" alignItems="center" gap={2}>
+      {value ? (
+        <Box
+          component="img"
+          src={value}
+          alt=""
+          sx={{ maxHeight: 40, maxWidth: 120, objectFit: 'contain' }}
+        />
+      ) : (
+        <Typography variant="body2" color="text.secondary">
+          {t('messages.no-image-uploaded')}
+        </Typography>
+      )}
+      <ButtonWithIcon
+        label={t('button.edit')}
+        onClick={isOpen.toggleOn}
+        Icon={<EditIcon />}
+        disabled={disabled}
+      />
+      {isOpen.isOn && (
+        <ImagePreferenceModal
+          value={value}
+          update={update}
+          onClose={isOpen.toggleOff}
+        />
+      )}
+    </Box>
+  );
+};
+
+const ImagePreferenceModal = ({
+  value,
+  update,
+  onClose,
+}: {
+  value: string;
+  update: (value: string) => Promise<boolean>;
+  onClose: () => void;
+}) => {
+  const t = useTranslation();
+  const { success, error } = useNotification();
+  const { Modal } = useDialog({ isOpen: true, onClose, disableBackdrop: true });
+
+  const [draft, setDraft] = useState(value);
+  const [loading, setLoading] = useState(false);
+
+  const rejectFile = (filename: string, reason: 'type' | 'size') =>
+    error(
+      reason === 'size'
+        ? t('error.file-exceeds-size-limit', {
+            filename,
+            maxSize: MAX_SIZE_LABEL,
+          })
+        : t('error.file-type-not-supported', { filename })
+    )();
+
+  // The drag & drop zone validates via `accept`/`maxSize`; these checks also
+  // cover the native file picker path.
+  const onUpload = (files: File[]) => {
+    const file = files[0];
+    if (!file) return;
+
+    const mimeType = mimeForFile(file);
+    if (!mimeType) return rejectFile(file.name, 'type');
+    if (file.size > MAX_FILE_BYTES) return rejectFile(file.name, 'size');
+
+    const reader = new FileReader();
+    reader.onload = e => {
+      const dataUrl = e.target?.result;
+      if (typeof dataUrl !== 'string') return;
+
+      const base64 = dataUrl.slice(
+        dataUrl.indexOf('base64,') + 'base64,'.length
+      );
+      const normalised = `data:${mimeType};base64,${base64}`;
+
+      // Authoritative check on what is actually stored (matches the server)
+      if (normalised.length > MAX_DATA_URL_LENGTH)
+        return rejectFile(file.name, 'size');
+
+      setDraft(normalised);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const onRejected = (rejections: FileRejection[]) =>
+    rejections.forEach(({ file, errors }) =>
+      rejectFile(
+        file.name,
+        errors.some(e => e.code === 'file-too-large') ? 'size' : 'type'
+      )
+    );
+
+  const save = async () => {
+    setLoading(true);
+    const successfulSave = await update(draft);
+    setLoading(false);
+
+    if (successfulSave) {
+      success(t('messages.saved'))();
+      onClose();
+    } else {
+      error(t('error.something-wrong'))();
+    }
+  };
+
+  return (
+    <Modal
+      title={t('label.edit-image')}
+      width={550}
+      cancelButton={<DialogButton variant="cancel" onClick={onClose} />}
+      okButton={
+        <LoadingButton
+          isLoading={loading}
+          onClick={save}
+          label={t('button.save')}
+          startIcon={<SaveIcon />}
+          variant="contained"
+          color="secondary"
+        />
+      }
+    >
+      <Box display="flex" flexDirection="column" gap={2} alignItems="center">
+        <UploadFile
+          onUpload={onUpload}
+          accept={IMAGE_ACCEPT}
+          maxSize={MAX_FILE_BYTES}
+          onRejected={onRejected}
+        />
+        <Typography variant="body2" color="text.secondary">
+          {t('messages.image-upload-helper', { maxSize: MAX_SIZE_LABEL })}
+        </Typography>
+        {draft ? (
+          <>
+            <Box
+              component="img"
+              src={draft}
+              alt=""
+              sx={{ maxHeight: 200, maxWidth: '100%', objectFit: 'contain' }}
+            />
+            <ButtonWithIcon
+              label={t('label.remove')}
+              onClick={() => setDraft('')}
+              Icon={<DeleteIcon />}
+              disabled={loading}
+            />
+          </>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            {t('messages.no-image-uploaded')}
+          </Typography>
+        )}
+      </Box>
+    </Modal>
+  );
+};

--- a/client/packages/system/src/Manage/Preferences/Components/EditImagePreference.tsx
+++ b/client/packages/system/src/Manage/Preferences/Components/EditImagePreference.tsx
@@ -14,10 +14,11 @@ import { useDialog, useNotification, useToggle } from '@common/hooks';
 
 /// Max length of the stored data-URL string. Must match
 /// MAX_GLOBAL_LOGO_DATA_URL_LENGTH in the server's global_logo.rs.
-export const MAX_DATA_URL_LENGTH = 250 * 1024;
+export const MAX_DATA_URL_LENGTH = 342 * 1024;
 
-/// Raw file cap, allowing for base64's 4/3 inflation plus the data-URL prefix.
-export const MAX_FILE_BYTES = Math.floor((MAX_DATA_URL_LENGTH * 3) / 4) - 64;
+/// Raw file cap. A 250KB file's data URL (base64's 4/3 inflation plus the
+/// prefix, ~341.4KB) still fits within MAX_DATA_URL_LENGTH.
+export const MAX_FILE_BYTES = 250 * 1024;
 
 export const IMAGE_ACCEPT: Accept = {
   'image/png': ['.png'],
@@ -65,8 +66,12 @@ export const EditImagePreference = ({
           sx={{ maxHeight: 40, maxWidth: 120, objectFit: 'contain' }}
         />
       ) : (
-        <Typography variant="body2" color="text.secondary">
-          {t('messages.no-image-uploaded')}
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ whiteSpace: 'nowrap' }}
+        >
+          {t('messages.none-uploaded')}
         </Typography>
       )}
       <ButtonWithIcon
@@ -205,7 +210,7 @@ const ImagePreferenceModal = ({
           </>
         ) : (
           <Typography variant="body2" color="text.secondary">
-            {t('messages.no-image-uploaded')}
+            {t('messages.none-uploaded')}
           </Typography>
         )}
       </Box>

--- a/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
+++ b/client/packages/system/src/Manage/Preferences/EditPage/EditPreference.tsx
@@ -26,6 +26,7 @@ import { EditBackdating } from '../Components/EditBackdating';
 import { EditWarningWhenMissingRecentStocktakeData } from '../Components/EditWarningWhenMissingRecentStocktakeData';
 import { PreferenceLabelRow } from './PreferenceLabelRow';
 import { ColorPickerPreference } from '../Components/ColorPickerPreference';
+import { EditImagePreference } from '../Components/EditImagePreference';
 
 interface EditPreferenceProps {
   preference: PreferenceDescriptionNode;
@@ -198,6 +199,26 @@ export const EditPreference = ({
               value={value}
               onChange={handleChange}
               preferenceKey={preference.key}
+            />
+          }
+          isLast={isLast}
+        />
+      );
+
+    case PreferenceValueNodeType.Image:
+      if (!isString(preference.value)) {
+        return t('error.something-wrong');
+      }
+      return (
+        <PreferenceLabelRow
+          label={preferenceLabel}
+          Input={
+            // Pass API value/update directly - saved on modal save rather than
+            // debounce-auto-saving the image blob
+            <EditImagePreference
+              value={preference.value}
+              update={update}
+              disabled={disabled}
             />
           }
           isLast={isLast}

--- a/server/graphql/core/src/loader/store.rs
+++ b/server/graphql/core/src/loader/store.rs
@@ -1,7 +1,10 @@
 use actix_web::web::Data;
 use async_graphql::dataloader::*;
 use async_graphql::*;
-use repository::{EqualFilter, RepositoryError, Store, StoreFilter, StoreLogoRow, StoreRowRepository};
+use repository::{
+    EqualFilter, RepositoryError, Store, StoreFilter, StoreLogoRow, StoreRowRepository,
+};
+use service::preference::{GlobalLogo, Preference};
 use service::service_provider::ServiceProvider;
 use std::collections::HashMap;
 
@@ -40,6 +43,7 @@ impl Loader<String> for StoreByIdLoader {
 /// Lazy-loads `store.logo` for the GraphQL `StoreNode.logo` resolver. Logos
 /// are large base64 TEXT blobs, so they're kept out of the default `StoreRow`
 /// shape and fetched only when explicitly requested.
+/// Stores without a logo of their own fall back to the global logo preference.
 pub struct StoreLogoLoader {
     pub service_provider: Data<ServiceProvider>,
 }
@@ -53,6 +57,24 @@ impl Loader<String> for StoreLogoLoader {
         let results =
             StoreRowRepository::new(&service_context.connection).find_logos_by_ids(keys)?;
 
-        Ok(results.into_iter().map(|row| (row.id.clone(), row)).collect())
+        // Only pay for the preference read when some requested store needs it
+        let global_logo = if results.iter().any(|row| row.logo.is_none()) {
+            let logo = GlobalLogo
+                .load(&service_context.connection, None)
+                .map_err(|e| e.into_repository_error())?;
+            (!logo.is_empty()).then_some(logo)
+        } else {
+            None
+        };
+
+        Ok(results
+            .into_iter()
+            .map(|mut row| {
+                if row.logo.is_none() {
+                    row.logo = global_logo.clone();
+                }
+                (row.id.clone(), row)
+            })
+            .collect())
     }
 }

--- a/server/graphql/preference/src/upsert.rs
+++ b/server/graphql/preference/src/upsert.rs
@@ -1,13 +1,16 @@
 use std::collections::BTreeMap;
 
 use async_graphql::*;
-use graphql_core::{standard_graphql_error::validate_auth, ContextExt};
+use graphql_core::{
+    standard_graphql_error::{validate_auth, StandardGraphqlError},
+    ContextExt,
+};
 use graphql_types::types::{patient::GenderTypeNode, InvoiceNodeStatus};
 use repository::{GenderType, InvoiceStatus};
 use service::{
     auth::{Resource, ResourceAccessRequest},
     preference::{
-        BackdatingData, StorePrefUpdate, UpsertPreferences,
+        BackdatingData, StorePrefUpdate, UpsertPreferenceError, UpsertPreferences,
         WarnWhenMissingRecentStocktakeData,
     },
 };
@@ -86,6 +89,7 @@ pub struct UpsertPreferencesInput {
     pub global_table_configs: Option<serde_json::Value>,
     pub backdating: Option<BackdatingInput>,
     pub receive_payments_from_prescriptions: Option<bool>,
+    pub global_logo: Option<String>,
 
     // Store preferences
     pub blind_stocktake: Option<Vec<BoolStorePrefInput>>,
@@ -134,7 +138,14 @@ pub fn upsert_preferences(
 
     service_provider
         .preference_service
-        .upsert(&service_context, input.to_domain())?;
+        .upsert(&service_context, input.to_domain())
+        .map_err(|error| match error {
+            // Failed validation is the caller's error, not a server fault
+            UpsertPreferenceError::InvalidValue(_, _) => {
+                StandardGraphqlError::BadUserInput(error.to_string()).extend()
+            }
+            _ => error.into(),
+        })?;
 
     Ok(())
 }
@@ -162,6 +173,7 @@ impl UpsertPreferencesInput {
             global_table_configs,
             backdating,
             receive_payments_from_prescriptions,
+            global_logo,
             // Store preferences
             blind_stocktake,
             manage_vaccines_in_doses,
@@ -219,6 +231,7 @@ impl UpsertPreferencesInput {
                 max_days: b.max_days,
             }),
             receive_payments_from_prescriptions: *receive_payments_from_prescriptions,
+            global_logo: global_logo.clone(),
             // Store preferences
             blind_stocktake: blind_stocktake
                 .as_ref()

--- a/server/graphql/types/src/types/preferences.rs
+++ b/server/graphql/types/src/types/preferences.rs
@@ -1,9 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::types::{
-    backdating::BackdatingNode,
-    invoice_query::InvoiceNodeStatus,
-    patient::GenderTypeNode,
+    backdating::BackdatingNode, invoice_query::InvoiceNodeStatus, patient::GenderTypeNode,
     warn_when_missing_recent_stocktake::WarnWhenMissingRecentStocktakeDataNode,
 };
 use async_graphql::*;
@@ -109,6 +107,12 @@ impl PreferencesNode {
 
     pub async fn receive_payments_from_prescriptions(&self) -> Result<bool> {
         self.load_preference(&self.preferences.receive_payments_from_prescriptions)
+    }
+
+    /// Base64 data-URL logo used as fallback when a store has no logo.
+    /// Large - don't add to eagerly-fetched preference queries.
+    pub async fn global_logo(&self) -> Result<String> {
+        self.load_preference(&self.preferences.global_logo)
     }
 
     // Store preferences
@@ -304,6 +308,7 @@ pub enum PreferenceKey {
     GlobalTableConfigs,
     Backdating,
     ReceivePaymentsFromPrescriptions,
+    GlobalLogo,
     // Store preferences
     BlindStocktake,
     ManageVaccinesInDoses,
@@ -346,10 +351,11 @@ pub enum PreferenceValueNodeType {
     Integer,
     Float,
     MultiChoice,
-    CustomTranslations, // Specific type for CustomTranslations preference
+    CustomTranslations,   // Specific type for CustomTranslations preference
     CustomTranslationsV2, // Specific type for v2 CustomTranslations preference
     WarnWhenMissingRecentStocktakeData,
     BackdatingData,
     String,
     Colour,
+    Image,
 }

--- a/server/graphql/types/src/types/store.rs
+++ b/server/graphql/types/src/types/store.rs
@@ -52,7 +52,8 @@ impl StoreNode {
     pub async fn is_disabled(&self) -> bool {
         self.row().is_disabled
     }
-    /// Returns the associated store logo.
+    /// Returns the associated store logo, falling back to the global logo
+    /// preference when the store has none.
     /// The logo is returned as a data URL schema, e.g. "data:image/png;base64,..."
     /// Lazy-loaded — the logo is not pulled with the default store row.
     pub async fn logo(&self, ctx: &Context<'_>) -> Result<Option<String>> {
@@ -86,7 +87,7 @@ mod test {
     use graphql_core::{assert_graphql_query, test_helpers::setup_graphql_test_with_data};
     use repository::{
         mock::{MockData, MockDataInserts},
-        NameRow, Store, StoreRow,
+        NameRow, PreferenceRow, Store, StoreRow, StoreRowRepository,
     };
     use serde_json::json;
 
@@ -142,6 +143,8 @@ mod test {
             "testQuery": {
                 "__typename": "StoreNode",
                 "storeName": name().name,
+                // No store logo and no global logo preference
+                "logo": null,
                 "name": {
                     "id": name().id
                 }
@@ -154,6 +157,7 @@ mod test {
             testQuery {
                 __typename
                 storeName
+                logo
                 name(storeId: $storeId) {
                     id
                 }
@@ -166,5 +170,98 @@ mod test {
         });
 
         assert_graphql_query!(&settings, &query, &Some(variables), expected, None);
+    }
+
+    #[actix_rt::test]
+    async fn graphql_test_store_logo_global_fallback() {
+        #[derive(Clone)]
+        struct TestQuery;
+
+        const OWN_LOGO: &str = "data:image/png;base64,own";
+        const GLOBAL_LOGO: &str = "data:image/png;base64,global";
+
+        fn name() -> NameRow {
+            NameRow {
+                id: "name_id".to_string(),
+                name: "name".to_string(),
+                ..Default::default()
+            }
+        }
+
+        fn store_with_logo() -> StoreRow {
+            StoreRow {
+                id: "store_with_logo".to_string(),
+                name_id: name().id,
+                ..Default::default()
+            }
+        }
+
+        fn store_without_logo() -> StoreRow {
+            StoreRow {
+                id: "store_without_logo".to_string(),
+                name_id: name().id,
+                ..Default::default()
+            }
+        }
+
+        let (_, connection, _, settings) = setup_graphql_test_with_data(
+            TestQuery,
+            EmptyMutation,
+            "graphql_test_store_logo_global_fallback",
+            MockDataInserts::none(),
+            MockData {
+                stores: vec![store_with_logo(), store_without_logo()],
+                names: vec![name()],
+                preferences: vec![PreferenceRow {
+                    id: "global_logo_global".to_string(),
+                    key: "global_logo".to_string(),
+                    value: serde_json::to_string(GLOBAL_LOGO).unwrap(),
+                    store_id: None,
+                }],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        StoreRowRepository::new(&connection)
+            .update_logo(&store_with_logo().id, Some(OWN_LOGO))
+            .unwrap();
+
+        #[Object]
+        impl TestQuery {
+            pub async fn with_logo(&self) -> StoreNode {
+                StoreNode {
+                    store: Store {
+                        store_row: store_with_logo(),
+                        name_row: name(),
+                    },
+                }
+            }
+
+            pub async fn without_logo(&self) -> StoreNode {
+                StoreNode {
+                    store: Store {
+                        store_row: store_without_logo(),
+                        name_row: name(),
+                    },
+                }
+            }
+        }
+
+        let expected = json!({
+            // A store's own logo wins over the global one
+            "withLogo": { "logo": OWN_LOGO },
+            // A store without a logo falls back to the global logo preference
+            "withoutLogo": { "logo": GLOBAL_LOGO }
+        });
+
+        let query = r#"
+        query {
+            withLogo { logo }
+            withoutLogo { logo }
+        }
+        "#;
+
+        assert_graphql_query!(&settings, &query, &None, expected, None);
     }
 }

--- a/server/service/src/preference/mod.rs
+++ b/server/service/src/preference/mod.rs
@@ -49,6 +49,7 @@ pub trait PreferenceServiceTrait: Sync + Send {
             // Hidden from the preferences edit UI until prescription payment
             // functionality is implemented (#6179)
             receive_payments_from_prescriptions: _,
+            global_logo,
 
             // Store preferences
             blind_stocktake,
@@ -105,6 +106,7 @@ pub trait PreferenceServiceTrait: Sync + Send {
         append_if_type(is_gaps, &mut prefs, &input)?;
         append_if_type(display_population_based_forecasting, &mut prefs, &input)?;
         append_if_type(backdating, &mut prefs, &input)?;
+        append_if_type(global_logo, &mut prefs, &input)?;
         // TODO: receive_payments_from_prescriptions intentionally omitted, hidden from
         // the edit UI until prescription payment functionality exists
 

--- a/server/service/src/preference/preferences/global_logo.rs
+++ b/server/service/src/preference/preferences/global_logo.rs
@@ -1,0 +1,154 @@
+use repository::StorageConnection;
+
+use crate::preference::{
+    upsert_helpers::upsert_global, PrefKey, Preference, PreferenceType, PreferenceValueType,
+    UpsertPreferenceError,
+};
+
+/// Max length of the stored data-URL string (~250KB). Data URLs are ASCII, so
+/// chars == bytes. Must match MAX_DATA_URL_LENGTH in the client's
+/// EditImagePreference.tsx. Kept small: the value rides inside an ordinary
+/// JSON sync batch (no chunking/resume), so it must stay cheap on poor links.
+pub const MAX_GLOBAL_LOGO_DATA_URL_LENGTH: usize = 250 * 1024;
+
+pub const ALLOWED_LOGO_DATA_URL_PREFIXES: &[&str] = &[
+    "data:image/png;base64,",
+    "data:image/jpeg;base64,",
+    "data:image/gif;base64,",
+    "data:image/svg+xml;base64,",
+];
+
+/// Logo shown on printed reports when the store has no logo of its own
+/// (StoreLogoLoader substitutes it wherever store.logo is null).
+/// Stored as a base64 data URL; "" means not set.
+pub struct GlobalLogo;
+
+impl Preference for GlobalLogo {
+    type Value = String;
+
+    fn key(&self) -> PrefKey {
+        PrefKey::GlobalLogo
+    }
+
+    fn preference_type(&self) -> PreferenceType {
+        PreferenceType::Global
+    }
+
+    fn value_type(&self) -> PreferenceValueType {
+        PreferenceValueType::Image
+    }
+
+    // Custom upsert to validate type and size. The client validates before
+    // upload; this is the backstop for any other caller.
+    fn upsert(
+        &self,
+        connection: &StorageConnection,
+        value: Self::Value,
+        _store_id: Option<String>,
+    ) -> Result<(), UpsertPreferenceError> {
+        validate_logo_data_url(&value)
+            .map_err(|reason| UpsertPreferenceError::InvalidValue(self.key_str(), reason))?;
+
+        let serialised_value = serde_json::to_string(&value)
+            .map_err(|e| UpsertPreferenceError::SerializeError(self.key_str(), e.to_string()))?;
+
+        upsert_global(connection, self.key_str(), serialised_value)
+    }
+}
+
+fn validate_logo_data_url(value: &str) -> Result<(), String> {
+    // Empty clears the logo
+    if value.is_empty() {
+        return Ok(());
+    }
+    if !ALLOWED_LOGO_DATA_URL_PREFIXES
+        .iter()
+        .any(|prefix| value.starts_with(prefix))
+    {
+        return Err("must be a png/jpeg/gif/svg base64 data URL".to_string());
+    }
+    if value.len() > MAX_GLOBAL_LOGO_DATA_URL_LENGTH {
+        return Err(format!(
+            "exceeds maximum size of {MAX_GLOBAL_LOGO_DATA_URL_LENGTH} bytes"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use repository::{mock::MockDataInserts, test_db::setup_all};
+
+    use super::*;
+    use crate::{
+        preference::{upsert_preferences, UpsertPreferences},
+        service_provider::ServiceProvider,
+        sync::test_util_set_is_central_server,
+    };
+
+    #[actix_rt::test]
+    async fn global_logo_upsert_validation() {
+        let (_, _, connection_manager, _) =
+            setup_all("global_logo_upsert_validation", MockDataInserts::none()).await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let ctx = service_provider.basic_context().unwrap();
+        test_util_set_is_central_server(true);
+
+        // Valid data URL round-trips
+        let logo = "data:image/png;base64,iVBORw0KGgo=".to_string();
+        upsert_preferences(
+            &ctx,
+            UpsertPreferences {
+                global_logo: Some(logo.clone()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(GlobalLogo.load(&ctx.connection, None).unwrap(), logo);
+
+        // Wrong mime type rejected
+        let result = GlobalLogo.upsert(
+            &ctx.connection,
+            "data:text/html;base64,PHNjcmlwdD4=".to_string(),
+            None,
+        );
+        assert!(matches!(
+            result,
+            Err(UpsertPreferenceError::InvalidValue(_, _))
+        ));
+
+        // Bare base64 (no data-URL prefix) rejected
+        let result = GlobalLogo.upsert(&ctx.connection, "iVBORw0KGgo=".to_string(), None);
+        assert!(matches!(
+            result,
+            Err(UpsertPreferenceError::InvalidValue(_, _))
+        ));
+
+        // Oversized rejected
+        let oversized = format!(
+            "data:image/png;base64,{}",
+            "A".repeat(MAX_GLOBAL_LOGO_DATA_URL_LENGTH)
+        );
+        let result = GlobalLogo.upsert(&ctx.connection, oversized, None);
+        assert!(matches!(
+            result,
+            Err(UpsertPreferenceError::InvalidValue(_, _))
+        ));
+
+        // Empty string clears
+        GlobalLogo
+            .upsert(&ctx.connection, "".to_string(), None)
+            .unwrap();
+        assert_eq!(GlobalLogo.load(&ctx.connection, None).unwrap(), "");
+
+        // Not a central server: rejected (validation passes, upsert_global refuses)
+        test_util_set_is_central_server(false);
+        let result = GlobalLogo.upsert(
+            &ctx.connection,
+            "data:image/png;base64,iVBORw0KGgo=".to_string(),
+            None,
+        );
+        assert_eq!(result, Err(UpsertPreferenceError::NotACentralServer));
+    }
+}

--- a/server/service/src/preference/preferences/global_logo.rs
+++ b/server/service/src/preference/preferences/global_logo.rs
@@ -1,3 +1,4 @@
+use base64::{prelude::BASE64_STANDARD, Engine};
 use repository::StorageConnection;
 
 use crate::preference::{
@@ -5,11 +6,12 @@ use crate::preference::{
     UpsertPreferenceError,
 };
 
-/// Max length of the stored data-URL string (~250KB). Data URLs are ASCII, so
-/// chars == bytes. Must match MAX_DATA_URL_LENGTH in the client's
-/// EditImagePreference.tsx. Kept small: the value rides inside an ordinary
-/// JSON sync batch (no chunking/resume), so it must stay cheap on poor links.
-pub const MAX_GLOBAL_LOGO_DATA_URL_LENGTH: usize = 250 * 1024;
+/// Max length of the stored data-URL string (~342KB, fits a 250KB file after
+/// base64's 4/3 inflation). Data URLs are ASCII, so chars == bytes. Must match
+/// MAX_DATA_URL_LENGTH in the client's EditImagePreference.tsx. Kept small:
+/// the value rides inside an ordinary JSON sync batch (no chunking/resume),
+/// so it must stay cheap on poor links.
+pub const MAX_GLOBAL_LOGO_DATA_URL_LENGTH: usize = 342 * 1024;
 
 pub const ALLOWED_LOGO_DATA_URL_PREFIXES: &[&str] = &[
     "data:image/png;base64,",
@@ -61,16 +63,19 @@ fn validate_logo_data_url(value: &str) -> Result<(), String> {
     if value.is_empty() {
         return Ok(());
     }
-    if !ALLOWED_LOGO_DATA_URL_PREFIXES
+    let Some(prefix) = ALLOWED_LOGO_DATA_URL_PREFIXES
         .iter()
-        .any(|prefix| value.starts_with(prefix))
-    {
+        .find(|prefix| value.starts_with(*prefix))
+    else {
         return Err("must be a png/jpeg/gif/svg base64 data URL".to_string());
-    }
+    };
     if value.len() > MAX_GLOBAL_LOGO_DATA_URL_LENGTH {
         return Err(format!(
             "exceeds maximum size of {MAX_GLOBAL_LOGO_DATA_URL_LENGTH} bytes"
         ));
+    }
+    if BASE64_STANDARD.decode(&value[prefix.len()..]).is_err() {
+        return Err("base64 payload does not decode".to_string());
     }
     Ok(())
 }
@@ -111,6 +116,17 @@ mod tests {
         let result = GlobalLogo.upsert(
             &ctx.connection,
             "data:text/html;base64,PHNjcmlwdD4=".to_string(),
+            None,
+        );
+        assert!(matches!(
+            result,
+            Err(UpsertPreferenceError::InvalidValue(_, _))
+        ));
+
+        // Corrupt base64 payload rejected
+        let result = GlobalLogo.upsert(
+            &ctx.connection,
+            "data:image/png;base64,not$valid".to_string(),
             None,
         );
         assert!(matches!(

--- a/server/service/src/preference/preferences/mod.rs
+++ b/server/service/src/preference/preferences/mod.rs
@@ -80,6 +80,8 @@ pub mod do_not_print_placeholder_line_labels;
 pub use do_not_print_placeholder_line_labels::*;
 pub mod blind_stocktake;
 pub use blind_stocktake::*;
+pub mod global_logo;
+pub use global_logo::*;
 
 pub struct PreferenceProvider {
     // Global preferences
@@ -102,6 +104,7 @@ pub struct PreferenceProvider {
     pub global_table_configs: GlobalTableConfigs,
     pub backdating: Backdating,
     pub receive_payments_from_prescriptions: ReceivePaymentsFromPrescriptions,
+    pub global_logo: GlobalLogo,
 
     // Store preferences
     pub blind_stocktake: BlindStocktake,
@@ -155,6 +158,7 @@ pub fn get_preference_provider() -> PreferenceProvider {
         global_table_configs: GlobalTableConfigs,
         backdating: Backdating,
         receive_payments_from_prescriptions: ReceivePaymentsFromPrescriptions,
+        global_logo: GlobalLogo,
 
         // Store preferences
         blind_stocktake: BlindStocktake,

--- a/server/service/src/preference/types.rs
+++ b/server/service/src/preference/types.rs
@@ -32,6 +32,7 @@ pub enum PrefKey {
     GlobalTableConfigs,
     Backdating,
     ReceivePaymentsFromPrescriptions,
+    GlobalLogo,
 
     // Store preferences
     BlindStocktake,
@@ -81,6 +82,7 @@ pub enum PreferenceValueType {
     BackdatingData,
     String,
     Colour,
+    Image,
     // MultilineString,
     // Add scalar or custom value types here - mapped to frontend renderers
 }
@@ -107,6 +109,8 @@ pub enum UpsertPreferenceError {
     NotACentralServer,
     #[error("Store ID is required for store preference")]
     StoreIdNotProvided,
+    #[error("Invalid value for preference {0}: {1}")]
+    InvalidValue(String, String),
 }
 
 pub trait Preference: Sync + Send {

--- a/server/service/src/preference/upsert.rs
+++ b/server/service/src/preference/upsert.rs
@@ -37,6 +37,7 @@ pub struct UpsertPreferences {
     pub global_table_configs: Option<serde_json::Value>,
     pub backdating: Option<BackdatingData>,
     pub receive_payments_from_prescriptions: Option<bool>,
+    pub global_logo: Option<String>,
 
     // Store preferences
     pub blind_stocktake: Option<Vec<StorePrefUpdate<bool>>>,
@@ -91,6 +92,7 @@ pub fn upsert_preferences(
         global_table_configs: global_table_configs_input,
         backdating: backdating_input,
         receive_payments_from_prescriptions: receive_payments_from_prescriptions_input,
+        global_logo: global_logo_input,
 
         // Store preferences
         blind_stocktake: blind_stocktake_input,
@@ -108,7 +110,8 @@ pub fn upsert_preferences(
             can_create_internal_order_from_a_requisition_input,
         select_destination_store_for_an_internal_order:
             select_destination_store_for_an_internal_order_input,
-        external_inbound_shipment_lines_must_be_authorised: external_inbound_shipment_lines_must_be_authorised_input,
+        external_inbound_shipment_lines_must_be_authorised:
+            external_inbound_shipment_lines_must_be_authorised_input,
         number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products:
             number_of_months_to_check_for_consumption_when_calculating_out_of_stock_products_input,
         number_of_months_threshold_to_show_low_stock_alerts_for_products:
@@ -144,6 +147,7 @@ pub fn upsert_preferences(
         global_table_configs,
         backdating,
         receive_payments_from_prescriptions,
+        global_logo,
 
         // Store preferences
         blind_stocktake,
@@ -251,6 +255,10 @@ pub fn upsert_preferences(
 
             if let Some(input) = receive_payments_from_prescriptions_input {
                 receive_payments_from_prescriptions.upsert(connection, input, None)?;
+            }
+
+            if let Some(input) = global_logo_input {
+                global_logo.upsert(connection, input, None)?;
             }
 
             // Store preferences, input could be array of store IDs and values - iterate and insert...
@@ -415,8 +423,7 @@ mod tests {
         test_util_set_is_central_server(true);
 
         // Seed an existing v1 (legacy) map.
-        let v1 =
-            BTreeMap::from([("button.close".to_string(), "Legacy Close".to_string())]);
+        let v1 = BTreeMap::from([("button.close".to_string(), "Legacy Close".to_string())]);
         CustomTranslations
             .upsert(&ctx.connection, v1.clone(), None)
             .unwrap();
@@ -435,13 +442,15 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(CustomTranslationsV2.load(&ctx.connection, None).unwrap(), v2);
+        assert_eq!(
+            CustomTranslationsV2.load(&ctx.connection, None).unwrap(),
+            v2
+        );
         // v1 is untouched
         assert_eq!(CustomTranslations.load(&ctx.connection, None).unwrap(), v1);
 
         // The legacy v1 map is edited directly via the custom_translations input.
-        let new_v1 =
-            BTreeMap::from([("button.save".to_string(), "Legacy Save".to_string())]);
+        let new_v1 = BTreeMap::from([("button.save".to_string(), "Legacy Save".to_string())]);
         upsert_preferences(
             &ctx,
             UpsertPreferences {


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

<img height="240" alt="Screenshot 2026-08-19 at 5 27 08 pm" src="https://github.com/user-attachments/assets/6fb48ccc-61f5-43db-9006-b6247a76f3ba" />
<img height="240" alt="Screenshot 2026-08-19 at 5 27 23 pm" src="https://github.com/user-attachments/assets/20f1006f-83ae-43ed-93e4-05204358ae7b" />

Fixes #12679

Adds a **global logo** that central server admins can upload under Manage → Global Preferences, which syncs to every site and is used wherever a store has no logo of its own — most importantly `data.store.logo` on printed forms.

- **New `global_logo` global preference** holding the image as a base64 data URL. Server-side validation restricts it to png/jpeg/gif/svg data URLs and caps it at **250KB** (per the size discussion on the issue) so the value stays cheap to carry in ordinary preference sync batches. Central→remote sync needs no new wiring — global preference rows already distribute to all sites.
- **New `Image` preference value type + editor**: the Global Preferences page shows a thumbnail of the current logo (or a "no image uploaded" hint) with an edit modal — drag & drop or file picker (reusing `UploadFile`), client-side type/size validation on both paths, preview, and a remove button. Saves only on the explicit Save button, so the blob is never debounce-auto-saved per interaction.
- **Fallback in `StoreLogoLoader`**: `StoreNode.logo` now returns the global logo for stores whose own logo is null. Since this loader is the single path behind `StoreNode.logo`, the fallback covers the report default queries (`data.store.logo`) and any UI consumer, on central and remote sites alike, with the preference read at most once per loader batch. Existing `{% if data.store.logo %}` templates work unchanged.

## 💌 Any notes for the reviewer?

- **Targets `v3.01.00-RC`.** We discussed storing the logo as a sync file with the preference as a pointer; that's the better long-term home (resumable transport, natural fit for the per-store-assignment extension the issue mentions), but it depends on background-download machinery from the frontend-sync stack (#12622) that isn't on RC. The blob-in-preference value can be migrated to a sync file later without breaking anything, since the pref value shape is server-internal.
- **SVG is accepted in addition to the issue's png/jpg/jpeg/gif** — a data-URL SVG inside `<img src=...>` is script-inert, it's the ideal logo format, and dropping it is a one-line change to each of the two accept-lists if you'd rather not.
- **SQL-query report parity is deferred**: reports whose queries read the `report_store` view get the raw column, not the fallback. All standard forms use the GraphQL default queries, which do get it. Coalescing the preference into the view needs per-DB JSON-string unquoting, so it was left out deliberately.
- **This does not fix #12669** (store logos missing from v7 sync payloads) — the global logo merely papers over it for stores that never had a logo. That regression comes from the lean-`StoreRow` refactor (`logo` never enters the v7 store payload) and needs its own fix.
- The blob is deliberately kept **out of the eager startup `preferences` query** (lesson of #11785) — it's only fetched by the admin preferences page and the report path.
- Validation failures surface as `BadUserInput` rather than internal errors; the client validates before upload so users shouldn't normally hit it.

# 🧪 Tested

- `cargo nextest run -p service global_logo` — upsert validation: valid data URL round-trips, wrong mime type / bare base64 / oversized rejected, empty string clears, non-central-server rejected.
- `cargo nextest run -p graphql_types store` — loader fallback: a store's own logo wins over the global, a store without one gets the global, and no preference row → null (extended the existing store loader test).
- `yarn jest EditImagePreference.test.tsx` — saves only on Save (as a data URL), rejects unsupported types and oversized files with toasts, remove + save clears the value.
- `cargo check --workspace --all-targets`, client `tsc`, eslint and prettier all clean.
- Tested a central remote pair - syncing and display of logo works great

# 📃 Documentation

- [ ] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [x] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  - New "Global logo" entry on the central server's Manage → Global Preferences page: upload (drag & drop or picker) a png/jpeg/gif/svg up to ~188KB; it syncs to all sites and appears on printed forms for any store without its own logo
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
