### PR TITLE
#12672 Allow invisible manufacturers when saving stocktakes

### DIFF
--- a/client/packages/common/src/intl/locales/en/common.json
+++ b/client/packages/common/src/intl/locales/en/common.json
@@ -2468,7 +2468,6 @@
   "messages.log-saved-successfully": "Log saved successfully",
   "messages.logout-confirm": "This will log you out.",
   "messages.manual-returns-preferences-disabled": "Manual returns are disabled for your store. Please contact your system administrator if you need to change this.",
-  "messages.manufacturer-not-visible-dropped": "Manufacturer \"{{name}}\" is not visible in this store, so it was not added to the stock line",
   "messages.mark-as-visited": "This encounter is still marked as pending. If you are finished, mark it as visited.",
   "messages.max-or-min-temperature": "Max/min temperature",
   "messages.message-not-sent": "Error! Your message was not sent",

--- a/client/packages/common/src/intl/locales/fr/common.json
+++ b/client/packages/common/src/intl/locales/fr/common.json
@@ -2434,7 +2434,6 @@
   "messages.log-saved-successfully": "Journal sauvegardé avec succès",
   "messages.logout-confirm": "Cela vous déconnectera.",
   "messages.manual-returns-preferences-disabled": "Les retours manuels sont désactivés pour votre dépôt. Veuillez contacter votre administrateur système si vous devez modifier ce paramètre.",
-  "messages.manufacturer-not-visible-dropped": "Le fabricant \"{{name}}\" n'est pas visible pour ce dépôt, il n'a donc pas été ajouté à la ligne de stock",
   "messages.mark-as-visited": "Cette consultation est encore en attente. Si elle est terminée, marquez-la comme réalisée.",
   "messages.max-or-min-temperature": "Température Max/Min",
   "messages.message-not-sent": "Erreur ! Message non envoyé",

--- a/client/packages/common/src/intl/locales/pt/common.json
+++ b/client/packages/common/src/intl/locales/pt/common.json
@@ -2409,7 +2409,6 @@
   "messages.log-saved-successfully": "Registo salvo com sucesso",
   "messages.logout-confirm": "Isto te desconectará.",
   "messages.manual-returns-preferences-disabled": "As devoluções manuais estão desativadas na sua loja. Se precisar de alterar esta configuração, contacte o administrador do sistema.",
-  "messages.manufacturer-not-visible-dropped": "O fabricante \"{{name}}\" não está visível nesta unidade de saúde, pelo que não foi adicionado à linha de estoque",
   "messages.mark-as-visited": "Esta consulta ainda está marcada como pendente. Caso tenha finalizado, marque como 'visitado'.",
   "messages.max-or-min-temperature": "Temperatura máx/mín",
   "messages.message-not-sent": "Erro! Sua mensagem não foi enviada",

--- a/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantForm.tsx
+++ b/client/packages/system/src/Item/DetailView/Tabs/ItemVariants/ItemVariantForm.tsx
@@ -83,11 +83,7 @@ export const ItemVariantForm = ({
                   value={variant.manufacturer ?? null}
                   onChange={manufacturer =>
                     updateVariant?.({
-                      // ManufacturerSearchInput only lists names visible in the
-                      // current store, so a selection is visible by definition.
-                      manufacturer: manufacturer
-                        ? { ...manufacturer, isVisible: true }
-                        : null,
+                      manufacturer,
                       manufacturerId: manufacturer?.id ?? null,
                     })
                   }

--- a/client/packages/system/src/Item/api/operations.generated.ts
+++ b/client/packages/system/src/Item/api/operations.generated.ts
@@ -241,7 +241,6 @@ export type ItemVariantFragment = {
   } | null;
   manufacturer?: {
     __typename: 'NameNode';
-    isVisible: boolean;
     code: string;
     id: string;
     isCustomer: boolean;
@@ -440,7 +439,6 @@ export type ItemFragment = {
     } | null;
     manufacturer?: {
       __typename: 'NameNode';
-      isVisible: boolean;
       code: string;
       id: string;
       isCustomer: boolean;
@@ -822,7 +820,6 @@ export type ItemByIdQuery = {
         } | null;
         manufacturer?: {
           __typename: 'NameNode';
-          isVisible: boolean;
           code: string;
           id: string;
           isCustomer: boolean;
@@ -983,7 +980,6 @@ export type ItemVariantsQuery = {
         } | null;
         manufacturer?: {
           __typename: 'NameNode';
-          isVisible: boolean;
           code: string;
           id: string;
           isCustomer: boolean;
@@ -1167,7 +1163,6 @@ export type UpsertItemVariantMutation = {
             } | null;
             manufacturer?: {
               __typename: 'NameNode';
-              isVisible: boolean;
               code: string;
               id: string;
               isCustomer: boolean;
@@ -1688,7 +1683,6 @@ export const ItemVariantFragmentDoc = gql`
     manufacturerId
     manufacturer(storeId: $storeId) {
       ...NameRow
-      isVisible
     }
     locationTypeId
     locationType {

--- a/client/packages/system/src/Item/api/operations.graphql
+++ b/client/packages/system/src/Item/api/operations.graphql
@@ -182,7 +182,6 @@ fragment ItemVariant on ItemVariantNode {
   manufacturerId
   manufacturer(storeId: $storeId) {
     ...NameRow
-    isVisible
   }
   locationTypeId
   locationType {

--- a/client/packages/system/src/Stock/Components/NewStockLineModal.tsx
+++ b/client/packages/system/src/Stock/Components/NewStockLineModal.tsx
@@ -36,7 +36,7 @@ export const NewStockLineModal = ({
 }: NewStockLineModalProps) => {
   const t = useTranslation();
   const navigate = useNavigate();
-  const { success, error, warning } = useNotification();
+  const { success, error } = useNotification();
   const pluginEvents = usePluginEvents({
     isDirty: false,
   });
@@ -113,22 +113,10 @@ export const NewStockLineModal = ({
   const onVariantSelected = useCallback(
     (variant: ItemVariantFragment) => {
       // A variant's manufacturer is configured centrally and may not be visible
-      // to this store. Drop it when not visible (else the save is rejected with
-      // ManufacturerNotVisible) and warn, so a valid variant is still usable.
-      const manufacturer =
-        variant.manufacturer && !variant.manufacturer.isVisible
-          ? null
-          : (variant.manufacturer ?? null);
-      if (variant.manufacturer && !manufacturer) {
-        warning(
-          t('messages.manufacturer-not-visible-dropped', {
-            name: variant.manufacturer.name,
-          })
-        )();
-      }
+      // to this store - that's still valid data, so it is kept as-is
       updatePatch({
         itemVariant: variant,
-        manufacturer,
+        manufacturer: variant.manufacturer ?? null,
         volumePerPack:
           getVolumePerPackFromVariant({
             packSize: draft.packSize,
@@ -137,7 +125,7 @@ export const NewStockLineModal = ({
       });
       setVariantPanelOpen(false);
     },
-    [updatePatch, draft.packSize, warning, t]
+    [updatePatch, draft.packSize]
   );
 
   return (

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/insert.rs
@@ -202,7 +202,6 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         | ServiceError::DonorNotVisible
         | ServiceError::SelectedDonorPartyIsNotADonor
         | ServiceError::ManufacturerDoesNotExist
-        | ServiceError::ManufacturerNotVisible
         | ServiceError::ManufacturerIsNotAManufacturer
         | ServiceError::ProgramDoesNotExist
         | ServiceError::PurchaseOrderLineIdRequired

--- a/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
+++ b/server/graphql/invoice_line/src/mutations/inbound_shipment_line/line/update.rs
@@ -243,7 +243,6 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         | ServiceError::ItemVariantDoesNotExist
         | ServiceError::VVMStatusDoesNotExist
         | ServiceError::ManufacturerDoesNotExist
-        | ServiceError::ManufacturerNotVisible
         | ServiceError::ManufacturerIsNotAManufacturer
         | ServiceError::ProgramDoesNotExist
         | ServiceError::CampaignDoesNotExist

--- a/server/graphql/item_variant/src/mutations/upsert.rs
+++ b/server/graphql/item_variant/src/mutations/upsert.rs
@@ -158,7 +158,6 @@ fn map_error(error: ServiceError) -> Result<UpsertItemVariantErrorInterface> {
         | ServiceError::CantChangeItem
         | ServiceError::LocationTypeDoesNotExist
         | ServiceError::OtherPartyDoesNotExist
-        | ServiceError::OtherPartyNotVisible
         | ServiceError::OtherPartyNotAManufacturer => BadUserInput(formatted_error),
 
         ServiceError::PackagingVariantError(upsert_packaging_variant_error) => {

--- a/server/graphql/purchase_order_line/src/mutations/insert.rs
+++ b/server/graphql/purchase_order_line/src/mutations/insert.rs
@@ -170,8 +170,7 @@ pub fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         | ServiceError::IncorrectStoreId
         | ServiceError::OtherPartyDoesNotExist
         | ServiceError::OtherPartyNotAManufacturer
-        | ServiceError::ItemCannotBeOrdered
-        | ServiceError::OtherPartyNotVisible => BadUserInput(formatted_error),
+        | ServiceError::ItemCannotBeOrdered => BadUserInput(formatted_error),
         ServiceError::DatabaseError(_) => InternalError(formatted_error),
     };
 

--- a/server/graphql/stock_line/src/mutations/update.rs
+++ b/server/graphql/stock_line/src/mutations/update.rs
@@ -164,7 +164,6 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         | ServiceError::DonorNotVisible
         | ServiceError::DonorIsNotADonor
         | ServiceError::ManufacturerDoesNotExist
-        | ServiceError::ManufacturerNotVisible
         | ServiceError::ManufacturerIsNotAManufacturer
         | ServiceError::VVMStatusDoesNotExist
         | ServiceError::StockDoesNotBelongToStore

--- a/server/graphql/stocktake_line/src/mutations/insert.rs
+++ b/server/graphql/stocktake_line/src/mutations/insert.rs
@@ -138,7 +138,6 @@ fn map_error(error: ServiceError) -> Result<InsertErrorInterface> {
         | ServiceError::CampaignDoesNotExist
         | ServiceError::ProgramDoesNotExist
         | ServiceError::ManufacturerDoesNotExist
-        | ServiceError::ManufacturerNotVisible
         | ServiceError::ManufacturerIsNotAManufacturer
         | ServiceError::VvmStatusDoesNotExist
         | ServiceError::ItemDoesNotExist => BadUserInput(formatted_error),

--- a/server/graphql/stocktake_line/src/mutations/update.rs
+++ b/server/graphql/stocktake_line/src/mutations/update.rs
@@ -208,7 +208,6 @@ fn map_error(error: ServiceError) -> Result<UpdateErrorInterface> {
         | ServiceError::LocationDoesNotExist
         | ServiceError::StocktakeIsLocked
         | ServiceError::ManufacturerDoesNotExist
-        | ServiceError::ManufacturerNotVisible
         | ServiceError::ManufacturerIsNotAManufacturer
         | ServiceError::CampaignDoesNotExist
         | ServiceError::VvmStatusDoesNotExist

--- a/server/service/src/invoice_line/stock_in_line/insert/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/mod.rs
@@ -119,7 +119,6 @@ pub enum InsertStockInLineError {
     NumberOfPacksBelowZero,
     NewlyCreatedLineDoesNotExist,
     ManufacturerDoesNotExist,
-    ManufacturerNotVisible,
     ManufacturerIsNotAManufacturer,
     VVMStatusDoesNotExist,
     ProgramDoesNotExist,

--- a/server/service/src/invoice_line/stock_in_line/insert/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/insert/validate.rs
@@ -118,7 +118,9 @@ pub fn validate(
             Ok(_) => {}
             Err(e) => match e {
                 OtherPartyErrors::OtherPartyDoesNotExist => return Err(ManufacturerDoesNotExist),
-                OtherPartyErrors::OtherPartyNotVisible => return Err(ManufacturerNotVisible),
+                // Invisible manufacturers are allowed - they can be configured centrally (e.g. on
+                // an item variant) or inherited from stock without being visible in this store
+                OtherPartyErrors::OtherPartyNotVisible => {}
                 OtherPartyErrors::TypeMismatched => return Err(ManufacturerIsNotAManufacturer),
                 OtherPartyErrors::DatabaseError(repository_error) => {
                     return Err(DatabaseError(repository_error))

--- a/server/service/src/invoice_line/stock_in_line/update/mod.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/mod.rs
@@ -127,7 +127,6 @@ pub enum UpdateStockInLineError {
     UpdatedLineDoesNotExist,
     NotThisInvoiceLine(String),
     ManufacturerDoesNotExist,
-    ManufacturerNotVisible,
     ManufacturerIsNotAManufacturer,
     VVMStatusDoesNotExist,
     ProgramDoesNotExist,

--- a/server/service/src/invoice_line/stock_in_line/update/validate.rs
+++ b/server/service/src/invoice_line/stock_in_line/update/validate.rs
@@ -139,7 +139,9 @@ pub fn validate(
             Ok(_) => {}
             Err(e) => match e {
                 OtherPartyErrors::OtherPartyDoesNotExist => return Err(ManufacturerDoesNotExist),
-                OtherPartyErrors::OtherPartyNotVisible => return Err(ManufacturerNotVisible),
+                // Invisible manufacturers are allowed - they can be configured centrally (e.g. on
+                // an item variant) or inherited from stock without being visible in this store
+                OtherPartyErrors::OtherPartyNotVisible => {}
                 OtherPartyErrors::TypeMismatched => return Err(ManufacturerIsNotAManufacturer),
                 OtherPartyErrors::DatabaseError(repository_error) => {
                     return Err(DatabaseError(repository_error))

--- a/server/service/src/item/item_variant/test/mod.rs
+++ b/server/service/src/item/item_variant/test/mod.rs
@@ -330,13 +330,14 @@ mod query {
         );
         assert_eq!(result.unwrap_err(), UpsertItemVariantError::DuplicateName);
 
-        // Test manufacturer not visible
+        // Test manufacturer type check: name_c is not visible in this store, but visibility
+        // no longer blocks manufacturers - the is-a-manufacturer check must still apply
         let result = service.upsert_item_variant(
             &context,
             UpsertItemVariantWithPackaging {
                 id: uuid(),
                 item_id: mock_item_a().id,
-                name: "OtherPartyNotVisible".to_string(),
+                name: "OtherPartyNotAManufacturer".to_string(),
                 manufacturer_id: Some(NullableUpdate {
                     value: Some(mock_name_c().id),
                 }),
@@ -345,7 +346,7 @@ mod query {
         );
         assert_eq!(
             result.unwrap_err(),
-            UpsertItemVariantError::OtherPartyNotVisible
+            UpsertItemVariantError::OtherPartyNotAManufacturer
         );
     }
 }

--- a/server/service/src/item/item_variant/upsert/mod.rs
+++ b/server/service/src/item/item_variant/upsert/mod.rs
@@ -29,7 +29,6 @@ pub enum UpsertItemVariantError {
     DuplicateName,
     LocationTypeDoesNotExist,
     OtherPartyDoesNotExist,
-    OtherPartyNotVisible,
     OtherPartyNotAManufacturer,
     PackagingVariantError(UpsertPackagingVariantError),
     DatabaseError(RepositoryError),

--- a/server/service/src/item/item_variant/upsert/validate.rs
+++ b/server/service/src/item/item_variant/upsert/validate.rs
@@ -39,18 +39,24 @@ pub fn validate(
         value: Some(ref manufacturer_id),
     }) = &input.manufacturer_id
     {
-        check_other_party(
+        match check_other_party(
             connection,
             store_id,
             manufacturer_id,
             CheckOtherPartyType::Manufacturer,
-        )
-        .map_err(|e| match e {
-            OtherPartyErrors::OtherPartyDoesNotExist => OtherPartyDoesNotExist {},
-            OtherPartyErrors::OtherPartyNotVisible => OtherPartyNotVisible,
-            OtherPartyErrors::TypeMismatched => OtherPartyNotAManufacturer,
-            OtherPartyErrors::DatabaseError(repository_error) => DatabaseError(repository_error),
-        })?;
+        ) {
+            Ok(_) => {}
+            Err(e) => match e {
+                OtherPartyErrors::OtherPartyDoesNotExist => return Err(OtherPartyDoesNotExist {}),
+                // Invisible manufacturers are allowed - they can be configured centrally (e.g. on
+                // an item variant) or inherited from stock without being visible in this store
+                OtherPartyErrors::OtherPartyNotVisible => {}
+                OtherPartyErrors::TypeMismatched => return Err(OtherPartyNotAManufacturer),
+                OtherPartyErrors::DatabaseError(repository_error) => {
+                    return Err(DatabaseError(repository_error))
+                }
+            },
+        };
     };
 
     if let Some(NullableUpdate {

--- a/server/service/src/purchase_order_line/insert/mod.rs
+++ b/server/service/src/purchase_order_line/insert/mod.rs
@@ -26,7 +26,6 @@ pub enum InsertPurchaseOrderLineError {
     CannotEditPurchaseOrder,
     OtherPartyDoesNotExist,
     OtherPartyNotAManufacturer,
-    OtherPartyNotVisible,
     PackSizeCodeCombinationExists(PackSizeCodeCombination),
     DatabaseError(RepositoryError),
     CannotFindItemByCode(String),

--- a/server/service/src/purchase_order_line/insert/validate.rs
+++ b/server/service/src/purchase_order_line/insert/validate.rs
@@ -80,26 +80,28 @@ pub fn validate(
     }
 
     if let Some(manufacturer_id) = &input.manufacturer_id {
-        check_other_party(
+        match check_other_party(
             connection,
             store_id,
             manufacturer_id,
             CheckOtherPartyType::Manufacturer,
-        )
-        .map_err(|e| match e {
-            OtherPartyErrors::OtherPartyDoesNotExist => {
-                InsertPurchaseOrderLineError::OtherPartyDoesNotExist {}
-            }
-            OtherPartyErrors::OtherPartyNotVisible => {
-                InsertPurchaseOrderLineError::OtherPartyNotVisible
-            }
-            OtherPartyErrors::TypeMismatched => {
-                InsertPurchaseOrderLineError::OtherPartyNotAManufacturer
-            }
-            OtherPartyErrors::DatabaseError(repository_error) => {
-                InsertPurchaseOrderLineError::DatabaseError(repository_error)
-            }
-        })?;
+        ) {
+            Ok(_) => {}
+            Err(e) => match e {
+                OtherPartyErrors::OtherPartyDoesNotExist => {
+                    return Err(InsertPurchaseOrderLineError::OtherPartyDoesNotExist {})
+                }
+                // Invisible manufacturers are allowed - they can be configured centrally (e.g. on
+                // an item variant) or inherited from stock without being visible in this store
+                OtherPartyErrors::OtherPartyNotVisible => {}
+                OtherPartyErrors::TypeMismatched => {
+                    return Err(InsertPurchaseOrderLineError::OtherPartyNotAManufacturer)
+                }
+                OtherPartyErrors::DatabaseError(repository_error) => {
+                    return Err(InsertPurchaseOrderLineError::DatabaseError(repository_error))
+                }
+            },
+        };
     };
 
     Ok(item)

--- a/server/service/src/stock_line/tests/update.rs
+++ b/server/service/src/stock_line/tests/update.rs
@@ -113,19 +113,20 @@ mod test {
             Err(ServiceError::ItemVariantDoesNotExist)
         );
 
-        // DonorNotVisible
+        // Invisible name which is also not a donor: the type check runs before the
+        // visibility check (it only needs name_row), so DonorIsNotADonor wins
         assert_eq!(
             service.update_stock_line(
                 &context,
                 UpdateStockLine {
                     id: mock_stock_line_a().id,
                     donor_id: Some(NullableUpdate {
-                        value: Some(mock_name_b().id), // Not visible in store_a
+                        value: Some(mock_name_b().id), // Not visible in store_a, not a donor
                     }),
                     ..Default::default()
                 }
             ),
-            Err(ServiceError::DonorNotVisible)
+            Err(ServiceError::DonorIsNotADonor)
         );
 
         // DonorIsNotADonor

--- a/server/service/src/stock_line/update.rs
+++ b/server/service/src/stock_line/update.rs
@@ -48,7 +48,6 @@ pub enum UpdateStockLineError {
     DonorNotVisible,
     DonorIsNotADonor,
     ManufacturerDoesNotExist,
-    ManufacturerNotVisible,
     ManufacturerIsNotAManufacturer,
     UpdatedStockNotFound,
     StockMovementNotFound,
@@ -164,18 +163,24 @@ fn validate(
         value: Some(manufacturer_id),
     }) = &input.manufacturer_id
     {
-        check_other_party(
+        match check_other_party(
             connection,
             store_id,
             manufacturer_id,
             CheckOtherPartyType::Manufacturer,
-        )
-        .map_err(|e| match e {
-            OtherPartyErrors::OtherPartyDoesNotExist => ManufacturerDoesNotExist,
-            OtherPartyErrors::OtherPartyNotVisible => ManufacturerNotVisible,
-            OtherPartyErrors::TypeMismatched => ManufacturerIsNotAManufacturer,
-            OtherPartyErrors::DatabaseError(repository_error) => DatabaseError(repository_error),
-        })?;
+        ) {
+            Ok(_) => {}
+            Err(e) => match e {
+                OtherPartyErrors::OtherPartyDoesNotExist => return Err(ManufacturerDoesNotExist),
+                // Invisible manufacturers are allowed - they can be configured centrally (e.g. on
+                // an item variant) or inherited from stock without being visible in this store
+                OtherPartyErrors::OtherPartyNotVisible => {}
+                OtherPartyErrors::TypeMismatched => return Err(ManufacturerIsNotAManufacturer),
+                OtherPartyErrors::DatabaseError(repository_error) => {
+                    return Err(DatabaseError(repository_error))
+                }
+            },
+        };
     };
 
     Ok(stock_line)

--- a/server/service/src/stocktake/update/mod.rs
+++ b/server/service/src/stocktake/update/mod.rs
@@ -194,7 +194,7 @@ mod test {
             MockDataInserts,
         },
         test_db::{setup_all, setup_all_with_data},
-        EqualFilter, InvoiceLineRepository, InvoiceLineRowRepository, InvoiceLineType,
+        EqualFilter, InvoiceLineRepository, InvoiceLineRowRepository, InvoiceLineType, NameRow,
         PreferenceRow, StockLineRow, StockLineRowRepository, StocktakeLine, StocktakeLineFilter,
         StocktakeLineRepository, StocktakeLineRow, StocktakeLineRowRepository, StocktakeRepository,
         StocktakeRow, StocktakeStatus,
@@ -930,6 +930,101 @@ mod test {
         assert_eq!(
             updated_stock_line.program_id,
             Some(mock_immunisation_program_a().id)
+        );
+    }
+
+    #[actix_rt::test]
+    async fn finalise_stocktake_with_manufacturer_not_visible_to_store() {
+        // Regression test for #12672: finalising a stocktake must succeed even when the
+        // adjusted stock line carries a manufacturer that is not visible to this store.
+        // This happens in practice when the manufacturer is configured centrally (e.g. on
+        // an item variant) or inherited from stock — the stocktake should not be blocked
+        // by that.
+        let invisible_manufacturer = NameRow {
+            id: "invisible_manufacturer".to_string(),
+            name: "Invisible manufacturer".to_string(),
+            code: "invisible_manufacturer".to_string(),
+            is_manufacturer: true,
+            ..Default::default()
+        };
+
+        let stock_line_with_invisible_manufacturer = StockLineRow {
+            id: "stock_line_invisible_manufacturer".to_string(),
+            item_id: mock_item_a().id,
+            store_id: mock_store_a().id,
+            pack_size: 1.0,
+            available_number_of_packs: 5.0,
+            total_number_of_packs: 5.0,
+            manufacturer_id: Some(invisible_manufacturer.id.clone()),
+            ..Default::default()
+        };
+
+        let stocktake = StocktakeRow {
+            id: "stocktake_manufacturer_not_visible".to_string(),
+            store_id: mock_store_a().id,
+            stocktake_number: 101,
+            created_datetime: NaiveDate::from_ymd_opt(2024, 1, 1)
+                .unwrap()
+                .and_hms_milli_opt(0, 0, 0, 0)
+                .unwrap(),
+            status: StocktakeStatus::New,
+            ..Default::default()
+        };
+
+        let stocktake_line = StocktakeLineRow {
+            id: "stocktake_line_manufacturer_not_visible".to_string(),
+            stocktake_id: stocktake.id.clone(),
+            stock_line_id: Some(stock_line_with_invisible_manufacturer.id.clone()),
+            item_id: mock_item_a().id,
+            // Force inventory addition path (counted > snapshot)
+            snapshot_number_of_packs: 5.0,
+            counted_number_of_packs: Some(10.0),
+            manufacturer_id: Some(invisible_manufacturer.id.clone()),
+            ..Default::default()
+        };
+
+        let (_, connection, connection_manager, _) = setup_all_with_data(
+            "finalise_stocktake_with_manufacturer_not_visible_to_store",
+            MockDataInserts::all(),
+            MockData {
+                names: vec![invisible_manufacturer.clone()],
+                stock_lines: vec![stock_line_with_invisible_manufacturer.clone()],
+                stocktakes: vec![stocktake.clone()],
+                stocktake_lines: vec![stocktake_line],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, "".to_string())
+            .unwrap();
+
+        let result = service_provider
+            .stocktake_service
+            .update_stocktake(
+                &context,
+                UpdateStocktake {
+                    id: stocktake.id.clone(),
+                    status: Some(UpdateStocktakeStatus::Finalised),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        // The inventory adjustment line should have been created and the resulting stock
+        // line should still carry the manufacturer (we don't strip it, just don't require
+        // visibility).
+        assert!(result.inventory_addition_id.is_some());
+        let updated_stock_line = StockLineRowRepository::new(&connection)
+            .find_one_by_id(&stock_line_with_invisible_manufacturer.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(updated_stock_line.total_number_of_packs, 10.0);
+        assert_eq!(
+            updated_stock_line.manufacturer_id,
+            Some(invisible_manufacturer.id)
         );
     }
 

--- a/server/service/src/stocktake_line/insert/mod.rs
+++ b/server/service/src/stocktake_line/insert/mod.rs
@@ -486,6 +486,16 @@ mod stocktake_line_test {
             }
         }
 
+        fn invisible_non_manufacturer() -> NameRow {
+            NameRow {
+                id: String::from("invisible_non_manufacturer"),
+                name: String::from("Invisible non-manufacturer"),
+                code: String::from("invisible_non_manufacturer"),
+                is_manufacturer: false,
+                ..Default::default()
+            }
+        }
+
         fn mock_stock_line_for_manufacturer_test() -> StockLineRow {
             StockLineRow {
                 id: String::from("mock_stock_line_for_manufacturer_test"),
@@ -502,7 +512,7 @@ mod stocktake_line_test {
             "insert_stocktake_line_with_invisible_manufacturer",
             MockDataInserts::all(),
             MockData {
-                names: vec![invisible_manufacturer()],
+                names: vec![invisible_manufacturer(), invisible_non_manufacturer()],
                 stock_lines: vec![mock_stock_line_for_manufacturer_test()],
                 ..Default::default()
             },
@@ -515,9 +525,27 @@ mod stocktake_line_test {
             .unwrap();
         let service = service_provider.stocktake_line_service;
 
-        // success: manufacturer exists but has no name_store_join for this store
+        // error: skipping the visibility check must not skip the type check - an invisible
+        // name that is not a manufacturer is still rejected
         let stocktake_a = mock_stocktake_a();
         let stock_line = mock_stock_line_for_manufacturer_test();
+        let result = service.insert_stocktake_line(
+            &context,
+            InsertStocktakeLine {
+                id: uuid(),
+                stocktake_id: stocktake_a.id.clone(),
+                stock_line_id: Some(stock_line.id.clone()),
+                manufacturer_id: Some(invisible_non_manufacturer().id),
+                counted_number_of_packs: Some(17.0),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            result.unwrap_err(),
+            InsertStocktakeLineError::ManufacturerIsNotAManufacturer
+        );
+
+        // success: manufacturer exists but has no name_store_join for this store
         let result = service
             .insert_stocktake_line(
                 &context,

--- a/server/service/src/stocktake_line/insert/mod.rs
+++ b/server/service/src/stocktake_line/insert/mod.rs
@@ -55,7 +55,6 @@ pub enum InsertStocktakeLineError {
     AdjustmentReasonNotProvided,
     AdjustmentReasonNotValid,
     ManufacturerDoesNotExist,
-    ManufacturerNotVisible,
     ManufacturerIsNotAManufacturer,
     VvmStatusDoesNotExist,
     CampaignDoesNotExist,
@@ -129,8 +128,8 @@ mod stocktake_line_test {
         },
         campaign::campaign_row::CampaignRow,
         test_db::{setup_all, setup_all_with_data},
-        EqualFilter, ReasonOptionRow, ReasonOptionType, StockLineFilter, StockLineRepository,
-        StockLineRow, StockLineRowRepository, StocktakeLineRow, StocktakeRow,
+        EqualFilter, NameRow, ReasonOptionRow, ReasonOptionType, StockLineFilter,
+        StockLineRepository, StockLineRow, StockLineRowRepository, StocktakeLineRow, StocktakeRow,
     };
     use util::uuid::uuid;
 
@@ -471,6 +470,71 @@ mod stocktake_line_test {
             .unwrap()
             .unwrap();
         assert_eq!(stock_line_row.donor_id, Some(donor_id));
+    }
+
+    #[actix_rt::test]
+    async fn insert_stocktake_line_with_invisible_manufacturer() {
+        // A manufacturer can be configured centrally (e.g. on an item variant) or inherited
+        // from stock without being visible in this store - this is valid data (see #12672)
+        fn invisible_manufacturer() -> NameRow {
+            NameRow {
+                id: String::from("invisible_manufacturer"),
+                name: String::from("Invisible manufacturer"),
+                code: String::from("invisible_manufacturer"),
+                is_manufacturer: true,
+                ..Default::default()
+            }
+        }
+
+        fn mock_stock_line_for_manufacturer_test() -> StockLineRow {
+            StockLineRow {
+                id: String::from("mock_stock_line_for_manufacturer_test"),
+                item_id: String::from("item_a"),
+                store_id: String::from("store_a"),
+                available_number_of_packs: 20.0,
+                pack_size: 1.0,
+                total_number_of_packs: 30.0,
+                ..Default::default()
+            }
+        }
+
+        let (_, _, connection_manager, _) = setup_all_with_data(
+            "insert_stocktake_line_with_invisible_manufacturer",
+            MockDataInserts::all(),
+            MockData {
+                names: vec![invisible_manufacturer()],
+                stock_lines: vec![mock_stock_line_for_manufacturer_test()],
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let service_provider = ServiceProvider::new(connection_manager);
+        let context = service_provider
+            .context(mock_store_a().id, "".to_string())
+            .unwrap();
+        let service = service_provider.stocktake_line_service;
+
+        // success: manufacturer exists but has no name_store_join for this store
+        let stocktake_a = mock_stocktake_a();
+        let stock_line = mock_stock_line_for_manufacturer_test();
+        let result = service
+            .insert_stocktake_line(
+                &context,
+                InsertStocktakeLine {
+                    id: uuid(),
+                    stocktake_id: stocktake_a.id,
+                    stock_line_id: Some(stock_line.id.clone()),
+                    manufacturer_id: Some(invisible_manufacturer().id),
+                    counted_number_of_packs: Some(17.0),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            result.line.manufacturer_id,
+            Some(invisible_manufacturer().id)
+        );
     }
 
     #[actix_rt::test]

--- a/server/service/src/stocktake_line/insert/validate.rs
+++ b/server/service/src/stocktake_line/insert/validate.rs
@@ -177,9 +177,9 @@ pub fn validate(
                 OtherPartyErrors::OtherPartyDoesNotExist => {
                     return Err(InsertStocktakeLineError::ManufacturerDoesNotExist)
                 }
-                OtherPartyErrors::OtherPartyNotVisible => {
-                    return Err(InsertStocktakeLineError::ManufacturerNotVisible)
-                }
+                // Invisible manufacturers are allowed - they can be configured centrally (e.g. on
+                // an item variant) or inherited from stock without being visible in this store
+                OtherPartyErrors::OtherPartyNotVisible => {}
                 OtherPartyErrors::TypeMismatched => {
                     return Err(InsertStocktakeLineError::ManufacturerIsNotAManufacturer)
                 }

--- a/server/service/src/stocktake_line/update/mod.rs
+++ b/server/service/src/stocktake_line/update/mod.rs
@@ -47,7 +47,6 @@ pub enum UpdateStocktakeLineError {
     AdjustmentReasonNotProvided,
     AdjustmentReasonNotValid,
     ManufacturerDoesNotExist,
-    ManufacturerNotVisible,
     ManufacturerIsNotAManufacturer,
     CampaignDoesNotExist,
     ProgramDoesNotExist,
@@ -89,9 +88,9 @@ mod stocktake_line_test {
             mock_stocktake_line_finalised, mock_store_a, MockData, MockDataInserts,
         },
         test_db::setup_all_with_data,
-        EqualFilter, InvoiceLineRow, InvoiceRow, InvoiceStatus, InvoiceType, ReasonOptionRow,
-        ReasonOptionRowRepository, ReasonOptionType, StockLineFilter, StockLineRepository,
-        StocktakeLineRow, StocktakeLineRowRepository,
+        EqualFilter, InvoiceLineRow, InvoiceRow, InvoiceStatus, InvoiceType, NameRow,
+        ReasonOptionRow, ReasonOptionRowRepository, ReasonOptionType, StockLineFilter,
+        StockLineRepository, StocktakeLineRow, StocktakeLineRowRepository,
     };
 
     use crate::{
@@ -118,6 +117,16 @@ mod stocktake_line_test {
                 is_active: true,
                 r#type: ReasonOptionType::NegativeInventoryAdjustment,
                 reason: "Lost".to_string(),
+                ..Default::default()
+            }
+        }
+
+        fn invisible_manufacturer() -> NameRow {
+            NameRow {
+                id: "invisible_manufacturer".to_string(),
+                name: "Invisible manufacturer".to_string(),
+                code: "invisible_manufacturer".to_string(),
+                is_manufacturer: true,
                 ..Default::default()
             }
         }
@@ -176,6 +185,7 @@ mod stocktake_line_test {
             MockData {
                 invoices: vec![outbound_shipment()],
                 invoice_lines: vec![outbound_shipment_line()],
+                names: vec![invisible_manufacturer()],
                 reason_options: vec![positive_reason(), negative_reason()],
                 stocktake_lines: vec![mock_stocktake_line(), mock_reduced_stock()],
                 ..Default::default()
@@ -318,6 +328,40 @@ mod stocktake_line_test {
             )
             .unwrap_err();
         assert_eq!(error, UpdateStocktakeLineError::ManufacturerDoesNotExist);
+
+        // success: manufacturer exists but has no name_store_join for this store - saving a
+        // line with an invisible manufacturer is allowed (see #12672)
+        let stocktake_line_a = mock_stocktake_line_a();
+        let result = service
+            .update_stocktake_line(
+                &context,
+                UpdateStocktakeLine {
+                    id: stocktake_line_a.id,
+                    manufacturer_id: Some(NullableUpdate {
+                        value: Some(invisible_manufacturer().id),
+                    }),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            result.line.manufacturer_id,
+            Some(invisible_manufacturer().id)
+        );
+
+        // clear the manufacturer again (also restores the line for the tests below)
+        let stocktake_line_a = mock_stocktake_line_a();
+        let result = service
+            .update_stocktake_line(
+                &context,
+                UpdateStocktakeLine {
+                    id: stocktake_line_a.id,
+                    manufacturer_id: Some(NullableUpdate { value: None }),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(result.line.manufacturer_id, None);
 
         // error: IncorrectLocationType
         let stocktake_line = StocktakeLineRow {

--- a/server/service/src/stocktake_line/update/validate.rs
+++ b/server/service/src/stocktake_line/update/validate.rs
@@ -162,7 +162,9 @@ pub fn validate(
             Ok(_) => {}
             Err(e) => match e {
                 OtherPartyErrors::OtherPartyDoesNotExist => return Err(ManufacturerDoesNotExist),
-                OtherPartyErrors::OtherPartyNotVisible => return Err(ManufacturerNotVisible),
+                // Invisible manufacturers are allowed - they can be configured centrally (e.g. on
+                // an item variant) or inherited from stock without being visible in this store
+                OtherPartyErrors::OtherPartyNotVisible => {}
                 OtherPartyErrors::TypeMismatched => return Err(ManufacturerIsNotAManufacturer),
                 OtherPartyErrors::DatabaseError(repository_error) => {
                     return Err(DatabaseError(repository_error))

--- a/server/service/src/validate.rs
+++ b/server/service/src/validate.rs
@@ -96,22 +96,10 @@ pub fn check_other_party(
     let other_party = get_other_party(connection, store_id, other_party_id)?
         .ok_or(OtherPartyErrors::OtherPartyDoesNotExist)?;
 
-    if !other_party.is_visible() {
-        return Err(OtherPartyErrors::OtherPartyNotVisible);
-    }
-
+    // is_manufacturer/is_donor are flags on name_row itself, so they are well-defined even for
+    // names with no name_store_join - check them before visibility, so that callers which allow
+    // invisible names (by ignoring OtherPartyNotVisible) still get the type check
     match other_party_type {
-        CheckOtherPartyType::Customer => {
-            if !other_party.is_customer() {
-                return Err(OtherPartyErrors::TypeMismatched);
-            }
-        }
-
-        CheckOtherPartyType::Supplier => {
-            if !other_party.is_supplier() {
-                return Err(OtherPartyErrors::TypeMismatched);
-            }
-        }
         CheckOtherPartyType::Manufacturer => {
             if !other_party.is_manufacturer() {
                 return Err(OtherPartyErrors::TypeMismatched);
@@ -122,8 +110,29 @@ pub fn check_other_party(
                 return Err(OtherPartyErrors::TypeMismatched);
             }
         }
+        _ => {}
+    };
+
+    if !other_party.is_visible() {
+        return Err(OtherPartyErrors::OtherPartyNotVisible);
+    }
+
+    // is_customer/is_supplier come from name_store_join, so they can only be checked for
+    // visible names
+    match other_party_type {
+        CheckOtherPartyType::Customer => {
+            if !other_party.is_customer() {
+                return Err(OtherPartyErrors::TypeMismatched);
+            }
+        }
+        CheckOtherPartyType::Supplier => {
+            if !other_party.is_supplier() {
+                return Err(OtherPartyErrors::TypeMismatched);
+            }
+        }
         // Already handled above
-        CheckOtherPartyType::Patient => {}
+        CheckOtherPartyType::Manufacturer | CheckOtherPartyType::Donor
+        | CheckOtherPartyType::Patient => {}
     };
 
     Ok(other_party)


### PR DESCRIPTION
Fixes #12672

# 👩🏻‍💻 What does this PR do?

Saving stocktake lines failed with `Bad user input: ManufacturerNotVisible` (`batchStocktakeLines`) when a line carried a manufacturer that has no `name_store_join` in the current store — even though the user never touched the manufacturer field. It's the stocktake counterpart of #12252.

**Why it happens:** a manufacturer can be configured centrally (e.g. on an item variant) or arrive on stock via sync, without being visible in the saving store. Stocktake creation copies `manufacturer_id` from each stock line onto its stocktake line with no validation, and the client echoes it back on every line save — the server then rejected it with `ManufacturerNotVisible`. The same check also fired on stocktake **finalise** (positive-delta lines go through `insert_stock_in_line`), surfacing as a generic `InternalError` for lines the user never edited. Those two surfaces can't be fixed client-side without silently destroying valid data.

**The fix:** treat an invisible-but-existing manufacturer as valid data, not an error — the same rule the codebase already applies to donors (`stock_in_line/insert/validate.rs`: "Invisible donors are allowed"). Manufacturer visibility remains a *picker-level* filter (`ManufacturerSearchInput` only lists visible names), just not a save-time validation. `ManufacturerDoesNotExist` and `ManufacturerIsNotAManufacturer` still error.

Changes:
- **Server** — tolerate `OtherPartyNotVisible` for manufacturers in `stocktake_line` insert/update, `stock_in_line` insert/update (fixes stocktake finalise + the latent inbound-shipment variant of this bug), and `stock_line` update (the original #12252 surface); removed the now-unused `ManufacturerNotVisible` error variants and their GraphQL mappings.
- **Client** — reverted the #12276 drop-and-warn in `NewStockLineModal`: selecting an item variant now keeps its manufacturer even when not visible in this store (the server accepts it, and a remote-store user couldn't re-add it once dropped). Removed the now-unused `messages.manufacturer-not-visible-dropped` translation key (en/fr/pt).

## 💌 Any notes for the reviewer?

- This intentionally takes the "allowing any manufacturer" option that was floated in the #12276 review, instead of patching each strict-validation surface one by one. #12252 itself asked for this: *"Ideally: I think we should be able to save stocklines even if manufacturer is not visible."*
- **Behaviour change from #12276:** the New Stock modal no longer drops a variant's not-visible manufacturer (and no longer warns) — it is kept on the stock line. The `isVisible` field on the item variant's manufacturer fragment is left in place (still used by `ItemVariantForm`).
- No structured GraphQL error types were removed — `ManufacturerNotVisible` was only ever a debug-formatted `BadUserInput`/`InternalError` string, so no client codegen is needed.

# 🧪 Tested

- New service test: `update_stocktake_line` succeeds when setting (and clearing) a manufacturer that exists but has no `name_store_join` for the store
- New service test: `insert_stocktake_line_with_invisible_manufacturer` succeeds and writes the manufacturer through to the stock line
- New regression test: `finalise_stocktake_with_manufacturer_not_visible_to_store` — finalising a stocktake with a positive count delta on a line carrying an invisible manufacturer succeeds and keeps the manufacturer on the stock line (mirrors the #11600 invisible-program test)
- `cargo nextest run -p service stocktake stock_in_line stock_line` and the affected GraphQL crates all pass
- Manual steps to verify:
  - [ ] On a store where some manufacturer is not visible (e.g. a dispensary on a remote site), create a stocktake over stock lines carrying that manufacturer
  - [ ] Edit a line (count/expiry/location) and save → no `ManufacturerNotVisible` error
  - [ ] Count a line above snapshot and finalise → succeeds, stock line keeps its manufacturer
  - [ ] Inventory → Stock → New stock: select an item variant whose manufacturer isn't visible → manufacturer field is filled (no warning) and the line saves

# 📃 Documentation

- [x] **No documentation required** — bug fix; the only user-visible change besides errors disappearing is that the New Stock modal no longer shows the "manufacturer not visible" warning snackbar
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`)
- [ ] **Developer docs needed** (`docs: internal`)
