### PR TITLE
Replace the item-stats semaphore with a raised dataloader batch cap

### DIFF
--- a/server/graphql/core/src/loader/item_stats.rs
+++ b/server/graphql/core/src/loader/item_stats.rs
@@ -4,25 +4,8 @@ use actix_web::web::Data;
 use async_graphql::dataloader::*;
 use chrono::NaiveDate;
 use ordered_float::OrderedFloat;
-use service::{
-    item_stats::{item_stats_uses_plugin, ItemStats},
-    service_provider::ServiceProvider,
-};
+use service::{item_stats::ItemStats, service_provider::ServiceProvider};
 use std::collections::HashMap;
-use tokio::sync::Semaphore;
-
-/// Batch sizes at or above this are "bulk" (report-scale) and compete for BULK_STATS_PERMITS;
-/// interactive batches (item detail, search results, list pages — typically 20-25 keys) bypass
-/// the cap so they never queue behind a report's bulk batches.
-const BULK_BATCH_SIZE: usize = 100;
-
-/// With an AMC/consumption plugin installed, each bulk stats batch is a full backend-plugin run
-/// (JS engine parse + heavy ledger SQL) that pins a pool connection for its whole duration. A
-/// report fans out into many such batches; letting them all take connections concurrently
-/// exhausted the pool and wedged the server (issue #12689). Bulk batches take a permit BEFORE
-/// checking out a connection, so however many batches a report shatters into, this loader holds
-/// at most 2 pool connections at a time (+1 for a concurrent interactive batch).
-static BULK_STATS_PERMITS: Semaphore = Semaphore::const_new(2);
 
 pub struct ItemsStatsForItemLoader {
     pub service_provider: Data<ServiceProvider>,
@@ -80,22 +63,6 @@ impl Loader<ItemStatsLoaderInput> for ItemsStatsForItemLoader {
         }
 
         let service_provider = self.service_provider.clone();
-
-        // The permit is acquired here — before the blocking task checks out a pool connection —
-        // so queued bulk batches wait without holding anything. Acquiring it after the
-        // connection would let 10 queued batches pin all 10 connections while they wait, which
-        // is exactly the exhaustion this guards against. Held (moved into scope) until the
-        // batch's computation finishes. Interactive-sized batches skip the queue entirely.
-        let _bulk_permit = if loader_inputs.len() >= BULK_BATCH_SIZE && item_stats_uses_plugin() {
-            Some(
-                BULK_STATS_PERMITS
-                    .acquire()
-                    .await
-                    .expect("BULK_STATS_PERMITS is never closed"),
-            )
-        } else {
-            None
-        };
 
         // get_item_stats is synchronous and may invoke the average_monthly_consumption /
         // get_consumption plugins (the whole boajs interpreter, including any blocking http). Run

--- a/server/graphql/core/src/loader/loader_registry.rs
+++ b/server/graphql/core/src/loader/loader_registry.rs
@@ -185,18 +185,30 @@ pub async fn get_loaders(
         tokio::spawn,
     );
 
-    // Item stats can be plugin-backed and very expensive per batch, and a report resolves stats
-    // on thousands of item nodes whose keys trickle in over time. The default 1ms coalescing
-    // window shatters them into many batches — each a separate plugin run holding a pool
-    // connection (#12689). A wider window collects a report's worth of keys into few batches;
-    // +50ms latency is imperceptible on interactive queries.
+    // Item stats can be plugin-backed and very expensive per batch: a report resolves stats on
+    // every item node (the Item Usage report asks for three AMC lookbacks across ~1500 items,
+    // so ~4500 keys), and each batch is a separate plugin run holding a pool connection.
+    //
+    // Two defaults have to be overridden to keep that as one batch (#12689):
+    //
+    // - `max_batch_size` (default 1000) dispatches immediately once that many keys are pending,
+    //   ignoring the delay entirely — so the default alone forces at least ceil(4500/1000) = 5
+    //   concurrent batches no matter how wide the window is. The cap here only exists to bound
+    //   the `eq_any` bind count in a single `get_item_stats` call: the batch is split by
+    //   (store, lookback) before querying, but worst case that is one group, and SQLite allows
+    //   32766 bind parameters — so stay well under it rather than at it.
+    // - The default 1ms delay fires while the keys are still being enqueued (async-graphql
+    //   resolves list items concurrently, so they arrive in one burst that takes a few ms),
+    //   stealing partial batches. 50ms comfortably covers the burst and is imperceptible on
+    //   interactive queries.
     let item_stats_for_item_loader = DataLoader::new(
         ItemsStatsForItemLoader {
             service_provider: service_provider.clone(),
         },
         tokio::spawn,
     )
-    .delay(std::time::Duration::from_millis(50));
+    .delay(std::time::Duration::from_millis(50))
+    .max_batch_size(20_000);
 
     let requisition_line_supply_status_loader = DataLoader::new(
         RequisitionLineSupplyStatusLoader {

--- a/server/service/src/item_stats.rs
+++ b/server/service/src/item_stats.rs
@@ -51,14 +51,6 @@ pub trait ItemStatsServiceTrait: Sync + Send {
 pub struct ItemStatsService {}
 impl ItemStatsServiceTrait for ItemStatsService {}
 
-/// Whether item-stats computations will invoke a backend plugin (a full JS engine run plus the
-/// plugin's own SQL). Used by callers that fan out many computations (the graphql dataloader) to
-/// decide whether to throttle — see `ItemsStatsForItemLoader`.
-pub fn item_stats_uses_plugin() -> bool {
-    PluginInstance::get_one(PluginType::GetConsumption).is_some()
-        || PluginInstance::get_one(PluginType::AverageMonthlyConsumption).is_some()
-}
-
 pub fn get_item_stats(
     connection: &StorageConnection,
     store_id: &str,


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Follow-up to #12709. That PR stopped the pool exhaustion in #12689 by capping how many item-stats batches could hold pool connections at once, with a semaphore. This removes the semaphore and fixes the fan-out that made it necessary — which also makes the Item Usage report **~5× faster** (24.3s → 4.8s measured, details below).

**To be clear up front: `develop` is not broken.** #12709 works. This is a simplification that happens to be a large performance win, not a bug fix.

**The fan-out is not caused by the coalescing window.** `async-graphql`'s `DataLoader` defaults `max_batch_size` to 1000, and `load_many` dispatches a batch *immediately* on reaching it.

The Item Usage report resolves `stats` on every item node across three AMC lookbacks — 5478 keys on the affected site — and `resolve_list`/`FuturesUnordered` enqueue them in one burst. So the default cap alone forces at least 6 concurrent batches, and no delay value can collapse them. Widening the window to 50ms in #12709 only tidied the batch sizes; it did not reduce the batch count.

Raising the cap turns those keys into **one** batch, so there is no fan-out left to throttle. This removes:

- `BULK_STATS_PERMITS` / `BULK_BATCH_SIZE` and the permit acquisition in `ItemsStatsForItemLoader`
- `item_stats_uses_plugin()` in `service/src/item_stats.rs`, which existed only to feed the semaphore

The 50ms window and the connection lending from #12709 both stay — measurements below show why.

The speedup comes from the same place: seven batches meant seven separate AMC plugin invocations (each re-parsing the plugin bundle), which the semaphore then deliberately serialised two at a time. One batch runs the plugin once.

## 💌 Any notes for the reviewer?

**The 50ms window is equally load-bearing, and I nearly assumed otherwise.** With the cap raised but the window back at the 1ms default, the timer fires repeatedly *during* the ~55ms enqueue burst and steals partial batches — 8 of them, pool at 10/10 for ~21s, slowest concurrent query 22.8s. Raising the cap without the window buys nothing at all.

**Why 20_000 and not unbounded.** The only hard constraint is the `eq_any` bind count in a single `get_item_stats` call. The batch is split by `(store, lookback)` before querying, but worst case that is one group, and SQLite allows 32766 bind parameters. 20_000 leaves ~39% headroom while covering ~6600 items × 3 lookbacks in one batch, or a 20k-item store on a plain single `stats` selection.

**Connection lending stays, and is now measured to work.** The instrumentation counted every boajs binding that fell back to its own pool checkout: **0** with lending on, 32 with it off. It is not what fixes this, but it halves per-batch connection cost — with the cap raised it is the difference between peaking at 8/10 and 5/10. Worth keeping as headroom for concurrent users and for Postgres central servers with different pool sizing, the concern raised on #12709.

**A correction to the reasoning in #12709.** That PR attributed the exhaustion primarily to hold-and-wait — each batch pinning one connection then blocking for a second. That is real and it makes things much worse, but it is not the whole story: with lending on and *zero* second checkouts, the pool still exhausted. The missing term is that this server idles at 5 of 10 connections already checked out (sync driver, file sync, processors), so usable headroom is ~5, not ~9. Eight batches at one connection each already exceed it. **Fan-out width is the dominant term; per-batch cost is a multiplier on it.**

**Known limitation, unchanged by this PR.** The loader registry is a process-wide `NoCache` singleton, so an interactive `stats` key arriving inside the 50ms window joins the report's batch and waits for the whole plugin run. That was already true (it would previously have joined one of several batches). If it ever bites, the clean fix is a separate loader instance for report traffic rather than reinstating a semaphore.

# 🧪 Tested

`cargo check --workspace --all-targets` clean; existing item-stats, boajs-context and graphql loader tests pass.

**Isolating the mechanism first.** A standalone harness against `async-graphql` 7.2.1 reproduced the batching without the server: 4500 keys give 6 batches at the default cap with a 1ms delay, 5 at 50ms, and exactly 1 at 50ms once the cap is raised. This confirmed the cap — not the window — is what splits batches, and that both are needed.

**Then against the affected site's data.** A 219MB copy of the reporting site's SQLite datafile with the AMC plugin installed (`civ_plugins` 1.0.4), pool 10, 30s timeout. The store under test has 1819 visible items, so the report's three `stats` aliases produce 5478 keys. Each run started a fresh server, generated the Item Usage report, and issued an `items` query every 400ms throughout. The server was instrumented to log per-batch key counts, per-batch fallback pool checkouts, and pool occupancy every 50ms. Idle baseline before each report: 5 of 10 connections already checked out.

Columns: **batches** = how many `ItemsStatsForItemLoader` batches the 5478 keys split into, each a separate AMC plugin run. **Peak connections** = highest simultaneous pool checkouts, of 10. **Pool exhausted** = wall time at 10/10 with nothing free. **Concurrent query** = slowest response to an `items` query issued *while the report was generating* — the user-visible "is the server wedged" signal.

| Configuration | batches | peak connections (of 10) | pool exhausted | report | slowest concurrent query |
|---|---|---|---|---|---|
| `develop` today (#12709 as shipped) | 7 | 7 | none | 24.3s | 7ms |
| This PR **without** the raised cap | 7 | **10** | ~25s | 33.7s | **25.6s** |
| This PR **without** the 50ms window | 8 | **10** | ~21s | 30.7s | **22.8s** |
| **This PR** | **1** | **5** | **none** | **4.8s** | **5ms** |

Both knobs are required; together they cut the report to a fifth of its current time while *lowering* peak pool usage.

Two further runs re-confirmed the original #12689 failure and pinned down its mechanism. With the pre-#12709 code the report's data fetch fails outright — 8 batches, 6 extra plugin connections each, pool at 10/10 for ~40s. Re-enabling connection lending alone drops the extra checkouts to 0 and the fetch **still** fails, with the pool still saturated: the evidence for the correction noted above.

**Caveat:** debug build on macOS, so absolute timings are not comparable to the tablet figures in #12709. The batch counts, connection accounting and relative timings are what these runs establish.

# 📃 Documentation

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
