### PR TITLE
Bump frontend pin to v0.0.355-rc0 on the RC branch

### DIFF
--- a/frontend-version.json
+++ b/frontend-version.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Which open-msupply-frontend release this repo ships. Bump tag to an FE release tag and sha256 to the value from its published frontend-dist-<tag>.zip.sha256 sidecar; build/fetch-frontend.js fetches and verifies it (see server/README.md, Serving front-end). v0.0.0-rc* tags are pre-release trial pins for proving the pipelines.",
   "repo": "msupply-foundation/open-msupply-frontend",
-  "tag": "v0.0.321",
-  "sha256": "b6a5c98f116db30a6bf2bbd78a59714a212e5ed40172e3fb1f26b5764c6612b0"
+  "tag": "v0.0.355-rc0",
+  "sha256": "8f22807bc66ac610c803224fb829becf0532f88f508bd74945ea77e39ee8f021"
 }


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Points the RC branch's `frontend-version.json` at a new-frontend dist actually built from the FE repo's `v3.01.00-RC` branch.

When the RC was cut, the pin stayed frozen at `v0.0.321` (a dist built from the FE repo's **main**) because `bump-frontend-pin.yaml` only commits bumps to `develop` — so every RC package (Android APK, Windows installers, Docker, mac) was shipping the main-branch new frontend instead of the RC one.

`v0.0.355-rc0` is a prerelease dist cut from the FE `v3.01.00-RC` head (`f516bb2`, includes the French catalog work and open-msupply-frontend#1148).

## 💌 Any notes for the reviewer?

- The FE-side tag `v0.0.355-rc0` was pushed to trigger the FE repo's `release-dist.yaml` on the RC branch; the release's check/test gate passed. Being a prerelease, develop's hourly `bump-frontend-pin` ignores it, so develop's pin is unaffected.
- Pin bumps on the RC branch stay manual until the monorepo: an FE RC fix needs a new `-rc<N>` tag over there and a bump like this one here.
- Related context: #12523 (dual-frontend serving / pinned FE dist fetch).

# 🧪 Tested

- Downloaded `frontend-dist-v0.0.355-rc0.zip` from the FE release and recomputed its sha256 — matches the pinned value (same verification `build/fetch-frontend.js` performs at package time).
- After merge, the next `v3.01.00-RC-*` tag (nightly or manual) builds the APK with this dist; the served `/VERSION.txt` should report `v0.0.355-rc0` / commit `f516bb2`.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
