### PR TITLE
electron: show a single SSL error dialog when a certificate changes

### DIFF
--- a/client/packages/electron/src/electron.ts
+++ b/client/packages/electron/src/electron.ts
@@ -456,9 +456,55 @@ process.on('uncaughtException', error => {
  */
 });
 
+// A certificate change raises a certificate-error for every request in flight,
+// so share one prompt (and one answer) per server and certificate instead of
+// opening a dialog for each event
+const pendingCertificatePrompts = new Map<string, Promise<boolean>>();
+
+const promptToAcceptCertificate = (
+  identifier: string,
+  fingerprint: string,
+  parent: BrowserWindow | null
+): Promise<boolean> => {
+  const key = `${identifier}-${fingerprint}`;
+  const pendingPrompt = pendingCertificatePrompts.get(key);
+  if (pendingPrompt) return pendingPrompt;
+
+  const options: Electron.MessageBoxOptions = {
+    type: 'warning',
+    buttons: ['No', 'Yes'],
+    title: 'SSL Error',
+    message:
+      'The security certificate on the server has changed!\r\n\r\nThis can happen when the server is reinstalled, so may be normal, but please check with your IT department if you are unsure.\r\n\r\nWould you like to accept the new certificate? ',
+  };
+
+  const prompt = (
+    parent
+      ? dialog.showMessageBox(parent, options)
+      : dialog.showMessageBox(options)
+  )
+    .then(({ response }) => {
+      if (response === 0) {
+        ipcMain.emit(IPC_MESSAGES.GO_BACK_TO_DISCOVERY);
+        return false;
+      }
+
+      // Update stored fingerprint
+      store.set(identifier, fingerprint);
+      return true;
+    })
+    .finally(() => {
+      pendingCertificatePrompts.delete(key);
+    });
+
+  pendingCertificatePrompts.set(key, prompt);
+
+  return prompt;
+};
+
 app.addListener(
   'certificate-error',
-  async (event, _webContents, url, error, certificate, callback) => {
+  async (event, contents, url, error, certificate, callback) => {
     // We are only handling self signed certificate errors
     if (
       error != 'net::ERR_CERT_INVALID' &&
@@ -493,23 +539,16 @@ app.addListener(
       store.set(identifier, storedFingerprint);
       // If fingerprint does not match
     } else if (storedFingerprint != certificate.fingerprint) {
-      // Display error message and go back to discovery
-      const returnValue = await dialog.showMessageBox({
-        type: 'warning',
-        buttons: ['No', 'Yes'],
-        title: 'SSL Error',
-        message:
-          'The security certificate on the server has changed!\r\n\r\nThis can happen when the server is reinstalled, so may be normal, but please check with your IT department if you are unsure.\r\n\r\nWould you like to accept the new certificate? ',
-      });
+      // Display error message and go back to discovery if not accepted
+      const accepted = await promptToAcceptCertificate(
+        identifier,
+        certificate.fingerprint,
+        BrowserWindow.fromWebContents(contents) ??
+          BrowserWindow.getAllWindows()[0] ??
+          null
+      );
 
-      if (returnValue.response === 0) {
-        ipcMain.emit(IPC_MESSAGES.GO_BACK_TO_DISCOVERY);
-        return callback(false);
-      }
-
-      // Update stored fingerprint
-      storedFingerprint = certificate.fingerprint;
-      store.set(identifier, storedFingerprint);
+      if (!accepted) return callback(false);
     }
 
     // storedFingerprint did not exist or it matched certificate fingerprint


### PR DESCRIPTION
# 👩🏻‍💻 What does this PR do?

Fixes #12714

A changed server certificate raises a certificate-error event for every request in flight, and the handler opened its own message box for each one, so users were left with a stack of separate "SSL Error" windows to answer. The dialogs were also unparented, floating free of the app rather than being modal to it.

Share one prompt per server and certificate: the first event opens the dialog, concurrent events wait on the same promise and are resolved with the same answer through their own callback, and `GO_BACK_TO_DISCOVERY` is emitted once. The dialog is parented to the window that raised the error.

## 💌 Any notes for the reviewer?

Untested. Generated the patch prior to filing the bug to reason about it, but it might not be your chosen approach.

# 📃 Documentation

<!--
Pick what applies. If docs are needed, add the matching label (`docs: external` / `docs: internal`)
and change it to `doc: done` once written. See docs/content/process/documentation for the full process.
-->

- [x] **No documentation required** — no user-facing change (e.g. a refactor, or a bug fix that doesn't change behaviour)
- [ ] **Part of an epic** — documentation will be completed for the feature as a whole
- [ ] **Public docs needed** (`docs: external`) — user-facing / UI change, written up in the [msupply_docs](https://github.com/msupply-foundation/msupply_docs) repo. Note what changed / how it works (bullets or screenshots):
  <!-- - _(e.g.)_ New `issued` column in `Requisitions` indicates stock quantity already in shipments -->
- [ ] **Developer docs needed** (`docs: internal`) — code or process worth documenting in `./docs`:
  <!-- - -->
