### PR TITLE
#12713 Send internal order report arguments for every program order

### DIFF
--- a/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -14,13 +14,11 @@ import { AddButton } from './AddButton';
 interface AppBarButtonProps {
   isDisabled: boolean;
   onAddItem: () => void;
-  showIndicators?: boolean;
 }
 
 export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
   onAddItem,
   isDisabled,
-  showIndicators = false,
 }) => {
   const { store } = useAuthContext();
   const isProgram = useRequest.utils.isProgram();
@@ -46,12 +44,18 @@ export const AppBarButtonsComponent: FC<AppBarButtonProps> = ({
           // Filters out reports that have a subContext (i.e. `R&R`)
           queryParams={{ filterBy: { subContext: { equalAnyOrNull: [] } } }}
           dataId={data?.id ?? ''}
+          // Sent for every program order, not just one showing the indicators
+          // tab: a report declaring $programId / $periodId / $customerNameId
+          // fails outright when they are absent from the arguments, so tying
+          // them to a display gate could only break such a report (#12713).
+          // Sending null instead is not an option — the indicator value fields
+          // take String! arguments and reject it.
           extraArguments={
-            showIndicators
+            data?.program?.id && data?.period?.id && store?.nameId
               ? {
-                  periodId: data?.period?.id,
-                  programId: data?.program?.id,
-                  customerNameId: store?.nameId,
+                  periodId: data.period.id,
+                  programId: data.program.id,
+                  customerNameId: store.nameId,
                 }
               : undefined
           }

--- a/client/packages/requisitions/src/RequestRequisition/DetailView/DetailView.tsx
+++ b/client/packages/requisitions/src/RequestRequisition/DetailView/DetailView.tsx
@@ -128,11 +128,7 @@ export const DetailView = () => {
 
   return (
     <RequestRequisitionLineErrorProvider>
-      <AppBarButtons
-        isDisabled={!data || isDisabled}
-        onAddItem={onAddItem}
-        showIndicators={showIndicatorTab}
-      />
+      <AppBarButtons isDisabled={!data || isDisabled} onAddItem={onAddItem} />
       <Toolbar />
 
       <DetailTabs tabs={tabs} />

--- a/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
+++ b/client/packages/requisitions/src/ResponseRequisition/DetailView/AppBarButtons/AppBarButtons.tsx
@@ -97,6 +97,21 @@ export const AppBarButtonsComponent = ({
           context={ReportContext.Requisition}
           dataId={data?.id ?? ''}
           queryParams={{ filterBy: { subContext: { equalAnyOrNull: [] } } }}
+          // Sent for every program requisition, not just one showing the
+          // indicators tab: a report declaring $programId / $periodId /
+          // $customerNameId fails outright when they are absent from the
+          // arguments, so tying them to a display gate could only break such a
+          // report (#12713). Sending null instead is not an option — the
+          // indicator value fields take String! arguments and reject it.
+          extraArguments={
+            data?.program?.id && data?.period?.id && data?.otherPartyId
+              ? {
+                  periodId: data.period.id,
+                  programId: data.program.id,
+                  customerNameId: data.otherPartyId,
+                }
+              : undefined
+          }
         />
         {OpenButton}
       </Grid>


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12713

Any custom report that used indicators could not be generated from an emergency Internal Order — it failed with `Variable programId is not defined.`

That report's embedded query declares three variables that don't come from the order record:

```graphql
query requisitionQuery(
  $storeId: String!
  $dataId: String!
  $programId: String!
  $customerNameId: String!
  $periodId: String!
)
```

The client has to hand those over as report `arguments`, and it only did so when the Indicators **tab** was visible. That gate (`showIndicatorTab`) wants a program order, a non-emergency order, a store-backed supplier, *and* a program defining at least one indicator. Fail any one of the four and all three arguments were dropped.

async-graphql has no fallback for a variable that is declared but not supplied — it errors at field-resolution time rather than treating it as null. So a hidden tab didn't yield a report without indicators, it yielded no report at all.

Whether the tab is *offered* is a display decision. Withholding the arguments can only break a report that declares them, never help it, so they are now sent for every program order regardless of the tab. Customer Requisitions previously sent no arguments at all and now sends the same three.

## 💌 Any notes for the reviewer?

**Which of the four conditions bit the reporter** isn't knowable from the issue, but any of them reproduces it. The likeliest are an emergency order or a program with no indicators defined.

**No server change.** The server behaviour here is correct as-is; the argument was simply never sent.

# 🧪 Tested

- Reproduced against the real `Rapport commande mensuel` report (`internal-order-indicators_2_6_2_true`) installed on a local server, driving `generateReport` directly so the result is independent of any UI
- On an emergency program order (has a program and a period, so `showIndicatorTab` is false only because of `isEmergency`), generating with `arguments: {timezone}` fails with exactly `Variable programId is not defined.` at path `programIndicators` — the issue's error
- Generating the same report on the same order with `programId` / `periodId` / `customerNameId` supplied succeeds and returns a file id
- Confirmed the null variant is rejected (errors quoted above), which is why the fix sends real ids or nothing
- `yarn tsc --noEmit` on `client/`: no new errors (7 pre-existing failures in unrelated test/config files)
- `eslint` clean on all three changed files
