### PR TITLE
#12710 Report generation no longer freezes the whole client

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4866,6 +4866,7 @@ dependencies = [
  "serde",
  "serde_json",
  "service",
+ "tokio",
  "util",
 ]
 

--- a/server/graphql/core/src/standard_graphql_error.rs
+++ b/server/graphql/core/src/standard_graphql_error.rs
@@ -59,9 +59,9 @@ impl StandardGraphqlError {
         StandardGraphqlError::from(error).extend()
     }
 
-    /// Maps a `spawn_blocking` join failure (e.g. the plugin task panicked) to an internal error.
+    /// Maps a `spawn_blocking` join failure (e.g. the blocking task panicked) to an internal error.
     pub fn from_join_error(error: tokio::task::JoinError) -> async_graphql::Error {
-        StandardGraphqlError::InternalError(format!("Plugin task error: {error}")).extend()
+        StandardGraphqlError::InternalError(format!("Blocking task error: {error}")).extend()
     }
 
     pub fn from_str_slice(str_slice: &str) -> async_graphql::Error {

--- a/server/graphql/reports/Cargo.toml
+++ b/server/graphql/reports/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 
 anyhow.workspace = true
 

--- a/server/graphql/reports/src/export.rs
+++ b/server/graphql/reports/src/export.rs
@@ -1,9 +1,11 @@
+use actix_web::web::Data;
 use async_graphql::{Context, Result};
 use graphql_core::{
     standard_graphql_error::{validate_auth, StandardGraphqlError},
     ContextExt,
 };
 use service::auth::{Resource, ResourceAccessRequest};
+use service::service_provider::ServiceProvider;
 
 use crate::print::{PrintReportNode, PrintReportResponse};
 
@@ -23,15 +25,24 @@ pub async fn csv_to_excel(
         },
     )?;
 
-    let service_provider = ctx.service_provider();
-    let service = &service_provider.report_service;
+    // Writing the workbook is CPU bound and sync. Under HTTP/2 a client has a single connection
+    // pinned to one actix worker, so occupying that worker's runtime thread stalls every other
+    // request the client makes - run it on the blocking pool instead (#12710).
+    let service_provider = ctx.data_unchecked::<Data<ServiceProvider>>().clone();
+    let base_dir = ctx.get_settings().server.base_dir.clone();
 
-    match service.csv_to_excel(
-        &ctx.get_settings().server.base_dir,
-        &csv_data,
-        &filename,
-        sheet_name.as_deref(),
-    ) {
+    let result = tokio::task::spawn_blocking(move || {
+        service_provider.report_service.csv_to_excel(
+            &base_dir,
+            &csv_data,
+            &filename,
+            sheet_name.as_deref(),
+        )
+    })
+    .await
+    .map_err(StandardGraphqlError::from_join_error)?;
+
+    match result {
         Ok(file_id) => Ok(PrintReportResponse::Response(PrintReportNode { file_id })),
         Err(err) => Err(StandardGraphqlError::InternalError(format!(
             "Failed to convert CSV to Excel: {err:?}"

--- a/server/graphql/reports/src/print.rs
+++ b/server/graphql/reports/src/print.rs
@@ -1,3 +1,4 @@
+use actix_web::web::Data;
 use async_graphql::*;
 use chrono::Utc;
 use graphql_core::generic_inputs::PrintReportSortInput;
@@ -7,6 +8,7 @@ use repository::{query_json, StoreRowRepository};
 use service::auth::{Resource, ResourceAccessRequest};
 use service::report::definition::{GraphQlQuery, PrintReportSort, ReportDefinition, SQLQuery};
 use service::report::report_service::{ReportError, ResolvedReportQuery};
+use service::service_provider::ServiceProvider;
 
 use crate::PrintFormat;
 
@@ -78,7 +80,7 @@ pub async fn generate_report(
     let service_provider = ctx.service_provider();
     let service_context = service_provider.context(store_id.clone(), user.user_id)?;
     let service = &service_provider.report_service;
-    let localisations = &service_provider
+    let localisations = service_provider
         .localisations_service
         .get_localisations(&service_context.connection)?;
 
@@ -117,17 +119,35 @@ pub async fn generate_report(
     // filename (best effort — a missing store just omits the prefix).
     let store_code = store_code(&service_context, &store_id)?;
 
+    // Nothing below needs the database, and generation can take tens of seconds, so hand the
+    // pooled connection back before starting it.
+    drop(service_context);
+
+    // Generation is CPU bound (BoaJs `convert_data`, Tera render, Excel/PDF conversion) and the
+    // service method is sync. Under HTTP/2 a client has a single connection pinned to one actix
+    // worker, so occupying that worker's runtime thread freezes every other request the client
+    // makes for the whole generation - run it on the blocking pool instead (#12710).
+    let service_provider = ctx.data_unchecked::<Data<ServiceProvider>>().clone();
+    let base_dir = ctx.get_settings().server.base_dir.clone();
+    let format = format.map(PrintFormat::to_domain);
+
     // generate the report with the fetched data
-    let file_id = match service.generate_html_report(
-        &ctx.get_settings().server.base_dir,
-        &resolved_report,
-        report_data,
-        arguments,
-        format.map(PrintFormat::to_domain),
-        localisations,
-        current_language,
-        store_code.as_deref(),
-    ) {
+    let generated = tokio::task::spawn_blocking(move || {
+        service_provider.report_service.generate_html_report(
+            &base_dir,
+            &resolved_report,
+            report_data,
+            arguments,
+            format,
+            &localisations,
+            current_language,
+            store_code.as_deref(),
+        )
+    })
+    .await
+    .map_err(StandardGraphqlError::from_join_error)?;
+
+    let file_id = match generated {
         Ok(file_id) => file_id,
         Err(err) => {
             return Ok(PrintReportResponse::Error(PrintReportError {
@@ -162,7 +182,7 @@ pub async fn generate_report_definition(
     let service_provider = ctx.service_provider();
     let service_context = service_provider.context(store_id.clone(), user.user_id)?;
     let service = &service_provider.report_service;
-    let localisations = &service_provider
+    let localisations = service_provider
         .localisations_service
         .get_localisations(&service_context.connection)?;
 
@@ -207,17 +227,35 @@ pub async fn generate_report_definition(
 
     let store_code = store_code(&service_context, &store_id)?;
 
+    // Nothing below needs the database, and generation can take tens of seconds, so hand the
+    // pooled connection back before starting it.
+    drop(service_context);
+
+    // Generation is CPU bound (BoaJs `convert_data`, Tera render, Excel/PDF conversion) and the
+    // service method is sync. Under HTTP/2 a client has a single connection pinned to one actix
+    // worker, so occupying that worker's runtime thread freezes every other request the client
+    // makes for the whole generation - run it on the blocking pool instead (#12710).
+    let service_provider = ctx.data_unchecked::<Data<ServiceProvider>>().clone();
+    let base_dir = ctx.get_settings().server.base_dir.clone();
+    let format = format.map(PrintFormat::to_domain);
+
     // generate the report with the fetched data
-    let file_id = match service.generate_html_report(
-        &ctx.get_settings().server.base_dir,
-        &resolved_report,
-        report_data,
-        arguments,
-        format.map(PrintFormat::to_domain),
-        localisations,
-        current_language,
-        store_code.as_deref(),
-    ) {
+    let generated = tokio::task::spawn_blocking(move || {
+        service_provider.report_service.generate_html_report(
+            &base_dir,
+            &resolved_report,
+            report_data,
+            arguments,
+            format,
+            &localisations,
+            current_language,
+            store_code.as_deref(),
+        )
+    })
+    .await
+    .map_err(StandardGraphqlError::from_join_error)?;
+
+    let file_id = match generated {
         Ok(file_id) => file_id,
         Err(err) => {
             return Ok(PrintReportResponse::Error(PrintReportError {


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12710

Generating a report froze the **entire** client until it finished — not "slowed down". Navigation stopped, lazily-loaded route chunks never arrived so screens never rendered, and some requests died with `net::ERR_TIMED_OUT`, leaving a permanently broken screen even after the report completed. On a tablet with the embedded server, a 60s report froze the app for the full 60s.

Two things combined:

1. **Report generation ran straight from the async GraphQL resolver.** The CPU-bound work (BoaJs `convert_data`, Tera render, Excel/PDF conversion) occupied the actix worker's runtime thread for the whole generation.
2. **The server speaks HTTP/2**, which nothing in our config asks for — `actix-http` unconditionally prepends `h2` to the ALPN list one layer below `bind_rustls_0_23`. A client therefore has *one* connection, pinned to *one* worker, with every request multiplexed onto that same single-threaded runtime. One blocking handler freezes every request that client makes. More cores and a bigger DB pool do nothing to help, because the connection is pinned and the blocking is CPU-bound, not connection checkout.

The fix wraps the three generation call sites in `tokio::task::spawn_blocking`, following the pattern already used for plugin calls in `graphql/plugin/src/plugin_graphql/query.rs` and the requisition mutations:

- `generate_report` and `generate_report_definition` — `server/graphql/reports/src/print.rs`
- `csv_to_excel` — `server/graphql/reports/src/export.rs`, the list-export path used by every list screen

To make the work `'static`, these clone `Data<ServiceProvider>` and `base_dir`, own the `Localisations` instead of borrowing a temporary, and resolve the print format before the closure.

## 💌 Any notes for the reviewer?

**Two small things beyond what the issue asked for:**

- **Both print paths now `drop(service_context)` before generating.** Nothing after the `store_code(...)` lookup touches the database, so there was no reason to keep a pooled connection parked for the length of a generation that can run tens of seconds. Free to do, and one less contention source (cf. #12689).
- **`StandardGraphqlError::from_join_error`'s message** was hardcoded to `"Plugin task error"`; it's now `"Blocking task error"`, since reports use it too. That's the only change outside `graphql/reports`, and it touches message text only.

**Deliberately not addressed:**

- **Cancellation.** A client that navigates away still leaves the generation running to completion — it just holds a blocking-pool thread now instead of a worker thread. Making generation cancellation-aware is a larger change.
- **The data-fetch phase.** `fetch_data`'s self-GraphQL request and the SQL queries still run on the worker's runtime thread. Measured TTFB stayed at 50–130ms throughout the freeze, so generation is what was blocking; the fetch phase belongs to the broader audit in #11856.

**On the boajs/blocking-pool interaction:** `do_async_blocking` (`service/src/boajs/utils.rs`) spawns its own thread and its own runtime, so nothing here nests a `block_on` inside the blocking pool's runtime context. The plugin path already relies on the same property.

**Base branch:** targeted at `develop`. `v3.01.00-RC` — where the sibling fixes #12709 / #12691 landed — has been merged (#12711) and deleted upstream, and the touched files are byte-identical between `main` and `develop`, so there's no drift to worry about. Happy to retarget if a new RC branch is cut.

# 🧪 Tested

- `cargo check --workspace --all-targets` — clean
- `cargo clippy -p graphql_reports -p graphql_core --all-targets` — no new warnings (the 3 remaining are pre-existing doc lints in `graphql_core`)
- `cargo nextest run -p graphql` — 3/3 pass, including `report_default_queries`. `graphql_reports` has no tests of its own.
- `cargo fmt --check` clean on the changed files

**Not yet run by me — worth a reviewer doing the on-device repro from the issue:**

- Take a copy of `item-list` with an artificial busy-loop delay in its `convert_data` so the duration is a knob, generate it, and while it runs navigate to the Dashboard and around the app. Navigation should stay responsive and the report should still land correctly at the end.
- Export a list view to Excel from a list screen (the `csv_to_excel` path) and confirm the file downloads unchanged.
- Generate a normal PDF and an Excel report to confirm the output, filename (store-code prefix) and error paths are unaffected.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
