### PR TITLE
Nightly tags: stop treating merge-*-RC-* branches as RC builds

### DIFF
--- a/.github/scripts/create-nightly-tags.sh
+++ b/.github/scripts/create-nightly-tags.sh
@@ -62,9 +62,13 @@ create_tag_for_branch() {
     fi
 }
 
-# Get all RC and develop branches
-RC_BRANCHES=$(git branch -r | grep -E 'v[0-9.]+-(R|r)(C|c)' | sed 's/.*origin\///')
-DEV_BRANCHES=$(git branch -r | grep -E 'v[0-9.]+-(dev|develop)$' | sed 's/.*origin\///')
+# Get all RC and develop branches. Match from 'origin/' so only branches whose
+# name STARTS with the version qualify: suffixed RC branches (v3.01.00-RC-fix-x)
+# still count, but prefixed ones like merge-v3.01.00-RC-to-develop don't — that
+# one carries develop's package version, so it minted v3.01.01-RC-* tags and
+# announced develop content on the RC release channel.
+RC_BRANCHES=$(git branch -r | grep -E 'origin/v[0-9.]+-(R|r)(C|c)' | sed 's/.*origin\///')
+DEV_BRANCHES=$(git branch -r | grep -E 'origin/v[0-9.]+-(dev|develop)$' | sed 's/.*origin\///')
 
 # Process all RC, develop branches, and the literal 'develop'
 for BRANCH in $RC_BRANCHES $DEV_BRANCHES 'develop'; do


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes the nightly tagger sweeping in branches that merely *contain* an RC-looking name.

<img width="492" height="237" alt="Screenshot 2026-08-20 at 12 21 53 pm" src="https://github.com/user-attachments/assets/a8c7572c-971c-43bc-b611-e681251eafb0" />

Noticed these builds in slack that didn't come from an RC branch. Turns out they came from `merge-v3.01.00-RC-to-develop` being matched as an RC branch...

`create-nightly-tags.sh` selected RC branches with an unanchored `grep -E 'v[0-9.]+-(R|r)(C|c)'`, which also matched `merge-v3.01.00-RC-to-develop`. That integration branch carries develop's package version (`3.01.01`), so every night it minted a `v3.01.01-RC-<date>` tag — building develop-plus-merge content (with develop's frontend pin, not the RC one) and announcing it on the **RC** Slack release channel as if it were an RC build. That's where the confusing mix of `v3.01.00-RC-*` and `v3.01.01-RC-*` tags came from.

The match is now anchored at `origin/`, so a branch only qualifies when its name *starts* with the version. Suffix-labelled RC branches (e.g. `v3.01.00-RC-fix-weird-bug`) still match; prefixed ones like `merge-…` don't. The develop pattern gets the same anchoring.

## 💌 Any notes for the reviewer?

- Verified against the current remote branch list: the old pattern picks up `merge-v3.01.00-RC-to-develop` + `v3.01.00-RC`; the new one picks up only the real RC branches.
- The existing `v3.01.01-RC-*` tags/builds already announced to testers are left alone — happy to clean those up separately if wanted.

# 🧪 Tested

- Ran both greps against `git branch -r` on the live repo and diffed the selections (only the `merge-…` branch drops out; `v2.10.00-RC` and `v3.01.00-RC` remain).
- After merge, the next nightly run's `create-tags` job log should list tags only for real RC/develop branches and mint no `v3.01.01-RC-*` tag.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
