### PR TITLE
#12689 Fix DB pool exhaustion from plugin-backed item stats

### DIFF
--- a/server/graphql/core/src/loader/item_stats.rs
+++ b/server/graphql/core/src/loader/item_stats.rs
@@ -4,8 +4,25 @@ use actix_web::web::Data;
 use async_graphql::dataloader::*;
 use chrono::NaiveDate;
 use ordered_float::OrderedFloat;
-use service::{item_stats::ItemStats, service_provider::ServiceProvider};
+use service::{
+    item_stats::{item_stats_uses_plugin, ItemStats},
+    service_provider::ServiceProvider,
+};
 use std::collections::HashMap;
+use tokio::sync::Semaphore;
+
+/// Batch sizes at or above this are "bulk" (report-scale) and compete for BULK_STATS_PERMITS;
+/// interactive batches (item detail, search results, list pages — typically 20-25 keys) bypass
+/// the cap so they never queue behind a report's bulk batches.
+const BULK_BATCH_SIZE: usize = 100;
+
+/// With an AMC/consumption plugin installed, each bulk stats batch is a full backend-plugin run
+/// (JS engine parse + heavy ledger SQL) that pins a pool connection for its whole duration. A
+/// report fans out into many such batches; letting them all take connections concurrently
+/// exhausted the pool and wedged the server (issue #12689). Bulk batches take a permit BEFORE
+/// checking out a connection, so however many batches a report shatters into, this loader holds
+/// at most 2 pool connections at a time (+1 for a concurrent interactive batch).
+static BULK_STATS_PERMITS: Semaphore = Semaphore::const_new(2);
 
 pub struct ItemsStatsForItemLoader {
     pub service_provider: Data<ServiceProvider>,
@@ -63,6 +80,22 @@ impl Loader<ItemStatsLoaderInput> for ItemsStatsForItemLoader {
         }
 
         let service_provider = self.service_provider.clone();
+
+        // The permit is acquired here — before the blocking task checks out a pool connection —
+        // so queued bulk batches wait without holding anything. Acquiring it after the
+        // connection would let 10 queued batches pin all 10 connections while they wait, which
+        // is exactly the exhaustion this guards against. Held (moved into scope) until the
+        // batch's computation finishes. Interactive-sized batches skip the queue entirely.
+        let _bulk_permit = if loader_inputs.len() >= BULK_BATCH_SIZE && item_stats_uses_plugin() {
+            Some(
+                BULK_STATS_PERMITS
+                    .acquire()
+                    .await
+                    .expect("BULK_STATS_PERMITS is never closed"),
+            )
+        } else {
+            None
+        };
 
         // get_item_stats is synchronous and may invoke the average_monthly_consumption /
         // get_consumption plugins (the whole boajs interpreter, including any blocking http). Run

--- a/server/graphql/core/src/loader/item_stock_on_hand.rs
+++ b/server/graphql/core/src/loader/item_stock_on_hand.rs
@@ -26,10 +26,10 @@ impl ItemsStockOnHandLoaderInput {
 /// `available` excludes held/reserved packs; `total` is all packs. Exposing both
 /// lets `ItemNode.stockOnHand` be served from this loader instead of the much more
 /// expensive item-stats path (which runs the AMC backend plugin).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub struct ItemStockOnHand {
-    pub available_stock_on_hand: u32,
-    pub total_stock_on_hand: u32,
+    pub available_stock_on_hand: f64,
+    pub total_stock_on_hand: f64,
 }
 
 impl Loader<ItemsStockOnHandLoaderInput> for ItemsStockOnHandLoader {
@@ -64,8 +64,8 @@ impl Loader<ItemsStockOnHandLoaderInput> for ItemsStockOnHandLoader {
                         &stock_on_hand.item_id,
                     ),
                     ItemStockOnHand {
-                        available_stock_on_hand: stock_on_hand.available_stock_on_hand as u32,
-                        total_stock_on_hand: stock_on_hand.total_stock_on_hand as u32,
+                        available_stock_on_hand: stock_on_hand.available_stock_on_hand,
+                        total_stock_on_hand: stock_on_hand.total_stock_on_hand,
                     },
                 )
             })

--- a/server/graphql/core/src/loader/loader_registry.rs
+++ b/server/graphql/core/src/loader/loader_registry.rs
@@ -185,12 +185,18 @@ pub async fn get_loaders(
         tokio::spawn,
     );
 
+    // Item stats can be plugin-backed and very expensive per batch, and a report resolves stats
+    // on thousands of item nodes whose keys trickle in over time. The default 1ms coalescing
+    // window shatters them into many batches — each a separate plugin run holding a pool
+    // connection (#12689). A wider window collects a report's worth of keys into few batches;
+    // +50ms latency is imperceptible on interactive queries.
     let item_stats_for_item_loader = DataLoader::new(
         ItemsStatsForItemLoader {
             service_provider: service_provider.clone(),
         },
         tokio::spawn,
-    );
+    )
+    .delay(std::time::Duration::from_millis(50));
 
     let requisition_line_supply_status_loader = DataLoader::new(
         RequisitionLineSupplyStatusLoader {

--- a/server/graphql/general/src/queries/tests/item_stats.rs
+++ b/server/graphql/general/src/queries/tests/item_stats.rs
@@ -66,5 +66,46 @@ mod tests {
         );
 
         assert_graphql_query!(&settings, query, &Some(variables.clone()), &expected, None);
+
+        // When only stock-on-hand fields are selected, stats short-circuits to the cheap
+        // ItemsStockOnHandLoader (no consumption/AMC computation). Same figures expected.
+        let soh_only_query = r#"
+        query($filter: ItemFilterInput) {
+          items(filter: $filter, storeId: \"store_a\") {
+            ... on ItemConnector {
+              nodes {
+                id
+                stats(storeId: \"store_a\") {
+                    __typename
+                    availableStockOnHand
+                    stockOnHand
+                }
+              }
+            }
+          }
+       }
+        "#;
+
+        let expected = json!({
+            "items": {
+                "nodes": [{
+                    "id": &test_item_stats::item().id,
+                    "stats": {
+                        "__typename": "ItemStatsNode",
+                        "availableStockOnHand": test_item_stats::item_1_soh(),
+                    }
+                },
+                {
+                    "id": &test_item_stats::item2().id,
+                    "stats": {
+                        "__typename": "ItemStatsNode",
+                        "availableStockOnHand": test_item_stats::item_2_soh(),
+                    },
+                }]
+            }
+        }
+        );
+
+        assert_graphql_query!(&settings, soh_only_query, &Some(variables), &expected, None);
     }
 }

--- a/server/graphql/types/src/types/item.rs
+++ b/server/graphql/types/src/types/item.rs
@@ -23,7 +23,7 @@ use graphql_core::{
 };
 use repository::{category_row::CategoryRow, Item, ItemRow};
 use serde_json::json;
-use service::ListResult;
+use service::{item_stats::ItemStats, ListResult};
 
 #[derive(PartialEq, Debug)]
 pub struct ItemNode {
@@ -124,6 +124,31 @@ impl ItemNode {
         #[graphql(desc = "Defaults to 3 months")] amc_lookback_months: Option<f64>,
         period_end: Option<NaiveDate>,
     ) -> Result<ItemStatsNode> {
+        // The full item-stats path computes consumption and runs the AMC backend plugin —
+        // far too expensive when the query only selects stock on hand (e.g. the item list
+        // export asks for stats { stockOnHand } across every item). Serve those selections
+        // from the cheap batched stock_on_hand loader instead.
+        let only_stock_on_hand = ctx.field().selection_set().all(|field| {
+            matches!(
+                field.name(),
+                "stockOnHand" | "availableStockOnHand" | "__typename"
+            )
+        });
+        if only_stock_on_hand {
+            let loader = ctx.get_loader::<DataLoader<ItemsStockOnHandLoader>>();
+            let stock_on_hand = loader
+                .load_one(ItemsStockOnHandLoaderInput::new(&store_id, &self.row().id))
+                .await?
+                .unwrap_or_default();
+
+            return Ok(ItemStatsNode::from_domain(ItemStats {
+                item_id: self.row().id.clone(),
+                available_stock_on_hand: stock_on_hand.available_stock_on_hand,
+                total_stock_on_hand: stock_on_hand.total_stock_on_hand,
+                ..Default::default()
+            }));
+        }
+
         let loader = ctx.get_loader::<DataLoader<ItemsStatsForItemLoader>>();
         let result = loader
             .load_one(ItemStatsLoaderInput::new(
@@ -172,7 +197,7 @@ impl ItemNode {
         let result = loader
             .load_one(ItemsStockOnHandLoaderInput::new(&store_id, &self.row().id))
             .await?
-            .map(|soh| soh.available_stock_on_hand)
+            .map(|soh| soh.available_stock_on_hand as u32)
             .unwrap_or(0);
 
         Ok(result)
@@ -187,7 +212,7 @@ impl ItemNode {
         let result = loader
             .load_one(ItemsStockOnHandLoaderInput::new(&store_id, &self.row().id))
             .await?
-            .map(|soh| soh.total_stock_on_hand)
+            .map(|soh| soh.total_stock_on_hand as u32)
             .unwrap_or(0);
 
         Ok(result)

--- a/server/service/src/boajs/context.rs
+++ b/server/service/src/boajs/context.rs
@@ -1,5 +1,7 @@
 use crate::service_provider::ServiceProvider;
 use actix_web::web::Data;
+use repository::{RepositoryError, StorageConnection};
+use std::cell::Cell;
 use std::sync::RwLock;
 
 use std::sync::Arc;
@@ -48,5 +50,82 @@ impl BoaJsContext {
             .expect("Global boajs context is not present")
             .graphql
             .clone()
+    }
+}
+
+thread_local! {
+    // Plugins execute synchronously on the calling thread (see call_method), so a caller that
+    // already holds a pool connection can lend it to the plugin's `sql()`/`use_repository()`
+    // bindings for the duration of the call. Without this, a plugin invocation checks out a
+    // second pool connection while the caller's one is pinned — under concurrent item-stats
+    // load that double-hold exhausts the pool (issue #12689).
+    static SHARED_CONNECTION: Cell<*const StorageConnection> = const { Cell::new(std::ptr::null()) };
+}
+
+/// Makes `connection` available to any boajs plugin methods invoked (on this thread) inside `f`,
+/// so they reuse it instead of checking out additional pool connections.
+pub fn with_shared_connection<R>(connection: &StorageConnection, f: impl FnOnce() -> R) -> R {
+    struct ResetGuard(*const StorageConnection);
+    impl Drop for ResetGuard {
+        fn drop(&mut self) {
+            SHARED_CONNECTION.with(|cell| cell.set(self.0));
+        }
+    }
+
+    let previous = SHARED_CONNECTION.with(|cell| cell.replace(connection as *const _));
+    // Restores the previous value even on unwind, so the pointer can never outlive `connection`.
+    let _guard = ResetGuard(previous);
+    f()
+}
+
+/// Runs `f` with the connection lent by an enclosing `with_shared_connection`, or with a fresh
+/// pool connection when there is none. For use by boajs method bindings only.
+pub(crate) fn use_boajs_connection<R>(
+    f: impl FnOnce(&StorageConnection) -> R,
+) -> Result<R, RepositoryError> {
+    SHARED_CONNECTION.with(|cell| {
+        let ptr = cell.get();
+        if ptr.is_null() {
+            let connection = BoaJsContext::service_provider().connection()?;
+            Ok(f(&connection))
+        } else {
+            // SAFETY: `ptr` is only ever set by `with_shared_connection`, whose guard clears it
+            // before the borrowed connection goes out of scope, and it is thread-local — so a
+            // non-null pointer here always refers to a live connection owned further up this
+            // thread's stack.
+            Ok(f(unsafe { &*ptr }))
+        }
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use repository::{mock::MockDataInserts, test_db};
+
+    #[actix_rt::test]
+    async fn shared_connection_is_lent_and_restored() {
+        let (_, _, connection_manager, _) = test_db::setup_all(
+            "shared_connection_is_lent_and_restored",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        let connection_a = connection_manager.connection().unwrap();
+        let connection_b = connection_manager.connection().unwrap();
+        let ptr_a = &connection_a as *const StorageConnection;
+        let ptr_b = &connection_b as *const StorageConnection;
+
+        let seen = |expected: *const StorageConnection| {
+            let seen = use_boajs_connection(|c| c as *const StorageConnection).unwrap();
+            assert_eq!(seen, expected);
+        };
+
+        with_shared_connection(&connection_a, || {
+            seen(ptr_a);
+            // A nested lend wins while in scope, and the outer one is restored on exit
+            with_shared_connection(&connection_b, || seen(ptr_b));
+            seen(ptr_a);
+        });
     }
 }

--- a/server/service/src/boajs/context.rs
+++ b/server/service/src/boajs/context.rs
@@ -64,7 +64,33 @@ thread_local! {
 
 /// Makes `connection` available to any boajs plugin methods invoked (on this thread) inside `f`,
 /// so they reuse it instead of checking out additional pool connections.
+///
+/// Lending is deliberately skipped when `connection` is already inside a transaction, because
+/// sharing it there would pull plugin statements into the caller's transaction:
+///
+/// - On postgres a failed statement aborts the whole transaction, and `sql()` hands the error to
+///   the plugin as a catchable JS error — so a plugin that swallows it would leave the caller's
+///   transaction poisoned and failing later for no visible reason.
+/// - Plugin writes (`use_repository` upserts) would roll back with the caller instead of
+///   persisting independently, and plugin reads would see the caller's uncommitted rows.
+///
+/// Those paths (requisition create/update, which call `get_item_stats` inside `transaction_sync`)
+/// keep the previous isolated behaviour and check out their own connection as before. The pool
+/// exhaustion this exists to fix (#12689) is in the graphql dataloader fan-out, which is not
+/// transactional.
 pub fn with_shared_connection<R>(connection: &StorageConnection, f: impl FnOnce() -> R) -> R {
+    // A transaction manager in an error state can't tell us the depth; treat that as "in a
+    // transaction" so we never lend a connection whose state we can't reason about.
+    let in_transaction = connection
+        .lock()
+        .transaction_level::<RepositoryError>()
+        .map(|level| level > 0)
+        .unwrap_or(true);
+
+    if in_transaction {
+        return f();
+    }
+
     struct ResetGuard(*const StorageConnection);
     impl Drop for ResetGuard {
         fn drop(&mut self) {
@@ -101,7 +127,24 @@ pub(crate) fn use_boajs_connection<R>(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::boajs::utils::{ExecuteGraphQlError, ExecuteGraphql};
     use repository::{mock::MockDataInserts, test_db};
+
+    // `use_boajs_connection`'s fallback path reads the global boajs context to check out a pool
+    // connection, and binding that context requires an ExecuteGraphql impl. These tests never
+    // call graphql, so a no-op stub is enough.
+    struct NoopGraphql;
+    #[async_trait::async_trait]
+    impl ExecuteGraphql for NoopGraphql {
+        async fn execute_graphql(
+            &self,
+            _: &str,
+            _: &str,
+            _: serde_json::Value,
+        ) -> Result<serde_json::Value, ExecuteGraphQlError> {
+            unreachable!("connection lending does not use graphql")
+        }
+    }
 
     #[actix_rt::test]
     async fn shared_connection_is_lent_and_restored() {
@@ -127,5 +170,38 @@ mod test {
             with_shared_connection(&connection_b, || seen(ptr_b));
             seen(ptr_a);
         });
+    }
+
+    /// A connection that is already in a transaction must not be lent — plugin statements would
+    /// otherwise join the caller's transaction. See `with_shared_connection`.
+    #[actix_rt::test]
+    async fn shared_connection_is_not_lent_inside_a_transaction() {
+        let (_, _, connection_manager, _) = test_db::setup_all(
+            "shared_connection_is_not_lent_inside_a_transaction",
+            MockDataInserts::none(),
+        )
+        .await;
+
+        let service_provider = Data::new(ServiceProvider::new(connection_manager.clone()));
+        BoaJsContext::new(&service_provider, NoopGraphql).bind();
+
+        let connection = connection_manager.connection().unwrap();
+        let uuid = connection.uuid().to_string();
+        let seen_uuid = || use_boajs_connection(|c| c.uuid().to_string()).unwrap();
+
+        // Outside a transaction the connection is lent, as usual
+        with_shared_connection(&connection, || assert_eq!(seen_uuid(), uuid));
+
+        // Inside one it isn't: the binding falls back to its own pool connection
+        connection
+            .transaction_sync(|tx_connection| -> Result<(), RepositoryError> {
+                assert_eq!(tx_connection.uuid(), uuid);
+                with_shared_connection(tx_connection, || assert_ne!(seen_uuid(), uuid));
+                Ok(())
+            })
+            .unwrap();
+
+        // ... and the lend works again once the transaction has closed
+        with_shared_connection(&connection, || assert_eq!(seen_uuid(), uuid));
     }
 }

--- a/server/service/src/boajs/methods/get_plugin_data.rs
+++ b/server/service/src/boajs/methods/get_plugin_data.rs
@@ -1,7 +1,7 @@
 use boa_engine::*;
 use repository::{PluginDataFilter, PluginDataRepository, PluginDataRow};
 
-use crate::{boajs::context::BoaJsContext, boajs::utils::*};
+use crate::{boajs::context::use_boajs_connection, boajs::utils::*};
 
 pub(crate) fn bind_method(context: &mut Context) -> Result<(), JsError> {
     context.register_global_callable(
@@ -11,16 +11,13 @@ pub(crate) fn bind_method(context: &mut Context) -> Result<(), JsError> {
             let filter: PluginDataFilter = get_serde_argument(ctx, args, 0)?;
 
             // When using BoaJsContext, it's best to use 'scope' see PluginContext for a link to testing repo
-            let plugin_data: Vec<PluginDataRow> = {
-                let service_provider = BoaJsContext::service_provider();
-                let connection = service_provider
-                    .connection()
-                    .map_err(std_error_to_js_error)?;
+            let plugin_data: Vec<PluginDataRow> = use_boajs_connection(|connection| {
                 // TODO pagination or restrictions ?
-                PluginDataRepository::new(&connection)
+                PluginDataRepository::new(connection)
                     .query_by_filter(filter)
                     .map_err(std_error_to_js_error)
-            }?
+            })
+            .map_err(std_error_to_js_error)??
             .into_iter()
             .map(|r| r.plugin_data)
             .collect();

--- a/server/service/src/boajs/methods/get_store_preferences.rs
+++ b/server/service/src/boajs/methods/get_store_preferences.rs
@@ -1,7 +1,8 @@
 use boa_engine::*;
 
 use crate::{
-    boajs::context::BoaJsContext, boajs::utils::*, store_preference::get_store_preferences,
+    boajs::context::use_boajs_connection, boajs::utils::*,
+    store_preference::get_store_preferences,
 };
 
 pub(crate) fn bind_method(context: &mut Context) -> Result<(), JsError> {
@@ -12,14 +13,10 @@ pub(crate) fn bind_method(context: &mut Context) -> Result<(), JsError> {
             let store_id = get_string_argument(args, 0)?;
 
             // When using BoaJsContext, it's best to use 'scope' see BoaJsContext for a link to testing repo
-            let preferences = {
-                let service_provider = BoaJsContext::service_provider();
-                let connection = service_provider
-                    .connection()
-                    .map_err(std_error_to_js_error)?;
-
-                get_store_preferences(&connection, &store_id).map_err(std_error_to_js_error)
-            }?;
+            let preferences = use_boajs_connection(|connection| {
+                get_store_preferences(connection, &store_id).map_err(std_error_to_js_error)
+            })
+            .map_err(std_error_to_js_error)??;
 
             let value: serde_json::Value =
                 serde_json::to_value(&preferences).map_err(std_error_to_js_error)?;

--- a/server/service/src/boajs/methods/sql.rs
+++ b/server/service/src/boajs/methods/sql.rs
@@ -2,7 +2,7 @@ use boa_engine::*;
 use repository::{raw_query, JsonRawRow};
 use util::format_error;
 
-use crate::boajs::{context::BoaJsContext, utils::*};
+use crate::boajs::{context::use_boajs_connection, utils::*};
 
 // SQL method accepts first argument as SQL string
 // TODO add the json row wrapper, so that consumer doesn't need to add "json_object" or "row_to_json"
@@ -15,15 +15,12 @@ pub(crate) fn bind_method(context: &mut Context) -> Result<(), JsError> {
             let sql = get_string_argument(args, 0)?;
 
             // When using BoaJsContext, it's best to use 'scope' see PluginContext for a link to testing repo
-            let results = {
-                let service_provider = BoaJsContext::service_provider();
-                let connection = service_provider
-                    .connection()
-                    .map_err(std_error_to_js_error)?;
-                raw_query(&connection, sql.clone())
+            let results = use_boajs_connection(|connection| -> Result<Vec<JsonRawRow>, JsError> {
+                raw_query(connection, sql.clone())
                     .inspect_err(|e| log::error!("{} {sql}", format_error(e)))
                     .map_err(std_error_to_js_error)
-            }?;
+            })
+            .map_err(std_error_to_js_error)??;
 
             let as_json: Vec<serde_json::Value> = results
                 .into_iter()

--- a/server/service/src/boajs/methods/use_repository.rs
+++ b/server/service/src/boajs/methods/use_repository.rs
@@ -6,7 +6,7 @@ use repository::{
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
-use crate::{boajs::context::BoaJsContext, boajs::utils::*};
+use crate::{boajs::context::use_boajs_connection, boajs::utils::*};
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[serde(tag = "t", content = "v")]
@@ -34,38 +34,37 @@ pub(crate) fn bind_method(context: &mut Context) -> Result<(), JsError> {
             let input: UseRepositoryInput = get_serde_argument(ctx, args, 0)?;
 
             // When using BoaJsContext, it's best to use 'scope'
-            let output: UseRepositoryOutput = {
-                let service_provider = BoaJsContext::service_provider();
-                let connection = service_provider
-                    .connection()
-                    .map_err(std_error_to_js_error)?;
+            let output: UseRepositoryOutput = use_boajs_connection(
+                |connection| -> Result<UseRepositoryOutput, JsError> {
+                    use UseRepositoryInput as In;
+                    use UseRepositoryOutput as Out;
 
-                use UseRepositoryInput as In;
-                use UseRepositoryOutput as Out;
-
-                match input {
-                    In::GetSyncMessageById(id) => Out::GetSyncMessageById(
-                        SyncMessageRowRepository::new(&connection)
-                            .find_one_by_id(&id)
-                            .map_err(std_error_to_js_error)?,
-                    ),
-                    In::UpsertSyncMessage(message_row) => Out::UpsertSyncMessage(
-                        SyncMessageRowRepository::new(&connection)
-                            .upsert_one(&message_row)
-                            .map_err(std_error_to_js_error)?,
-                    ),
-                    In::UpsertPluginData(plugin_data_row) => Out::UpsertPluginData(
-                        PluginDataRowRepository::new(&connection)
-                            .upsert_one(&plugin_data_row)
-                            .map_err(std_error_to_js_error)?,
-                    ),
-                    In::GetDaysOutOfStock(filter) => Out::GetDaysOutOfStock(
-                        DaysOutOfStockRepository::new(&connection)
-                            .query(filter)
-                            .map_err(std_error_to_js_error)?,
-                    ),
-                }
-            };
+                    let output = match input {
+                        In::GetSyncMessageById(id) => Out::GetSyncMessageById(
+                            SyncMessageRowRepository::new(connection)
+                                .find_one_by_id(&id)
+                                .map_err(std_error_to_js_error)?,
+                        ),
+                        In::UpsertSyncMessage(message_row) => Out::UpsertSyncMessage(
+                            SyncMessageRowRepository::new(connection)
+                                .upsert_one(&message_row)
+                                .map_err(std_error_to_js_error)?,
+                        ),
+                        In::UpsertPluginData(plugin_data_row) => Out::UpsertPluginData(
+                            PluginDataRowRepository::new(connection)
+                                .upsert_one(&plugin_data_row)
+                                .map_err(std_error_to_js_error)?,
+                        ),
+                        In::GetDaysOutOfStock(filter) => Out::GetDaysOutOfStock(
+                            DaysOutOfStockRepository::new(connection)
+                                .query(filter)
+                                .map_err(std_error_to_js_error)?,
+                        ),
+                    };
+                    Ok(output)
+                },
+            )
+            .map_err(std_error_to_js_error)??;
 
             let value: serde_json::Value =
                 serde_json::to_value(&output).map_err(std_error_to_js_error)?;

--- a/server/service/src/item_stats.rs
+++ b/server/service/src/item_stats.rs
@@ -1,4 +1,5 @@
 use crate::backend_plugin::types::get_consumption;
+use crate::boajs::context::with_shared_connection;
 use crate::common::days_in_a_month;
 use crate::preference::{AdjustForNumberOfDaysOutOfStock, Preference};
 use crate::{
@@ -10,7 +11,6 @@ use crate::{
     store_preference::get_store_preferences,
     PluginOrRepositoryError,
 };
-use crate::boajs::context::with_shared_connection;
 use chrono::{Duration, NaiveDate};
 use repository::{
     ConsumptionFilter, ConsumptionRepository, DateFilter, DaysOutOfStockFilter,
@@ -68,6 +68,8 @@ pub fn get_item_stats(
 ) -> Result<Vec<ItemStats>, PluginOrRepositoryError> {
     // Lend `connection` to the plugin's sql()/use_repository() bindings so a plugin run reuses
     // it instead of checking out a second pool connection while this one is pinned (#12689).
+    // No-op when already in a transaction (the requisition create/update callers) — see
+    // `with_shared_connection` for why plugin statements are kept out of a caller's transaction.
     with_shared_connection(connection, || {
         get_item_stats_inner(
             connection,

--- a/server/service/src/item_stats.rs
+++ b/server/service/src/item_stats.rs
@@ -10,6 +10,7 @@ use crate::{
     store_preference::get_store_preferences,
     PluginOrRepositoryError,
 };
+use crate::boajs::context::with_shared_connection;
 use chrono::{Duration, NaiveDate};
 use repository::{
     ConsumptionFilter, ConsumptionRepository, DateFilter, DaysOutOfStockFilter,
@@ -50,7 +51,35 @@ pub trait ItemStatsServiceTrait: Sync + Send {
 pub struct ItemStatsService {}
 impl ItemStatsServiceTrait for ItemStatsService {}
 
+/// Whether item-stats computations will invoke a backend plugin (a full JS engine run plus the
+/// plugin's own SQL). Used by callers that fan out many computations (the graphql dataloader) to
+/// decide whether to throttle — see `ItemsStatsForItemLoader`.
+pub fn item_stats_uses_plugin() -> bool {
+    PluginInstance::get_one(PluginType::GetConsumption).is_some()
+        || PluginInstance::get_one(PluginType::AverageMonthlyConsumption).is_some()
+}
+
 pub fn get_item_stats(
+    connection: &StorageConnection,
+    store_id: &str,
+    amc_lookback_months: Option<f64>,
+    item_ids: Vec<String>,
+    period_end: Option<NaiveDate>,
+) -> Result<Vec<ItemStats>, PluginOrRepositoryError> {
+    // Lend `connection` to the plugin's sql()/use_repository() bindings so a plugin run reuses
+    // it instead of checking out a second pool connection while this one is pinned (#12689).
+    with_shared_connection(connection, || {
+        get_item_stats_inner(
+            connection,
+            store_id,
+            amc_lookback_months,
+            item_ids,
+            period_end,
+        )
+    })
+}
+
+fn get_item_stats_inner(
     connection: &StorageConnection,
     store_id: &str,
     amc_lookback_months: Option<f64>,


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12689

Running the Item Usage report on a site with an AMC backend plugin installed exhausted the DB connection pool within a second and wedged the whole server for minutes — the report failed, and every other query (dashboard, item search, even `initialisationStatus`) died with `Failed to open Connection` after 30s pool timeouts.

Root cause: the report resolves `stats` on ~1500 item nodes × 3 AMC lookbacks. The dataloader's 1ms coalescing window shatters those keys into many batches; each batch pinned a pool connection for the whole plugin run (a full boajs engine evaluation plus heavy ledger SQL), and the plugin's own `sql()` / `use_repository()` calls checked out *additional* connections while the batch's one was pinned. 7+ concurrent batches + the report context + dashboard/sync traffic = 10/10 connections held for minutes.

Four changes, in order of importance:

1. **Bulk-batch throttle** (`graphql/core/src/loader/item_stats.rs`): report-scale stats batches (≥100 keys, only when an AMC/consumption plugin is installed) now take one of 2 semaphore permits **before** checking out a pool connection, so queued batches hold nothing. Interactive-sized batches (item detail, search pages) bypass the queue so they never stall behind a report.
2. **Connection lending** (`service/src/boajs/context.rs` + the `sql` / `use_repository` / `get_plugin_data` / `get_store_preferences` bindings): plugins execute synchronously on the calling thread, so `get_item_stats` lends its already-held connection to the plugin via a scoped thread-local. A stats computation now costs exactly 1 connection instead of 2, and the hold-while-acquire pattern is gone. Plugin SQL also now sees the caller's transaction.
3. **50ms coalescing window** on the item-stats loader (`loader_registry.rs`): a report's keys land in a few large batches instead of dozens — far fewer plugin invocations (each one re-parses the plugin bundle).
4. **Stock-on-hand short-circuit** (`graphql/types/src/types/item.rs`): `stats { stockOnHand }`-only selections (the item-list export does this for every item) are served from the batched SOH view loader and skip the consumption/AMC/plugin path entirely. `ItemStockOnHand` widened to f64 so figures match the full path.

## 💌 Any notes for the reviewer?

- The semaphore count (2) and bulk threshold (100 keys) are empirical: bulk batches were effectively serialized by CPU anyway, and interactive batches are 20–25 keys. Both are compile-time consts, easy to tune.
- The thread-local lend in `boajs/context.rs` uses a raw pointer with an RAII reset guard (restores on panic/nesting). Safety argument is in the comments; there's a unit test covering lend/nest/restore. Plugins that hop threads (`use_graphql` nested execution) are unaffected — the TLS doesn't follow, and they fall back to pool checkout as before.
- Without a plugin installed, behaviour is unchanged except the 50ms loader delay and the SOH short-circuit (which is a pure win for the export path: 9.5s → 11ms per page in testing).
- This makes the server survive the report; it does **not** make the plugin fast — Item Usage still takes ~2min on a Galaxy Tab A8 (that's plugin compute cost, tracked on the plugin side).
- Alternative considered and measured: raising `connection_pool_max_connections` to 50 also stops the exhaustion, but peak server RSS doubles (383MB → 763MB — unacceptable on tablets), the same load completes 2.3× slower (CPU thrash from unbounded concurrent plugin runs), and the required pool size scales with how many times an impatient user retries.
- The SOH short-circuit (change 4) is separable if you'd rather it be its own PR.

# 🧪 Tested

- New unit test: `stats` SOH-only selection short-circuits and returns the same figures (graphql_general); new unit test for the connection lend/nest/restore guard (service). Existing item-stats/plugin/boajs/loader tests all pass.
- Reproduced and verified against a copy of the affected site's actual database (219MB SQLite, AMC plugin installed), replaying the failure recipe from the issue: dashboard counts + Item Usage report + a concurrent retry + item-list browsing, pool of 10:
  - **Before**: both reports fail, 32–58 pool-exhaustion events, 7–17 connection failures, item queries take 22–55s (3 runs).
  - **After**: both reports succeed, **zero** pool events, item queries 3–7ms during generation, same peak memory.
- On-device (Galaxy Tab A8, debug APK of this branch + the AMC plugin, real site data): Item Usage report completed in ~2m08s with zero pool exhaustion / waits / failures across the whole window — versus the issue's behaviour (instant 10/10, wedged 4+ minutes, report error) reproduced on the same tablet that morning.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
