### PR TITLE
#12615 Align outbound backdating with prescription pattern

### DIFF
--- a/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PickedDateInput.tsx
+++ b/client/packages/invoices/src/OutboundShipment/DetailView/SidePanel/PickedDateInput.tsx
@@ -53,6 +53,7 @@ export const PickedDateInput = () => {
   const disabled = !!disabledReason;
 
   const { sdk, storeId } = useOutbound.utils.api();
+  const { mutateAsync: deleteLines } = useOutbound.line.delete();
 
   const [dateValue, setDateValue] = useState<Date | null>(currentDate);
 
@@ -102,6 +103,16 @@ export const PickedDateInput = () => {
       ? newDate.toISOString()
       : Formatter.toIsoString(DateUtils.endOfDayOrNull(newDate));
 
+    // The backend rejects backdating while lines exist (they were allocated at the
+    // old date), so any lines are deleted here first - once every confirmation has
+    // been accepted. Mirrors the prescription toolbar's date change.
+    const applyBackdate = async () => {
+      if (lineCount > 0) {
+        await deleteLines(lines?.nodes ?? []);
+      }
+      await update({ backdatedDatetime });
+    };
+
     const doUpdate = async () => {
       const hasStocktakeAfter = await checkStocktakeAfterDate(newDate);
       if (hasStocktakeAfter) {
@@ -109,18 +120,16 @@ export const PickedDateInput = () => {
           message: t('messages.stocktake-after-backdate-warning', {
             date: formattedDate,
           }),
-          onConfirm: async () => {
-            await update({ backdatedDatetime });
-          },
+          onConfirm: applyBackdate,
           onCancel: () => setDateValue(previousValue),
         });
         return;
       }
 
-      await update({ backdatedDatetime });
+      await applyBackdate();
     };
 
-    // If lines exist, warn they'll be deleted (backend handles deletion atomically)
+    // If lines exist, warn they'll be deleted
     if (lineCount > 0) {
       getDeleteLinesConfirmation({
         message: t('messages.confirm-backdate-picked-date', {

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/index.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/index.ts
@@ -36,6 +36,7 @@ export const useOutbound = {
   line: {
     serviceLines: Lines.useOutboundServiceLines,
     save: Lines.useOutboundSaveLines,
+    delete: Lines.useOutboundDeleteLines,
     deleteSelected: Lines.useOutboundDeleteSelectedLines,
     allocateSelected: Lines.useOutboundAllocateSelectedLines,
   },

--- a/client/packages/invoices/src/OutboundShipment/api/hooks/line/index.ts
+++ b/client/packages/invoices/src/OutboundShipment/api/hooks/line/index.ts
@@ -1,11 +1,15 @@
 import { useOutboundServiceLines } from './useOutboundServiceLines';
 import { useOutboundSaveLines } from './useOutboundSaveLines';
-import { useOutboundDeleteSelectedLines } from './useOutboundDeleteLines';
+import {
+  useOutboundDeleteLines,
+  useOutboundDeleteSelectedLines,
+} from './useOutboundDeleteLines';
 import { useOutboundAllocateSelectedLines } from './useOutboundAllocateSelectedLines';
 
 export const Lines = {
   useOutboundServiceLines,
   useOutboundSaveLines,
+  useOutboundDeleteLines,
   useOutboundDeleteSelectedLines,
   useOutboundAllocateSelectedLines,
 };

--- a/server/graphql/invoice/src/mutations/outbound_shipment/update.rs
+++ b/server/graphql/invoice/src/mutations/outbound_shipment/update.rs
@@ -211,7 +211,6 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
         ServiceError::PreferenceError(_) => InternalError(formatted_error),
         ServiceError::InvoiceLineHasNoStockLine(_) => InternalError(formatted_error),
-        ServiceError::LineDeleteError { .. } => InternalError(formatted_error),
         ServiceError::UpdatedInvoiceDoesNotExist => InternalError(formatted_error),
     };
 

--- a/server/service/src/invoice/outbound_shipment/update/generate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/generate.rs
@@ -15,7 +15,7 @@ use crate::{
         common::{
             calculate_foreign_currency_total, calculate_total_after_tax,
             generate_batches_total_number_of_packs_update, get_invoice_status_datetime,
-            get_lines_for_invoice, InvoiceLineHasNoStockLine,
+            InvoiceLineHasNoStockLine,
         },
         invoice_date_utils::handle_new_backdated_datetime,
         stock_effect::{stock_effects, StockEffect},
@@ -33,10 +33,6 @@ pub(crate) struct GenerateResult {
     pub(crate) batches_to_update: Option<Vec<StockLineRow>>,
     pub(crate) update_invoice: InvoiceRow,
     pub(crate) lines_to_trim: Option<Vec<InvoiceLineRow>>,
-    /// All of the invoice's lines, when it's being backdated (they need re-allocation
-    /// at the new date). Deleted via the stock out line service rather than trimmed,
-    /// so the stock they had reserved is released.
-    pub(crate) backdated_lines_to_delete: Option<Vec<InvoiceLineRow>>,
     pub(crate) location_movements: Option<Vec<LocationMovementRow>>,
     pub(crate) update_lines: Option<Vec<InvoiceLineRow>>,
 }
@@ -67,8 +63,6 @@ pub(crate) fn generate(
         backdated_datetime_change(input_backdated_datetime, &existing_invoice);
     let new_status = UpdateOutboundShipmentStatus::full_status_option(&input_status);
     let should_update_batches_total_number_of_packs = match &new_status {
-        // Backdating removes every line below, so there's nothing left to issue stock for
-        Some(_) if new_backdated_datetime.is_some() => false,
         Some(to) => {
             stock_effects(&InvoiceType::OutboundShipment, &existing_invoice.status, to)
                 == StockEffect::ReduceStock
@@ -142,7 +136,7 @@ pub(crate) fn generate(
         None
     };
 
-    let mut update_lines = if update_invoice.tax_percentage.is_some() || input_currency_rate.is_some() {
+    let update_lines = if update_invoice.tax_percentage.is_some() || input_currency_rate.is_some() {
         Some(generate_update_for_lines(
             connection,
             &update_invoice.id,
@@ -154,30 +148,11 @@ pub(crate) fn generate(
         None
     };
 
-    let mut lines_to_trim = lines_to_trim(connection, &existing_invoice, &input_status)?;
-
-    // When backdating, delete all existing lines (they need re-allocation at the new
-    // date) and clear update_lines so deleted lines don't get re-inserted. The lines are
-    // returned separately from lines_to_trim because they're deleted via the stock out
-    // line service, which releases the stock they had reserved (lines_to_trim only ever
-    // holds lines that reserve nothing - unallocated and zero quantity lines). That set
-    // is a subset of every line, so it's cleared to avoid deleting a line twice.
-    let backdated_lines_to_delete = if new_backdated_datetime.is_some() {
-        update_lines = None;
-        lines_to_trim = None;
-        let all_lines = get_lines_for_invoice(connection, &existing_invoice.id)?;
-        match all_lines.is_empty() {
-            true => None,
-            false => Some(all_lines.into_iter().map(|l| l.invoice_line_row).collect()),
-        }
-    } else {
-        None
-    };
+    let lines_to_trim = lines_to_trim(connection, &existing_invoice, &input_status)?;
 
     Ok(GenerateResult {
         batches_to_update,
         lines_to_trim,
-        backdated_lines_to_delete,
         update_invoice,
         location_movements,
         update_lines,

--- a/server/service/src/invoice/outbound_shipment/update/mod.rs
+++ b/server/service/src/invoice/outbound_shipment/update/mod.rs
@@ -14,10 +14,6 @@ use validate::validate;
 use crate::activity_log::{activity_log_entry, log_type_from_invoice_status};
 use crate::invoice::outbound_shipment::update::generate::GenerateResult;
 use crate::invoice::query::get_invoice;
-use crate::invoice_line::stock_out_line::{
-    delete::{delete_stock_out_line, DeleteStockOutLine, DeleteStockOutLineError},
-    StockOutType,
-};
 use crate::invoice_line::ShipmentTaxUpdate;
 use crate::processors::ProcessorType::RequisitionAutoFinalise;
 use crate::service_provider::ServiceContext;
@@ -74,19 +70,14 @@ pub enum UpdateOutboundShipmentError {
     PreferenceError(crate::preference::PreferenceError),
     /// Holds the id of the invalid invoice line
     InvoiceLineHasNoStockLine(String),
-    /// Deleting one of the lines removed by backdating failed
-    LineDeleteError {
-        line_id: String,
-        error: DeleteStockOutLineError,
-    },
 }
 
 type OutError = UpdateOutboundShipmentError;
 
 /// The patch's backdated datetime, but only when it differs from the one the invoice
-/// already carries. Backdating is destructive - every line goes - so it must trigger on
-/// a *change*, not on the field's mere presence: a client that sends a full patch,
-/// echoing the datetime already stored, must not lose its lines.
+/// already carries. Backdating is rejected once the invoice has lines or has moved past
+/// New, so it must trigger on a *change*, not on the field's mere presence: a client
+/// that sends a full patch, echoing the datetime already stored, must not be rejected.
 pub(crate) fn backdated_datetime_change(
     input: Option<DateTime<Utc>>,
     invoice: &InvoiceRow,
@@ -106,32 +97,9 @@ pub fn update_outbound_shipment(
                 batches_to_update,
                 update_invoice,
                 lines_to_trim,
-                backdated_lines_to_delete,
                 location_movements,
                 update_lines,
             } = generate(&ctx.store_id, invoice, patch.clone(), connection)?;
-
-            // Backdating removes the shipment's lines. They go through the stock out line
-            // service so that the stock they had reserved is released - deleting the rows
-            // directly leaves the reservation behind, silently reducing available stock
-            // (open-msupply#12574). Done before the invoice row is updated so the delete
-            // still sees the invoice as New (the only status that can be backdated), which
-            // is both editable and reservation-only.
-            if let Some(lines) = backdated_lines_to_delete {
-                for line in lines {
-                    delete_stock_out_line(
-                        ctx,
-                        DeleteStockOutLine {
-                            id: line.id.clone(),
-                            r#type: Some(StockOutType::OutboundShipment),
-                        },
-                    )
-                    .map_err(|error| OutError::LineDeleteError {
-                        line_id: line.id,
-                        error,
-                    })?;
-                }
-            }
 
             InvoiceRowRepository::new(connection).upsert_one(&update_invoice)?;
             let invoice_line_repo = InvoiceLineRowRepository::new(connection);
@@ -1036,16 +1004,21 @@ mod test {
             ))
         );
 
-        // Backdating with existing lines should succeed (lines deleted atomically)
-        let result = service.update_outbound_shipment(
-            &context,
-            UpdateOutboundShipment {
-                id: outbound_with_line().id,
-                backdated_datetime: Some(two_days_ago),
-                ..Default::default()
-            },
+        // CantBackDate: existing lines - the caller has to delete them first, same as
+        // prescriptions (open-msupply#12615)
+        assert_eq!(
+            service.update_outbound_shipment(
+                &context,
+                UpdateOutboundShipment {
+                    id: outbound_with_line().id,
+                    backdated_datetime: Some(two_days_ago),
+                    ..Default::default()
+                }
+            ),
+            Err(ServiceError::CantBackDate(
+                "Can't backdate as invoice has allocated lines".to_string()
+            ))
         );
-        assert!(result.is_ok(), "Expected Ok, got {:#?}", result);
 
         // CantBackDate: future date
         let future = Utc::now() + Duration::days(5);
@@ -1133,236 +1106,6 @@ mod test {
         // Status datetimes should not be set (invoice is still New)
         assert_eq!(updated.allocated_datetime, None);
         assert_eq!(updated.picked_datetime, None);
-    }
-
-    // Regression test for #12574: backdating removes the shipment's lines, and the stock
-    // those lines had reserved must be released - otherwise available stock stays reduced
-    // with no shipment to explain the gap.
-    #[actix_rt::test]
-    async fn update_outbound_shipment_backdate_releases_reserved_stock() {
-        use chrono::{Duration, Utc};
-
-        fn new_outbound() -> InvoiceRow {
-            InvoiceRow {
-                id: "backdate_release_outbound".to_string(),
-                name_id: mock_name_a().id,
-                store_id: mock_store_a().id,
-                r#type: InvoiceType::OutboundShipment,
-                status: InvoiceStatus::New,
-                ..Default::default()
-            }
-        }
-
-        // 2 of the 10 packs on hand are reserved by the invoice line below
-        fn stock_line() -> StockLineRow {
-            StockLineRow {
-                id: "backdate_release_stock_line".to_string(),
-                store_id: mock_store_a().id,
-                available_number_of_packs: 8.0,
-                total_number_of_packs: 10.0,
-                pack_size: 1.0,
-                item_id: mock_item_a().id,
-                ..Default::default()
-            }
-        }
-
-        fn invoice_line() -> InvoiceLineRow {
-            InvoiceLineRow {
-                id: "backdate_release_invoice_line".to_string(),
-                invoice_id: new_outbound().id,
-                stock_line_id: Some(stock_line().id),
-                number_of_packs: 2.0,
-                item_id: mock_item_a().id,
-                r#type: InvoiceLineType::StockOut,
-                ..Default::default()
-            }
-        }
-
-        // A placeholder line reserves nothing, so it should just be removed
-        fn unallocated_line() -> InvoiceLineRow {
-            InvoiceLineRow {
-                id: "backdate_release_unallocated_line".to_string(),
-                invoice_id: new_outbound().id,
-                number_of_packs: 5.0,
-                item_id: mock_item_a().id,
-                r#type: InvoiceLineType::UnallocatedStock,
-                ..Default::default()
-            }
-        }
-
-        let (_, connection, connection_manager, _) = setup_all_with_data(
-            "update_outbound_shipment_backdate_releases_reserved_stock",
-            MockDataInserts::all(),
-            MockData {
-                invoices: vec![new_outbound()],
-                stock_lines: vec![stock_line()],
-                invoice_lines: vec![invoice_line(), unallocated_line()],
-                ..Default::default()
-            },
-        )
-        .await;
-
-        enable_backdating(&connection, 30);
-
-        let service_provider = ServiceProvider::new(connection_manager);
-        let context = service_provider
-            .context(mock_store_a().id, "".to_string())
-            .unwrap();
-        let service = service_provider.invoice_service;
-
-        let two_days_ago = Utc::now() - Duration::days(2);
-
-        let result = service.update_outbound_shipment(
-            &context,
-            UpdateOutboundShipment {
-                id: new_outbound().id,
-                backdated_datetime: Some(two_days_ago),
-                ..Default::default()
-            },
-        );
-        assert!(result.is_ok(), "Not Ok(_) {:#?}", result);
-
-        // Both lines are gone
-        let invoice_line_repo = InvoiceLineRowRepository::new(&connection);
-        assert_eq!(
-            invoice_line_repo
-                .find_one_by_id(&invoice_line().id)
-                .unwrap(),
-            None
-        );
-        assert_eq!(
-            invoice_line_repo
-                .find_one_by_id(&unallocated_line().id)
-                .unwrap(),
-            None
-        );
-
-        // And the packs the deleted line had reserved are available again, with stock on
-        // hand untouched (the shipment was never picked)
-        assert_eq!(
-            StockLineRowRepository::new(&connection)
-                .find_one_by_id(&stock_line().id)
-                .unwrap()
-                .unwrap(),
-            StockLineRow {
-                available_number_of_packs: 10.0,
-                ..stock_line()
-            }
-        );
-    }
-
-    // A line carrying a VVM status log: the log references the invoice line by a foreign
-    // key, so removing the line has to take its log with it.
-    #[actix_rt::test]
-    async fn update_outbound_shipment_backdate_removes_a_lines_vvm_status_log() {
-        use chrono::{Duration, Utc};
-        use repository::{
-            mock::mock_vvm_status_a,
-            vvm_status::vvm_status_log_row::{VVMStatusLogRow, VVMStatusLogRowRepository},
-        };
-
-        fn new_outbound() -> InvoiceRow {
-            InvoiceRow {
-                id: "backdate_vvm_outbound".to_string(),
-                name_id: mock_name_a().id,
-                store_id: mock_store_a().id,
-                r#type: InvoiceType::OutboundShipment,
-                status: InvoiceStatus::New,
-                ..Default::default()
-            }
-        }
-
-        fn stock_line() -> StockLineRow {
-            StockLineRow {
-                id: "backdate_vvm_stock_line".to_string(),
-                store_id: mock_store_a().id,
-                available_number_of_packs: 8.0,
-                total_number_of_packs: 10.0,
-                pack_size: 1.0,
-                item_id: mock_item_a().id,
-                ..Default::default()
-            }
-        }
-
-        fn invoice_line() -> InvoiceLineRow {
-            InvoiceLineRow {
-                id: "backdate_vvm_invoice_line".to_string(),
-                invoice_id: new_outbound().id,
-                stock_line_id: Some(stock_line().id),
-                number_of_packs: 2.0,
-                item_id: mock_item_a().id,
-                r#type: InvoiceLineType::StockOut,
-                ..Default::default()
-            }
-        }
-
-        fn vvm_status_log() -> VVMStatusLogRow {
-            VVMStatusLogRow {
-                id: "backdate_vvm_status_log".to_string(),
-                status_id: mock_vvm_status_a().id,
-                created_datetime: Utc::now().naive_utc(),
-                stock_line_id: stock_line().id,
-                comment: None,
-                created_by: "".to_string(),
-                invoice_line_id: Some(invoice_line().id),
-                store_id: mock_store_a().id,
-            }
-        }
-
-        let (_, connection, connection_manager, _) = setup_all_with_data(
-            "update_outbound_shipment_backdate_removes_a_lines_vvm_status_log",
-            MockDataInserts::all(),
-            MockData {
-                invoices: vec![new_outbound()],
-                stock_lines: vec![stock_line()],
-                invoice_lines: vec![invoice_line()],
-                ..Default::default()
-            },
-        )
-        .await;
-
-        let vvm_log_repo = VVMStatusLogRowRepository::new(&connection);
-        vvm_log_repo.upsert_one(&vvm_status_log()).unwrap();
-        enable_backdating(&connection, 30);
-
-        let service_provider = ServiceProvider::new(connection_manager);
-        let context = service_provider
-            .context(mock_store_a().id, "".to_string())
-            .unwrap();
-        let service = service_provider.invoice_service;
-
-        let result = service.update_outbound_shipment(
-            &context,
-            UpdateOutboundShipment {
-                id: new_outbound().id,
-                backdated_datetime: Some(Utc::now() - Duration::days(2)),
-                ..Default::default()
-            },
-        );
-        assert!(result.is_ok(), "Not Ok(_) {:#?}", result);
-
-        // The line, and the log that pointed at it, are both gone - and the reservation
-        // is still released
-        assert_eq!(
-            InvoiceLineRowRepository::new(&connection)
-                .find_one_by_id(&invoice_line().id)
-                .unwrap(),
-            None
-        );
-        assert_eq!(
-            vvm_log_repo.find_one_by_id(&vvm_status_log().id).unwrap(),
-            None
-        );
-        assert_eq!(
-            StockLineRowRepository::new(&connection)
-                .find_one_by_id(&stock_line().id)
-                .unwrap()
-                .unwrap(),
-            StockLineRow {
-                available_number_of_packs: 10.0,
-                ..stock_line()
-            }
-        );
     }
 
     // Backdating triggers on a *change* to the datetime, not on its presence: a client
@@ -1549,101 +1292,6 @@ mod test {
             Err(ServiceError::CantBackDate(
                 "Can only backdate new outbound shipments".to_string()
             ))
-        );
-    }
-
-    // Backdating and advancing the status in one update: the lines are still removed, so
-    // no stock is issued and the reservation is released (rather than stock on hand being
-    // reduced for lines that no longer exist).
-    #[actix_rt::test]
-    async fn update_outbound_shipment_backdate_with_status_change_does_not_issue_stock() {
-        use chrono::{Duration, Utc};
-
-        fn new_outbound() -> InvoiceRow {
-            InvoiceRow {
-                id: "backdate_and_pick_outbound".to_string(),
-                name_id: mock_name_a().id,
-                store_id: mock_store_a().id,
-                r#type: InvoiceType::OutboundShipment,
-                status: InvoiceStatus::New,
-                ..Default::default()
-            }
-        }
-
-        fn stock_line() -> StockLineRow {
-            StockLineRow {
-                id: "backdate_and_pick_stock_line".to_string(),
-                store_id: mock_store_a().id,
-                available_number_of_packs: 8.0,
-                total_number_of_packs: 10.0,
-                pack_size: 1.0,
-                item_id: mock_item_a().id,
-                ..Default::default()
-            }
-        }
-
-        fn invoice_line() -> InvoiceLineRow {
-            InvoiceLineRow {
-                id: "backdate_and_pick_invoice_line".to_string(),
-                invoice_id: new_outbound().id,
-                stock_line_id: Some(stock_line().id),
-                number_of_packs: 2.0,
-                item_id: mock_item_a().id,
-                r#type: InvoiceLineType::StockOut,
-                ..Default::default()
-            }
-        }
-
-        let (_, connection, connection_manager, _) = setup_all_with_data(
-            "update_outbound_shipment_backdate_with_status_change_does_not_issue_stock",
-            MockDataInserts::all(),
-            MockData {
-                invoices: vec![new_outbound()],
-                stock_lines: vec![stock_line()],
-                invoice_lines: vec![invoice_line()],
-                ..Default::default()
-            },
-        )
-        .await;
-
-        enable_backdating(&connection, 30);
-
-        let service_provider = ServiceProvider::new(connection_manager);
-        let context = service_provider
-            .context(mock_store_a().id, "".to_string())
-            .unwrap();
-        let service = service_provider.invoice_service;
-
-        let two_days_ago = Utc::now() - Duration::days(2);
-
-        let result = service.update_outbound_shipment(
-            &context,
-            UpdateOutboundShipment {
-                id: new_outbound().id,
-                status: Some(UpdateOutboundShipmentStatus::Picked),
-                backdated_datetime: Some(two_days_ago),
-                ..Default::default()
-            },
-        );
-        assert!(result.is_ok(), "Not Ok(_) {:#?}", result);
-
-        assert_eq!(
-            InvoiceLineRowRepository::new(&connection)
-                .find_one_by_id(&invoice_line().id)
-                .unwrap(),
-            None
-        );
-
-        // Reservation released, nothing issued
-        assert_eq!(
-            StockLineRowRepository::new(&connection)
-                .find_one_by_id(&stock_line().id)
-                .unwrap()
-                .unwrap(),
-            StockLineRow {
-                available_number_of_packs: 10.0,
-                ..stock_line()
-            }
         );
     }
 

--- a/server/service/src/invoice/outbound_shipment/update/validate.rs
+++ b/server/service/src/invoice/outbound_shipment/update/validate.rs
@@ -86,7 +86,17 @@ pub fn validate(
             return Err(CantBackDate("Cannot set date in the future".to_string()));
         }
 
-        // Lines are deleted atomically in generate if backdating with existing lines
+        // Existing lines were allocated at the old date, so they'd need re-allocation.
+        // Rather than deleting them as a side effect, leave that decision to the caller
+        // - same as prescriptions (see open-msupply#12615)
+        let line_count = InvoiceLineRepository::new(connection).count(Some(
+            InvoiceLineFilter::new().invoice_id(EqualFilter::equal_to(patch.id.to_string())),
+        ))?;
+        if line_count > 0 {
+            return Err(CantBackDate(
+                "Can't backdate as invoice has allocated lines".to_string(),
+            ));
+        }
 
         if backdating.max_days > 0 {
             let earliest_allowed = Utc::now() - Duration::days(backdating.max_days as i64);


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12615

Backdating an outbound shipment used to delete all of the shipment's lines as a side effect of the update mutation (the backend detected a change to `backdated_datetime` and deleted every line atomically). Prescriptions handle the same situation by returning an error and leaving the decision to delete lines with the caller. This PR aligns outbound shipments with the prescription pattern:

- **Server**: `update_outbound_shipment` now returns `CantBackDate("Can't backdate as invoice has allocated lines")` when the invoice has any lines — the same check (and message) as `update_prescription`. All of the line-deletion machinery is removed from the update service (`backdated_lines_to_delete` in generate, the `delete_stock_out_line` loop, and the `LineDeleteError` variant).
- **Client**: the Picked Date input on the outbound detail view now deletes the lines itself (after the existing "lines will be removed" confirmation) via the existing `deleteOutboundShipmentLines` mutation, then updates the backdated datetime — mirroring the prescription toolbar's date change. Deletion only happens once *every* confirmation (including the stocktake warning) has been accepted, so cancelling any dialog leaves the lines untouched.

## 💌 Any notes for the reviewer?

- The issue floated two options (error like prescriptions, or an explicit `backdate_and_delete_existing_lines` endpoint); this implements option 1, which triage agreed with.
- One deliberate difference from prescriptions is kept: the backdate check still gates on a *change* to the datetime (`backdated_datetime_change`), not its mere presence. A full-patch client echoing the stored datetime on an invoice that has lines (or has moved past New) must not be rejected — the two `echoed_backdated_datetime` tests cover this.
- Because line deletion goes through the stock out line service (same path as a user deleting lines manually), the #12574 fix (releasing reserved stock) still holds — it's just driven by the client now. The three service tests that asserted the backend's delete-on-backdate behaviour (`backdate_releases_reserved_stock`, `backdate_removes_a_lines_vvm_status_log`, `backdate_with_status_change_does_not_issue_stock`) are removed; the stock-release behaviour itself is covered by the stock out line delete service's own tests.
- On the QA note about partial failure: line deletion and the date update are now two mutations. If the update fails after deletion, the lines are gone but the date is unchanged — consistent data, and identical to how prescriptions already behave.
- Permissions are unchanged: the client uses the existing outbound line delete mutation, so the same permission checks apply as when a user deletes lines directly.

# 🧪 Tested

- Updated `update_outbound_shipment_backdate_errors` to assert the new `CantBackDate` error when lines exist; all 14 `outbound_shipment::update` service tests pass (`cargo nextest run -p service outbound_shipment::update`).
- `cargo check` clean on `service` and `graphql_invoice`; `tsc` clean on the touched client files (the two pre-existing errors in `Prescriptions/DetailView/hooks/utils.test.tsx` are on develop already).
- Tested end-to-end against a live server built from this branch (fresh sqlite DB from the `e2e` datafile, which has the backdating preference on with `maxDays` 30), driving the GraphQL API directly:
  - Backdating an empty New outbound → succeeds, `backdatedDatetime` stored.
  - Adding a line reserves stock (available 50 → 45), then *changing* the backdated datetime → rejected with `CantBackDate("Can't backdate as invoice has allocated lines")`.
  - Echoing the *stored* backdated datetime alongside a comment edit, with the line still present → succeeds and the line is kept (the full-patch client case).
  - Deleting the line via `deleteOutboundShipmentLines` releases the reservation (available back to 50), after which backdating to a new datetime succeeds — the exact sequence the frontend now runs.
  - Backdating beyond `maxDays` → still rejected with `ExceedsMaximumBackdatingDays`.
- One incidental confirmation of *why* the error-first pattern is right: inserting a line into a shipment backdated to before the stock existed is rejected by ledger-aware stock validation (`NotEnoughStockForReduction`) — lines genuinely need re-entering after the date changes.
- UI itself not exercised — worth a QA pass on: backdating a New outbound with lines (confirm → lines removed → date set), cancelling either confirmation (lines and date untouched), and the stocktake-after-date warning path.

# 📃 Documentation

- [x] **No documentation required** — user-facing behaviour is unchanged (same confirmation, lines still removed on backdate); only where the deletion happens moved
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:

