### PR TITLE
#12692 Retry sync pulls when the connection drops mid-response body

### DIFF
--- a/server/service/src/sync/api/core.rs
+++ b/server/service/src/sync/api/core.rs
@@ -248,8 +248,34 @@ impl SyncApiV5 {
 pub(crate) const CENTRAL_BUSY_POLL_PERIOD_SECONDS: u64 = 15;
 pub(crate) const CENTRAL_BUSY_TIMEOUT_SECONDS: u64 = 30 * 60;
 
+// A transient transport failure on an idempotent read is retried in place, waiting this
+// long before each attempt. Attempts reset after any successful batch, so a long pull
+// isn't capped globally - only a persistently broken connection gives up.
+//
+// The first retry is immediate: a dropped connection is usually a momentary blip (proxy
+// dropping a long-lived connection, NAT timeout, network handover) that's over by the time
+// the next packet goes out, and `with_retries` retries transport failures with no wait at
+// all. The later waits cover what an instant retry can't - an outage lasting seconds, or a
+// central busy enough to be dropping connections, where retrying instantly would just burn
+// the attempt budget in a few hundred milliseconds.
+pub(crate) const TRANSIENT_RETRY_DELAYS_SECONDS: [u64; 3] = [0, 5, 30];
+
+/// "immediately" / "in 5s" - so the retry log reads properly when the delay is zero.
+pub(crate) fn retry_delay_description(delay_seconds: u64) -> String {
+    if delay_seconds == 0 {
+        "immediately".to_string()
+    } else {
+        format!("in {}s", delay_seconds)
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum ParsingResponseError {
+    /// The connection dropped part-way through the response body (reset, incomplete
+    /// message). Nothing was parsed - the body never arrived in full - so this is a
+    /// transport failure and the request can be retried.
+    #[error("Connection dropped while reading response body")]
+    ConnectionDropped(#[source] reqwest::Error),
     #[error("Cannot retrieve response body")]
     CannotGetTextResponse(#[from] reqwest::Error),
     #[error("Could not parse response body, response: '{response_text}'")]
@@ -259,13 +285,44 @@ pub enum ParsingResponseError {
     },
 }
 
+impl ParsingResponseError {
+    /// Classify a failed body read at the point it fails, so callers match on a variant
+    /// instead of re-deriving this from the error chain.
+    ///
+    /// Signature-based only: a genuine idle timeout stays `CannotGetTextResponse`, since
+    /// sync v5 deliberately doesn't retry those (see `with_retries_opts` -
+    /// server-side work continues after the client gives up, and retrying overlaps it).
+    pub(crate) fn from_body_read_error(error: reqwest::Error) -> Self {
+        if !error.is_status() && !error.is_builder() && util::chain_contains_transient_drop(&error)
+        {
+            Self::ConnectionDropped(error)
+        } else {
+            Self::CannotGetTextResponse(error)
+        }
+    }
+}
+
 pub(crate) async fn to_json<T: DeserializeOwned>(
     response: Response,
 ) -> Result<T, ParsingResponseError> {
     let url = util::redact_url_for_log(response.url());
     let started = std::time::Instant::now();
     // TODO not owned (to avoid double parsing)
-    let response_text = response.text().await?;
+    let response_text = match response.text().await {
+        Ok(text) => text,
+        // Headers already logged a successful response, so without this the log just
+        // stops - no "API body read" line, no explanation. Say what broke, here.
+        Err(error) => {
+            let error = ParsingResponseError::from_body_read_error(error);
+            log::warn!(
+                "API body read failed: url '{}', after {:.1}s: {}",
+                url,
+                started.elapsed().as_secs_f64(),
+                util::format_error(&error),
+            );
+            return Err(error);
+        }
+    };
     let elapsed = started.elapsed();
     let bytes = response_text.len();
     let kb_per_sec = (bytes as f64 / 1024.0) / elapsed.as_secs_f64().max(0.001);
@@ -341,6 +398,31 @@ mod tests {
     use util::assert_matches;
 
     use super::*;
+
+    /// A dropped response body while polling must not abort the wait: the poll loop
+    /// tolerates it via `is_transient()` and keeps going, so a truncated first reply
+    /// followed by a valid `Idle` reply still resolves to `Ok`.
+    #[actix_rt::test]
+    async fn test_wait_until_central_idle_retries_dropped_body() {
+        use crate::sync::api::test_helpers::{ScriptedResponse, ScriptedServer};
+
+        let server = ScriptedServer::start(vec![
+            ScriptedResponse::TruncatedBody {
+                content_length: 500,
+                body: r#"{"cod"#,
+            },
+            ScriptedResponse::Complete(
+                r#"{ "code": "idle", "message": "", "data": null }"#.to_string(),
+            ),
+        ]);
+
+        let api = SyncApiV5::new_test(server.url(), "", "", "site_id");
+
+        // 0s poll period keeps the test fast; the loop still makes two requests.
+        let result = api.wait_until_central_idle(0, 30).await;
+
+        assert!(result.is_ok(), "Expected Ok, got {:#?}", result);
+    }
 
     #[actix_rt::test]
     async fn test_headers() {

--- a/server/service/src/sync/api/error.rs
+++ b/server/service/src/sync/api/error.rs
@@ -31,7 +31,10 @@ pub enum SyncApiErrorVariantV5 {
     },
     #[error("Connection problem")]
     ConnectionError(#[from] reqwest::Error),
-    #[error("Could not parse response")]
+    // Transparent: the inner variant already says what happened (body dropped mid-read
+    // vs. unreadable vs. genuinely unparseable). A wrapper message here only ever claimed
+    // a parse was attempted, which for a dropped connection it never was.
+    #[error(transparent)]
     ResponseParsingError(#[from] ParsingResponseError),
     #[error("Could not parse url")]
     FailToParseUrl(#[from] ParseError),
@@ -96,7 +99,10 @@ impl SyncApiErrorVariantV5 {
 
         use ParsingResponseError::*;
         match error {
-            CannotGetTextResponse(source) => {
+            // The body we couldn't read was central's *error* body, so the error status is
+            // the more useful thing to report; whether to retry follows from that status,
+            // not from how the error body was lost.
+            ConnectionDropped(source) | CannotGetTextResponse(source) => {
                 SyncApiErrorVariantV5::ErrorParsingError { status, source }
             }
             ParseError {
@@ -134,10 +140,21 @@ impl SyncApiError {
         matches!(self.source, SyncApiErrorVariantV5::Other(_))
     }
 
-    /// Transient transport-level failure (dropped connection, unknown/unparseable error).
-    /// Safe to retry within a bounded polling loop rather than aborting it outright.
+    /// The connection dropped part-way through reading the response body - central
+    /// answered, then the socket died mid-stream. Distinct from `is_connection`, which
+    /// only covers failures to *establish* the connection.
+    pub(crate) fn is_dropped_response_body(&self) -> bool {
+        matches!(
+            &self.source,
+            SyncApiErrorVariantV5::ResponseParsingError(ParsingResponseError::ConnectionDropped(_))
+        )
+    }
+
+    /// Transient transport-level failure (dropped connection, dropped response body,
+    /// unknown/unparseable error). Safe to retry within a bounded polling loop rather
+    /// than aborting it outright.
     pub(crate) fn is_transient(&self) -> bool {
-        self.is_connection() || self.is_unknown()
+        self.is_connection() || self.is_unknown() || self.is_dropped_response_body()
     }
 
     /// Central is busy with another session for this site (sync / integration / initialisation in
@@ -410,6 +427,69 @@ mod test {
             .expect_err("Should result in error");
         assert!(!result.is_central_busy());
         assert!(result.is_connection());
+    }
+
+    /// The reported failure: central answers 200, then the connection dies part-way
+    /// through the response body. Nothing is parsed - the body never arrives in full - so
+    /// it must classify as a dropped body and be transient, not as a parse failure.
+    #[actix_rt::test]
+    async fn test_dropped_response_body_is_transient() {
+        use crate::sync::api::test_helpers::{ScriptedResponse, ScriptedServer};
+
+        let server = ScriptedServer::start(vec![ScriptedResponse::TruncatedBody {
+            content_length: 1000,
+            body: r#"{"maxCurs"#,
+        }]);
+
+        let result = create_api(server.url(), "", "")
+            .get_central_records(100, 2)
+            .await
+            .expect_err("Should result in error");
+
+        assert_matches!(
+            result,
+            SyncApiError {
+                source: SyncApiErrorVariantV5::ResponseParsingError(
+                    ParsingResponseError::ConnectionDropped(_)
+                ),
+                ..
+            }
+        );
+        assert!(result.is_dropped_response_body());
+        assert!(result.is_transient());
+        // Not a failure to *establish* the connection - that distinction still holds.
+        assert!(!result.is_connection());
+        // And it no longer claims something was parsed.
+        assert!(
+            util::format_error(&result).contains("Connection dropped while reading response body")
+        );
+    }
+
+    /// A body that arrives in full but isn't valid JSON is a protocol error, not a
+    /// transport one - retrying would fetch the same bytes.
+    #[actix_rt::test]
+    async fn test_unparseable_body_is_not_transient() {
+        use crate::sync::api::test_helpers::{ScriptedResponse, ScriptedServer};
+
+        let server = ScriptedServer::start(vec![ScriptedResponse::Complete(
+            "not json at all".to_string(),
+        )]);
+
+        let result = create_api(server.url(), "", "")
+            .get_central_records(100, 2)
+            .await
+            .expect_err("Should result in error");
+
+        assert_matches!(
+            result,
+            SyncApiError {
+                source: SyncApiErrorVariantV5::ResponseParsingError(
+                    ParsingResponseError::ParseError { .. }
+                ),
+                ..
+            }
+        );
+        assert!(!result.is_transient());
     }
 
     #[actix_rt::test]

--- a/server/service/src/sync/api/mod.rs
+++ b/server/service/src/sync/api/mod.rs
@@ -8,6 +8,8 @@ mod get_site_status;
 mod post_acknowledged_records;
 mod post_initialise;
 mod post_queued_records;
+#[cfg(test)]
+pub(crate) mod test_helpers;
 
 pub(crate) use self::common_records::*;
 pub use self::core::*;

--- a/server/service/src/sync/api/test_helpers.rs
+++ b/server/service/src/sync/api/test_helpers.rs
@@ -1,0 +1,95 @@
+use std::{
+    io::{Read, Write},
+    net::TcpListener,
+    thread,
+};
+
+/// One scripted reply, consumed by one incoming connection in order.
+pub(crate) enum ScriptedResponse {
+    /// Promise `content_length` bytes, send `body` (shorter), then drop the socket - the
+    /// client sees the connection die part-way through reading the response body.
+    TruncatedBody {
+        content_length: usize,
+        body: &'static str,
+    },
+    /// A complete `200` with this body.
+    Complete(String),
+}
+
+/// A minimal HTTP server that replies to each connection with the next scripted response.
+///
+/// `httpmock` can't truncate a response mid-body, which is the failure we need to
+/// reproduce: central answers `200 OK`, then the connection dies while the body streams.
+/// Requests are answered in order, so `[TruncatedBody, Complete]` reproduces
+/// "fails once, then succeeds on retry".
+///
+/// Only request headers are read, so scripted endpoints should be GETs (or POSTs whose
+/// body is small enough to fit the socket buffer).
+pub(crate) struct ScriptedServer {
+    url: String,
+}
+
+impl ScriptedServer {
+    pub(crate) fn start(responses: Vec<ScriptedResponse>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("Cannot bind test listener");
+        let url = format!(
+            "http://{}",
+            listener
+                .local_addr()
+                .expect("Cannot read test listener addr")
+        );
+
+        thread::spawn(move || {
+            for response in responses {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    return;
+                };
+                read_request_headers(&mut stream);
+
+                match response {
+                    ScriptedResponse::TruncatedBody {
+                        content_length,
+                        body,
+                    } => {
+                        let _ = write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                            content_length, body
+                        );
+                        let _ = stream.flush();
+                        // Dropping mid-body is the whole point: the client is left waiting
+                        // for bytes that never arrive.
+                        drop(stream);
+                    }
+                    ScriptedResponse::Complete(body) => {
+                        let _ = write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                            body.len(),
+                            body
+                        );
+                        let _ = stream.flush();
+                    }
+                }
+            }
+        });
+
+        ScriptedServer { url }
+    }
+
+    pub(crate) fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+/// Read up to the end of the request headers, so the client's write completes before we reply.
+fn read_request_headers(stream: &mut std::net::TcpStream) {
+    let mut request = Vec::new();
+    let mut buffer = [0u8; 1024];
+    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        match stream.read(&mut buffer) {
+            Ok(0) | Err(_) => return,
+            Ok(read) => request.extend_from_slice(&buffer[..read]),
+        }
+    }
+}

--- a/server/service/src/sync/api_v6/core.rs
+++ b/server/service/src/sync/api_v6/core.rs
@@ -186,3 +186,69 @@ impl SyncApiV6 {
         })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::sync::api::{
+        test_helpers::{ScriptedResponse, ScriptedServer},
+        ParsingResponseError, SyncApiV5,
+    };
+    use util::assert_matches;
+
+    fn api_v6(url: &str) -> SyncApiV6 {
+        let settings = SyncApiV5::new_test(url, "", "", "site_id").settings;
+        SyncApiV6::new(url, &settings, 1).unwrap()
+    }
+
+    /// Same failure as sync v5's `test_dropped_response_body_is_transient`: v6 reads its
+    /// body after the transport retry loop has returned, so it needs the same
+    /// classification to be retryable.
+    #[actix_rt::test]
+    async fn test_dropped_response_body_is_transient() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::TruncatedBody {
+            content_length: 1000,
+            body: r#"{"data": {"endC"#,
+        }]);
+
+        let result = api_v6(server.url())
+            .pull(0, 100, true)
+            .await
+            .expect_err("Should result in error");
+
+        assert_matches!(
+            result,
+            SyncApiErrorV6 {
+                source: SyncApiErrorVariantV6::ParsingResponseError(
+                    ParsingResponseError::ConnectionDropped(_)
+                ),
+                ..
+            }
+        );
+        assert!(result.is_transient());
+    }
+
+    /// A body that arrives in full but doesn't parse is not a transport fault.
+    #[actix_rt::test]
+    async fn test_unparseable_body_is_not_transient() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::Complete(
+            "not json at all".to_string(),
+        )]);
+
+        let result = api_v6(server.url())
+            .pull(0, 100, true)
+            .await
+            .expect_err("Should result in error");
+
+        assert_matches!(
+            result,
+            SyncApiErrorV6 {
+                source: SyncApiErrorVariantV6::ParsingResponseError(
+                    ParsingResponseError::ParseError { .. }
+                ),
+                ..
+            }
+        );
+        assert!(!result.is_transient());
+    }
+}

--- a/server/service/src/sync/api_v6/mod.rs
+++ b/server/service/src/sync/api_v6/mod.rs
@@ -121,10 +121,26 @@ pub enum SyncApiErrorVariantV6 {
     ConnectionError(#[from] reqwest::Error),
     #[error("Could not parse response")]
     ParsedError(#[from] SyncParsedErrorV6),
-    #[error("Could not parse response")]
+    // See sync v5's equivalent: let the inner variant speak.
+    #[error(transparent)]
     ParsingResponseError(#[from] ParsingResponseError),
     #[error("Unknown api error")]
     Other(#[from] anyhow::Error),
+}
+
+impl SyncApiErrorV6 {
+    /// Transient transport-level failure, safe to retry on an idempotent read.
+    /// Mirrors `SyncApiError::is_transient` for sync v5.
+    pub(crate) fn is_transient(&self) -> bool {
+        match &self.source {
+            SyncApiErrorVariantV6::ConnectionError(_) | SyncApiErrorVariantV6::Other(_) => true,
+            SyncApiErrorVariantV6::ParsingResponseError(error) => {
+                matches!(error, ParsingResponseError::ConnectionDropped(_))
+            }
+            // An error central deliberately returned - authoritative, not a transport fault.
+            SyncApiErrorVariantV6::ParsedError(_) => false,
+        }
+    }
 }
 
 #[derive(Deserialize, Debug, Serialize)]
@@ -259,10 +275,21 @@ async fn response_or_err<T: DeserializeOwned>(
     let url = util::redact_url_for_log(response.url());
     let started = std::time::Instant::now();
     // Not checking for status, expecting 200 only, even if there is error
-    let response_text = response
-        .text()
-        .await
-        .map_err(ParsingResponseError::CannotGetTextResponse)?;
+    let response_text = match response.text().await {
+        Ok(text) => text,
+        // Same as sync v5's `to_json`: classify the drop where it happens, and say so in
+        // the log rather than leaving a gap after the successful-headers line.
+        Err(error) => {
+            let error = ParsingResponseError::from_body_read_error(error);
+            log::warn!(
+                "API body read failed: url '{}', after {:.1}s: {}",
+                url,
+                started.elapsed().as_secs_f64(),
+                format_error(&error),
+            );
+            return Err(error.into());
+        }
+    };
     let elapsed = started.elapsed();
     let bytes = response_text.len();
     let kb_per_sec = (bytes as f64 / 1024.0) / elapsed.as_secs_f64().max(0.001);

--- a/server/service/src/sync/central_data_synchroniser.rs
+++ b/server/service/src/sync/central_data_synchroniser.rs
@@ -1,9 +1,10 @@
-use std::cmp;
+use std::{cmp, time::Duration};
 
 use super::{
     api::{
-        CommonSyncRecord, ParsingSyncRecordError, SyncApiError, SyncApiV5,
+        retry_delay_description, CommonSyncRecord, ParsingSyncRecordError, SyncApiError, SyncApiV5,
         CENTRAL_BUSY_POLL_PERIOD_SECONDS, CENTRAL_BUSY_TIMEOUT_SECONDS,
+        TRANSIENT_RETRY_DELAYS_SECONDS,
     },
     sync_status::logger::{SyncLogger, SyncLoggerError, SyncStepProgress},
 };
@@ -54,7 +55,10 @@ impl CentralDataSynchroniser {
 
             // Retry while central is busy with another sync session for this site
             // (legacy central gates sync per-site); wait for idle then re-request the
-            // same cursor.
+            // same cursor. Transient transport failures are retried with backoff for the
+            // same reason it's safe to: the cursor hasn't advanced, so re-requesting is
+            // a plain repeat of an idempotent read.
+            let mut transient_attempts = 0;
             let CentralSyncBatchV5 { max_cursor, data } = loop {
                 match self
                     .sync_api_v5
@@ -69,6 +73,22 @@ impl CentralDataSynchroniser {
                                 CENTRAL_BUSY_TIMEOUT_SECONDS,
                             )
                             .await?;
+                    }
+                    Err(error)
+                        if error.is_transient()
+                            && transient_attempts < TRANSIENT_RETRY_DELAYS_SECONDS.len() =>
+                    {
+                        let delay = TRANSIENT_RETRY_DELAYS_SECONDS[transient_attempts];
+                        transient_attempts += 1;
+                        log::warn!(
+                            "Pulling central records at cursor {} failed with a transient transport error (attempt {}/{}, retrying {}): {:#?}",
+                            start_cursor,
+                            transient_attempts,
+                            TRANSIENT_RETRY_DELAYS_SECONDS.len(),
+                            retry_delay_description(delay),
+                            error
+                        );
+                        tokio::time::sleep(Duration::from_secs(delay)).await;
                     }
                     Err(error) => return Err(error.into()),
                 }
@@ -107,5 +127,74 @@ impl CentralDataSynchroniser {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::sync::{
+        api::{
+            test_helpers::{ScriptedResponse, ScriptedServer},
+            SyncApiV5,
+        },
+        sync_status::logger::SyncLogger,
+    };
+    use repository::{mock::MockDataInserts, test_db, SyncBufferRowRepository};
+
+    /// The reported failure, at the level that has to survive it: central drops the
+    /// connection part-way through a batch body, the pull retries the same cursor, and the
+    /// batch from the retry lands in the sync buffer. Before this, the drop aborted the
+    /// whole sync run and the user had to press Retry.
+    #[actix_rt::test]
+    async fn test_pull_retries_dropped_response_body() {
+        let (_, connection, _, _) = test_db::setup_all(
+            "test_pull_retries_dropped_response_body",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        let server = ScriptedServer::start(vec![
+            // Attempt 1: headers, then the body is cut short.
+            ScriptedResponse::TruncatedBody {
+                content_length: 5000,
+                body: r#"{"maxCursor": 2, "data": [{"ID": 2, "tableN"#,
+            },
+            // Attempt 2 (the retry): the same cursor, served in full.
+            ScriptedResponse::Complete(
+                r#"{
+                    "maxCursor": 2,
+                    "data": [
+                        {
+                            "ID": 2,
+                            "tableName": "test_table_1",
+                            "recordId": "record_from_retry",
+                            "action": "delete"
+                        }
+                    ]
+                }"#
+                .to_string(),
+            ),
+            // Nothing left to pull - ends the loop.
+            ScriptedResponse::Complete(r#"{ "maxCursor": 2, "data": [] }"#.to_string()),
+        ]);
+
+        let synchroniser = CentralDataSynchroniser {
+            sync_api_v5: SyncApiV5::new_test(server.url(), "", "", "site_id"),
+        };
+
+        let mut logger = SyncLogger::start(&connection).unwrap();
+        let result = synchroniser.pull(&connection, 100, &mut logger).await;
+
+        assert!(result.is_ok(), "Expected Ok, got {:#?}", result);
+
+        // The record only exists in the response served to the retry.
+        let buffered = SyncBufferRowRepository::new(&connection)
+            .find_one_by_record_id("record_from_retry")
+            .unwrap();
+        assert!(
+            buffered.is_some(),
+            "Batch from the retried request was not saved"
+        );
     }
 }

--- a/server/service/src/sync/central_data_synchroniser_v6.rs
+++ b/server/service/src/sync/central_data_synchroniser_v6.rs
@@ -9,7 +9,10 @@ use crate::{
 };
 
 use super::{
-    api::{CommonSyncRecord, ParsingSyncRecordError, SyncApiSettings},
+    api::{
+        retry_delay_description, CommonSyncRecord, ParsingSyncRecordError, SyncApiSettings,
+        TRANSIENT_RETRY_DELAYS_SECONDS,
+    },
     api_v6::{SyncApiErrorV6, SyncApiV6, SyncApiV6CreatingError},
     get_sync_push_changelogs_filter,
     sync_status::logger::{SyncLogger, SyncLoggerError},
@@ -23,6 +26,44 @@ use repository::{
     ChangelogRepository, KeyType, RepositoryError, StorageConnection, SyncBufferRowRepository,
 };
 use thiserror::Error;
+
+/// Run an idempotent v6 read, retrying transient transport failures (dropped connection,
+/// dropped response body) with backoff before giving up.
+///
+/// Only for reads that can be repeated as-is: each attempt re-requests the same cursor,
+/// which hasn't advanced. Pushes are deliberately not retried this way - central may have
+/// integrated the batch and only lost the acknowledgement.
+async fn with_transient_retries<T, F, Fut>(
+    description: &str,
+    mut request: F,
+) -> Result<T, SyncApiErrorV6>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, SyncApiErrorV6>>,
+{
+    let mut attempts = 0;
+    loop {
+        match request().await {
+            Ok(result) => return Ok(result),
+            Err(error)
+                if error.is_transient() && attempts < TRANSIENT_RETRY_DELAYS_SECONDS.len() =>
+            {
+                let delay = TRANSIENT_RETRY_DELAYS_SECONDS[attempts];
+                attempts += 1;
+                log::warn!(
+                    "{} failed with a transient transport error (attempt {}/{}, retrying {}): {:#?}",
+                    description,
+                    attempts,
+                    TRANSIENT_RETRY_DELAYS_SECONDS.len(),
+                    retry_delay_description(delay),
+                    error
+                );
+                tokio::time::sleep(Duration::from_secs(delay)).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
 
 #[derive(Error, Debug)]
 pub(crate) enum CentralPullErrorV6 {
@@ -97,15 +138,17 @@ impl SynchroniserV6 {
         loop {
             let start_cursor = cursor_controller.get(connection)?;
 
+            let api = &self.sync_api_v6;
             let SyncBatchV6 {
                 end_cursor,
                 total_records,
                 is_last_batch,
                 records,
-            } = self
-                .sync_api_v6
-                .pull(start_cursor, batch_size, is_initialised)
-                .await?;
+            } = with_transient_retries(
+                &format!("Pulling v6 central records at cursor {}", start_cursor),
+                || api.pull(start_cursor, batch_size, is_initialised),
+            )
+            .await?;
 
             logger.progress(SyncStepProgress::PullCentralV6, total_records)?;
 
@@ -209,15 +252,17 @@ impl SynchroniserV6 {
 
         // TODO protection from infinite loop
         loop {
+            let api = &self.sync_api_v6;
             let SyncBatchV6 {
                 end_cursor,
                 total_records,
                 is_last_batch,
                 records,
-            } = self
-                .sync_api_v6
-                .patient_pull(patient_cursor, batch_size, fetch_patient_id.clone())
-                .await?;
+            } = with_transient_retries(
+                &format!("Pulling v6 patient records at cursor {}", patient_cursor),
+                || api.patient_pull(patient_cursor, batch_size, fetch_patient_id.clone()),
+            )
+            .await?;
 
             logger.progress(SyncStepProgress::PullCentralV6, total_records)?;
 

--- a/server/service/src/sync/remote_data_synchroniser.rs
+++ b/server/service/src/sync/remote_data_synchroniser.rs
@@ -252,6 +252,9 @@ impl RemoteDataSynchroniser {
         loop {
             // Retry while central is busy with another sync session for this site
             // (legacy central gates sync per-site); wait for idle then re-request.
+            // Transient transport failures are retried with backoff - records stay queued
+            // centrally until acknowledged, so re-requesting returns the same batch.
+            let mut transient_attempts = 0;
             let sync_batch = loop {
                 match self.sync_api_v5.get_queued_records(batch_size).await {
                     Ok(batch) => break batch,
@@ -262,6 +265,21 @@ impl RemoteDataSynchroniser {
                                 CENTRAL_BUSY_TIMEOUT_SECONDS,
                             )
                             .await?;
+                    }
+                    Err(error)
+                        if error.is_transient()
+                            && transient_attempts < TRANSIENT_RETRY_DELAYS_SECONDS.len() =>
+                    {
+                        let delay = TRANSIENT_RETRY_DELAYS_SECONDS[transient_attempts];
+                        transient_attempts += 1;
+                        log::warn!(
+                            "Pulling queued records failed with a transient transport error (attempt {}/{}, retrying {}): {:#?}",
+                            transient_attempts,
+                            TRANSIENT_RETRY_DELAYS_SECONDS.len(),
+                            retry_delay_description(delay),
+                            error
+                        );
+                        tokio::time::sleep(Duration::from_secs(delay)).await;
                     }
                     Err(error) => return Err(error.into()),
                 }

--- a/server/util/src/api_helper.rs
+++ b/server/util/src/api_helper.rs
@@ -180,14 +180,21 @@ fn is_connection_dropped(error: &reqwest::Error) -> bool {
 }
 
 /// Walk the error's source chain looking for a transient transport-drop signature.
-fn chain_contains_transient_drop(error: &(dyn std::error::Error + 'static)) -> bool {
+///
+/// Public so callers that read a response body *after* the retry loop above has returned
+/// (the body is read by the caller, not here) can classify the same failure the same way -
+/// see `ParsingResponseError::from_body_read_error` in the sync api.
+pub fn chain_contains_transient_drop(error: &(dyn std::error::Error + 'static)) -> bool {
     // hyper renders `IncompleteMessage` as "connection closed before message completed".
-    const SIGNATURES: [&str; 5] = [
+    const SIGNATURES: [&str; 6] = [
         "connection closed before message completed",
         "incompletemessage",
         "connection reset",
         "broken pipe",
         "unexpected end of file",
+        // hyper's `IncompleteBody`: the body ended before Content-Length was reached, i.e.
+        // the response was cut short. Same failure as a reset, just a clean FIN.
+        "end of file before message length reached",
     ];
 
     let mut current: Option<&(dyn std::error::Error + 'static)> = Some(error);
@@ -253,6 +260,34 @@ mod test {
     #[test]
     fn detects_connection_reset() {
         let error = chain(&["error sending request", "Connection reset by peer (os error 54)"]);
+        assert!(chain_contains_transient_drop(&error));
+    }
+
+    /// The chain reported from the field when a central server reset the connection
+    /// part-way through streaming a `/sync/v5/central_records` batch body. The drop
+    /// happens while *reading the body*, so it surfaces as a decode/body error rather
+    /// than the request-phase error `detects_connection_reset` covers.
+    #[test]
+    fn detects_body_read_reset() {
+        let error = chain(&[
+            "error decoding response body",
+            "request or response body error",
+            "error reading a body from connection",
+            "Connection reset by peer (os error 104)",
+        ]);
+        assert!(chain_contains_transient_drop(&error));
+    }
+
+    /// A body cut short with a clean FIN rather than a reset: hyper reports
+    /// `IncompleteBody` and the chain otherwise matches `detects_body_read_reset`.
+    #[test]
+    fn detects_truncated_body() {
+        let error = chain(&[
+            "error decoding response body",
+            "request or response body error",
+            "error reading a body from connection",
+            "end of file before message length reached",
+        ]);
         assert!(chain_contains_transient_drop(&error));
     }
 


### PR DESCRIPTION
Fixes #12692

# 👩🏻‍💻 What does this PR do?

A site's initial sync aborted on Pull central at 98850/105094 records. Central answered `200 OK`, then reset the connection part-way through streaming the batch body. That is a transport failure and should be retried, but it aborted the whole sync run and left the user to press Retry by hand — repeatedly, on a slow link.

It fell through both existing retry mechanisms:

1. **The transport retry never saw it.** `util::with_retries_opts` only wraps `client.execute(request)`, which returns as soon as response *headers* arrive. The body is read afterwards by the caller — `to_json` for v5, `response_or_err` for v6 — outside the retry loop entirely.
2. **The classifier didn't either.** The failure landed as `ResponseParsingError`, while `is_connection()` only matches `ConnectionError` (produced solely for `error.is_connect()`), so `is_transient()` was false and the pull loop returned early.

**The fix classifies the drop where it happens** rather than re-deriving it later: a new `ParsingResponseError::ConnectionDropped`, selected by `from_body_read_error` using the drop signatures `util::api_helper` already matches (`chain_contains_transient_drop`, now `pub`). Downstream, v5's `is_transient()` and v6's new `is_transient()` are plain variant matches.

Both v5 pull loops (`central_data_synchroniser.rs`, `remote_data_synchroniser.rs`) and both v6 read loops (`central_data_synchroniser_v6.rs` — `pull` and `patient_pull`) then retry the **same cursor**, which is a repeat of an idempotent read since the cursor is only committed per batch. Delays are `[0, 5, 30]` seconds: the first retry is immediate, because a dropped connection is usually a momentary blip and `with_retries` already retries transport failures with no wait at all; the later two cover outages an instant retry can't fix. Attempts reset after any successful batch, so a long pull isn't capped globally.

**It also fixes a misleading error message.** The old chain led with "Could not parse response" when nothing had been parsed — `to_json` fails at `response.text()` and never reaches `serde_json` — which sent the initial investigation towards a malformed-payload theory. The wrapper variants are now `#[error(transparent)]`, so the error reads:

```
Sync api error, url: '<central>/', route: '/sync/v5/central_records' -> [
    "Connection dropped while reading response body",
    "error decoding response body",
    "request or response body error",
    "error reading a body from connection",
    "Connection reset by peer (os error 104)",
]
```

The underlying OS error is still in the chain — nothing is lost, the misleading line is gone.

## 💌 Any notes for the reviewer?

**Pushes are deliberately not retried** — neither `post_queued_records` (v5) nor `SyncApiV6::push`. Central may have received and integrated the batch with only the acknowledgement lost, so an in-loop replay is a different risk class from replaying a read. Not a regression: the push cursor only advances on success, so the next sync run re-pushes anyway. Adding it later is the same one-arm change.

**Worth a specific look:**

- `ParsingResponseError::from_body_read_error` (`sync/api/core.rs`) — the classification predicate. It's signature-based on purpose: a genuine idle timeout stays `CannotGetTextResponse` and is *not* retried, matching v5's existing `retry_on_idle_timeout: false` policy (retrying there overlaps still-running server-side work and trips `sync_is_running`).
- One new signature in `api_helper.rs`: `"end of file before message length reached"`. A clean truncation reports that rather than "connection reset", so the original list would have missed half the cases. Found by writing the test, not by reading the code.
- `is_connection_dropped` and its `is_request()` guard are untouched — that predicate governs the in-loop transport retry and shouldn't start matching body errors.

**Behaviour changes reviewers should be aware of:** the sync error message text changes as shown above (nothing matches on that string — no frontend checks, no test assertions), and a transient drop now adds up to 35s before a run fails rather than failing instantly.

**Deliberately out of scope:** sync v7 on `develop` has the identical seam (`sync_v7/api/mod.rs` calls `with_retries`, then its own `response_or_err` reads `.text()` after the retry loop returns, and only maps `is_connect()` to a connection error). It needs the same treatment in a separate PR against `develop` — this branch targets the release line, where `sync_v7` doesn't exist.

Also noticed but not changed: v6's `ParsedError` variant *also* renders as "Could not parse response", though it represents an error central deliberately returned. Different code path; changing it would alter messages for unrelated sync failures.

# 🧪 Testing

The field failure needs a server that answers `200`, promises a `Content-Length`, then dies mid-body — `httpmock` can't truncate a response, so this PR adds `sync/api/test_helpers.rs`: a scripted `TcpListener` that replies to each connection in turn, making "fails once, then succeeds on retry" deterministic.

Automated (`cargo nextest run`, from `server/`):

- [ ] `cargo nextest run -p util api_helper` — both real-world chains classify as transient: the field's `Connection reset by peer (os error 104)`, and a clean truncation's `end of file before message length reached`. The existing `ignores_non_transient_errors` case still holds (a connect refusal must *not* match here).
- [ ] `cargo nextest run -p service --lib sync::api` — a truncated body gives `ResponseParsingError(ConnectionDropped(_))` and is transient; a complete-but-garbage body gives `ParseError` and is **not** transient. Asserted for both v5 and v6.
- [ ] `cargo nextest run -p service --lib sync::central_data_synchroniser` — `CentralDataSynchroniser::pull` against a truncate-then-succeed server completes, and the batch served to the *retry* is in the sync buffer.
- [ ] `cargo nextest run -p service --lib sync::api::core` — `wait_until_central_idle` survives a dropped body mid-poll instead of aborting the wait.
- [ ] `cargo nextest run -p service sync` — full sync suite, 175 tests.

Log check (this is what makes "was it retried?" answerable from a saved log — previously the log just stopped after the successful-headers line):

- [ ] Run the pull test with `RUST_LOG=info` and confirm the sequence: `API response: ... status 200` → `API body read failed: ... Connection dropped while reading response body` → `Pulling central records at cursor 0 failed with a transient transport error (attempt 1/3, retrying immediately)` → `API body read: ... 361 bytes`.

Optional manual check, if you want to see it against a real central: put a TCP proxy between a remote site and central (`toxiproxy` or a `socat` you can kill) and sever the connection during Pull central. Sync should log the retry and continue from the same cursor rather than dropping to the error screen.

# 📃 Documentation

- [ ] **Part of an epic**: documentation will be completed for the feature as a whole
- [x] **No documentation required**: no user facing changes or a bug fix which isn't a change in behaviour
- [ ] **These areas should be updated or checked**:
  1.
  2.


# 📃 Reviewer Checklist

The PR Reviewer(s) should fill out this section before approving the PR

**Issue Review**
- [ ] All requirements in original issue have been covered
- [ ] A follow up issue(s) have been created to cover additional requirements

**Tests Pass**
- [ ] Postgres
- [ ] SQLite
- [ ] Frontend
