### PR TITLE
Strip NUL characters from sync records before integration

### DIFF
--- a/server/service/src/sync/translation_and_integration.rs
+++ b/server/service/src/sync/translation_and_integration.rs
@@ -6,8 +6,9 @@ use super::{
 };
 use log::{debug, warn};
 use repository::*;
+use std::borrow::Cow;
 use std::collections::HashMap;
-use util::datetime_now;
+use util::{datetime_now, json_without_nulls};
 
 pub(crate) struct TranslationAndIntegration<'a> {
     connection: &'a StorageConnection,
@@ -41,6 +42,8 @@ impl<'a> TranslationAndIntegration<'a> {
         sync_record: &SyncBufferRow,
         translators: &SyncTranslators,
     ) -> Result<Vec<PullTranslateResult>, anyhow::Error> {
+        let sync_record = strip_nulls_from_sync_record(sync_record);
+        let sync_record = sync_record.as_ref();
         let mut translation_results = Vec::new();
 
         for translator in translators.iter() {
@@ -175,6 +178,27 @@ impl<'a> TranslationAndIntegration<'a> {
     }
 }
 
+/// Postgres text columns cannot store the NUL character (0x00), and legacy mSupply sometimes
+/// sends NUL padded strings, which fail to integrate with
+/// `invalid byte sequence for encoding "UTF8": 0x00`. Since a record that errors is not
+/// retried, the affected rows are then silently missing, so strip NULs out of the record
+/// before it is translated.
+///
+/// The sync buffer keeps the payload exactly as it was received, so what central sent is
+/// still available for debugging.
+///
+/// Records containing a NUL are very rare, so the common case is a read only scan of the
+/// record, no clone and no allocation.
+fn strip_nulls_from_sync_record(sync_record: &SyncBufferRow) -> Cow<'_, SyncBufferRow> {
+    match json_without_nulls(&sync_record.data) {
+        Cow::Borrowed(_) => Cow::Borrowed(sync_record),
+        Cow::Owned(data) => Cow::Owned(SyncBufferRow {
+            data: SyncRecordData(data),
+            ..sync_record.clone()
+        }),
+    }
+}
+
 impl IntegrationOperation {
     fn integrate(
         &self,
@@ -268,7 +292,33 @@ impl TranslationAndIntegrationResults {
 mod test {
     use super::*;
     use repository::mock::MockDataInserts;
+    use serde_json::json;
     use util::{assert_matches, uuid::uuid};
+
+    #[test]
+    fn test_strip_nulls_from_sync_record() {
+        let row = |data: serde_json::Value| SyncBufferRow {
+            data: SyncRecordData(data),
+            ..Default::default()
+        };
+
+        // Records without NULs are passed through, without a clone or an allocation
+        let without_nuls = row(json!({ "itemName": "Amoxicillin" }));
+        assert_matches!(
+            strip_nulls_from_sync_record(&without_nuls),
+            Cow::Borrowed(_)
+        );
+
+        // NUL padded strings, as sent by legacy mSupply, are stripped
+        let with_nuls = row(json!({
+            "itemName": "Amoxicillin\u{0000}\u{0000}",
+            "daily_usage": 1.0,
+        }));
+        assert_eq!(
+            strip_nulls_from_sync_record(&with_nuls).data.0,
+            json!({ "itemName": "Amoxicillin", "daily_usage": 1.0 })
+        );
+    }
 
     #[actix_rt::test]
     async fn test_fall_through_inner_transaction() {

--- a/server/service/src/sync_v7/serde.rs
+++ b/server/service/src/sync_v7/serde.rs
@@ -4,6 +4,7 @@ use repository::{
     syncv7::SyncRecordSerializeError, *,
 };
 use serde::de::DeserializeOwned;
+use util::json_without_nulls;
 
 use crate::sync_v7::{
     translations::{
@@ -151,7 +152,13 @@ pub(crate) fn deserialize(
     sync_context: &SyncContext,
 ) -> DeserializeResult {
     let changelog_insert = create_changelog(table_name.clone(), RowActionType::Upsert, row);
-    let data = &row.data;
+    // Postgres text columns cannot store the NUL character (0x00). Sqlite sites do accept
+    // NULs, so a NUL padded string that came from legacy mSupply can be pushed on to a
+    // Postgres server over v7, where it would fail to integrate with
+    // `invalid byte sequence for encoding "UTF8": 0x00`. Records containing a NUL are very
+    // rare, so the common case here is a read only scan of the record, no clone.
+    let data = json_without_nulls(&row.data);
+    let data = &*data;
     let upsert = match table_name {
         // Special
         ChangelogTableName::Store => return translate_store(connection, changelog_insert, data),

--- a/server/service/src/sync_v7/validate_translate_integrate.rs
+++ b/server/service/src/sync_v7/validate_translate_integrate.rs
@@ -651,6 +651,34 @@ mod test {
     }
 
     #[actix_rt::test]
+    async fn integrate_strips_nul_characters() {
+        // Sqlite sites accept NUL padded strings (as sent by legacy mSupply), and can
+        // push them on over v7. Postgres text columns cannot store a NUL, so they are
+        // stripped before integration rather than failing the record with
+        // `invalid byte sequence for encoding "UTF8": 0x00`.
+        let connection = setup("integrate_strips_nul_characters", MockDataInserts::none()).await;
+
+        let mut data = unit_data("u1");
+        data["name"] = serde_json::json!("Tablet\u{0000}\u{0000}");
+
+        SyncBufferRepository::new(&connection)
+            .insert_many(&[buffer_row("u1", SyncAction::Upsert, data)])
+            .unwrap();
+
+        integrate(&connection, None);
+
+        let unit = UnitRowRepository::new(&connection)
+            .find_one_by_id("u1")
+            .unwrap()
+            .expect("unit must exist after integration");
+        assert_eq!(unit.name, "Tablet");
+
+        let (result, error) = buffer_result(&connection, 1);
+        assert_eq!(result, Some(IntegrationResult::Success));
+        assert_eq!(error, None);
+    }
+
+    #[actix_rt::test]
     async fn integrate_marks_stale_delete_superseded() {
         // The #12610 shape: a stale Delete arrives in an earlier batch than the
         // record's re-create Upsert. The delete must be superseded, not applied

--- a/server/util/src/json.rs
+++ b/server/util/src/json.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 // https://github.com/serde-rs/json/issues/377#issuecomment-341490464
 pub fn merge_json(a: &mut serde_json::Value, b: &serde_json::Value) {
     match (a, b) {
@@ -9,5 +11,113 @@ pub fn merge_json(a: &mut serde_json::Value, b: &serde_json::Value) {
         (a, b) => {
             *a = b.clone();
         }
+    }
+}
+
+/// The NUL character, which Postgres text columns cannot store.
+const NUL: char = '\u{0000}';
+
+// Postgres text columns cannot store the NUL character (0x00), inserting a string that
+// contains one fails with `invalid byte sequence for encoding "UTF8": 0x00`. Legacy mSupply
+// sometimes sends NUL padded strings, and sqlite sites (which do accept NULs) can pass them
+// on to a Postgres server over sync.
+//
+// Note the helpers below operate on parsed json, not on serialised json text. A textual
+// replace of the escape sequence would also match the tail of an escaped backslash, in a
+// string that legitimately contains those six characters, leaving a dangling escape and
+// making the json unparsable.
+
+/// True if any string in `value` contains a NUL. Read only, so it can be used to avoid
+/// cloning the (vast majority of) records that don't need stripping.
+pub fn json_contains_nulls(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::String(string) => string.contains(NUL),
+        serde_json::Value::Array(values) => values.iter().any(json_contains_nulls),
+        serde_json::Value::Object(map) => map.values().any(json_contains_nulls),
+        // Numbers, bools and null cannot contain a NUL. Object keys are not checked, they map
+        // to struct fields when the record is deserialised, so never reach the database as a
+        // value.
+        _ => false,
+    }
+}
+
+/// Recursively remove NULs from every string in `value`.
+pub fn strip_json_nulls(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::String(string) => {
+            if string.contains(NUL) {
+                string.retain(|char| char != NUL);
+            }
+        }
+        serde_json::Value::Array(values) => values.iter_mut().for_each(strip_json_nulls),
+        serde_json::Value::Object(map) => map.values_mut().for_each(strip_json_nulls),
+        _ => {}
+    }
+}
+
+/// `value` with all NULs removed, borrowed unchanged when there are none to remove (the
+/// common case, so no clone and no allocation).
+pub fn json_without_nulls(value: &serde_json::Value) -> Cow<'_, serde_json::Value> {
+    if !json_contains_nulls(value) {
+        return Cow::Borrowed(value);
+    }
+
+    let mut owned = value.clone();
+    strip_json_nulls(&mut owned);
+    Cow::Owned(owned)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn json_without_nulls_removes_nuls_from_nested_strings() {
+        let value = json!({
+            "itemName": "Amoxicillin\u{0000}\u{0000}",
+            "comment": "no nuls here",
+            "quantity": 10.0,
+            "authorised": true,
+            "optionID": null,
+            "lines": [{ "name": "\u{0000}Paracetamol" }, "plain\u{0000}string"],
+        });
+
+        assert!(json_contains_nulls(&value));
+        assert_eq!(
+            json_without_nulls(&value).into_owned(),
+            json!({
+                "itemName": "Amoxicillin",
+                "comment": "no nuls here",
+                "quantity": 10.0,
+                "authorised": true,
+                "optionID": null,
+                "lines": [{ "name": "Paracetamol" }, "plainstring"],
+            })
+        );
+    }
+
+    #[test]
+    fn json_without_nulls_borrows_when_there_is_nothing_to_strip() {
+        let value = json!({ "itemName": "Amoxicillin", "quantity": 10.0 });
+
+        assert!(!json_contains_nulls(&value));
+        assert!(matches!(json_without_nulls(&value), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn json_without_nulls_keeps_literal_escape_sequence_text() {
+        // A field that legitimately contains the characters of the NUL escape sequence must
+        // be left alone, a textual replace would eat the escaped backslash and leave the
+        // serialised record unparsable
+        let value = json!({ "comment": r"\u0000" });
+
+        assert!(!json_contains_nulls(&value));
+        // Still parsable after a serialise round trip
+        let serialised = serde_json::to_string(&json_without_nulls(&value)).unwrap();
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&serialised).unwrap(),
+            value
+        );
     }
 }


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Postgres text columns cannot store the NUL character (`0x00`) — inserting a string
containing one fails with `invalid byte sequence for encoding "UTF8": 0x00`. Legacy mSupply
sometimes sends NUL padded strings, and a site running Postgres logs a burst of these on
integration:

```
ERROR:   invalid byte sequence for encoding "UTF8": 0x00
CONTEXT: unnamed portal parameter $3
STATEMENT: INSERT INTO "requisition_line" ("id", "requisition_id", "item_name", ...
```

`$3` there is `item_name`, so the item name arriving over sync carries a NUL. This is not
Postgres 18 specific — `0x00` has never been storable in a `text` column, and it is the only
byte a valid UTF-8 string can contain that Postgres rejects.

The record survives the trip into the sync buffer (`serde_json` escapes the NUL, so the
buffer holds the six-character escape sequence, which stores fine), and only fails once the
decoded string is bound as a parameter. Because a record that fails integration is marked as
integrated and never retried, **the affected rows go silently missing** — in the reported
case, most of the lines of a requisition.

The fix strips NULs from the parsed record before it is used:

- **v5/v6** — `strip_nulls_from_sync_record` in
  `server/service/src/sync/translation_and_integration.rs`, applied in
  `translate_sync_record` so it covers every translator.
- **v7** — applied in `deserialize` in `server/service/src/sync_v7/serde.rs`, which is the
  single funnel every v7 table (and every special-cased v7 translator) goes through.
- **Shared helpers** — `json_contains_nulls` / `strip_json_nulls` / `json_without_nulls` in
  `server/util/src/json.rs`.

## 💌 Any notes for the reviewer?

**Why v7 needs it too.** Sqlite happily stores NULs, so a sqlite site that took a NUL padded
string in over v5 can push it on to a Postgres server over v7, where it fails the same way.
So both incoming paths are covered.

**Why the stripping is json-aware rather than a textual replace.** Replacing the escape
sequence in the serialised record text looks equivalent but corrupts a field that
legitimately contains those same six characters: serialised, such a field holds an *escaped*
backslash followed by `u0000`, the replace matches starting at the second backslash, and the
record is left with a dangling escape and no longer parses — the same silent-drop outcome,
just with a different error. The helpers therefore walk the parsed json, where a NUL is
unambiguous. There is a unit test for exactly this case.

**Performance.** The integration path targets thousands of records per second, so the common
case must stay cheap. `json_without_nulls` does a read-only walk and returns `Cow::Borrowed`
when there is nothing to strip — no clone, no allocation, and nothing added to the write
path. Only a record that actually contains a NUL is cloned. For context, per record this
path already runs ~105 translator dispatches, a full `serde_json` deserialise, several FK
lookups, and a nested transaction (savepoint + release) on Postgres — all of which dominate.

**Not included.** Buffer rows that already failed on a live site are not re-queued by this
PR: they keep `integration_datetime`, so they won't retry on their own. That is being handled
manually on the affected server with a SQL script — find the rows with
`strpos(data, chr(92) || 'u0000') > 0` (`chr(92)` being the backslash, so this matches the
escape sequence as stored, and avoids `LIKE` treating the backslash as its escape character),
clear `integration_datetime` / `integration_error`, and let the next sync re-integrate them.
Happy to add a migration instead if reviewers would prefer it in the codebase.

**Also worth knowing.** Object keys are deliberately not sanitised — they map to struct field
names on deserialise and never reach the database as a value. And the real fix for the
reported data is still to clean the item name in legacy mSupply; this PR stops it taking rows
out on the way in.

# 🧪 Tested

- Added unit tests for the helpers in `server/util/src/json.rs`: NULs stripped from nested
  objects/arrays, `Cow::Borrowed` returned when there is nothing to strip, and a field
  containing the literal escape-sequence characters left untouched and still parsable after a
  serialise round trip
- Added `test_strip_nulls_from_sync_record` in `translation_and_integration.rs` covering the
  borrowed pass-through and the NUL-padded `itemName` case
- Added `integrate_strips_nul_characters` in `sync_v7/validate_translate_integrate.rs`, which
  pushes a NUL padded `unit.name` through the real v7 integrate path and asserts the row is
  stored clean with `IntegrationResult::Success` and no integration error
- `cargo nextest run -p service sync` — 266 passed, 0 failed (v5/v6 and v7 suites)
- `cargo nextest run -p util json::` — passed
- `cargo clippy -p service -p util --lib --tests` — no new warnings on the touched files

Not yet exercised against a live Postgres site with real NUL data — worth a reviewer check if
anyone has that datafile handy.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
