### PR TITLE
#12710 Run report SQL queries on the blocking pool, sharing one connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ server/target-postgres/
 
 # Playwright MCP scratch logs / page dumps
 .playwright-mcp/
+.scratch/*

--- a/server/graphql/reports/src/print.rs
+++ b/server/graphql/reports/src/print.rs
@@ -4,9 +4,9 @@ use chrono::Utc;
 use graphql_core::generic_inputs::PrintReportSortInput;
 use graphql_core::standard_graphql_error::{validate_auth, StandardGraphqlError};
 use graphql_core::{ContextExt, RequestUserData};
-use repository::{query_json, StoreRowRepository};
+use repository::{ReportQueryExecutor, ReportSqlQuery, StoreRowRepository};
 use service::auth::{Resource, ResourceAccessRequest};
-use service::report::definition::{GraphQlQuery, PrintReportSort, ReportDefinition, SQLQuery};
+use service::report::definition::{GraphQlQuery, PrintReportSort, ReportDefinition};
 use service::report::report_service::{ReportError, ResolvedReportQuery};
 use service::service_provider::ServiceProvider;
 
@@ -371,41 +371,37 @@ async fn fetch_data(
         serde_json::Map::new()
     };
 
-    for sql in queries.iter().filter_map(|query| match query {
-        ResolvedReportQuery::SQLQuery(sql) => Some(sql),
-        ResolvedReportQuery::GraphQlQuery(_) => None,
-    }) {
+    let sql_queries: Vec<ReportSqlQuery> = queries
+        .iter()
+        .filter_map(|query| match query {
+            ResolvedReportQuery::SQLQuery(sql) => Some(ReportSqlQuery {
+                name: sql.name.clone(),
+                sqlite: sql.query_sqlite.clone(),
+                postgres: sql.query_postgres.clone(),
+            }),
+            ResolvedReportQuery::GraphQlQuery(_) => None,
+        })
+        .collect();
+
+    if !sql_queries.is_empty() {
+        // Hoisted out of the per-query loop: these variables were already identical for every SQL
+        // query, and computing them once also gives every query the same `now` rather than one
+        // `Utc::now()` per query.
         let variables = query_variables(store_id, &data_id, &arguments, &sort, &None);
-        let result = fetch_sql_data(ctx, sql, variables)?;
-        data.insert(sql.name.clone(), result);
+
+        // The report's SQL queries are synchronous, so run them on the blocking pool rather than
+        // the actix worker's runtime thread (#12710) - see the note on `generate_html_report`.
+        // The executor runs them sequentially on one connection; see `ReportQueryExecutor::run`.
+        let executor =
+            ReportQueryExecutor::new(&ctx.get_settings().database, ctx.get_connection_manager());
+        let results = tokio::task::spawn_blocking(move || executor.run(sql_queries, &variables))
+            .await??;
+        for (name, rows) in results {
+            data.insert(name, serde_json::Value::Array(rows));
+        }
     }
 
     Ok(FetchResult::Data(serde_json::Value::Object(data)))
-}
-
-#[cfg(not(feature = "postgres"))]
-fn fetch_sql_data(
-    ctx: &Context<'_>,
-    query: &SQLQuery,
-    variables: serde_json::Map<String, serde_json::Value>,
-) -> anyhow::Result<serde_json::Value> {
-    let data = query_json(
-        &ctx.get_settings().database,
-        &query.query_sqlite,
-        &variables,
-    )?;
-    Ok(serde_json::Value::Array(data))
-}
-
-#[cfg(feature = "postgres")]
-fn fetch_sql_data(
-    ctx: &Context<'_>,
-    query: &SQLQuery,
-    variables: serde_json::Map<String, serde_json::Value>,
-) -> anyhow::Result<serde_json::Value> {
-    let connection = ctx.get_connection_manager().connection()?;
-    let data = query_json(&connection, &query.query_postgres, &variables)?;
-    Ok(serde_json::Value::Array(data))
 }
 
 async fn fetch_graphql_data(

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -9,7 +9,6 @@ use std::time::Duration;
 
 // Timeout for waiting for the SQLite lock (https://www.sqlite.org/c3ref/busy_timeout.html).
 // A locked DB results in the "SQLite database is locked" error.
-#[cfg(not(feature = "postgres"))]
 pub(crate) const SQLITE_LOCKWAIT_MS: u32 = 30 * 1000;
 
 #[cfg(not(feature = "postgres"))]

--- a/server/repository/src/database_settings.rs
+++ b/server/repository/src/database_settings.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 // Timeout for waiting for the SQLite lock (https://www.sqlite.org/c3ref/busy_timeout.html).
 // A locked DB results in the "SQLite database is locked" error.
 #[cfg(not(feature = "postgres"))]
-const SQLITE_LOCKWAIT_MS: u32 = 30 * 1000;
+pub(crate) const SQLITE_LOCKWAIT_MS: u32 = 30 * 1000;
 
 #[cfg(not(feature = "postgres"))]
 const SQLITE_WAL_PRAGMA: &str = "PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL;";

--- a/server/repository/src/db_diesel/report_query.rs
+++ b/server/repository/src/db_diesel/report_query.rs
@@ -1,8 +1,94 @@
+use crate::database_settings::DatabaseSettings;
 use crate::RepositoryError;
+use crate::StorageConnectionManager;
 #[cfg(feature = "postgres")]
 use crate::StorageConnection;
 #[cfg(feature = "postgres")]
 use diesel::sql_types::*;
+
+/// A report's SQL query, carrying both dialects. Which one runs is decided by
+/// [`ReportQueryExecutor`], so callers never need to know the backend.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReportSqlQuery {
+    pub name: String,
+    pub sqlite: String,
+    pub postgres: String,
+}
+
+/// Runs a report's SQL queries. Owned and `Clone`, so it can be moved onto a blocking thread.
+///
+/// Report queries are synchronous, so callers are expected to run [`ReportQueryExecutor::run`]
+/// inside `spawn_blocking` rather than on an async worker thread (#12710).
+#[derive(Clone)]
+pub struct ReportQueryExecutor {
+    #[cfg(not(feature = "postgres"))]
+    settings: DatabaseSettings,
+    #[cfg(feature = "postgres")]
+    connection_manager: StorageConnectionManager,
+}
+
+impl ReportQueryExecutor {
+    #[cfg(not(feature = "postgres"))]
+    pub fn new(
+        settings: &DatabaseSettings,
+        _connection_manager: &StorageConnectionManager,
+    ) -> Self {
+        Self {
+            settings: settings.clone(),
+        }
+    }
+
+    #[cfg(feature = "postgres")]
+    pub fn new(
+        _settings: &DatabaseSettings,
+        connection_manager: &StorageConnectionManager,
+    ) -> Self {
+        Self {
+            connection_manager: connection_manager.clone(),
+        }
+    }
+
+    /// Run every query in order, returning `(name, rows)` per query.
+    ///
+    /// The queries run sequentially on a single connection. On SQLite that matters: the page cache
+    /// is per-connection, so later queries reuse pages the earlier ones loaded, and the schema is
+    /// parsed once rather than per query. Running them concurrently instead would put each on its
+    /// own blocking-pool thread, which oversubscribes low-core devices and is bounded by nothing
+    /// (these connections are outside the diesel pool).
+    #[cfg(not(feature = "postgres"))]
+    pub fn run(
+        &self,
+        queries: Vec<ReportSqlQuery>,
+        parameters: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<Vec<(String, Vec<serde_json::Value>)>, RepositoryError> {
+        let connection = report_connection(&self.settings)?;
+        queries
+            .into_iter()
+            .map(|query| {
+                let rows = query_json_with_connection(&connection, &query.sqlite, parameters)?;
+                Ok((query.name, rows))
+            })
+            .collect()
+    }
+
+    #[cfg(feature = "postgres")]
+    pub fn run(
+        &self,
+        queries: Vec<ReportSqlQuery>,
+        parameters: &serde_json::Map<String, serde_json::Value>,
+    ) -> Result<Vec<(String, Vec<serde_json::Value>)>, RepositoryError> {
+        // Checked out here rather than by the caller so that waiting for a pooled connection also
+        // happens off the async worker, and nothing non-`Send` has to cross into the closure.
+        let connection = self.connection_manager.connection()?;
+        queries
+            .into_iter()
+            .map(|query| {
+                let rows = query_json(&connection, &query.postgres, parameters)?;
+                Ok((query.name, rows))
+            })
+            .collect()
+    }
+}
 
 #[cfg(feature = "postgres")]
 #[derive(QueryableByName, Debug, PartialEq)]
@@ -12,7 +98,7 @@ pub struct JsonDataRow {
 }
 
 #[cfg(feature = "postgres")]
-pub fn query_json(
+pub(crate) fn query_json(
     connection: &StorageConnection,
     sql: &str,
     parameters: &serde_json::Map<String, serde_json::Value>,
@@ -99,7 +185,7 @@ pub fn query_json(
 }
 
 #[cfg(not(feature = "postgres"))]
-use crate::database_settings::DatabaseSettings;
+use crate::database_settings::SQLITE_LOCKWAIT_MS;
 #[cfg(not(feature = "postgres"))]
 impl From<rusqlite::Error> for RepositoryError {
     fn from(value: rusqlite::Error) -> Self {
@@ -110,16 +196,34 @@ impl From<rusqlite::Error> for RepositoryError {
     }
 }
 
+/// Open a connection for running report queries.
+///
+/// These queries bypass the diesel pool, so they don't get the customiser's pragmas
+/// (`SqliteConnectionOptions::on_acquire`). `busy_timeout` in particular defaults to 0, which
+/// means a report query that collides with a sync write fails immediately with "database is
+/// locked" instead of waiting, so set it explicitly to match the pooled connections.
 #[cfg(not(feature = "postgres"))]
-pub fn query_json(
+pub(crate) fn report_connection(
     settings: &DatabaseSettings,
+) -> Result<rusqlite::Connection, RepositoryError> {
+    let conn = rusqlite::Connection::open(settings.connection_string())?;
+    conn.busy_timeout(std::time::Duration::from_millis(SQLITE_LOCKWAIT_MS.into()))?;
+    Ok(conn)
+}
+
+/// Run a report query on an existing connection.
+///
+/// Prefer this over [`query_json`] when running several queries for one report: SQLite's page
+/// cache is per-connection, so reusing one connection lets later queries hit pages the earlier
+/// ones already loaded, and pays the schema parse once rather than per query.
+#[cfg(not(feature = "postgres"))]
+pub(crate) fn query_json_with_connection(
+    conn: &rusqlite::Connection,
     sql: &str,
     parameters: &serde_json::Map<String, serde_json::Value>,
 ) -> Result<Vec<serde_json::Value>, RepositoryError> {
-    use rusqlite::{types::Null, Connection as RusqliteConnection};
+    use rusqlite::types::Null;
     use serde_json::Number;
-
-    let conn = RusqliteConnection::open(settings.connection_string())?;
 
     let mut statement = conn.prepare(sql)?;
 
@@ -200,42 +304,40 @@ pub fn query_json(
 mod tests {
     use serde_json::json;
 
-    use crate::{mock::MockDataInserts, query_json, test_db};
+    use crate::{mock::MockDataInserts, test_db};
 
-    use crate::{database_settings::DatabaseSettings, RepositoryError, StorageConnection};
+    use super::{ReportQueryExecutor, ReportSqlQuery};
 
-    #[cfg(feature = "postgres")]
-    pub fn query(
-        connection: &StorageConnection,
-        _settings: &DatabaseSettings,
+    /// Run one query through the executor. The SQL here is valid in both dialects, so the same
+    /// string is given for each and the executor picks whichever matches the build.
+    fn query(
+        executor: &ReportQueryExecutor,
         sql: &str,
         parameters: &serde_json::Map<String, serde_json::Value>,
-    ) -> Result<Vec<serde_json::Value>, RepositoryError> {
-        query_json(connection, sql, parameters)
-    }
-
-    #[cfg(not(feature = "postgres"))]
-    pub fn query(
-        _connection: &StorageConnection,
-        settings: &DatabaseSettings,
-        sql: &str,
-        parameters: &serde_json::Map<String, serde_json::Value>,
-    ) -> Result<Vec<serde_json::Value>, RepositoryError> {
-        query_json(settings, sql, parameters)
+    ) -> Result<Vec<serde_json::Value>, crate::RepositoryError> {
+        let mut results = executor.run(
+            vec![ReportSqlQuery {
+                name: "query".to_string(),
+                sqlite: sql.to_string(),
+                postgres: sql.to_string(),
+            }],
+            parameters,
+        )?;
+        Ok(results.remove(0).1)
     }
 
     #[actix_rt::test]
     async fn test_report_query() {
-        let (_, connection, _, settings) = test_db::setup_all(
+        let (_, _, connection_manager, settings) = test_db::setup_all(
             "test_report_query",
             MockDataInserts::none().names().stores(),
         )
         .await;
+        let executor = ReportQueryExecutor::new(&settings, &connection_manager);
 
         // query with no params
         let result = query(
-            &connection,
-            &settings,
+            &executor,
             "SELECT id, code, logo FROM store LIMIT 1;", // test with trailing ";"
             &serde_json::Map::new(),
         )
@@ -247,8 +349,7 @@ mod tests {
 
         // simple params
         let result = query(
-            &connection,
-            &settings,
+            &executor,
             "SELECT id, code FROM store WHERE id=$store LIMIT $limit", // test without trailing ";"
             json!({
                 "store": "store_a",
@@ -266,8 +367,7 @@ mod tests {
 
         // multiple used params
         let result = query(
-            &connection,
-            &settings,
+            &executor,
             "SELECT id, code FROM store WHERE id LIKE $b || '%' AND code LIKE $b || '%' LIMIT $a",
             json!({
                 "a": 5,

--- a/server/repository/src/db_diesel/report_query.rs
+++ b/server/repository/src/db_diesel/report_query.rs
@@ -1,10 +1,8 @@
-use crate::database_settings::DatabaseSettings;
+use crate::database_settings::{DatabaseSettings, SQLITE_LOCKWAIT_MS};
 use crate::RepositoryError;
-use crate::StorageConnectionManager;
-#[cfg(feature = "postgres")]
 use crate::StorageConnection;
-#[cfg(feature = "postgres")]
-use diesel::sql_types::*;
+use crate::StorageConnectionManager;
+use diesel::sql_types::Text;
 
 /// A report's SQL query, carrying both dialects. Which one runs is decided by
 /// [`ReportQueryExecutor`], so callers never need to know the backend.
@@ -19,31 +17,19 @@ pub struct ReportSqlQuery {
 ///
 /// Report queries are synchronous, so callers are expected to run [`ReportQueryExecutor::run`]
 /// inside `spawn_blocking` rather than on an async worker thread (#12710).
+///
+/// Both backends' fields are always present and only one is used, so that both arms stay
+/// compiled (and type checked) under either feature. See [`ReportQueryExecutor::run`].
 #[derive(Clone)]
 pub struct ReportQueryExecutor {
-    #[cfg(not(feature = "postgres"))]
     settings: DatabaseSettings,
-    #[cfg(feature = "postgres")]
     connection_manager: StorageConnectionManager,
 }
 
 impl ReportQueryExecutor {
-    #[cfg(not(feature = "postgres"))]
-    pub fn new(
-        settings: &DatabaseSettings,
-        _connection_manager: &StorageConnectionManager,
-    ) -> Self {
+    pub fn new(settings: &DatabaseSettings, connection_manager: &StorageConnectionManager) -> Self {
         Self {
             settings: settings.clone(),
-        }
-    }
-
-    #[cfg(feature = "postgres")]
-    pub fn new(
-        _settings: &DatabaseSettings,
-        connection_manager: &StorageConnectionManager,
-    ) -> Self {
-        Self {
             connection_manager: connection_manager.clone(),
         }
     }
@@ -55,50 +41,53 @@ impl ReportQueryExecutor {
     /// parsed once rather than per query. Running them concurrently instead would put each on its
     /// own blocking-pool thread, which oversubscribes low-core devices and is bounded by nothing
     /// (these connections are outside the diesel pool).
-    #[cfg(not(feature = "postgres"))]
+    ///
+    /// The backend is picked with `if cfg!` rather than `#[cfg]` so both arms are compiled under
+    /// either feature - one build proves the other still type checks, and rust-analyzer doesn't
+    /// grey out half the file depending on which feature the editor is configured with. The unused
+    /// arm is dead code the optimiser drops.
     pub fn run(
         &self,
         queries: Vec<ReportSqlQuery>,
         parameters: &serde_json::Map<String, serde_json::Value>,
     ) -> Result<Vec<(String, Vec<serde_json::Value>)>, RepositoryError> {
-        let connection = report_connection(&self.settings)?;
-        queries
-            .into_iter()
-            .map(|query| {
-                let rows = query_json_with_connection(&connection, &query.sqlite, parameters)?;
-                Ok((query.name, rows))
-            })
-            .collect()
-    }
-
-    #[cfg(feature = "postgres")]
-    pub fn run(
-        &self,
-        queries: Vec<ReportSqlQuery>,
-        parameters: &serde_json::Map<String, serde_json::Value>,
-    ) -> Result<Vec<(String, Vec<serde_json::Value>)>, RepositoryError> {
-        // Checked out here rather than by the caller so that waiting for a pooled connection also
-        // happens off the async worker, and nothing non-`Send` has to cross into the closure.
-        let connection = self.connection_manager.connection()?;
-        queries
-            .into_iter()
-            .map(|query| {
-                let rows = query_json(&connection, &query.postgres, parameters)?;
-                Ok((query.name, rows))
-            })
-            .collect()
+        if cfg!(feature = "postgres") {
+            // Checked out here rather than by the caller so that waiting for a pooled connection
+            // also happens off the async worker, and nothing non-`Send` has to cross into the
+            // `spawn_blocking` closure.
+            let connection = self.connection_manager.connection()?;
+            queries
+                .into_iter()
+                .map(|query| {
+                    let rows = query_json_postgres(&connection, &query.postgres, parameters)?;
+                    Ok((query.name, rows))
+                })
+                .collect()
+        } else {
+            let connection = report_connection(&self.settings)?;
+            queries
+                .into_iter()
+                .map(|query| {
+                    let rows = query_json_sqlite(&connection, &query.sqlite, parameters)?;
+                    Ok((query.name, rows))
+                })
+                .collect()
+        }
     }
 }
 
-#[cfg(feature = "postgres")]
 #[derive(QueryableByName, Debug, PartialEq)]
-pub struct JsonDataRow {
+struct JsonDataRow {
     #[diesel(sql_type = Text)]
     data: String,
 }
 
-#[cfg(feature = "postgres")]
-pub(crate) fn query_json(
+/// Run a report query through diesel, wrapping it so each row comes back as JSON.
+///
+/// Postgres only - the SQL it builds (`PREPARE`, `row_to_json`) is Postgres syntax. It still
+/// compiles on a SQLite build because everything it touches is backend generic; it just never
+/// runs there.
+fn query_json_postgres(
     connection: &StorageConnection,
     sql: &str,
     parameters: &serde_json::Map<String, serde_json::Value>,
@@ -184,9 +173,6 @@ pub(crate) fn query_json(
     Ok(rows)
 }
 
-#[cfg(not(feature = "postgres"))]
-use crate::database_settings::SQLITE_LOCKWAIT_MS;
-#[cfg(not(feature = "postgres"))]
 impl From<rusqlite::Error> for RepositoryError {
     fn from(value: rusqlite::Error) -> Self {
         RepositoryError::DBError {
@@ -202,8 +188,10 @@ impl From<rusqlite::Error> for RepositoryError {
 /// (`SqliteConnectionOptions::on_acquire`). `busy_timeout` in particular defaults to 0, which
 /// means a report query that collides with a sync write fails immediately with "database is
 /// locked" instead of waiting, so set it explicitly to match the pooled connections.
-#[cfg(not(feature = "postgres"))]
-pub(crate) fn report_connection(
+///
+/// SQLite only - on a Postgres build `connection_string()` returns a Postgres URL and this is
+/// never called.
+fn report_connection(
     settings: &DatabaseSettings,
 ) -> Result<rusqlite::Connection, RepositoryError> {
     let conn = rusqlite::Connection::open(settings.connection_string())?;
@@ -211,13 +199,12 @@ pub(crate) fn report_connection(
     Ok(conn)
 }
 
-/// Run a report query on an existing connection.
+/// Run a report query on an existing SQLite connection.
 ///
-/// Prefer this over [`query_json`] when running several queries for one report: SQLite's page
-/// cache is per-connection, so reusing one connection lets later queries hit pages the earlier
-/// ones already loaded, and pays the schema parse once rather than per query.
-#[cfg(not(feature = "postgres"))]
-pub(crate) fn query_json_with_connection(
+/// The connection is passed in rather than opened per query: SQLite's page cache is
+/// per-connection, so reusing one connection lets later queries hit pages the earlier ones
+/// already loaded, and pays the schema parse once rather than per query.
+fn query_json_sqlite(
     conn: &rusqlite::Connection,
     sql: &str,
     parameters: &serde_json::Map<String, serde_json::Value>,
@@ -382,5 +369,31 @@ mod tests {
             &serde_json::to_string(&result).unwrap().to_string(),
             "[{\"code\":\"name_store_code\",\"id\":\"name_store_id\"},{\"code\":\"name_store_code_a\",\"id\":\"name_store_a_id\"}]"
         );
+
+        // a batch comes back in input order, with each name paired to its own rows
+        let results = executor
+            .run(
+                vec![
+                    ReportSqlQuery {
+                        name: "first".to_string(),
+                        sqlite: "SELECT id FROM store WHERE id=$store".to_string(),
+                        postgres: "SELECT id FROM store WHERE id=$store".to_string(),
+                    },
+                    ReportSqlQuery {
+                        name: "second".to_string(),
+                        sqlite: "SELECT code FROM store WHERE id=$store".to_string(),
+                        postgres: "SELECT code FROM store WHERE id=$store".to_string(),
+                    },
+                ],
+                json!({ "store": "store_a" }).as_object().unwrap(),
+            )
+            .unwrap();
+        assert_eq!(results[0].0, "first");
+        assert_eq!(results[1].0, "second");
+        assert_eq!(results[0].1.len(), 1);
+        assert_eq!(results[1].1.len(), 1);
+        // the two queries select different columns, so rows paired with the wrong name surface here
+        assert!(results[0].1[0].as_object().unwrap().contains_key("id"));
+        assert!(results[1].1[0].as_object().unwrap().contains_key("code"));
     }
 }


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Follow-up to #12716 (now merged), targeting `develop`.

That PR moved report *generation* onto the blocking pool. The data-fetch phase stayed behind: `fetch_data` ran each of a report's SQL queries inline with **no `await` anywhere**, so they executed on the actix worker's runtime thread. Under HTTP/2 a client has one connection pinned to one worker, so that blocks every other request that client makes — the same mechanism as #12710.

These are store-wide aggregates (`SUM(quantity) FROM consumption ... GROUP BY item_id`) that scale with **consumption history**, not item count, so on a site with years of data they are not small.

Three things here:

1. **The SQL loop moves onto the blocking pool**, as one closure for all of a report's queries rather than one `spawn_blocking` each.
2. **All of a report's queries now share one connection.** SQLite's page cache is per-connection, so opening one per query meant every query started with a cold cache and re-parsed the schema. This roughly halves the phase — numbers below.
3. **`busy_timeout` is now set on the report connection.** The pool applies it via `SqliteConnectionOptions::on_acquire`, but these connections are opened directly and so defaulted to `0` — meaning a report query colliding with a sync write failed immediately with "database is locked" instead of waiting. Latent bug, independent of the rest.

Backend selection moved into the repository behind `ReportQueryExecutor`, so the graphql layer no longer carries `cfg(feature = "postgres")` attributes and no longer chooses between `query_sqlite` and `query_postgres`. `print.rs` now has zero `cfg`. The single-query `query_json` entry point is deleted and the remaining primitives are `pub(crate)`, leaving `ReportSqlQuery` + `ReportQueryExecutor` as the public surface. The `report_query` test drives the executor and loses its own cfg'd helper.

## 💌 Any notes for the reviewer?

**Why sequential and not six concurrent queries.** `spawn_blocking` puts each call on its own blocking-pool thread and the OS spreads those across cores, so six calls really would run ~4-wide on a 4-core tablet — oversubscribing the CPU against generation, the WebView and sync, which is the responsiveness this work exists to protect. It is also unbounded: these connections sit outside the diesel pool, so `connection_pool_max_connections` does not cap them and N reports × 6 would need an explicit semaphore. Sharing the connection turned out to be the bigger win anyway.

**One intentional behaviour change.** `query_variables` was recomputed on every loop iteration with identical inputs, and it inserts `"now": Utc::now()` — so each query got a *slightly different* `now`. It is now computed once, giving every query in a report one consistent point-in-time, matching how the GraphQL query already gets its own single `now`.

**Relationship to #11856 / #78.** The Postgres arm is a deliberate stopgap: `query_json` there takes a `StorageConnection`, so making the blocking happen at the connection boundary (#78) subsumes it, and `ReportQueryExecutor::run` becomes a clean deletion. The SQLite arm is not — it opens a raw `rusqlite` connection outside the diesel pool entirely, so #78 will never reach it, and SQLite is what the embedded Android server runs. Worth noting for #11856 that this pool-bypassing path also means "increase the db connection pool" does nothing for report queries on embedded deployments.

## 🧪 Tested

`cargo check`/`clippy` on **both** feature sets (the cfg split means one target proves nothing); `clippy` shows 7 warnings in `report_query.rs` before *and* after on a forced rebuild — all pre-existing in the Postgres `query_json` body. 252 repository tests + 3 graphql tests pass, including the rewritten `test_report_query`.

Measured on a 4-core Android tablet (Lenovo TB-X505X) with the embedded server, driving `generateReport` over an `adb` port-forward. To separate the SQL phase from generation, the blocking numbers use a report definition containing **only** the six `item-usage` aggregates — no GraphQL query, no `convert_data`. That matters: probes against a *full* report are answered at its first `await` (the GraphQL self-request), which happens before the SQL phase, so they never witness this block at all.

| | SQL phase | probes during it | control | worker blocked |
|---|---|---|---|---|
| sync (before) | 215ms | 166ms | 24ms | **~142ms** |
| blocking pool, connection per query | 216ms | 62ms | 22ms | **~40ms** |
| blocking pool, shared connection | **120ms** | 44ms | 20ms | **~24ms** |

Connection sharing alone takes the phase from 216ms to ~124ms median across two runs (n=9 and n=12) — the two middle rows differ *only* in connection reuse. End to end `item-usage` went 3009ms → 2902ms median (n=7 each), and the generated report is **byte-identical** to the pre-change output (5706 bytes, `cmp` clean).

Caveat: this datafile is small (6 stocked items, little consumption history). The absolute numbers are correspondingly small; the argument for the change is that these queries scale with history and the blocking is unbounded on a real site.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`)
- [ ] **Developer docs needed** (`docs: internal`)
